### PR TITLE
Refactor proxy concurrency architecture

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "XcodeMCPKit",
+    platforms: [
+        .macOS(.v15)
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/README.ja.md
+++ b/README.ja.md
@@ -111,6 +111,18 @@ url = "http://127.0.0.1:8765/mcp"
 
 ## トラブルシューティング
 
+- `mcpbridge` が実行できない  
+  Apple ドキュメントより引用:
+
+  > In Terminal, use the xcrun mcpbridge command to configure the agentic coding tool to use Xcode Tools.
+
+  参考: [Giving external agentic coding tools access to Xcode](https://developer.apple.com/documentation/Xcode/giving-agentic-coding-tools-access-to-xcode#Configure-external-coding-tools-to-use-the-MCP-server)
+
+  ```bash
+  claude mcp add --transport stdio xcode -- xcrun mcpbridge
+  codex mcp add xcode -- xcrun mcpbridge
+  ```
+
 - `MCP client ... timed out`  
   プロキシが起動しているか確認し、必要なら `startup_timeout_sec` を増やしてください。
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ url = "http://127.0.0.1:8765/mcp"
 
 ## Troubleshooting
 
+- `mcpbridge` fails to run  
+  Apple documentation notes:
+
+  > In Terminal, use the xcrun mcpbridge command to configure the agentic coding tool to use Xcode Tools.
+
+  Reference: [Giving external agentic coding tools access to Xcode](https://developer.apple.com/documentation/Xcode/giving-agentic-coding-tools-access-to-xcode#Configure-external-coding-tools-to-use-the-MCP-server)
+
+  ```bash
+  claude mcp add --transport stdio xcode -- xcrun mcpbridge
+  codex mcp add xcode -- xcrun mcpbridge
+  ```
+
 - `MCP client ... timed out`  
   Ensure the proxy is running, then increase `startup_timeout_sec` if needed.
 

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -1,20 +1,24 @@
 import Foundation
-@preconcurrency import NIO
-@preconcurrency import NIOHTTP1
-@preconcurrency import NIOFoundationCompat
+import NIO
+import NIOHTTP1
+import NIOFoundationCompat
+import NIOConcurrencyHelpers
 
-final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
+final class HTTPHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 
+    private struct State: Sendable {
+        var requestHead: HTTPRequestHead?
+        var bodyBuffer: ByteBuffer?
+        var isSSE = false
+        var sseSessionId: String?
+        var bodyTooLarge = false
+    }
+
+    private let state = NIOLockedValueBox(State())
     private let config: ProxyConfig
     private let sessionManager: SessionManager
-
-    private var requestHead: HTTPRequestHead?
-    private var bodyBuffer: ByteBuffer?
-    private var isSSE = false
-    private var sseSessionId: String?
-    private var bodyTooLarge = false
 
     init(config: ProxyConfig, sessionManager: SessionManager) {
         self.config = config
@@ -25,37 +29,55 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         let part = unwrapInboundIn(data)
         switch part {
         case .head(let head):
-            requestHead = head
-            bodyBuffer = context.channel.allocator.buffer(capacity: 0)
-            bodyTooLarge = false
+            state.withLockedValue { state in
+                state.requestHead = head
+                state.bodyBuffer = context.channel.allocator.buffer(capacity: 0)
+                state.bodyTooLarge = false
+            }
         case .body(var buffer):
-            guard var body = bodyBuffer, !bodyTooLarge else { return }
-            if body.readableBytes + buffer.readableBytes > config.maxBodyBytes {
-                bodyTooLarge = true
-                bodyBuffer = body
+            var shouldReturn = false
+            state.withLockedValue { state in
+                guard var body = state.bodyBuffer, !state.bodyTooLarge else {
+                    shouldReturn = true
+                    return
+                }
+                if body.readableBytes + buffer.readableBytes > config.maxBodyBytes {
+                    state.bodyTooLarge = true
+                    state.bodyBuffer = body
+                    shouldReturn = true
+                    return
+                }
+                body.writeBuffer(&buffer)
+                state.bodyBuffer = body
+            }
+            if shouldReturn {
                 return
             }
-            body.writeBuffer(&buffer)
-            bodyBuffer = body
         case .end:
             handleRequest(context: context)
         }
     }
 
     func channelInactive(context: ChannelHandlerContext) {
-        if let sessionId = sseSessionId {
+        let sessionId = state.withLockedValue { $0.sseSessionId }
+        if let sessionId {
             let session = sessionManager.session(id: sessionId)
             session.sseHub.remove(context.channel)
         }
     }
 
     private func handleRequest(context: ChannelHandlerContext) {
-        guard let head = requestHead else { return }
-        requestHead = nil
+        let head = state.withLockedValue { state -> HTTPRequestHead? in
+            let head = state.requestHead
+            state.requestHead = nil
+            return head
+        }
+        guard let head else { return }
 
+        let bodyTooLarge = state.withLockedValue { $0.bodyTooLarge }
         if bodyTooLarge {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .payloadTooLarge,
                 body: "request body too large",
                 keepAlive: head.isKeepAlive,
@@ -67,7 +89,7 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         let path = head.uri.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: true).first.map(String.init) ?? head.uri
         switch (head.method, path) {
         case (.GET, "/health"):
-            sendPlain(context: context, status: .ok, body: "ok", keepAlive: head.isKeepAlive, sessionId: nil)
+            Self.sendPlain(on: context.channel, status: .ok, body: "ok", keepAlive: head.isKeepAlive, sessionId: nil)
         case (.GET, "/mcp"), (.GET, "/"), (.GET, "/mcp/events"), (.GET, "/events"):
             handleSSE(context: context, head: head)
         case (.DELETE, "/mcp"), (.DELETE, "/"):
@@ -75,18 +97,19 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         case (.POST, "/mcp"), (.POST, "/"):
             handlePost(context: context, head: head)
         default:
-            sendPlain(context: context, status: .notFound, body: "not found", keepAlive: head.isKeepAlive, sessionId: nil)
+            Self.sendPlain(on: context.channel, status: .notFound, body: "not found", keepAlive: head.isKeepAlive, sessionId: nil)
         }
     }
 
     private func handleSSE(context: ChannelHandlerContext, head: HTTPRequestHead) {
-        if isSSE {
+        let alreadySSE = state.withLockedValue { $0.isSSE }
+        if alreadySSE {
             return
         }
 
         guard acceptsEventStream(head.headers) else {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .notAcceptable,
                 body: "client must accept text/event-stream",
                 keepAlive: head.isKeepAlive,
@@ -96,8 +119,8 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         }
 
         guard let sessionId = sessionIdFromHeaders(head.headers) else {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .unauthorized,
                 body: "session id required",
                 keepAlive: head.isKeepAlive,
@@ -107,8 +130,8 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         }
 
         guard sessionManager.hasSession(id: sessionId) else {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .unauthorized,
                 body: "session not found",
                 keepAlive: head.isKeepAlive,
@@ -120,8 +143,10 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         let session = sessionManager.session(id: sessionId)
         let hadClients = session.sseHub.hasClients
 
-        isSSE = true
-        sseSessionId = sessionId
+        state.withLockedValue { state in
+            state.isSSE = true
+            state.sseSessionId = sessionId
+        }
         session.sseHub.add(context.channel)
 
         var headers = HTTPHeaders()
@@ -147,8 +172,8 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
 
     private func handleDelete(context: ChannelHandlerContext, head: HTTPRequestHead) {
         guard let sessionId = sessionIdFromHeaders(head.headers) else {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .unauthorized,
                 body: "session id required",
                 keepAlive: head.isKeepAlive,
@@ -157,8 +182,8 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             return
         }
         guard sessionManager.hasSession(id: sessionId) else {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .unauthorized,
                 body: "session not found",
                 keepAlive: head.isKeepAlive,
@@ -167,15 +192,15 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             return
         }
         sessionManager.removeSession(id: sessionId)
-        sendEmpty(context: context, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId)
+        Self.sendEmpty(on: context.channel, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId)
     }
 
     private func handlePost(context: ChannelHandlerContext, head: HTTPRequestHead) {
         let wantsEventStream = acceptsEventStream(head.headers)
         let wantsJSON = acceptsJSON(head.headers)
         guard wantsEventStream || wantsJSON else {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .notAcceptable,
                 body: "client must accept application/json or text/event-stream",
                 keepAlive: head.isKeepAlive,
@@ -185,8 +210,8 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
         }
 
         guard contentTypeIsJSON(head.headers) else {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .unsupportedMediaType,
                 body: "content-type must be application/json",
                 keepAlive: head.isKeepAlive,
@@ -195,21 +220,25 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             return
         }
 
-        guard var body = bodyBuffer else {
-            sendPlain(context: context, status: .badRequest, body: "missing body", keepAlive: head.isKeepAlive, sessionId: nil)
+        let body = state.withLockedValue { state -> ByteBuffer? in
+            let body = state.bodyBuffer
+            state.bodyBuffer = nil
+            return body
+        }
+        guard var body = body else {
+            Self.sendPlain(on: context.channel, status: .badRequest, body: "missing body", keepAlive: head.isKeepAlive, sessionId: nil)
             return
         }
-        bodyBuffer = nil
 
         guard let bodyData = body.readData(length: body.readableBytes) else {
-            sendPlain(context: context, status: .badRequest, body: "invalid body", keepAlive: head.isKeepAlive, sessionId: nil)
+            Self.sendPlain(on: context.channel, status: .badRequest, body: "invalid body", keepAlive: head.isKeepAlive, sessionId: nil)
             return
         }
 
         let headerSessionId = sessionIdFromHeaders(head.headers)
         if let headerSessionId, !sessionManager.hasSession(id: headerSessionId) {
-            sendPlain(
-                context: context,
+            Self.sendPlain(
+                on: context.channel,
                 status: .unauthorized,
                 body: "session not found",
                 keepAlive: head.isKeepAlive,
@@ -222,8 +251,8 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
            let method = object["method"] as? String,
            method == "initialize",
            headerSessionId == nil {
-            guard let originalId = object["id"], !(originalId is NSNull) else {
-                sendPlain(context: context, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: nil)
+            guard let originalIdValue = object["id"], let originalId = RPCId(any: originalIdValue) else {
+                Self.sendPlain(on: context.channel, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: nil)
                 return
             }
             let sessionId = UUID().uuidString
@@ -235,26 +264,24 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             )
             let keepAlive = head.isKeepAlive
             let prefersEventStream = wantsEventStream
-            future.whenComplete { [weak self, contextBox = ContextBox(context)] result in
-                guard let self else { return }
-                contextBox.context.eventLoop.execute {
-                    switch result {
-                    case .success(let buffer):
-                        var buffer = buffer
-                        guard let data = buffer.readData(length: buffer.readableBytes) else {
-                            self.sendPlain(context: contextBox.context, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionId)
-                            return
-                        }
-                        if prefersEventStream {
-                            self.sendSingleSSE(context: contextBox.context, data: data, keepAlive: keepAlive, sessionId: sessionId)
-                        } else {
-                            var out = contextBox.context.channel.allocator.buffer(capacity: data.count)
-                            out.writeBytes(data)
-                            self.sendJSON(context: contextBox.context, buffer: out, keepAlive: keepAlive, sessionId: sessionId)
-                        }
-                    case .failure:
-                        self.sendPlain(context: contextBox.context, status: .gatewayTimeout, body: "upstream timeout", keepAlive: keepAlive, sessionId: sessionId)
+            let channel = context.channel
+            future.whenComplete { result in
+                switch result {
+                case .success(let buffer):
+                    var buffer = buffer
+                    guard let data = buffer.readData(length: buffer.readableBytes) else {
+                        Self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionId)
+                        return
                     }
+                    if prefersEventStream {
+                        Self.sendSingleSSE(on: channel, data: data, keepAlive: keepAlive, sessionId: sessionId)
+                    } else {
+                        var out = channel.allocator.buffer(capacity: data.count)
+                        out.writeBytes(data)
+                        Self.sendJSON(on: channel, buffer: out, keepAlive: keepAlive, sessionId: sessionId)
+                    }
+                case .failure:
+                    Self.sendPlain(on: channel, status: .gatewayTimeout, body: "upstream timeout", keepAlive: keepAlive, sessionId: sessionId)
                 }
             }
             return
@@ -272,14 +299,14 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
                 }
             )
         } catch {
-            sendPlain(context: context, status: .badRequest, body: "invalid json", keepAlive: head.isKeepAlive, sessionId: sessionId)
+            Self.sendPlain(on: context.channel, status: .badRequest, body: "invalid json", keepAlive: head.isKeepAlive, sessionId: sessionId)
             return
         }
 
         if headerSessionId == nil {
             if transform.isBatch || transform.method != "initialize" || !transform.expectsResponse {
-                sendPlain(
-                    context: context,
+                Self.sendPlain(
+                    on: context.channel,
                     status: .unprocessableEntity,
                     body: "expected initialize request",
                     keepAlive: head.isKeepAlive,
@@ -298,48 +325,45 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
             } else if let idKey = transform.idKey {
                 future = session.router.registerRequest(idKey: idKey, on: context.eventLoop)
             } else {
-                sendPlain(context: context, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: sessionId)
+                Self.sendPlain(on: context.channel, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: sessionId)
                 return
             }
 
-            sessionManager.upstream.send(transform.upstreamData)
-            let contextBox = ContextBox(context)
+            sessionManager.sendUpstream(transform.upstreamData)
             let keepAlive = head.isKeepAlive
             let sessionIdCopy = sessionId
             let prefersEventStream = wantsEventStream
-            future.whenComplete { [weak self, contextBox] result in
-                guard let self else { return }
-                contextBox.context.eventLoop.execute {
-                    switch result {
-                    case .success(let buffer):
-                        var buffer = buffer
-                        guard let data = buffer.readData(length: buffer.readableBytes) else {
-                            self.sendPlain(context: contextBox.context, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionIdCopy)
-                            return
-                        }
-                        if prefersEventStream {
-                            self.sendSingleSSE(context: contextBox.context, data: data, keepAlive: keepAlive, sessionId: sessionIdCopy)
-                        } else {
-                            var out = contextBox.context.channel.allocator.buffer(capacity: data.count)
-                            out.writeBytes(data)
-                            self.sendJSON(context: contextBox.context, buffer: out, keepAlive: keepAlive, sessionId: sessionIdCopy)
-                        }
-                    case .failure:
-                        self.sendPlain(context: contextBox.context, status: .gatewayTimeout, body: "upstream timeout", keepAlive: keepAlive, sessionId: sessionIdCopy)
+            let channel = context.channel
+            future.whenComplete { result in
+                switch result {
+                case .success(let buffer):
+                    var buffer = buffer
+                    guard let data = buffer.readData(length: buffer.readableBytes) else {
+                        Self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionIdCopy)
+                        return
                     }
+                    if prefersEventStream {
+                        Self.sendSingleSSE(on: channel, data: data, keepAlive: keepAlive, sessionId: sessionIdCopy)
+                    } else {
+                        var out = channel.allocator.buffer(capacity: data.count)
+                        out.writeBytes(data)
+                        Self.sendJSON(on: channel, buffer: out, keepAlive: keepAlive, sessionId: sessionIdCopy)
+                    }
+                case .failure:
+                    Self.sendPlain(on: channel, status: .gatewayTimeout, body: "upstream timeout", keepAlive: keepAlive, sessionId: sessionIdCopy)
                 }
             }
         } else {
             if transform.method == "notifications/initialized" && sessionManager.isInitialized() {
-                sendEmpty(context: context, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId)
+                Self.sendEmpty(on: context.channel, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId)
             } else {
-                sessionManager.upstream.send(transform.upstreamData)
-                sendEmpty(context: context, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId)
+                sessionManager.sendUpstream(transform.upstreamData)
+                Self.sendEmpty(on: context.channel, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId)
             }
         }
     }
 
-    private func sendSingleSSE(context: ChannelHandlerContext, data: Data, keepAlive: Bool, sessionId: String) {
+    private static func sendSingleSSE(on channel: Channel, data: Data, keepAlive: Bool, sessionId: String) {
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "text/event-stream")
         headers.add(name: "Cache-Control", value: "no-cache")
@@ -347,45 +371,45 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
 
         var head = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
         head.headers.add(name: "Connection", value: keepAlive ? "keep-alive" : "close")
-        context.write(wrapOutboundOut(.head(head)), promise: nil)
+        channel.write(HTTPServerResponsePart.head(head), promise: nil)
 
-        var buffer = context.channel.allocator.buffer(capacity: data.count + 16)
+        var buffer = channel.allocator.buffer(capacity: data.count + 16)
         buffer.writeString("data: ")
         buffer.writeBytes(data)
         buffer.writeString("\n\n")
-        context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
-        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+        channel.write(HTTPServerResponsePart.body(.byteBuffer(buffer)), promise: nil)
+        channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
         if !keepAlive {
-            context.close(promise: nil)
+            channel.close(promise: nil)
         }
     }
 
-    private func sendJSON(context: ChannelHandlerContext, buffer: ByteBuffer, keepAlive: Bool, sessionId: String) {
+    private static func sendJSON(on channel: Channel, buffer: ByteBuffer, keepAlive: Bool, sessionId: String) {
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "application/json")
         headers.add(name: "Mcp-Session-Id", value: sessionId)
-        sendBuffer(context: context, status: .ok, headers: headers, buffer: buffer, keepAlive: keepAlive)
+        sendBuffer(on: channel, status: .ok, headers: headers, buffer: buffer, keepAlive: keepAlive)
     }
 
-    private func sendPlain(context: ChannelHandlerContext, status: HTTPResponseStatus, body: String, keepAlive: Bool, sessionId: String?) {
+    private static func sendPlain(on channel: Channel, status: HTTPResponseStatus, body: String, keepAlive: Bool, sessionId: String?) {
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         if let sessionId {
             headers.add(name: "Mcp-Session-Id", value: sessionId)
         }
-        var buffer = context.channel.allocator.buffer(capacity: body.utf8.count)
+        var buffer = channel.allocator.buffer(capacity: body.utf8.count)
         buffer.writeString(body)
-        sendBuffer(context: context, status: status, headers: headers, buffer: buffer, keepAlive: keepAlive)
+        sendBuffer(on: channel, status: status, headers: headers, buffer: buffer, keepAlive: keepAlive)
     }
 
-    private func sendEmpty(context: ChannelHandlerContext, status: HTTPResponseStatus, keepAlive: Bool, sessionId: String) {
+    private static func sendEmpty(on channel: Channel, status: HTTPResponseStatus, keepAlive: Bool, sessionId: String) {
         var headers = HTTPHeaders()
         headers.add(name: "Mcp-Session-Id", value: sessionId)
-        sendBuffer(context: context, status: status, headers: headers, buffer: nil, keepAlive: keepAlive)
+        sendBuffer(on: channel, status: status, headers: headers, buffer: nil, keepAlive: keepAlive)
     }
 
-    private func sendBuffer(
-        context: ChannelHandlerContext,
+    private static func sendBuffer(
+        on channel: Channel,
         status: HTTPResponseStatus,
         headers: HTTPHeaders,
         buffer: ByteBuffer?,
@@ -393,13 +417,13 @@ final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     ) {
         var head = HTTPResponseHead(version: .http1_1, status: status, headers: headers)
         head.headers.add(name: "Connection", value: keepAlive ? "keep-alive" : "close")
-        context.write(wrapOutboundOut(.head(head)), promise: nil)
+        channel.write(HTTPServerResponsePart.head(head), promise: nil)
         if let buffer {
-            context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+            channel.write(HTTPServerResponsePart.body(.byteBuffer(buffer)), promise: nil)
         }
-        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+        channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
         if !keepAlive {
-            context.close(promise: nil)
+            channel.close(promise: nil)
         }
     }
 
@@ -451,20 +475,20 @@ enum RequestInspector {
     static func transform(
         _ data: Data,
         sessionId: String,
-        mapId: (_ sessionId: String, _ originalId: Any) -> Int64
+        mapId: (_ sessionId: String, _ originalId: RPCId) -> Int64
     ) throws -> RequestTransform {
         let json = try JSONSerialization.jsonObject(with: data, options: [])
         if var object = json as? [String: Any] {
             let method = object["method"] as? String
-            if let id = object["id"], !(id is NSNull) {
-                let upstreamId = mapId(sessionId, id)
+            if let id = object["id"], let rpcId = RPCId(any: id) {
+                let upstreamId = mapId(sessionId, rpcId)
                 object["id"] = upstreamId
                 let upstream = try JSONSerialization.data(withJSONObject: object, options: [])
                 return RequestTransform(
                     upstreamData: upstream,
                     expectsResponse: true,
                     isBatch: false,
-                    idKey: idKey(from: id),
+                    idKey: rpcId.key,
                     method: method
                 )
             }
@@ -483,8 +507,8 @@ enum RequestInspector {
             var hasRequest = false
             for item in array {
                 if var object = item as? [String: Any] {
-                    if let id = object["id"], !(id is NSNull) {
-                        let upstreamId = mapId(sessionId, id)
+                    if let id = object["id"], let rpcId = RPCId(any: id) {
+                        let upstreamId = mapId(sessionId, rpcId)
                         object["id"] = upstreamId
                         hasRequest = true
                     }
@@ -510,23 +534,5 @@ enum RequestInspector {
             idKey: nil,
             method: nil
         )
-    }
-
-    private static func idKey(from value: Any) -> String {
-        if let stringId = value as? String {
-            return stringId
-        }
-        if let numberId = value as? NSNumber {
-            return numberId.stringValue
-        }
-        return String(describing: value)
-    }
-}
-
-private struct ContextBox: @unchecked Sendable {
-    let context: ChannelHandlerContext
-
-    init(_ context: ChannelHandlerContext) {
-        self.context = context
     }
 }

--- a/Sources/XcodeMCPProxy/JSONValue.swift
+++ b/Sources/XcodeMCPProxy/JSONValue.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+enum JSONNumber: Sendable {
+    case int(Int64)
+    case double(Double)
+
+    init(_ number: NSNumber) {
+        if CFNumberIsFloatType(number) {
+            self = .double(number.doubleValue)
+        } else {
+            self = .int(number.int64Value)
+        }
+    }
+
+    var stringValue: String {
+        switch self {
+        case .int(let value):
+            return String(value)
+        case .double(let value):
+            return String(value)
+        }
+    }
+
+    var foundationObject: NSNumber {
+        switch self {
+        case .int(let value):
+            return NSNumber(value: value)
+        case .double(let value):
+            return NSNumber(value: value)
+        }
+    }
+}
+
+enum JSONValue: Sendable {
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case string(String)
+    case number(JSONNumber)
+    case bool(Bool)
+    case null
+
+    init?(any: Any) {
+        switch any {
+        case is NSNull:
+            self = .null
+        case let string as String:
+            self = .string(string)
+        case let number as NSNumber:
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                self = .bool(number.boolValue)
+            } else {
+                self = .number(JSONNumber(number))
+            }
+        case let array as [Any]:
+            var values: [JSONValue] = []
+            values.reserveCapacity(array.count)
+            for item in array {
+                guard let value = JSONValue(any: item) else { return nil }
+                values.append(value)
+            }
+            self = .array(values)
+        case let object as [String: Any]:
+            var values: [String: JSONValue] = [:]
+            values.reserveCapacity(object.count)
+            for (key, value) in object {
+                guard let mapped = JSONValue(any: value) else { return nil }
+                values[key] = mapped
+            }
+            self = .object(values)
+        default:
+            return nil
+        }
+    }
+
+    var foundationObject: Any {
+        switch self {
+        case .object(let values):
+            return values.mapValues { $0.foundationObject }
+        case .array(let values):
+            return values.map { $0.foundationObject }
+        case .string(let value):
+            return value
+        case .number(let value):
+            return value.foundationObject
+        case .bool(let value):
+            return value
+        case .null:
+            return NSNull()
+        }
+    }
+}
+
+struct RPCId: Sendable {
+    let key: String
+    let value: JSONValue
+
+    init?(any: Any) {
+        guard !(any is NSNull) else { return nil }
+
+        if let string = any as? String {
+            key = string
+            value = .string(string)
+            return
+        }
+
+        if let number = any as? NSNumber {
+            key = number.stringValue
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                value = .bool(number.boolValue)
+            } else {
+                value = .number(JSONNumber(number))
+            }
+            return
+        }
+
+        let fallbackKey = String(describing: any)
+        key = fallbackKey
+        value = JSONValue(any: any) ?? .string(fallbackKey)
+    }
+}

--- a/Sources/XcodeMCPProxy/ProxyConfig.swift
+++ b/Sources/XcodeMCPProxy/ProxyConfig.swift
@@ -47,7 +47,7 @@ public enum CLIError: Error, CustomStringConvertible {
 
 public struct CLIParser {
     public static func parse(args: [String], environment: [String: String]) throws -> ProxyConfig {
-        var listenHost = "localhost"
+        var listenHost = "127.0.0.1"
         var listenPort = 8765
         var upstreamCommand = "xcrun"
         var upstreamArgs = ["mcpbridge"]
@@ -167,8 +167,8 @@ public struct CLIParser {
         Usage: xcode-mcp-proxy [options]
 
         Options:
-          --listen host:port         Listen address (default: localhost:8765)
-          --host host                Listen host (default: localhost)
+          --listen host:port         Listen address (default: 127.0.0.1:8765)
+          --host host                Listen host (default: 127.0.0.1)
           --port port                Listen port (default: 8765)
           --upstream-command cmd     Upstream command (default: xcrun)
           --upstream-args a,b,c      Upstream args (default: mcpbridge)
@@ -191,7 +191,7 @@ public struct CLIParser {
         guard let port = Int(portPart), port > 0 else {
             throw CLIError.message("--listen expects host:port (got \(value))")
         }
-        let host = hostPart.isEmpty ? "localhost" : hostPart
+        let host = hostPart.isEmpty ? "127.0.0.1" : hostPart
         return (host, port)
     }
 }

--- a/Sources/XcodeMCPProxy/ProxyConfig.swift
+++ b/Sources/XcodeMCPProxy/ProxyConfig.swift
@@ -47,7 +47,7 @@ public enum CLIError: Error, CustomStringConvertible {
 
 public struct CLIParser {
     public static func parse(args: [String], environment: [String: String]) throws -> ProxyConfig {
-        var listenHost = "127.0.0.1"
+        var listenHost = "localhost"
         var listenPort = 8765
         var upstreamCommand = "xcrun"
         var upstreamArgs = ["mcpbridge"]
@@ -167,8 +167,8 @@ public struct CLIParser {
         Usage: xcode-mcp-proxy [options]
 
         Options:
-          --listen host:port         Listen address (default: 127.0.0.1:8765)
-          --host host                Listen host (default: 127.0.0.1)
+          --listen host:port         Listen address (default: localhost:8765)
+          --host host                Listen host (default: localhost)
           --port port                Listen port (default: 8765)
           --upstream-command cmd     Upstream command (default: xcrun)
           --upstream-args a,b,c      Upstream args (default: mcpbridge)
@@ -191,7 +191,7 @@ public struct CLIParser {
         guard let port = Int(portPart), port > 0 else {
             throw CLIError.message("--listen expects host:port (got \(value))")
         }
-        let host = hostPart.isEmpty ? "127.0.0.1" : hostPart
+        let host = hostPart.isEmpty ? "localhost" : hostPart
         return (host, port)
     }
 }

--- a/Sources/XcodeMCPProxy/ProxyRouter.swift
+++ b/Sources/XcodeMCPProxy/ProxyRouter.swift
@@ -2,26 +2,29 @@ import Foundation
 import NIO
 import NIOConcurrencyHelpers
 
-final class ProxyRouter: @unchecked Sendable {
-    private struct Pending {
+final class ProxyRouter: Sendable {
+    private struct Pending: Sendable {
         var promise: EventLoopPromise<ByteBuffer>
         var timeout: Scheduled<Void>
     }
 
-    private let lock = NIOLock()
-    private var pendingById: [String: Pending] = [:]
-    private var pendingBatches: [Pending] = []
-    private var notificationBuffer: [Data] = []
+    private struct State: Sendable {
+        var pendingById: [String: Pending] = [:]
+        var pendingBatches: [Pending] = []
+        var notificationBuffer: [Data] = []
+    }
+
+    private let state = NIOLockedValueBox(State())
     private let notificationBufferLimit: Int
     private let requestTimeout: TimeAmount
-    private let hasActiveSSE: () -> Bool
-    private let sendNotification: (Data) -> Void
+    private let hasActiveSSE: @Sendable () -> Bool
+    private let sendNotification: @Sendable (Data) -> Void
 
     init(
         requestTimeout: TimeAmount,
         notificationBufferLimit: Int = 50,
-        hasActiveSSE: @escaping () -> Bool,
-        sendNotification: @escaping (Data) -> Void
+        hasActiveSSE: @escaping @Sendable () -> Bool,
+        sendNotification: @escaping @Sendable (Data) -> Void
     ) {
         self.requestTimeout = requestTimeout
         self.notificationBufferLimit = notificationBufferLimit
@@ -35,8 +38,8 @@ final class ProxyRouter: @unchecked Sendable {
             guard let self else { return }
             self.failTimeout(idKey: idKey)
         }
-        lock.withLock {
-            pendingById[idKey] = Pending(promise: promise, timeout: timeout)
+        state.withLockedValue { state in
+            state.pendingById[idKey] = Pending(promise: promise, timeout: timeout)
         }
         return promise.futureResult
     }
@@ -47,8 +50,8 @@ final class ProxyRouter: @unchecked Sendable {
             guard let self else { return }
             self.failBatchTimeout()
         }
-        lock.withLock {
-            pendingBatches.append(Pending(promise: promise, timeout: timeout))
+        state.withLockedValue { state in
+            state.pendingBatches.append(Pending(promise: promise, timeout: timeout))
         }
         return promise.futureResult
     }
@@ -81,32 +84,36 @@ final class ProxyRouter: @unchecked Sendable {
     }
 
     func drainBufferedNotifications() -> [Data] {
-        lock.withLock {
-            let drained = notificationBuffer
-            notificationBuffer.removeAll()
+        state.withLockedValue { state in
+            let drained = state.notificationBuffer
+            state.notificationBuffer.removeAll()
             return drained
         }
     }
 
     private func failTimeout(idKey: String) {
-        let pending = lock.withLock { pendingById.removeValue(forKey: idKey) }
+        let pending = state.withLockedValue { state in
+            state.pendingById.removeValue(forKey: idKey)
+        }
         pending?.promise.fail(TimeoutError())
     }
 
     private func failBatchTimeout() {
-        let pending = lock.withLock { pendingBatches.isEmpty ? nil : pendingBatches.removeFirst() }
+        let pending = state.withLockedValue { state in
+            state.pendingBatches.isEmpty ? nil : state.pendingBatches.removeFirst()
+        }
         pending?.promise.fail(TimeoutError())
     }
 
     private func pop(idKey: String) -> Pending? {
-        lock.withLock {
-            pendingById.removeValue(forKey: idKey)
+        state.withLockedValue { state in
+            state.pendingById.removeValue(forKey: idKey)
         }
     }
 
     private func popBatch() -> Pending? {
-        lock.withLock {
-            pendingBatches.isEmpty ? nil : pendingBatches.removeFirst()
+        state.withLockedValue { state in
+            state.pendingBatches.isEmpty ? nil : state.pendingBatches.removeFirst()
         }
     }
 
@@ -126,10 +133,10 @@ final class ProxyRouter: @unchecked Sendable {
     }
 
     private func bufferNotification(_ data: Data) {
-        lock.withLock {
-            notificationBuffer.append(data)
-            if notificationBuffer.count > notificationBufferLimit {
-                notificationBuffer.removeFirst(notificationBuffer.count - notificationBufferLimit)
+        state.withLockedValue { state in
+            state.notificationBuffer.append(data)
+            if state.notificationBuffer.count > notificationBufferLimit {
+                state.notificationBuffer.removeFirst(state.notificationBuffer.count - notificationBufferLimit)
             }
         }
     }

--- a/Sources/XcodeMCPProxy/SSEHub.swift
+++ b/Sources/XcodeMCPProxy/SSEHub.swift
@@ -3,29 +3,32 @@ import NIO
 import NIOHTTP1
 import NIOConcurrencyHelpers
 
-final class SSEHub: @unchecked Sendable {
-    private let lock = NIOLock()
-    private var clients: [ObjectIdentifier: Channel] = [:]
+final class SSEHub: Sendable {
+    private struct State: Sendable {
+        var clients: [ObjectIdentifier: Channel] = [:]
+    }
+
+    private let state = NIOLockedValueBox(State())
 
     var hasClients: Bool {
-        lock.withLock { !clients.isEmpty }
+        state.withLockedValue { !$0.clients.isEmpty }
     }
 
     func add(_ channel: Channel) {
-        lock.withLock {
-            clients[ObjectIdentifier(channel)] = channel
+        state.withLockedValue { state in
+            state.clients[ObjectIdentifier(channel)] = channel
         }
     }
 
     func remove(_ channel: Channel) {
-        _ = lock.withLock {
-            clients.removeValue(forKey: ObjectIdentifier(channel))
+        _ = state.withLockedValue { state in
+            state.clients.removeValue(forKey: ObjectIdentifier(channel))
         }
     }
 
     func broadcast(_ data: Data) {
         let payload = "data: \(String(decoding: data, as: UTF8.self))\n\n"
-        let channels = lock.withLock { Array(clients.values) }
+        let channels = state.withLockedValue { Array($0.clients.values) }
         for channel in channels {
             channel.eventLoop.execute {
                 guard channel.isActive else { return }
@@ -37,10 +40,8 @@ final class SSEHub: @unchecked Sendable {
     }
 
     func closeAll() {
-        let channels = lock.withLock { Array(clients.values) }
-        lock.withLock {
-            clients.removeAll()
-        }
+        let channels = state.withLockedValue { Array($0.clients.values) }
+        state.withLockedValue { $0.clients.removeAll() }
         for channel in channels {
             channel.eventLoop.execute {
                 channel.close(promise: nil)

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import NIO
 import NIOConcurrencyHelpers
 
-final class SessionContext {
+final class SessionContext: Sendable {
     let id: String
     let router: ProxyRouter
     let sseHub: SSEHub
@@ -22,25 +22,32 @@ final class SessionContext {
     }
 }
 
-final class SessionManager: @unchecked Sendable {
-    private struct InitPending: @unchecked Sendable {
+final class SessionManager: Sendable {
+    private struct InitPending: Sendable {
         let eventLoop: EventLoop
         let promise: EventLoopPromise<ByteBuffer>
-        let originalId: Any
+        let originalId: RPCId
     }
 
-    private let lock = NIOLock()
-    private let initLock = NIOLock()
+    private struct SessionState: Sendable {
+        var sessions: [String: SessionContext] = [:]
+    }
+
+    private struct InitState: Sendable {
+        var initResult: JSONValue?
+        var initPending: [InitPending] = []
+        var initInFlight = false
+        var initTimeout: Scheduled<Void>?
+        var didSendInitialized = false
+        var isShuttingDown = false
+    }
+
+    private let sessionsState = NIOLockedValueBox(SessionState())
+    private let initState = NIOLockedValueBox(InitState())
+    private let upstreamTaskBox = NIOLockedValueBox<Task<Void, Never>?>(nil)
     private let eventLoop: EventLoop
-    private var sessions: [String: SessionContext] = [:]
     private let idMapper = UpstreamIdMapper()
     private let config: ProxyConfig
-    private var initResult: Any?
-    private var initPending: [InitPending] = []
-    private var initInFlight = false
-    private var initTimeout: Scheduled<Void>?
-    private var didSendInitialized = false
-    private var isShuttingDown = false
     let upstream: UpstreamProcess
 
     init(config: ProxyConfig, eventLoop: EventLoop) {
@@ -64,88 +71,117 @@ final class SessionManager: @unchecked Sendable {
         )
         let process = UpstreamProcess(config: upstreamConfig)
         self.upstream = process
-        self.upstream.onMessage = { [weak self] data in
-            self?.routeUpstreamMessage(data)
+        let task = Task { [weak self] in
+            guard let self else { return }
+            for await event in process.events {
+                switch event {
+                case .message(let data):
+                    self.routeUpstreamMessage(data)
+                case .exit(let status):
+                    self.handleUpstreamExit(status)
+                }
+            }
         }
-        self.upstream.onExit = { [weak self] status in
-            self?.handleUpstreamExit(status)
+        upstreamTaskBox.withLockedValue { taskBox in
+            taskBox = task
         }
-        self.upstream.start()
+        Task {
+            await process.start()
+        }
         if config.eagerInitialize {
             startEagerInitialize()
         }
     }
 
     func session(id: String) -> SessionContext {
-        lock.withLock {
-            if let existing = sessions[id] {
+        sessionsState.withLockedValue { state in
+            if let existing = state.sessions[id] {
                 return existing
             }
             let context = SessionContext(id: id, config: config)
-            sessions[id] = context
+            state.sessions[id] = context
             return context
         }
     }
 
     func hasSession(id: String) -> Bool {
-        lock.withLock { sessions[id] != nil }
+        sessionsState.withLockedValue { state in
+            state.sessions[id] != nil
+        }
     }
 
     func removeSession(id: String) {
-        let context = lock.withLock { sessions.removeValue(forKey: id) }
+        let context = sessionsState.withLockedValue { state in
+            state.sessions.removeValue(forKey: id)
+        }
         context?.sseHub.closeAll()
     }
 
     func shutdown() {
-        upstream.stop()
-        initLock.withLock {
-            isShuttingDown = true
-            initInFlight = false
-            initTimeout?.cancel()
-            initTimeout = nil
-            initPending.removeAll()
+        let timeout = initState.withLockedValue { state -> Scheduled<Void>? in
+            state.isShuttingDown = true
+            state.initInFlight = false
+            let existing = state.initTimeout
+            state.initTimeout = nil
+            state.initPending.removeAll()
+            return existing
+        }
+        timeout?.cancel()
+        let task = upstreamTaskBox.withLockedValue { taskBox -> Task<Void, Never>? in
+            let current = taskBox
+            taskBox = nil
+            return current
+        }
+        task?.cancel()
+        Task {
+            await upstream.stop()
         }
     }
 
     func isInitialized() -> Bool {
-        initLock.withLock { initResult != nil }
+        initState.withLockedValue { $0.initResult != nil }
     }
 
     func registerInitialize(
-        originalId: Any,
+        originalId: RPCId,
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
         var shouldSend = false
+        var shouldScheduleTimeout = false
         var initRequest: [String: Any]?
-        var cachedResult: Any?
+        var cachedResult: JSONValue?
         var shuttingDown = false
         var pendingPromise: EventLoopPromise<ByteBuffer>?
 
-        initLock.withLock {
-            if isShuttingDown {
+        initState.withLockedValue { state in
+            if state.isShuttingDown {
                 shuttingDown = true
                 return
             }
-            if let result = initResult {
+            if let result = state.initResult {
                 cachedResult = result
                 return
             }
             let promise = eventLoop.makePromise(of: ByteBuffer.self)
             pendingPromise = promise
-            initPending.append(
+            state.initPending.append(
                 InitPending(
                     eventLoop: eventLoop,
                     promise: promise,
                     originalId: originalId
                 )
             )
-            if !initInFlight {
-                initInFlight = true
+            if !state.initInFlight {
+                state.initInFlight = true
                 shouldSend = true
                 initRequest = requestObject
-                scheduleInitTimeout()
+                shouldScheduleTimeout = true
             }
+        }
+
+        if shouldScheduleTimeout {
+            scheduleInitTimeout()
         }
 
         if let cachedResult {
@@ -163,7 +199,7 @@ final class SessionManager: @unchecked Sendable {
             let upstreamId = idMapper.assignInitialize()
             initRequest["id"] = upstreamId
             if let data = try? JSONSerialization.data(withJSONObject: initRequest, options: []) {
-                upstream.send(data)
+                sendUpstream(data)
             } else {
                 failInitPending(error: TimeoutError())
             }
@@ -189,7 +225,7 @@ final class SessionManager: @unchecked Sendable {
                 return
             }
             if let sessionId = mapping.sessionId, let originalId = mapping.originalId {
-                object["id"] = originalId
+                object["id"] = originalId.value.foundationObject
                 if let rewritten = try? JSONSerialization.data(withJSONObject: object, options: []) {
                     let target = session(id: sessionId)
                     target.router.handleIncoming(rewritten)
@@ -217,7 +253,7 @@ final class SessionManager: @unchecked Sendable {
                     transformed.append(item)
                     continue
                 }
-                object["id"] = originalId
+                object["id"] = originalId.value.foundationObject
                 sessionId = sessionId ?? mapping.sessionId
                 rewrittenAny = true
                 transformed.append(object)
@@ -233,22 +269,23 @@ final class SessionManager: @unchecked Sendable {
     }
 
     private func handleUpstreamExit(_ status: Int32) {
-        var pending: [InitPending] = []
-        var shouldEagerInitialize = false
-
-        initLock.withLock {
-            if isShuttingDown {
-                return
+        let result = initState.withLockedValue { state -> (pending: [InitPending], shouldEagerInitialize: Bool, timeout: Scheduled<Void>?)? in
+            if state.isShuttingDown {
+                return nil
             }
-            initResult = nil
-            initInFlight = false
-            didSendInitialized = false
-            initTimeout?.cancel()
-            initTimeout = nil
-            pending = initPending
-            initPending.removeAll()
-            shouldEagerInitialize = config.eagerInitialize
+            state.initResult = nil
+            state.initInFlight = false
+            state.didSendInitialized = false
+            let timeout = state.initTimeout
+            state.initTimeout = nil
+            let pending = state.initPending
+            state.initPending.removeAll()
+            return (pending, config.eagerInitialize, timeout)
         }
+        guard let result else { return }
+        result.timeout?.cancel()
+        let pending = result.pending
+        let shouldEagerInitialize = result.shouldEagerInitialize
 
         idMapper.reset()
 
@@ -263,8 +300,14 @@ final class SessionManager: @unchecked Sendable {
         }
     }
 
-    func assignUpstreamId(sessionId: String, originalId: Any) -> Int64 {
+    func assignUpstreamId(sessionId: String, originalId: RPCId) -> Int64 {
         idMapper.assign(sessionId: sessionId, originalId: originalId, isInitialize: false)
+    }
+
+    func sendUpstream(_ data: Data) {
+        Task {
+            await upstream.send(data)
+        }
     }
 
     private func upstreamId(from value: Any?) -> Int64? {
@@ -278,7 +321,9 @@ final class SessionManager: @unchecked Sendable {
     }
 
     private func broadcastToAllSessions(_ data: Data) {
-        let snapshot = lock.withLock { Array(self.sessions.values) }
+        let snapshot = sessionsState.withLockedValue { state in
+            Array(state.sessions.values)
+        }
         for session in snapshot {
             session.router.handleIncoming(data)
         }
@@ -286,12 +331,16 @@ final class SessionManager: @unchecked Sendable {
 
     private func startEagerInitialize() {
         var shouldSend = false
-        initLock.withLock {
-            if initResult == nil && !initInFlight {
-                initInFlight = true
+        var shouldScheduleTimeout = false
+        initState.withLockedValue { state in
+            if state.initResult == nil && !state.initInFlight {
+                state.initInFlight = true
                 shouldSend = true
-                scheduleInitTimeout()
+                shouldScheduleTimeout = true
             }
+        }
+        if shouldScheduleTimeout {
+            scheduleInitTimeout()
         }
         guard shouldSend else { return }
 
@@ -310,43 +359,44 @@ final class SessionManager: @unchecked Sendable {
             ],
         ]
         if let data = try? JSONSerialization.data(withJSONObject: request, options: []) {
-            upstream.send(data)
+            sendUpstream(data)
         } else {
             failInitPending(error: TimeoutError())
         }
     }
 
     private func handleInitializeResponse(_ object: [String: Any]) {
-        guard let result = object["result"] else {
+        guard let resultValue = object["result"], let result = JSONValue(any: resultValue) else {
             failInitPending(error: TimeoutError())
             return
         }
 
-        var pending: [InitPending] = []
-        var shouldSendInitialized = false
-        initLock.withLock {
-            if isShuttingDown {
-                return
+        let update = initState.withLockedValue { state -> (pending: [InitPending], shouldSendInitialized: Bool, timeout: Scheduled<Void>?)? in
+            if state.isShuttingDown {
+                return nil
             }
-            if initResult == nil {
-                initResult = result
+            if state.initResult == nil {
+                state.initResult = result
             }
-            initInFlight = false
-            initTimeout?.cancel()
-            initTimeout = nil
-            pending = initPending
-            initPending.removeAll()
-            if !didSendInitialized {
-                didSendInitialized = true
-                shouldSendInitialized = true
+            state.initInFlight = false
+            let timeout = state.initTimeout
+            state.initTimeout = nil
+            let pending = state.initPending
+            state.initPending.removeAll()
+            let shouldSendInitialized = !state.didSendInitialized
+            if shouldSendInitialized {
+                state.didSendInitialized = true
             }
+            return (pending, shouldSendInitialized, timeout)
         }
+        guard let update else { return }
+        update.timeout?.cancel()
 
-        if shouldSendInitialized {
+        if update.shouldSendInitialized {
             sendInitializedNotification()
         }
 
-        for item in pending {
+        for item in update.pending {
             if let buffer = encodeInitializeResponse(originalId: item.originalId, result: result) {
                 item.eventLoop.execute {
                     item.promise.succeed(buffer)
@@ -359,11 +409,11 @@ final class SessionManager: @unchecked Sendable {
         }
     }
 
-    private func encodeInitializeResponse(originalId: Any, result: Any) -> ByteBuffer? {
+    private func encodeInitializeResponse(originalId: RPCId, result: JSONValue) -> ByteBuffer? {
         let response: [String: Any] = [
             "jsonrpc": "2.0",
-            "id": originalId,
-            "result": result,
+            "id": originalId.value.foundationObject,
+            "result": result.foundationObject,
         ]
         guard JSONSerialization.isValidJSONObject(response),
               let data = try? JSONSerialization.data(withJSONObject: response, options: []) else {
@@ -380,30 +430,38 @@ final class SessionManager: @unchecked Sendable {
             "method": "notifications/initialized",
         ]
         if let data = try? JSONSerialization.data(withJSONObject: notification, options: []) {
-            upstream.send(data)
+            sendUpstream(data)
         }
     }
 
     private func scheduleInitTimeout() {
-        initTimeout?.cancel()
-        initTimeout = eventLoop.scheduleTask(in: .seconds(Int64(config.requestTimeout))) { [weak self] in
-            self?.failInitPending(error: TimeoutError())
+        let timeout = eventLoop.scheduleTask(in: .seconds(Int64(config.requestTimeout))) { [weak self] in
+            guard let self else { return }
+            self.failInitPending(error: TimeoutError())
         }
+        let previous = initState.withLockedValue { state -> Scheduled<Void>? in
+            let existing = state.initTimeout
+            state.initTimeout = timeout
+            return existing
+        }
+        previous?.cancel()
     }
 
     private func failInitPending(error: Error) {
-        var pending: [InitPending] = []
-        initLock.withLock {
-            if isShuttingDown {
-                return
+        let result = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?)? in
+            if state.isShuttingDown {
+                return nil
             }
-            initInFlight = false
-            initTimeout?.cancel()
-            initTimeout = nil
-            pending = initPending
-            initPending.removeAll()
+            state.initInFlight = false
+            let timeout = state.initTimeout
+            state.initTimeout = nil
+            let pending = state.initPending
+            state.initPending.removeAll()
+            return (pending, timeout)
         }
-        for item in pending {
+        guard let result else { return }
+        result.timeout?.cancel()
+        for item in result.pending {
             item.eventLoop.execute {
                 item.promise.fail(error)
             }
@@ -411,16 +469,19 @@ final class SessionManager: @unchecked Sendable {
     }
 }
 
-private final class UpstreamIdMapper {
-    private let lock = NIOLock()
-    private var nextId: Int64 = 1
-    private var mapping: [Int64: UpstreamMapping] = [:]
+private final class UpstreamIdMapper: Sendable {
+    private struct State: Sendable {
+        var nextId: Int64 = 1
+        var mapping: [Int64: UpstreamMapping] = [:]
+    }
 
-    func assign(sessionId: String, originalId: Any, isInitialize: Bool) -> Int64 {
-        lock.withLock {
-            let id = nextId
-            nextId += 1
-            mapping[id] = UpstreamMapping(
+    private let state = NIOLockedValueBox(State())
+
+    func assign(sessionId: String, originalId: RPCId, isInitialize: Bool) -> Int64 {
+        state.withLockedValue { state in
+            let id = state.nextId
+            state.nextId += 1
+            state.mapping[id] = UpstreamMapping(
                 sessionId: sessionId,
                 originalId: originalId,
                 isInitialize: isInitialize
@@ -430,10 +491,10 @@ private final class UpstreamIdMapper {
     }
 
     func assignInitialize() -> Int64 {
-        lock.withLock {
-            let id = nextId
-            nextId += 1
-            mapping[id] = UpstreamMapping(
+        state.withLockedValue { state in
+            let id = state.nextId
+            state.nextId += 1
+            state.mapping[id] = UpstreamMapping(
                 sessionId: nil,
                 originalId: nil,
                 isInitialize: true
@@ -443,20 +504,20 @@ private final class UpstreamIdMapper {
     }
 
     func consume(_ upstreamId: Int64) -> UpstreamMapping? {
-        lock.withLock {
-            mapping.removeValue(forKey: upstreamId)
+        state.withLockedValue { state in
+            state.mapping.removeValue(forKey: upstreamId)
         }
     }
 
     func reset() {
-        lock.withLock {
-            mapping.removeAll()
+        state.withLockedValue { state in
+            state.mapping.removeAll()
         }
     }
 }
 
-private struct UpstreamMapping {
+private struct UpstreamMapping: Sendable {
     let sessionId: String?
-    let originalId: Any?
+    let originalId: RPCId?
     let isInitialize: Bool
 }

--- a/Sources/XcodeMCPProxy/UpstreamProcess.swift
+++ b/Sources/XcodeMCPProxy/UpstreamProcess.swift
@@ -140,7 +140,12 @@ actor UpstreamProcess {
         restartTask = Task { [weak self] in
             guard let self else { return }
             let nanos = UInt64(delay * 1_000_000_000)
-            try? await Task.sleep(nanoseconds: nanos)
+            do {
+                try await Task.sleep(nanoseconds: nanos)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
             await self.start()
         }
     }

--- a/Sources/XcodeMCPProxy/UpstreamProcess.swift
+++ b/Sources/XcodeMCPProxy/UpstreamProcess.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class UpstreamProcess: @unchecked Sendable {
+actor UpstreamProcess {
     struct Config {
         var command: String
         var args: [String]
@@ -9,39 +9,56 @@ final class UpstreamProcess: @unchecked Sendable {
         var restartMaxDelay: TimeInterval
     }
 
+    enum Event: Sendable {
+        case message(Data)
+        case exit(Int32)
+    }
+
+    nonisolated let events: AsyncStream<Event>
+    private let continuation: AsyncStream<Event>.Continuation
+
     private let config: Config
-    private let queue = DispatchQueue(label: "XcodeMCPProxy.UpstreamProcess")
     private var process: Process?
     private var stdinPipe = Pipe()
     private var stdoutPipe = Pipe()
     private var stderrPipe = Pipe()
     private var restartDelay: TimeInterval
     private var framer = StdioFramer()
-
-    var onMessage: ((Data) -> Void)?
-    var onExit: ((Int32) -> Void)?
+    private var isStopping = false
+    private var restartTask: Task<Void, Never>?
 
     init(config: Config) {
         self.config = config
         self.restartDelay = config.restartInitialDelay
+        var streamContinuation: AsyncStream<Event>.Continuation!
+        self.events = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
     }
 
     func start() {
-        queue.async { [weak self] in
-            self?.startLocked()
-        }
+        isStopping = false
+        startLocked()
     }
 
     func stop() {
-        queue.async { [weak self] in
-            self?.stopLocked()
-        }
+        isStopping = true
+        restartTask?.cancel()
+        restartTask = nil
+        stopLocked()
+        continuation.finish()
     }
 
     func send(_ data: Data) {
-        queue.async { [weak self] in
-            self?.sendLocked(data)
+        if process == nil {
+            startLocked()
         }
+        var payload = data
+        if payload.last != 0x0A {
+            payload.append(0x0A)
+        }
+        stdinPipe.fileHandleForWriting.write(payload)
     }
 
     private func startLocked() {
@@ -50,6 +67,7 @@ final class UpstreamProcess: @unchecked Sendable {
         stdinPipe = Pipe()
         stdoutPipe = Pipe()
         stderrPipe = Pipe()
+        framer = StdioFramer()
 
         let (executableURL, args) = resolveCommand(command: config.command, args: config.args)
         let process = Process()
@@ -65,7 +83,9 @@ final class UpstreamProcess: @unchecked Sendable {
             if data.isEmpty {
                 return
             }
-            self?.handleStdoutData(data)
+            Task {
+                await self?.handleStdoutData(data)
+            }
         }
 
         stderrPipe.fileHandleForReading.readabilityHandler = { handle in
@@ -73,7 +93,9 @@ final class UpstreamProcess: @unchecked Sendable {
         }
 
         process.terminationHandler = { [weak self] proc in
-            self?.handleTermination(status: proc.terminationStatus)
+            Task {
+                await self?.handleTermination(status: proc.terminationStatus)
+            }
         }
 
         do {
@@ -94,35 +116,32 @@ final class UpstreamProcess: @unchecked Sendable {
         process = nil
     }
 
-    private func sendLocked(_ data: Data) {
-        if process == nil {
-            startLocked()
-        }
-        var payload = data
-        if payload.last != 0x0A {
-            payload.append(0x0A)
-        }
-        stdinPipe.fileHandleForWriting.write(payload)
-    }
-
     private func handleStdoutData(_ data: Data) {
         let messages = framer.append(data)
         for message in messages {
-            onMessage?(message)
+            continuation.yield(.message(message))
         }
     }
 
     private func handleTermination(status: Int32) {
         process = nil
-        onExit?(status)
+        guard !isStopping else {
+            return
+        }
+        continuation.yield(.exit(status))
         scheduleRestart()
     }
 
     private func scheduleRestart() {
+        guard !isStopping else { return }
         let delay = restartDelay
         restartDelay = min(restartDelay * 2, config.restartMaxDelay)
-        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.startLocked()
+        restartTask?.cancel()
+        restartTask = Task { [weak self] in
+            guard let self else { return }
+            let nanos = UInt64(delay * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanos)
+            await self.start()
         }
     }
 

--- a/Tests/XcodeMCPProxyTests/JSONValueTests.swift
+++ b/Tests/XcodeMCPProxyTests/JSONValueTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import XcodeMCPProxy
+
+@Test func rpcIdFromString() async throws {
+    let rpcId = RPCId(any: "abc")
+    #expect(rpcId?.key == "abc")
+    #expect(rpcId?.value.foundationObject as? String == "abc")
+}
+
+@Test func rpcIdFromNumber() async throws {
+    let rpcId = RPCId(any: NSNumber(value: 42))
+    #expect(rpcId?.key == "42")
+    #expect((rpcId?.value.foundationObject as? NSNumber)?.intValue == 42)
+}
+
+@Test func jsonValueRoundTrip() async throws {
+    let input: [String: Any] = [
+        "name": "x",
+        "count": 2,
+        "ok": true,
+        "items": [1, 2],
+    ]
+    let jsonValue = JSONValue(any: input)
+    #expect(jsonValue != nil)
+    guard let jsonValue else { return }
+    let object = jsonValue.foundationObject as? [String: Any]
+    #expect(object?["name"] as? String == "x")
+    #expect((object?["count"] as? NSNumber)?.intValue == 2)
+    #expect(object?["ok"] as? Bool == true)
+    #expect((object?["items"] as? [Any])?.count == 2)
+}

--- a/Tests/XcodeMCPProxyTests/ProxyRouterTests.swift
+++ b/Tests/XcodeMCPProxyTests/ProxyRouterTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NIO
+import NIOConcurrencyHelpers
 import Testing
 @testable import XcodeMCPProxy
 
@@ -38,18 +39,20 @@ import Testing
 }
 
 @Test func proxyRouterSendsNotifications() async throws {
-    var received: [String] = []
+    let received = NIOLockedValueBox<[String]>([])
     let router = ProxyRouter(
         requestTimeout: .seconds(5),
         hasActiveSSE: { true },
         sendNotification: { data in
-            received.append(String(decoding: data, as: UTF8.self))
+            received.withLockedValue { values in
+                values.append(String(decoding: data, as: UTF8.self))
+            }
         }
     )
 
     let notification = "{\"jsonrpc\":\"2.0\",\"method\":\"ping\"}"
     router.handleIncoming(Data(notification.utf8))
-    #expect(received == [notification])
+    #expect(received.withLockedValue { $0 } == [notification])
 }
 
 private func shutdown(_ group: EventLoopGroup) async {

--- a/Tests/XcodeMCPProxyTests/RunProxyScriptTests.swift
+++ b/Tests/XcodeMCPProxyTests/RunProxyScriptTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@Test func runProxyUsesProvidedPid() async throws {
+    let output = try runProxyScriptOutput(environment: [
+        "XCODE_PID": "4242",
+        "DRY_RUN": "1",
+    ])
+    #expect(output.contains("--xcode-pid"))
+    #expect(output.contains("4242"))
+}
+
+@Test func runProxyAutoDetectsPid() async throws {
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+    let pgrepURL = tempDir.appendingPathComponent("pgrep")
+    let script = "#!/bin/bash\necho 9999\n"
+    try script.write(to: pgrepURL, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: pgrepURL.path)
+
+    let output = try runProxyScriptOutput(environment: [
+        "PATH": "\(tempDir.path):\(ProcessInfo.processInfo.environment["PATH"] ?? "")",
+        "DRY_RUN": "1",
+    ])
+    #expect(output.contains("--xcode-pid"))
+    #expect(output.contains("9999"))
+}
+
+private func runProxyScriptOutput(environment overrides: [String: String]) throws -> String {
+    var environment = ProcessInfo.processInfo.environment
+    for (key, value) in overrides {
+        environment[key] = value
+    }
+    environment["XCODE_PID"] = overrides["XCODE_PID"]
+    environment["MCP_XCODE_PID"] = overrides["MCP_XCODE_PID"]
+
+    let scriptURL = repositoryRoot()
+        .appendingPathComponent("scripts")
+        .appendingPathComponent("run_proxy.sh")
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/bash")
+    process.arguments = ["-c", scriptURL.path]
+    process.environment = environment
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+
+    let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+    let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: stdoutData, encoding: .utf8) ?? ""
+    let errorOutput = String(data: stderrData, encoding: .utf8) ?? ""
+
+    if process.terminationStatus != 0 {
+        throw ScriptError(exitCode: process.terminationStatus, stderr: errorOutput)
+    }
+
+    return output
+}
+
+private func repositoryRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}
+
+private struct ScriptError: Error {
+    let exitCode: Int32
+    let stderr: String
+}

--- a/scripts/run_proxy.sh
+++ b/scripts/run_proxy.sh
@@ -4,12 +4,51 @@ set -euo pipefail
 HOST="${HOST:-127.0.0.1}"
 PORT="${PORT:-8765}"
 LISTEN="${LISTEN:-$HOST:$PORT}"
-XCODE_PID="${XCODE_PID:-}"
+XCODE_PID="${XCODE_PID:-${MCP_XCODE_PID:-}}"
 LAZY_INIT="${LAZY_INIT:-}"
 
+resolve_xcode_pid() {
+  local pid=""
+
+  if [[ -n "$XCODE_PID" ]]; then
+    echo "$XCODE_PID"
+    return 0
+  fi
+
+  pid="$(pgrep -x Xcode | head -n 1 || true)"
+  if [[ -z "$pid" ]]; then
+    pid="$(pgrep -f "/Applications/Xcode.*\\.app/Contents/MacOS/Xcode" | head -n 1 || true)"
+  fi
+  if [[ -z "$pid" ]]; then
+    pid="$(pgrep -f "Xcode.app/Contents/MacOS/Xcode" | head -n 1 || true)"
+  fi
+
+  if [[ -z "$pid" ]]; then
+    return 1
+  fi
+
+  echo "$pid"
+  return 0
+}
+
 ARGS=(--listen "$LISTEN")
-if [[ -n "$XCODE_PID" ]]; then
+
+if XCODE_PID="$(resolve_xcode_pid)"; then
   ARGS+=(--xcode-pid "$XCODE_PID")
+else
+  open -a Xcode >/dev/null 2>&1 || true
+  for _ in {1..40}; do
+    if XCODE_PID="$(resolve_xcode_pid)"; then
+      ARGS+=(--xcode-pid "$XCODE_PID")
+      break
+    fi
+    sleep 0.25
+  done
+fi
+
+if [[ -z "${XCODE_PID:-}" ]]; then
+  echo "error: Xcode PID not found. Launch Xcode and retry, or set XCODE_PID." >&2
+  exit 1
 fi
 if [[ -n "$LAZY_INIT" ]]; then
   ARGS+=(--lazy-init)

--- a/scripts/run_proxy.sh
+++ b/scripts/run_proxy.sh
@@ -6,6 +6,7 @@ PORT="${PORT:-8765}"
 LISTEN="${LISTEN:-$HOST:$PORT}"
 XCODE_PID="${XCODE_PID:-${MCP_XCODE_PID:-}}"
 LAZY_INIT="${LAZY_INIT:-}"
+DRY_RUN="${DRY_RUN:-}"
 
 resolve_xcode_pid() {
   local pid=""
@@ -49,6 +50,11 @@ fi
 if [[ -z "${XCODE_PID:-}" ]]; then
   echo "error: Xcode PID not found. Launch Xcode and retry, or set XCODE_PID." >&2
   exit 1
+fi
+
+if [[ -n "$DRY_RUN" ]]; then
+  printf '%s\n' "${ARGS[@]}"
+  exit 0
 fi
 if [[ -n "$LAZY_INIT" ]]; then
   ARGS+=(--lazy-init)

--- a/scripts/run_proxy.sh
+++ b/scripts/run_proxy.sh
@@ -48,8 +48,7 @@ else
 fi
 
 if [[ -z "${XCODE_PID:-}" ]]; then
-  echo "error: Xcode PID not found. Launch Xcode and retry, or set XCODE_PID." >&2
-  exit 1
+  echo "warning: Xcode PID not found; running without --xcode-pid." >&2
 fi
 
 if [[ -n "$DRY_RUN" ]]; then


### PR DESCRIPTION
Summary:
- Add Sendable-friendly JSONValue/RPCId handling for JSON-RPC IDs/results
- Refactor proxy concurrency to AsyncStream-based upstream events and locked state boxes
- Restore IPv4 default listen host (127.0.0.1) for MCP tool compatibility
- Auto-detect Xcode PID in run_proxy.sh (launches Xcode if needed)
- Add run_proxy.sh dry-run tests for PID detection and argument wiring

Testing:
- swift test