### PR TITLE
feat: discovery auto port

### DIFF
--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -84,3 +84,8 @@ flowchart LR
 ## Ports and Addressing
 - Only the central proxy uses `--listen` / `--host` / `--port`.
 - STDIO adapters do not use ports.
+- The server binds to `localhost:0` by default and writes the resolved endpoint to
+  `~/Library/Caches/XcodeMCPProxy/endpoint.json`.
+- HTTP/SSE clients should read `url` from the discovery file to locate the active proxy endpoint.
+- STDIO adapters resolve the upstream via `XCODE_MCP_PROXY_ENDPOINT` or the discovery file,
+  with `http://localhost:8765/mcp` as a fallback.

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -15,8 +15,16 @@ codex mcp add xcode -- xcrun mcpbridge
 ## `MCP client ... timed out`
 Ensure the proxy is running. Increase `startup_timeout_sec` in the client config if needed.
 
+## HTTP/SSE client cannot connect
+Ensure the proxy is running. If the server uses an auto-assigned port, check
+`~/Library/Caches/XcodeMCPProxy/endpoint.json`. Confirm `pid` is alive and
+`updatedAt` is recent; stale data should be ignored.
+
 ## STDIO adapter cannot connect
 Ensure the HTTP proxy is running.
+If the server uses an auto-assigned port, confirm the discovery file exists at
+`~/Library/Caches/XcodeMCPProxy/endpoint.json`, or set `XCODE_MCP_PROXY_ENDPOINT`
+to the server URL (for example: `http://localhost:9000/mcp`).
 
 ## Codex `tools/call` times out after 60 seconds
 Increase `tool_timeout_sec` in `~/.codex/config.toml` (this is client-side and separate from the proxy `--request-timeout`).

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,6 +48,7 @@ source ~/.zshrc
 
 - command: `xcrun`
 - args: `mcpbridge`
+- listen: `localhost:0`（自動割り当て）
 - request timeout: `300` seconds（`0` で無制限）
 - max body size: `1048576` bytes
 - initialization: eager at startup
@@ -99,6 +100,35 @@ args = ["--stdio"]
 ```
 
 `xcode-mcp-proxy` が `PATH` にない場合はフルパスを指定してください。
+
+#### HTTP/SSE クライアントの解決
+
+プロキシは起動時に discovery ファイルを書き出します:
+`~/Library/Caches/XcodeMCPProxy/endpoint.json`
+
+HTTP/SSE クライアントは、このファイルの `url` を読んで接続先を解決します。
+
+```json
+{
+  "url": "http://localhost:51234/mcp",
+  "host": "localhost",
+  "port": 51234,
+  "pid": 12345,
+  "updatedAt": "2026-02-05T12:34:56Z"
+}
+```
+
+`host`/`port` は参考情報、`pid` は生存確認、`updatedAt` は最終更新時刻（ISO 8601）です。
+
+#### STDIO 接続先の解決順
+
+`--stdio` で URL を省略した場合、以下の順に接続先を解決します:
+
+1. `XCODE_MCP_PROXY_ENDPOINT`（http/https URL; STDIO アダプタの上書き）
+2. discovery ファイル: `~/Library/Caches/XcodeMCPProxy/endpoint.json`
+3. フォールバック: `http://localhost:8765/mcp`
+
+サーバー起動時に discovery ファイルへ実ポートを書き込みます。`XCODE_MCP_PROXY_ENDPOINT` は STDIO アダプタにのみ影響します。
 
 ## トラブルシューティング
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ See Quick Start for how to launch.
 
 - command: `xcrun`
 - args: `mcpbridge`
+- listen: `localhost:0` (auto-assign port)
 - request timeout: `300` seconds (`0` disables)
 - max body size: `1048576` bytes
 - initialization: eager at startup
-- mode: HTTP by default; STDIO when `--stdio` is set
+- mode: HTTP by default; STDIO adapter when `--stdio` is set
 
 #### Environment Variables
 
