### PR TITLE
feat: request timeout unlimited

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,7 @@ swift run xcode-mcp-proxy --xcode-pid 12345
 - Listen address: `127.0.0.1:8765`
 - command: `xcrun`
 - args: `mcpbridge`
-- request timeout: `30` seconds
+- request timeout: `300` seconds（`0` で無制限）
 - max body size: `1048576` bytes
 - initialization: eager at startup
 
@@ -80,7 +80,7 @@ swift run xcode-mcp-proxy --xcode-pid 12345
 | `--xcode-pid pid` | 対象 Xcode の PID |
 | `--session-id id` | Xcode MCP セッション ID |
 | `--max-body-bytes n` | 最大ボディサイズ |
-| `--request-timeout seconds` | リクエストタイムアウト |
+| `--request-timeout seconds` | リクエストタイムアウト（`0` で無制限） |
 | `--lazy-init` | 初回リクエストまで初期化を遅延 |
 
 ## クライアント設定

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ swift run xcode-mcp-proxy --xcode-pid 12345
 - Listen address: `127.0.0.1:8765`
 - `mcpbridge` command: `xcrun`
 - `mcpbridge` args: `mcpbridge`
-- Request timeout: `30` seconds
+- Request timeout: `300` seconds (`0` disables)
 - Max body size: `1048576` bytes
 - Initialization: eager at startup
 
@@ -80,7 +80,7 @@ Logs are written to stderr.
 | `--xcode-pid pid` | Xcode PID |
 | `--session-id id` | Xcode MCP session id |
 | `--max-body-bytes n` | Max request body size |
-| `--request-timeout seconds` | Request timeout |
+| `--request-timeout seconds` | Request timeout (`0` disables) |
 | `--lazy-init` | Delay initialization until first request |
 
 ## Client Config