@@ -100,6 +101,35 @@ args = ["--stdio"]
 ```
 
 If `xcode-mcp-proxy` is not on your `PATH`, use the full path.
+
+#### HTTP/SSE Client Resolution
+
+The proxy writes a discovery file at startup:
+`~/Library/Caches/XcodeMCPProxy/endpoint.json`
+
+HTTP/SSE clients should read `url` from this file to locate the active proxy endpoint.
+
+```json
+{
+  "url": "http://localhost:51234/mcp",
+  "host": "localhost",
+  "port": 51234,
+  "pid": 12345,
+  "updatedAt": "2026-02-05T12:34:56Z"
+}
+```
+
+`host`/`port` are informational, `pid` can be used to check liveness, and `updatedAt` is the last write time (ISO 8601).
+
+#### STDIO Upstream Resolution
+
+When `--stdio` is used without a URL, the upstream is resolved in this order:
+
+1. `XCODE_MCP_PROXY_ENDPOINT` (http/https URL; STDIO adapter override)
+2. Discovery file: `~/Library/Caches/XcodeMCPProxy/endpoint.json`
+3. Fallback: `http://localhost:8765/mcp`
+
+The server writes the discovery file at startup with the actual port. `XCODE_MCP_PROXY_ENDPOINT` only affects STDIO adapters.
 
 ## Troubleshooting
 

--- a/Sources/XcodeMCPProxy/Discovery.swift
+++ b/Sources/XcodeMCPProxy/Discovery.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Darwin
+
+public struct DiscoveryRecord: Codable, Sendable {
+    public var url: String
+    public var host: String
+    public var port: Int
+    public var pid: Int
+    public var updatedAt: Date
+
+    public init(
+        url: String,
+        host: String,
+        port: Int,
+        pid: Int,
+        updatedAt: Date
+    ) {
+        self.url = url
+        self.host = host
+        self.port = port
+        self.pid = pid
+        self.updatedAt = updatedAt
+    }
+}
+
+public enum Discovery {
+    public static var defaultFileURL: URL {
+        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        return (base ?? FileManager.default.temporaryDirectory)
+            .appendingPathComponent("XcodeMCPProxy", isDirectory: true)
+            .appendingPathComponent("endpoint.json")
+    }
+
+    public static func read(overrideURL: URL? = nil) -> DiscoveryRecord? {
+        let url = fileURL(overrideURL)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let record = try? decoder.decode(DiscoveryRecord.self, from: data) else { return nil }
+        guard isProcessAlive(record.pid) else { return nil }
+        return record
+    }
+
+    public static func write(record: DiscoveryRecord, overrideURL: URL? = nil) throws {
+        let url = fileURL(overrideURL)
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try encoder.encode(record)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    public static func makeRecord(
+        host: String,
+        port: Int,
+        pid: Int,
+        scheme: String = "http"
+    ) -> DiscoveryRecord? {
+        guard port > 0 else { return nil }
+        let url = makeURLString(host: host, port: port, scheme: scheme)
+        return DiscoveryRecord(
+            url: url,
+            host: host,
+            port: port,
+            pid: pid,
+            updatedAt: Date()
+        )
+    }
+
+    private static func fileURL(_ overrideURL: URL?) -> URL {
+        if let overrideURL {
+            return overrideURL
+        }
+        return defaultFileURL
+    }
+
+    private static func isProcessAlive(_ pid: Int) -> Bool {
+        guard pid > 0 else { return false }
+        let result = kill(pid_t(pid), 0)
+        if result == 0 {
+            return true
+        }
+        return errno == EPERM
+    }
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    private static func makeURLString(host: String, port: Int, scheme: String) -> String {
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = host
+        components.port = port
+        components.path = "/mcp"
+        if let url = components.url {
+            return url.absoluteString
+        }
+        let normalizedHost = host.contains(":") ? "[\(host)]" : host
+        return "\(scheme)://\(normalizedHost):\(port)/mcp"
+    }
+}

--- a/Sources/XcodeMCPProxy/ProxyConfig.swift
+++ b/Sources/XcodeMCPProxy/ProxyConfig.swift
@@ -5,6 +5,13 @@ public enum ProxyTransport: String, CaseIterable, Sendable {
     case stdio
 }
 
+public enum StdioUpstreamSource: String, Sendable {
+    case explicit
+    case environment
+    case discovery
+    case fallback
+}
+
 public struct ProxyConfig: Sendable {
     public var listenHost: String
     public var listenPort: Int
@@ -17,6 +24,7 @@ public struct ProxyConfig: Sendable {
     public var eagerInitialize: Bool
     public var transport: ProxyTransport
     public var stdioUpstreamURL: URL?
+    public var stdioUpstreamSource: StdioUpstreamSource?
 
     public init(
         listenHost: String,
@@ -29,7 +37,8 @@ public struct ProxyConfig: Sendable {
         requestTimeout: TimeInterval,
         eagerInitialize: Bool = true,
         transport: ProxyTransport = .http,
-        stdioUpstreamURL: URL? = nil
+        stdioUpstreamURL: URL? = nil,
+        stdioUpstreamSource: StdioUpstreamSource? = nil
     ) {
         self.listenHost = listenHost
         self.listenPort = listenPort
@@ -42,6 +51,7 @@ public struct ProxyConfig: Sendable {
         self.eagerInitialize = eagerInitialize
         self.transport = transport
         self.stdioUpstreamURL = stdioUpstreamURL
+        self.stdioUpstreamSource = stdioUpstreamSource
     }
 }
 
@@ -58,10 +68,19 @@ public enum CLIError: Error, CustomStringConvertible {
 
 public struct CLIParser {
     private static let defaultStdioUpstream = "http://localhost:8765/mcp"
+    private static let stdioEndpointEnv = "XCODE_MCP_PROXY_ENDPOINT"
 
     public static func parse(args: [String], environment: [String: String]) throws -> ProxyConfig {
+        return try parse(args: args, environment: environment, discoveryOverrideURL: nil)
+    }
+
+    static func parse(
+        args: [String],
+        environment: [String: String],
+        discoveryOverrideURL: URL?
+    ) throws -> ProxyConfig {
         var listenHost = "localhost"
-        var listenPort = 8765
+        var listenPort = 0
         var upstreamCommand = "xcrun"
         var upstreamArgs = ["mcpbridge"]
         var xcodePID: Int?
@@ -70,6 +89,7 @@ public struct CLIParser {
         var requestTimeout: TimeInterval = 300
         var eagerInitialize = true
         var stdioUpstreamURL: URL?
+        var stdioUpstreamSource: StdioUpstreamSource?
 
         var index = 1
         while index < args.count {
@@ -154,14 +174,17 @@ public struct CLIParser {
                     let candidate = args[index + 1]
                     if !candidate.hasPrefix("-") {
                         stdioUpstreamURL = try parseHTTPURL(candidate, label: "--stdio")
+                        stdioUpstreamSource = .explicit
                         index += 2
                         break
                     }
                 }
-                guard let defaultURL = URL(string: Self.defaultStdioUpstream) else {
-                    throw CLIError.message("Default stdio upstream URL is invalid")
-                }
-                stdioUpstreamURL = defaultURL
+                let resolved = try resolveDefaultStdioUpstream(
+                    environment: environment,
+                    discoveryOverrideURL: discoveryOverrideURL
+                )
+                stdioUpstreamURL = resolved.url
+                stdioUpstreamSource = resolved.source
                 index += 1
             case "-h", "--help":
                 throw CLIError.message(usage())
@@ -189,7 +212,8 @@ public struct CLIParser {
             requestTimeout: requestTimeout,
             eagerInitialize: eagerInitialize,
             transport: transport,
-            stdioUpstreamURL: stdioUpstreamURL
+            stdioUpstreamURL: stdioUpstreamURL,
+            stdioUpstreamSource: stdioUpstreamSource
         )
     }
 
@@ -198,9 +222,9 @@ public struct CLIParser {
         Usage: xcode-mcp-proxy [options]
 
         Options:
-          --listen host:port         Listen address (default: localhost:8765)
+          --listen host:port         Listen address (default: localhost:0)
           --host host                Listen host (default: localhost)
-          --port port                Listen port (default: 8765)
+          --port port                Listen port (default: 0)
           --upstream-command cmd     Upstream command (default: xcrun)
           --upstream-args a,b,c      Upstream args (default: mcpbridge)
           --upstream-arg value       Append a single upstream arg
@@ -209,7 +233,7 @@ public struct CLIParser {
           --max-body-bytes n         Max request body size (default: 1048576)
           --request-timeout seconds  Request timeout (default: 300, 0 disables)
           --lazy-init                Initialize upstream only on first client request
-          --stdio [url]              Run in STDIO mode (default: http://localhost:8765/mcp)
+          --stdio [url]              Run in STDIO mode (default: discovery -> http://localhost:8765/mcp)
           -h, --help                 Show help
         """
     }
@@ -220,7 +244,7 @@ public struct CLIParser {
         }
         let hostPart = String(value[..<colonIndex])
         let portPart = String(value[value.index(after: colonIndex)...])
-        guard let port = Int(portPart), port > 0 else {
+        guard let port = Int(portPart), port >= 0 else {
             throw CLIError.message("--listen expects host:port (got \(value))")
         }
         let host = hostPart.isEmpty ? "localhost" : hostPart
@@ -234,5 +258,30 @@ public struct CLIParser {
             throw CLIError.message("\(label) must be an http/https URL")
         }
         return url
+    }
+
+    private static func resolveDefaultStdioUpstream(
+        environment: [String: String],
+        discoveryOverrideURL: URL? = nil
+    ) throws -> (url: URL, source: StdioUpstreamSource) {
+        if let raw = nonEmpty(environment[Self.stdioEndpointEnv]) {
+            return (try parseHTTPURL(raw, label: Self.stdioEndpointEnv), .environment)
+        }
+        if let record = Discovery.read(overrideURL: discoveryOverrideURL),
+           let resolved = try? parseHTTPURL(record.url, label: "discovery") {
+            return (resolved, .discovery)
+        }
+        guard let defaultURL = URL(string: Self.defaultStdioUpstream) else {
+            throw CLIError.message("Default stdio upstream URL is invalid")
+        }
+        return (defaultURL, .fallback)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        return value
     }
 }

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -21,6 +21,7 @@ public final class ProxyServer {
         let channel = try start()
         let (host, port) = resolvedListenAddress(for: channel)
         let displayHost = config.listenHost == "localhost" ? "localhost" : host
+        writeDiscovery(resolvedHost: host, port: port)
         logger.info("Xcode MCP proxy listening on http://\(displayHost):\(port)")
         try await waitForHTTP()
     }
@@ -107,6 +108,36 @@ public final class ProxyServer {
             return
         }
         try await EventLoopFuture.andAllSucceed(futures, on: group.next()).get()
+    }
+
+    private func writeDiscovery(resolvedHost: String, port: Int) {
+        guard let record = Discovery.makeRecord(
+            host: discoveryHost(resolvedHost),
+            port: port,
+            pid: Int(ProcessInfo.processInfo.processIdentifier)
+        ) else {
+            return
+        }
+        do {
+            try Discovery.write(record: record)
+        } catch {
+            logger.warning(
+                "Failed to write discovery file",
+                metadata: [
+                    "error": "\(error)",
+                    "path": "\(Discovery.defaultFileURL.path)",
+                ]
+            )
+        }
+    }
+
+    private func discoveryHost(_ resolvedHost: String) -> String {
+        switch config.listenHost {
+        case "localhost", "0.0.0.0", "::":
+            return "localhost"
+        default:
+            return resolvedHost
+        }
     }
 }
 

--- a/Sources/XcodeMCPProxyCLI/XcodeMCPProxyCLI.swift
+++ b/Sources/XcodeMCPProxyCLI/XcodeMCPProxyCLI.swift
@@ -14,6 +14,34 @@ struct XcodeMCPProxyCLI {
                 environment: ProcessInfo.processInfo.environment
             )
             if let stdioUpstreamURL = config.stdioUpstreamURL {
+                let url = stdioUpstreamURL.absoluteString
+                if let source = config.stdioUpstreamSource {
+                    switch source {
+                    case .discovery:
+                        logger.warning(
+                            "STDIO upstream resolved from discovery file",
+                            metadata: [
+                                "url": "\(url)",
+                                "path": "\(Discovery.defaultFileURL.path)",
+                            ]
+                        )
+                    case .fallback:
+                        logger.warning(
+                            "STDIO upstream fell back to default",
+                            metadata: ["url": "\(url)"]
+                        )
+                    case .environment:
+                        logger.info(
+                            "STDIO upstream resolved from XCODE_MCP_PROXY_ENDPOINT",
+                            metadata: ["url": "\(url)"]
+                        )
+                    case .explicit:
+                        logger.info(
+                            "STDIO upstream resolved from CLI",
+                            metadata: ["url": "\(url)"]
+                        )
+                    }
+                }
                 let adapter = StdioAdapter(
                     upstreamURL: stdioUpstreamURL,
                     requestTimeout: config.requestTimeout

--- a/Sources/XcodeMCPProxyServer/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyServer/XcodeMCPProxyServer.swift
@@ -144,7 +144,7 @@ private func applyDefaults(from environment: [String: String], to options: inout
             options.forwardedArgs += ["--listen", listen]
         } else {
             let host = environment["HOST"] ?? "localhost"
-            let port = environment["PORT"] ?? "8765"
+            let port = environment["PORT"] ?? "0"
             if nonEmpty(environment["HOST"]) != nil || nonEmpty(environment["PORT"]) != nil {
                 options.forwardedArgs += ["--listen", "\(host):\(port)"]
             }

--- a/Tests/XcodeMCPProxyTests/CLIParserTests.swift
+++ b/Tests/XcodeMCPProxyTests/CLIParserTests.swift
@@ -1,5 +1,12 @@
+import Foundation
 import Testing
 @testable import XcodeMCPProxy
+
+private func makeTempDiscoveryURL() -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        .appendingPathComponent("endpoint.json")
+}
 
 @Test func cliParsesListenAddress() async throws {
     let config = try CLIParser.parse(
@@ -17,6 +24,15 @@ import Testing
     )
     #expect(config.listenHost == "localhost")
     #expect(config.listenPort == 8080)
+}
+
+@Test func cliAllowsListenPortZero() async throws {
+    let config = try CLIParser.parse(
+        args: ["xcode-mcp-proxy", "--listen", "localhost:0"],
+        environment: [:]
+    )
+    #expect(config.listenHost == "localhost")
+    #expect(config.listenPort == 0)
 }
 
 @Test func cliParsesTimeoutAndLazyInit() async throws {
@@ -51,18 +67,62 @@ import Testing
     )
     #expect(config.transport == .stdio)
     #expect(config.stdioUpstreamURL?.absoluteString == "http://localhost:8765/mcp")
+    #expect(config.stdioUpstreamSource == .explicit)
 }
 
-@Test func cliDefaultsStdioUpstream() async throws {
+@Test func cliDefaultsStdioUpstreamFallback() async throws {
+    let tempURL = makeTempDiscoveryURL()
     let config = try CLIParser.parse(
         args: [
             "xcode-mcp-proxy",
             "--stdio",
         ],
-        environment: [:]
+        environment: [:],
+        discoveryOverrideURL: tempURL
     )
     #expect(config.transport == .stdio)
     #expect(config.stdioUpstreamURL?.absoluteString == "http://localhost:8765/mcp")
+    #expect(config.stdioUpstreamSource == .fallback)
+}
+
+@Test func cliDefaultsStdioUpstreamFromDiscovery() async throws {
+    let tempURL = makeTempDiscoveryURL()
+    let record = DiscoveryRecord(
+        url: "http://localhost:5555/mcp",
+        host: "localhost",
+        port: 5555,
+        pid: Int(ProcessInfo.processInfo.processIdentifier),
+        updatedAt: Date()
+    )
+    try Discovery.write(record: record, overrideURL: tempURL)
+    let config = try CLIParser.parse(
+        args: [
+            "xcode-mcp-proxy",
+            "--stdio",
+        ],
+        environment: [:],
+        discoveryOverrideURL: tempURL
+    )
+    #expect(config.transport == .stdio)
+    #expect(config.stdioUpstreamURL?.absoluteString == "http://localhost:5555/mcp")
+    #expect(config.stdioUpstreamSource == .discovery)
+}
+
+@Test func cliDefaultsStdioUpstreamFromEnvironment() async throws {
+    let tempURL = makeTempDiscoveryURL()
+    let config = try CLIParser.parse(
+        args: [
+            "xcode-mcp-proxy",
+            "--stdio",
+        ],
+        environment: [
+            "XCODE_MCP_PROXY_ENDPOINT": "http://localhost:9000/mcp",
+        ],
+        discoveryOverrideURL: tempURL
+    )
+    #expect(config.transport == .stdio)
+    #expect(config.stdioUpstreamURL?.absoluteString == "http://localhost:9000/mcp")
+    #expect(config.stdioUpstreamSource == .environment)
 }
 
 @Test func cliDefaultsToHTTP() async throws {
@@ -72,4 +132,5 @@ import Testing
     )
     #expect(config.transport == .http)
     #expect(config.stdioUpstreamURL == nil)
+    #expect(config.listenPort == 0)
 }

--- a/Tests/XcodeMCPProxyTests/DiscoveryTests.swift
+++ b/Tests/XcodeMCPProxyTests/DiscoveryTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import XcodeMCPProxy
+
+private func makeTempDiscoveryURL() -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        .appendingPathComponent("endpoint.json")
+}
+
+private func cleanupTempDiscoveryURL(_ url: URL) {
+    let directory = url.deletingLastPathComponent()
+    try? FileManager.default.removeItem(at: directory)
+}
+
+@Test func discoveryRoundTrip() async throws {
+    let url = makeTempDiscoveryURL()
+    defer { cleanupTempDiscoveryURL(url) }
+    let record = DiscoveryRecord(
+        url: "http://localhost:7777/mcp",
+        host: "localhost",
+        port: 7777,
+        pid: Int(ProcessInfo.processInfo.processIdentifier),
+        updatedAt: Date()
+    )
+    try Discovery.write(record: record, overrideURL: url)
+    let loaded = Discovery.read(overrideURL: url)
+    #expect(loaded?.url == record.url)
+    #expect(loaded?.host == record.host)
+    #expect(loaded?.port == record.port)
+    #expect(loaded?.pid == record.pid)
+}
+
+@Test func discoveryIgnoresInvalidJSON() async throws {
+    let url = makeTempDiscoveryURL()
+    defer { cleanupTempDiscoveryURL(url) }
+    let directory = url.deletingLastPathComponent()
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try Data("not json".utf8).write(to: url)
+    #expect(Discovery.read(overrideURL: url) == nil)
+}
+
+@Test func discoveryRejectsDeadPid() async throws {
+    let url = makeTempDiscoveryURL()
+    defer { cleanupTempDiscoveryURL(url) }
+    let record = DiscoveryRecord(
+        url: "http://localhost:8888/mcp",
+        host: "localhost",
+        port: 8888,
+        pid: 0,
+        updatedAt: Date()
+    )
+    try Discovery.write(record: record, overrideURL: url)
+    #expect(Discovery.read(overrideURL: url) == nil)
+}
+
+@Test func discoveryFormatsIPv6Host() async throws {
+    let record = Discovery.makeRecord(host: "::1", port: 1234, pid: 1)
+    #expect(record?.url == "http://[::1]:1234/mcp")
+}


### PR DESCRIPTION
Summary:
- Default the server listen port to 0 (auto-assign) and write the resolved endpoint to ~/Library/Caches/XcodeMCPProxy/endpoint.json
- Add discovery file read/write utilities with PID liveness checks
- Resolve STDIO upstream via XCODE_MCP_PROXY_ENDPOINT -> discovery -> http://localhost:8765/mcp
- Document discovery file format and client resolution behavior

Testing:
- swift test