--- a/Sources/XcodeMCPProxy/ProxyConfig.swift
+++ b/Sources/XcodeMCPProxy/ProxyConfig.swift
@@ -54,7 +54,7 @@ public struct CLIParser {
         var xcodePID: Int?
         var upstreamSessionID: String?
         var maxBodyBytes = 1_048_576
-        var requestTimeout: TimeInterval = 30
+        var requestTimeout: TimeInterval = 300
         var eagerInitialize = true
 
         var index = 1
@@ -176,7 +176,7 @@ public struct CLIParser {
           --xcode-pid pid            Xcode PID (env MCP_XCODE_PID)
           --session-id id            Upstream session id (env MCP_XCODE_SESSION_ID)
           --max-body-bytes n         Max request body size (default: 1048576)
-          --request-timeout seconds  Request timeout (default: 30)
+          --request-timeout seconds  Request timeout (default: 300, 0 disables)
           --lazy-init                Initialize upstream only on first client request
           -h, --help                 Show help
         """

--- a/Sources/XcodeMCPProxy/ProxyRouter.swift
+++ b/Sources/XcodeMCPProxy/ProxyRouter.swift
@@ -5,7 +5,7 @@ import NIOConcurrencyHelpers
 final class ProxyRouter: Sendable {
     private struct Pending: Sendable {
         var promise: EventLoopPromise<ByteBuffer>
-        var timeout: Scheduled<Void>
+        var timeout: Scheduled<Void>?
     }
 
     private struct State: Sendable {
@@ -16,12 +16,12 @@ final class ProxyRouter: Sendable {
 
     private let state = NIOLockedValueBox(State())
     private let notificationBufferLimit: Int
-    private let requestTimeout: TimeAmount
+    private let requestTimeout: TimeAmount?
     private let hasActiveSSE: @Sendable () -> Bool
     private let sendNotification: @Sendable (Data) -> Void
 
     init(
-        requestTimeout: TimeAmount,
+        requestTimeout: TimeAmount?,
         notificationBufferLimit: Int = 50,
         hasActiveSSE: @escaping @Sendable () -> Bool,
         sendNotification: @escaping @Sendable (Data) -> Void
@@ -34,9 +34,11 @@ final class ProxyRouter: Sendable {
 
     func registerRequest(idKey: String, on eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
         let promise = eventLoop.makePromise(of: ByteBuffer.self)
-        let timeout = eventLoop.scheduleTask(in: requestTimeout) { [weak self] in
-            guard let self else { return }
-            self.failTimeout(idKey: idKey)
+        let timeout = requestTimeout.map { timeout in
+            eventLoop.scheduleTask(in: timeout) { [weak self] in
+                guard let self else { return }
+                self.failTimeout(idKey: idKey)
+            }
         }
         state.withLockedValue { state in
             state.pendingById[idKey] = Pending(promise: promise, timeout: timeout)
@@ -46,9 +48,11 @@ final class ProxyRouter: Sendable {
 
     func registerBatch(on eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
         let promise = eventLoop.makePromise(of: ByteBuffer.self)
-        let timeout = eventLoop.scheduleTask(in: requestTimeout) { [weak self] in
-            guard let self else { return }
-            self.failBatchTimeout()
+        let timeout = requestTimeout.map { timeout in
+            eventLoop.scheduleTask(in: timeout) { [weak self] in
+                guard let self else { return }
+                self.failBatchTimeout()
+            }
         }
         state.withLockedValue { state in
             state.pendingBatches.append(Pending(promise: promise, timeout: timeout))
@@ -118,7 +122,7 @@ final class ProxyRouter: Sendable {
     }
 
     private func complete(pending: Pending, data: Data) {
-        pending.timeout.cancel()
+        pending.timeout?.cancel()
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
         buffer.writeBytes(data)
         pending.promise.succeed(buffer)

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -11,7 +11,7 @@ final class SessionContext: Sendable {
         self.id = id
         self.sseHub = SSEHub()
         self.router = ProxyRouter(
-            requestTimeout: .seconds(Int64(config.requestTimeout)),
+            requestTimeout: makeRequestTimeout(config.requestTimeout),
             hasActiveSSE: { [weak sseHub] in
                 sseHub?.hasClients ?? false
             },
@@ -438,7 +438,10 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func scheduleInitTimeout() {
-        let timeout = eventLoop.scheduleTask(in: .seconds(Int64(config.requestTimeout))) { [weak self] in
+        guard let timeoutAmount = makeRequestTimeout(config.requestTimeout) else {
+            return
+        }
+        let timeout = eventLoop.scheduleTask(in: timeoutAmount) { [weak self] in
             guard let self else { return }
             self.failInitPending(error: TimeoutError())
         }
@@ -470,6 +473,12 @@ final class SessionManager: Sendable, SessionManaging {
             }
         }
     }
+}
+
+private func makeRequestTimeout(_ seconds: TimeInterval) -> TimeAmount? {
+    guard seconds > 0 else { return nil }
+    let nanos = max(1, Int64(seconds * 1_000_000_000))
+    return .nanoseconds(nanos)
 }
 
 private extension SessionManager {

--- a/Tests/XcodeMCPProxyTests/ProxyRouterTests.swift
+++ b/Tests/XcodeMCPProxyTests/ProxyRouterTests.swift
@@ -103,6 +103,32 @@ private func shutdown(_ group: EventLoopGroup) async {
     }
 }
 
+@Test func proxyRouterDisablesTimeoutWhenRequestTimeoutIsNil() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let router = ProxyRouter(
+        requestTimeout: nil,
+        hasActiveSSE: { false },
+        sendNotification: { _ in }
+    )
+
+    let future = router.registerRequest(idKey: "1", on: eventLoop)
+    let failed = NIOLockedValueBox(false)
+    let succeeded = NIOLockedValueBox(false)
+    future.whenFailure { _ in
+        failed.withLockedValue { $0 = true }
+    }
+    future.whenSuccess { _ in
+        succeeded.withLockedValue { $0 = true }
+    }
+
+    try await Task.sleep(nanoseconds: 1_500_000_000)
+
+    #expect(failed.withLockedValue { $0 } == false)
+    #expect(succeeded.withLockedValue { $0 } == false)
+}
+
 @Test func proxyRouterEnforcesNotificationBufferLimit() async throws {
     let router = ProxyRouter(
         requestTimeout: .seconds(5),


### PR DESCRIPTION
Summary:
- Allow disabling request timeout with `--request-timeout 0` by skipping router/init timeouts
- Document `0` as unlimited and keep default at 300 seconds

Testing:
- Not run (not requested)