### PR TITLE
Multiplex upstream mcpbridge processes

### DIFF
--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -3,7 +3,7 @@
 ## Summary
 - `xcode-mcp-proxy` runs as a single HTTP/SSE proxy.
 - MCP clients connect over HTTP to `/mcp` (no STDIO adapter).
-- The proxy spawns `xcrun mcpbridge`, which bridges to the Xcode MCP server.
+- The proxy spawns one or more `xcrun mcpbridge` processes, which bridge to the Xcode MCP server.
 
 ## Diagrams
 
@@ -17,14 +17,23 @@ flowchart LR
     clientN(["Client N"])
   end
   proxy["xcode-mcp-proxy<br/>HTTP/SSE"]
-  upstream(["xcrun mcpbridge<br/>stdio JSON-RPC"])
+  subgraph Upstreams["Upstream (mcpbridge pool)"]
+    direction TB
+    upstream1(["xcrun mcpbridge #1<br/>stdio JSON-RPC"])
+    upstream2(["xcrun mcpbridge #2<br/>stdio JSON-RPC"])
+    upstreamN(["xcrun mcpbridge #N<br/>stdio JSON-RPC"])
+  end
   xcode["Xcode MCP server"]
 
   clientA -->|HTTP POST / SSE| proxy
   clientB -->|HTTP POST / SSE| proxy
   clientN -->|HTTP POST / SSE| proxy
-  proxy -->|stdio JSON-RPC| upstream
-  upstream <--> |MCP bridge| xcode
+  proxy -->|stdio JSON-RPC| upstream1
+  proxy -->|stdio JSON-RPC| upstream2
+  proxy -->|stdio JSON-RPC| upstreamN
+  upstream1 <--> |MCP bridge| xcode
+  upstream2 <--> |MCP bridge| xcode
+  upstreamN <--> |MCP bridge| xcode
 ```
 
 ### STDIO Adapter (Optional)
@@ -43,19 +52,28 @@ flowchart LR
   end
 
   proxy["xcode-mcp-proxy<br/>HTTP/SSE"]
-  upstream(["xcrun mcpbridge<br/>stdio JSON-RPC"])
+  subgraph Upstreams["Upstream (mcpbridge pool)"]
+    direction TB
+    upstream1(["xcrun mcpbridge #1<br/>stdio JSON-RPC"])
+    upstream2(["xcrun mcpbridge #2<br/>stdio JSON-RPC"])
+    upstreamN(["xcrun mcpbridge #N<br/>stdio JSON-RPC"])
+  end
   xcode["Xcode MCP server"]
 
   adapterA -->|HTTP POST / SSE| proxy
   adapterB -->|HTTP POST / SSE| proxy
-  proxy -->|stdio JSON-RPC| upstream
-  upstream <--> |MCP bridge| xcode
+  proxy -->|stdio JSON-RPC| upstream1
+  proxy -->|stdio JSON-RPC| upstream2
+  proxy -->|stdio JSON-RPC| upstreamN
+  upstream1 <--> |MCP bridge| xcode
+  upstream2 <--> |MCP bridge| xcode
+  upstreamN <--> |MCP bridge| xcode
 ```
 
 ## Processes (HTTP/SSE)
 - **Client**: MCP client (Codex / Claude Code / etc.).
 - **Proxy**: `xcode-mcp-proxy` (central proxy).
-- **Upstream**: `xcrun mcpbridge` (stdio JSON-RPC).
+- **Upstream**: `xcrun mcpbridge` (stdio JSON-RPC; one or more processes).
 - **Xcode**: Xcode MCP server and tool implementations.
 
 ## Optional: STDIO Adapter Mode
@@ -65,21 +83,21 @@ flowchart LR
 - **A/B** in the diagram just means **multiple clients/adapters** (one per STDIO stream).
 
 ## Data Flow (HTTP/SSE)
-1. Start the central HTTP proxy, which launches `mcpbridge`.
+1. Start the central HTTP proxy, which launches one or more `mcpbridge` processes.
 2. The client connects to `/mcp` over HTTP.
-3. The proxy forwards requests to `mcpbridge` over stdio JSON-RPC.
+3. The proxy forwards requests to the `mcpbridge` pool over stdio JSON-RPC.
 4. Responses and notifications return over HTTP/SSE.
 
 ## Data Flow (STDIO Adapter)
-1. Start the central HTTP proxy, which launches `mcpbridge`.
+1. Start the central HTTP proxy, which launches one or more `mcpbridge` processes.
 2. Each client starts a STDIO adapter.
 3. The adapter forwards NDJSON to the proxy via HTTP POST.
 4. Notifications flow back over SSE and are emitted on STDIO (one stream per client).
 
 ## Initialization Behavior
-- The central proxy starts `mcpbridge` at launch.
+- The central proxy starts one or more `mcpbridge` processes at launch.
 - With `--lazy-init`, it delays `initialize` until the first request.
-- If `mcpbridge` exits, it restarts with exponential backoff.
+- If a `mcpbridge` process exits, it restarts with exponential backoff.
 
 ## Ports and Addressing
 - Only the central proxy uses `--listen` / `--host` / `--port`.

--- a/Docs/mcp-benchmark.md
+++ b/Docs/mcp-benchmark.md
@@ -214,6 +214,43 @@ Observations:
 Observations:
 - `sessions=5` produced timeouts in this run; avoid high session counts for `DocumentationSearch` unless you have measured it.
 
+## Upstream Processes (Real `mcpbridge` Multiplexing)
+`xcode-mcp-proxy-server --upstream-processes N` starts **N** upstream `mcpbridge` processes and routes requests across them (round-robin).
+
+### Environment
+- Date: `2026-02-06T18:12:36+09:00`
+- macOS: `26.2 (25C56)`
+- Xcode: `26.3 (17C519)`
+- CPU: `Apple M1 Pro` (`hw.ncpu=10`)
+- RAM: `32 GiB` (`hw.memsize=34359738368`)
+- Server: `xcode-mcp-proxy-server --upstream-processes 4` (listening on `http://localhost:58176/mcp`)
+- `tabIdentifier`: `windowtab4` (`/Users/kn/Dev/XcodeMCPKit`)
+
+### XcodeListNavigatorIssues (`concurrency=20`, `requests=100`, `timeout=30s`, `warmup=10`)
+| run | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 100 | 0 | 327.1 | 58.2 | 65.3 | 68.9 | 55.0 |
+| 2 | 100 | 0 | 302.2 | 62.4 | 74.8 | 81.7 | 60.7 |
+| 3 | 100 | 0 | 186.2 | 60.3 | 288.0 | 311.9 | 103.2 |
+
+### XcodeGrep (`concurrency=20`, `requests=100`, `timeout=30s`, `warmup=10`)
+| run | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 100 | 0 | 246.6 | 75.2 | 99.8 | 116.6 | 76.0 |
+| 2 | 100 | 0 | 304.8 | 56.0 | 97.6 | 103.1 | 61.0 |
+| 3 | 100 | 0 | 337.0 | 55.9 | 64.5 | 72.7 | 53.8 |
+
+### DocumentationSearch (`concurrency=3`, `requests=30`, `timeout=60s`, `warmup=10`)
+| run | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 30 | 0 | 15.6 | 174.8 | 237.1 | 287.8 | 185.3 |
+| 2 | 30 | 0 | 14.2 | 160.4 | 194.3 | 649.7 | 206.1 |
+| 3 | 30 | 0 | 14.1 | 176.3 | 315.1 | 420.9 | 206.7 |
+
+Observations:
+- `XcodeListNavigatorIssues` / `XcodeGrep` improved notably in throughput vs the `--sessions` approximation runs above, but variance still exists (run 3 spiked in tail latency).
+- `DocumentationSearch` remained heavy; multiplexing did not produce a clear, consistent win at `concurrency=3` in this snapshot.
+
 ## Practical Guidance (Tentative)
 - `XcodeListNavigatorIssues`: start with `concurrency=10..20`; raise only if you can tolerate higher tail latency.
 - `XcodeGrep`: start with `concurrency=10..20`; `50..100` tends to trade p99 for small throughput changes (tool/query dependent).

--- a/Docs/mcp-benchmark.md
+++ b/Docs/mcp-benchmark.md
@@ -1,46 +1,59 @@
-# MCP / Xcode MCP Benchmark Notes (Xcode 26.3)
+# MCP / Xcode MCP Benchmark Notes (Upstream Processes: 1 vs 4)
 
-## TL;DR
-- `XcodeListNavigatorIssues` / `XcodeGrep`: raising parallelism (in-flight) increases throughput, but past a point latency spikes and throughput plateaus or degrades.
-- `DocumentationSearch`: tends to be heavy and does not scale well; higher parallelism increases latency and may introduce timeouts, so keep it low (1 to 3) in production.
+This document benchmarks `xcode-mcp-proxy-server` with:
+- `--upstream-processes 1` (no multiplexing)
+- `--upstream-processes 4` (multiplexed upstream `mcpbridge` processes)
+
+## TL;DR (This Run)
+- `XcodeListNavigatorIssues`: throughput improved at `concurrency=10..100` (about 1.4x to 1.6x); slightly slower at `concurrency=1`.
+- `XcodeGrep`: throughput improved at `concurrency=10..100` (about 1.3x to 1.8x); slower at `concurrency=1`.
+- `DocumentationSearch`: mixed. Throughput got worse at low concurrency (`1..2`) but improved at `>=3`; tail latency can spike, so keep parallelism low.
+
+Important: results vary significantly depending on Xcode state (indexing/build activity, issue count, etc.). Treat these as snapshots and re-run under production-like conditions.
 
 ## Environment
-- Date: `2026-02-06T05:06:24+09:00`
+- Date:
+  - upstream=4: `2026-02-06T19:49:11+09:00`
+  - upstream=1: `2026-02-06T19:29:37+09:00`
 - macOS: `26.2 (25C56)`
 - Xcode: `26.3 (17C519)`
 - CPU: `Apple M1 Pro` (`hw.ncpu=10`)
 - RAM: `32 GiB` (`hw.memsize=34359738368`)
-- Target endpoint: `http://localhost:8765/mcp`
+
+## Servers Used
+Both servers were started with an auto-selected port (default `--listen localhost:0`).
+
+- upstream=4:
+  - endpoint: `http://localhost:65341/mcp`
+  - raw logs: `/tmp/mcp_bench_upstream4_rerun_20260206_194911`
+- upstream=1:
+  - endpoint: `http://localhost:63766/mcp`
+  - raw logs: `/tmp/mcp_bench_upstream1_rerun_20260206_192937`
+
+`tabIdentifier` used in this run: `windowtab4` (`/Users/kn/Dev/XcodeMCPKit`)
 
 ## Method
 - Benchmark tool: `Tools/mcp_bench.swift`
-- 1 request = 1 MCP JSON-RPC call (`tools/list` or `tools/call`)
+- 1 request = 1 MCP JSON-RPC call (`tools/call`)
 - `--concurrency` = number of in-flight HTTP `POST /mcp` requests
 - `--warmup` requests are not measured
 - `--timeout` is the client-side per-request timeout (timeouts are counted as `err`)
-- `initialize` is performed before the benchmark run (session setup)
+- `initialize` is performed before each benchmark run (session setup)
 
-## How To Run
-```bash
-swiftc -O Tools/mcp_bench.swift -o /tmp/mcp_bench
-
-# tools/list (tool list)
-/tmp/mcp_bench --print-tools
-
-# tools/call
-/tmp/mcp_bench --mode call --tool XcodeListWindows --requests 200 --concurrency 20 --warmup 20 --timeout 10
-```
+Per tool settings:
+- `XcodeListNavigatorIssues` / `XcodeGrep`: `requests=100`, `warmup=10`, `timeout=30s`
+- `DocumentationSearch`: `timeout=60s` (warmup is `mcp_bench` default `20`; request counts vary by row)
 
 Notes:
-- For tools that require `tabIdentifier`, obtain it first via `XcodeListWindows`.
 - If the Xcode permission dialog has not been approved, `initialize` / `tools/call` may time out. Approving once before benchmarking makes results more stable.
+- For easier replication and `mcp_bench`'s default URL, consider using a fixed port: `--listen localhost:8765`.
 
 ## Inputs Used
 
 ### XcodeListNavigatorIssues
 ```json
 {
-  "tabIdentifier": "windowtab11",
+  "tabIdentifier": "windowtab4",
   "severity": "warning"
 }
 ```
@@ -48,7 +61,7 @@ Notes:
 ### XcodeGrep
 ```json
 {
-  "tabIdentifier": "windowtab11",
+  "tabIdentifier": "windowtab4",
   "pattern": "mcpbridge",
   "type": "swift",
   "outputMode": "count",
@@ -65,194 +78,168 @@ Notes:
 
 ## Results
 Legend:
-- latency is reported by `mcp_bench` (ms)
-- throughput is `requests / wall` (req/s)
+- throughput = `requests / wall` (req/s). Higher is better.
+- latency is reported by `mcp_bench` (ms). Lower is better.
+- speedup = `throughput(upstream=4) / throughput(upstream=1)`. Higher is better.
 
-Important: numbers can vary significantly depending on Xcode state (indexing/build activity, issue count, etc.). Treat these as snapshots and re-run with production-like load.
+Graph colors (fixed via Mermaid `plotColorPalette` in every chart):
+- upstream=1: blue (`#1f77b4`)
+- upstream=4: orange (`#ff7f0e`)
 
-### XcodeListNavigatorIssues (`timeout=30s`, `warmup=10`)
-| concurrency | requests | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
-|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 100 | 100 | 0 | 88.9 | 10.7 | 14.4 | 19.3 | 11.2 |
-| 10 | 100 | 100 | 0 | 195.5 | 49.8 | 54.9 | 58.8 | 48.9 |
-| 20 | 100 | 100 | 0 | 207.2 | 93.7 | 99.1 | 102.4 | 87.3 |
-| 50 | 100 | 100 | 0 | 205.5 | 230.0 | 236.5 | 244.1 | 180.8 |
-| 100 | 100 | 100 | 0 | 193.6 | 280.3 | 463.6 | 512.9 | 267.9 |
+### XcodeListNavigatorIssues
+#### Table (Throughput)
+| concurrency | thr (1) | thr (4) | speedup |
+|---:|---:|---:|---:|
+| 1 | 105.1 | 99.9 | 0.95x |
+| 10 | 216.4 | 351.4 | 1.62x |
+| 20 | 234.2 | 332.0 | 1.42x |
+| 50 | 239.0 | 351.3 | 1.47x |
+| 100 | 218.2 | 344.4 | 1.58x |
+
+#### Table (Latency)
+| concurrency | p50 (1) | p50 (4) | p99 (1) | p99 (4) |
+|---:|---:|---:|---:|---:|
+| 1 | 8.3 | 9.2 | 28.6 | 17.2 |
+| 10 | 44.8 | 27.0 | 56.3 | 40.3 |
+| 20 | 83.2 | 58.2 | 87.4 | 68.6 |
+| 50 | 201.4 | 132.2 | 213.7 | 154.4 |
+| 100 | 247.8 | 150.9 | 452.1 | 283.8 |
 
 #### Graphs (Mermaid)
-Note: `xychart-beta` is not supported by all Mermaid renderers. If it does not render, refer to the table above.
-
 ```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
 xychart-beta
-    title "XcodeListNavigatorIssues throughput (req/s)"
+    title "XcodeListNavigatorIssues throughput (req/s) (upstream=1 blue, upstream=4 orange)"
     x-axis [1, 10, 20, 50, 100]
-    y-axis "req/s" 0 --> 250
-    bar [88.9, 195.5, 207.2, 205.5, 193.6]
+    y-axis "req/s" 0 --> 400
+    line [105.1, 216.4, 234.2, 239.0, 218.2]
+    line [99.9, 351.4, 332.0, 351.3, 344.4]
 ```
 
 ```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
 xychart-beta
-    title "XcodeListNavigatorIssues latency p50/p99 (ms)"
+    title "XcodeListNavigatorIssues latency p50 (ms) (upstream=1 blue, upstream=4 orange)"
+    x-axis [1, 10, 20, 50, 100]
+    y-axis "ms" 0 --> 260
+    line [8.3, 44.8, 83.2, 201.4, 247.8]
+    line [9.2, 27.0, 58.2, 132.2, 150.9]
+```
+
+```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
+xychart-beta
+    title "XcodeListNavigatorIssues latency p99 (ms) (upstream=1 blue, upstream=4 orange)"
     x-axis [1, 10, 20, 50, 100]
     y-axis "ms" 0 --> 600
-    line [10.7, 49.8, 93.7, 230.0, 280.3]
-    line [19.3, 58.8, 102.4, 244.1, 512.9]
+    line [28.6, 56.3, 87.4, 213.7, 452.1]
+    line [17.2, 40.3, 68.6, 154.4, 283.8]
 ```
 
-Observations:
-- Throughput peaked around `concurrency=20..50` in this run.
-- Higher concurrency increases latency; at `concurrency=100`, tail latency (p99) grows noticeably.
+### XcodeGrep
+#### Table (Throughput)
+| concurrency | thr (1) | thr (4) | speedup | note |
+|---:|---:|---:|---:|---|
+| 1 | 95.5 | 81.1 | 0.85x | |
+| 10 | 168.4 | 220.5 | 1.31x | |
+| 20 | 183.3 | 290.9 | 1.59x | |
+| 50 | 185.6 | 319.5 | 1.72x | |
+| 100 | 183.4 | 325.0 | 1.77x | |
 
-### XcodeGrep (`timeout=30s`, `warmup=10`)
-| concurrency | requests | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
-|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 100 | 100 | 0 | 77.7 | 11.5 | 17.0 | 30.6 | 12.8 |
-| 10 | 100 | 100 | 0 | 156.7 | 61.4 | 73.5 | 78.9 | 61.3 |
-| 20 | 100 | 100 | 0 | 160.1 | 118.0 | 137.7 | 143.5 | 112.8 |
-| 50 | 100 | 100 | 0 | 163.4 | 290.8 | 299.2 | 307.8 | 231.3 |
-| 100 | 100 | 100 | 0 | 161.0 | 331.2 | 560.7 | 613.9 | 323.9 |
+#### Table (Latency)
+| concurrency | p50 (1) | p50 (4) | p99 (1) | p99 (4) |
+|---:|---:|---:|---:|---:|
+| 1 | 9.8 | 10.9 | 16.8 | 25.3 |
+| 10 | 55.2 | 30.5 | 95.7 | 161.3 |
+| 20 | 105.9 | 66.1 | 116.0 | 84.9 |
+| 50 | 257.0 | 147.6 | 272.5 | 166.9 |
+| 100 | 282.2 | 167.2 | 538.4 | 302.0 |
 
 #### Graphs (Mermaid)
-Note: `xychart-beta` is not supported by all Mermaid renderers. If it does not render, refer to the table above.
-
 ```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
 xychart-beta
-    title "XcodeGrep throughput (req/s)"
+    title "XcodeGrep throughput (req/s) (upstream=1 blue, upstream=4 orange)"
     x-axis [1, 10, 20, 50, 100]
-    y-axis "req/s" 0 --> 200
-    bar [77.7, 156.7, 160.1, 163.4, 161.0]
+    y-axis "req/s" 0 --> 400
+    line [95.5, 168.4, 183.3, 185.6, 183.4]
+    line [81.1, 220.5, 290.9, 319.5, 325.0]
 ```
 
 ```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
 xychart-beta
-    title "XcodeGrep latency p50/p99 (ms)"
+    title "XcodeGrep latency p50 (ms) (upstream=1 blue, upstream=4 orange)"
     x-axis [1, 10, 20, 50, 100]
-    y-axis "ms" 0 --> 700
-    line [11.5, 61.4, 118.0, 290.8, 331.2]
-    line [30.6, 78.9, 143.5, 307.8, 613.9]
+    y-axis "ms" 0 --> 350
+    line [9.8, 55.2, 105.9, 257.0, 282.2]
+    line [10.9, 30.5, 66.1, 147.6, 167.2]
 ```
 
-Observations:
-- Throughput is relatively flat once `concurrency` is in the `10..100` range for this query.
-- Higher concurrency increases latency and tail latency; `concurrency=50..100` trades p99 for marginal throughput change.
-- Load varies a lot depending on `pattern` and `type`/`glob`. Re-benchmark with production-like queries to be safe.
+```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
+xychart-beta
+    title "XcodeGrep latency p99 (ms) (upstream=1 blue, upstream=4 orange)"
+    x-axis [1, 10, 20, 50, 100]
+    y-axis "ms" 0 --> 600
+    line [16.8, 95.7, 116.0, 272.5, 538.4]
+    line [25.3, 161.3, 84.9, 166.9, 302.0]
+```
 
-### DocumentationSearch (`timeout=60s`)
-| concurrency | requests | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) | note |
-|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
-| 1 | 20 | 20 | 0 | 9.4 | 94.5 | 158.0 | 199.1 | 106.0 | |
-| 2 | 20 | 20 | 0 | 12.5 | 146.6 | 182.1 | 238.5 | 157.0 | |
-| 3 | 30 | 30 | 0 | 13.6 | 216.6 | 235.0 | 251.5 | 213.4 | |
-| 4 | 40 | 40 | 0 | 14.4 | 269.5 | 294.3 | 328.0 | 267.3 | |
-| 5 | 30 | 30 | 0 | 11.2 | 366.9 | 649.3 | 872.7 | 424.4 | latency worsened significantly |
-| 5 | 50 | 46 | 4 | 0.8 | 395.9 | 505.4 | 680.2 | 415.6 | timeouts mixed in (`transport error: timeout`) |
-| 10 | 20 | 20 | 0 | 10.0 | 959.0 | 1215.9 | 1220.7 | 825.1 | latency worsened significantly |
+### DocumentationSearch
+The `concurrency=5` rows are often timeout-prone and can dominate wall time. They are included in the tables, but the line charts below use the **no-error** `concurrency=5 requests=50` row.
+
+#### Table (Throughput)
+| concurrency | requests | err (1) | err (4) | thr (1) | thr (4) | speedup | note |
+|---:|---:|---:|---:|---:|---:|---:|---|
+| 1 | 20 | 0 | 0 | 10.9 | 9.1 | 0.83x | |
+| 2 | 20 | 0 | 0 | 13.9 | 10.6 | 0.76x | |
+| 3 | 30 | 0 | 0 | 14.0 | 15.3 | 1.09x | |
+| 4 | 40 | 0 | 0 | 13.3 | 14.0 | 1.05x | |
+| 5 | 30 | 1 | 0 | 0.5 | 18.4 | 36.80x | timeouts mixed in (upstream=1) |
+| 5 | 50 | 0 | 0 | 13.8 | 18.7 | 1.36x | |
+| 10 | 20 | 0 | 0 | 12.3 | 14.0 | 1.14x | |
+
+#### Table (Latency)
+| concurrency | requests | p50 (1) | p50 (4) | p99 (1) | p99 (4) | note |
+|---:|---:|---:|---:|---:|---:|---|
+| 1 | 20 | 89.7 | 100.7 | 121.5 | 216.8 | |
+| 2 | 20 | 140.1 | 193.0 | 190.5 | 320.7 | |
+| 3 | 30 | 211.8 | 160.0 | 243.2 | 523.5 | tail spike (upstream=4) |
+| 4 | 40 | 288.1 | 233.5 | 452.6 | 679.5 | tail spike |
+| 5 | 30 | 337.1 | 314.9 | 378.4 | 913.9 | timeouts mixed in (upstream=1) |
+| 5 | 50 | 357.2 | 251.5 | 411.4 | 342.8 | |
+| 10 | 20 | 825.9 | 747.6 | 874.1 | 876.7 | |
 
 #### Graphs (Mermaid)
-Note: `xychart-beta` is not supported by all Mermaid renderers. If it does not render, refer to the table above.
-
-These plots exclude the timeout-mixed row at `concurrency=5` (`requests=50`). Only stable, fully-completed rows (plus `concurrency=10`) are included.
+These charts use the stable `concurrency=5 requests=50` row (no errors in this run) and exclude the timeout-mixed row.
 
 ```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
 xychart-beta
-    title "DocumentationSearch throughput (req/s)"
+    title "DocumentationSearch throughput (req/s) (upstream=1 blue, upstream=4 orange)"
     x-axis [1, 2, 3, 4, 5, 10]
-    y-axis "req/s" 0 --> 16
-    bar [9.4, 12.5, 13.6, 14.4, 11.2, 10.0]
+    y-axis "req/s" 0 --> 22
+    line [10.9, 13.9, 14.0, 13.3, 13.8, 12.3]
+    line [9.1, 10.6, 15.3, 14.0, 18.7, 14.0]
 ```
 
 ```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
 xychart-beta
-    title "DocumentationSearch latency p50/p99 (ms)"
+    title "DocumentationSearch latency p50 (ms) (upstream=1 blue, upstream=4 orange)"
     x-axis [1, 2, 3, 4, 5, 10]
-    y-axis "ms" 0 --> 1300
-    line [94.5, 146.6, 216.6, 269.5, 366.9, 959.0]
-    line [199.1, 238.5, 251.5, 328.0, 872.7, 1220.7]
+    y-axis "ms" 0 --> 900
+    line [89.7, 140.1, 211.8, 288.1, 357.2, 825.9]
+    line [100.7, 193.0, 160.0, 233.5, 251.5, 747.6]
 ```
 
-Observations:
-- At low parallelism throughput improves slightly, but higher parallelism causes **rapid latency growth**.
-- Depending on conditions, timeouts may appear and wall time can be dragged close to 60 seconds.
-
-## Sessions (Approximation of `mcpbridge` Multiplexing)
-`mcp_bench --sessions` creates **multiple MCP sessions** (runs `initialize` multiple times and distributes requests across different `Mcp-Session-Id` values).
-
-In production, running multiple `mcpbridge` processes effectively results in multiple sessions, so `--sessions` is a reasonable approximation.
-
-Notes:
-- This can help in some cases, but it is not a universal win (at high load it can also get worse).
-- Numbers vary depending on machine, Xcode state (indexing/windows/load), etc. Use this section for trend validation, not as an absolute guarantee.
-
-### XcodeListNavigatorIssues (`concurrency=20`, `requests=100`)
-| sessions | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 100 | 0 | 203.3 | 96.1 | 100.7 | 105.8 | 89.5 |
-| 2 | 100 | 0 | 196.8 | 96.3 | 100.2 | 118.8 | 92.5 |
-| 5 | 100 | 0 | 193.3 | 92.7 | 129.9 | 136.2 | 91.2 |
-| 10 | 100 | 0 | 204.4 | 95.8 | 100.4 | 102.6 | 89.0 |
-
-Observations:
-- No clear win from more sessions in this run; variance exists. Prioritize per-tool in-flight caps first.
-
-### XcodeGrep (`concurrency=20`, `requests=100`)
-| sessions | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 100 | 0 | 153.1 | 122.6 | 147.2 | 157.1 | 119.6 |
-| 2 | 100 | 0 | 162.3 | 121.0 | 124.7 | 130.4 | 111.7 |
-| 5 | 100 | 0 | 167.1 | 116.9 | 124.4 | 131.8 | 108.5 |
-| 10 | 100 | 0 | 169.7 | 116.3 | 119.3 | 123.1 | 106.9 |
-
-Observations:
-- Session count can change results, but the effect is not consistent. Measure on your machine before relying on it.
-
-### DocumentationSearch (`concurrency=3`, `requests=30`)
-| sessions | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) | note |
-|---:|---:|---:|---:|---:|---:|---:|---:|---|
-| 1 | 30 | 0 | 11.6 | 217.3 | 351.0 | 425.4 | 250.2 | |
-| 5 | 28 | 2 | 0.5 | 210.4 | 220.8 | 241.7 | 168.8 | timeouts mixed in (`transport error: timeout`) |
-
-Observations:
-- `sessions=5` produced timeouts in this run; avoid high session counts for `DocumentationSearch` unless you have measured it.
-
-## Upstream Processes (Real `mcpbridge` Multiplexing)
-`xcode-mcp-proxy-server --upstream-processes N` starts **N** upstream `mcpbridge` processes and routes requests across them (round-robin).
-
-### Environment
-- Date: `2026-02-06T18:12:36+09:00`
-- macOS: `26.2 (25C56)`
-- Xcode: `26.3 (17C519)`
-- CPU: `Apple M1 Pro` (`hw.ncpu=10`)
-- RAM: `32 GiB` (`hw.memsize=34359738368`)
-- Server: `xcode-mcp-proxy-server --upstream-processes 4` (listening on `http://localhost:58176/mcp`)
-- `tabIdentifier`: `windowtab4` (`/Users/kn/Dev/XcodeMCPKit`)
-
-### XcodeListNavigatorIssues (`concurrency=20`, `requests=100`, `timeout=30s`, `warmup=10`)
-| run | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 100 | 0 | 327.1 | 58.2 | 65.3 | 68.9 | 55.0 |
-| 2 | 100 | 0 | 302.2 | 62.4 | 74.8 | 81.7 | 60.7 |
-| 3 | 100 | 0 | 186.2 | 60.3 | 288.0 | 311.9 | 103.2 |
-
-### XcodeGrep (`concurrency=20`, `requests=100`, `timeout=30s`, `warmup=10`)
-| run | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 100 | 0 | 246.6 | 75.2 | 99.8 | 116.6 | 76.0 |
-| 2 | 100 | 0 | 304.8 | 56.0 | 97.6 | 103.1 | 61.0 |
-| 3 | 100 | 0 | 337.0 | 55.9 | 64.5 | 72.7 | 53.8 |
-
-### DocumentationSearch (`concurrency=3`, `requests=30`, `timeout=60s`, `warmup=10`)
-| run | ok | err | throughput (req/s) | p50 (ms) | p90 (ms) | p99 (ms) | avg (ms) |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1 | 30 | 0 | 15.6 | 174.8 | 237.1 | 287.8 | 185.3 |
-| 2 | 30 | 0 | 14.2 | 160.4 | 194.3 | 649.7 | 206.1 |
-| 3 | 30 | 0 | 14.1 | 176.3 | 315.1 | 420.9 | 206.7 |
-
-Observations:
-- `XcodeListNavigatorIssues` / `XcodeGrep` improved notably in throughput vs the `--sessions` approximation runs above, but variance still exists (run 3 spiked in tail latency).
-- `DocumentationSearch` remained heavy; multiplexing did not produce a clear, consistent win at `concurrency=3` in this snapshot.
-
-## Practical Guidance (Tentative)
-- `XcodeListNavigatorIssues`: start with `concurrency=10..20`; raise only if you can tolerate higher tail latency.
-- `XcodeGrep`: start with `concurrency=10..20`; `50..100` tends to trade p99 for small throughput changes (tool/query dependent).
-- `DocumentationSearch`: keep `concurrency=1..3` and prefer `sessions=1`; if needed, raise timeout and put it behind a dedicated low-parallelism queue on the client side.
-- `mcpbridge` multiplexing (validated via `--sessions` approximation): do not assume multi-process helps. Cap in-flight first, then measure session/process count as a secondary lever.
+```mermaid
+%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e'}}}}%%
+xychart-beta
+    title "DocumentationSearch latency p99 (ms) (upstream=1 blue, upstream=4 orange)"
+    x-axis [1, 2, 3, 4, 5, 10]
+    y-axis "ms" 0 --> 1000
+    line [121.5, 190.5, 243.2, 452.6, 411.4, 874.1]
+    line [216.8, 320.7, 523.5, 679.5, 342.8, 876.7]
+```

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,6 +48,7 @@ source ~/.zshrc
 
 - command: `xcrun`
 - args: `mcpbridge`
+- upstream processes: `1`（増やすと `mcpbridge` を複数プロセス起動）
 - listen: `localhost:0`（自動割り当て）
 - request timeout: `300` seconds（`0` で無制限）
 - max body size: `1048576` bytes
@@ -61,6 +62,8 @@ source ~/.zshrc
 
 ログは stderr に出力されます。
 
+Note: `--upstream-processes` > 1 を使う場合、`--session-id` / `MCP_XCODE_SESSION_ID` でセッション ID を固定すると、Xcode の許可ダイアログを減らせる場合があります。
+
 #### オプション
 
 | オプション | 説明 |
@@ -68,6 +71,7 @@ source ~/.zshrc
 | `--upstream-command cmd` | `mcpbridge` コマンド |
 | `--upstream-args a,b,c` | `mcpbridge` 引数（カンマ区切り） |
 | `--upstream-arg value` | `mcpbridge` 引数を1つ追加 |
+| `--upstream-processes n` | upstream `mcpbridge` を `n` プロセス起動（default: 1, max: 10） |
 | `--xcode-pid pid` | 対象 Xcode の PID |
 | `--session-id id` | Xcode MCP セッション ID（通常は不要） |
 | `--max-body-bytes n` | 最大ボディサイズ |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See Quick Start for how to launch.
 
 - command: `xcrun`
 - args: `mcpbridge`
+- upstream processes: `1` (spawns multiple `mcpbridge` processes when increased)
 - listen: `localhost:0` (auto-assign port)
 - request timeout: `300` seconds (`0` disables)
 - max body size: `1048576` bytes
@@ -62,6 +63,8 @@ See Quick Start for how to launch.
 
 Logs are written to stderr.
 
+Note: when using `--upstream-processes` > 1, fixing the session id via `--session-id` / `MCP_XCODE_SESSION_ID` can help reduce permission dialog prompts in Xcode.
+
 #### Options
 
 | Option | Description |
@@ -69,6 +72,7 @@ Logs are written to stderr.
 | `--upstream-command cmd` | `mcpbridge` command |
 | `--upstream-args a,b,c` | `mcpbridge` args (comma-separated) |
 | `--upstream-arg value` | Append a single `mcpbridge` arg |
+| `--upstream-processes n` | Spawn `n` upstream `mcpbridge` processes (default: 1, max: 10) |
 | `--xcode-pid pid` | Xcode PID |
 | `--session-id id` | Xcode MCP session ID (usually not needed) |
 | `--max-body-bytes n` | Max request body size |

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -313,13 +313,31 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         let sessionId = headerSessionId ?? UUID().uuidString
 
+        if sessionManager.isInitialized() == false {
+            sendPlain(
+                on: context.channel,
+                status: .unprocessableEntity,
+                body: "expected initialize request",
+                keepAlive: head.isKeepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
+            return
+        }
+
+        let upstreamIndex = sessionManager.chooseUpstreamIndex(sessionId: sessionId)
+
         let transform: RequestTransform
         do {
             transform = try RequestInspector.transform(
                 bodyData,
                 sessionId: sessionId,
                 mapId: { sessionId, originalId in
-                    sessionManager.assignUpstreamId(sessionId: sessionId, originalId: originalId)
+                    sessionManager.assignUpstreamId(
+                        sessionId: sessionId,
+                        originalId: originalId,
+                        upstreamIndex: upstreamIndex
+                    )
                 }
             )
         } catch {
@@ -354,7 +372,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return
             }
 
-            sessionManager.sendUpstream(transform.upstreamData)
+            sessionManager.sendUpstream(transform.upstreamData, upstreamIndex: upstreamIndex)
             let keepAlive = head.isKeepAlive
             let sessionIdCopy = sessionId
             let prefersEventStream = wantsEventStream
@@ -382,7 +400,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             if transform.method == "notifications/initialized" && sessionManager.isInitialized() {
                 sendEmpty(on: context.channel, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
             } else {
-                sessionManager.sendUpstream(transform.upstreamData)
+                sessionManager.sendUpstream(transform.upstreamData, upstreamIndex: upstreamIndex)
                 sendEmpty(on: context.channel, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
             }
         }

--- a/Sources/XcodeMCPProxy/ProxyConfig.swift
+++ b/Sources/XcodeMCPProxy/ProxyConfig.swift
@@ -17,6 +17,7 @@ public struct ProxyConfig: Sendable {
     public var listenPort: Int
     public var upstreamCommand: String
     public var upstreamArgs: [String]
+    public var upstreamProcessCount: Int
     public var xcodePID: Int?
     public var upstreamSessionID: String?
     public var maxBodyBytes: Int
@@ -31,6 +32,7 @@ public struct ProxyConfig: Sendable {
         listenPort: Int,
         upstreamCommand: String,
         upstreamArgs: [String],
+        upstreamProcessCount: Int = 1,
         xcodePID: Int? = nil,
         upstreamSessionID: String? = nil,
         maxBodyBytes: Int,
@@ -44,6 +46,7 @@ public struct ProxyConfig: Sendable {
         self.listenPort = listenPort
         self.upstreamCommand = upstreamCommand
         self.upstreamArgs = upstreamArgs
+        self.upstreamProcessCount = upstreamProcessCount
         self.xcodePID = xcodePID
         self.upstreamSessionID = upstreamSessionID
         self.maxBodyBytes = maxBodyBytes
@@ -83,6 +86,7 @@ public struct CLIParser {
         var listenPort = 0
         var upstreamCommand = "xcrun"
         var upstreamArgs = ["mcpbridge"]
+        var upstreamProcessCount = 1
         var xcodePID: Int?
         var upstreamSessionID: String?
         var maxBodyBytes = 1_048_576
@@ -141,6 +145,15 @@ public struct CLIParser {
                     throw CLIError.message("--upstream-arg requires a value")
                 }
                 upstreamArgs.append(args[index + 1])
+                index += 2
+            case "--upstream-processes":
+                guard index + 1 < args.count else {
+                    throw CLIError.message("--upstream-processes requires a value")
+                }
+                guard let parsed = Int(args[index + 1]), (1...10).contains(parsed) else {
+                    throw CLIError.message("--upstream-processes must be an integer in 1..10")
+                }
+                upstreamProcessCount = parsed
                 index += 2
             case "--xcode-pid":
                 guard index + 1 < args.count else {
@@ -206,6 +219,7 @@ public struct CLIParser {
             listenPort: listenPort,
             upstreamCommand: upstreamCommand,
             upstreamArgs: upstreamArgs,
+            upstreamProcessCount: upstreamProcessCount,
             xcodePID: xcodePID,
             upstreamSessionID: upstreamSessionID,
             maxBodyBytes: maxBodyBytes,
@@ -228,6 +242,7 @@ public struct CLIParser {
           --upstream-command cmd     Upstream command (default: xcrun)
           --upstream-args a,b,c      Upstream args (default: mcpbridge)
           --upstream-arg value       Append a single upstream arg
+          --upstream-processes n     Upstream process count (default: 1, max: 10)
           --xcode-pid pid            Xcode PID (env MCP_XCODE_PID)
           --session-id id            Upstream session id (env MCP_XCODE_SESSION_ID)
           --max-body-bytes n         Max request body size (default: 1048576)

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -410,6 +410,18 @@ final class SessionManager: Sendable, SessionManaging {
                     startUpstreamWarmInitialize(upstreamIndex: 0)
                 }
             } else if globalInit.hadGlobalInit {
+                if shouldResetGlobalInit {
+                    // When the last initialized upstream exits, we drop the cached init result.
+                    // Ensure the primary/global initialize path is re-run so the proxy becomes usable
+                    // again without requiring a downstream initialize retry.
+                    let primaryInitInFlight = upstreamState.withLockedValue { state in
+                        guard !state.upstreamStates.isEmpty else { return false }
+                        return state.upstreamStates[0].initInFlight
+                    }
+                    if !primaryInitInFlight {
+                        startEagerInitializePrimary()
+                    }
+                }
                 startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
             }
         }

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -382,12 +382,12 @@ final class SessionManager: Sendable, SessionManaging {
         clearUpstreamState(upstreamIndex: upstreamIndex)
         idMapper.reset(upstreamIndex: upstreamIndex)
 
-        // If the primary upstream dies after a successful global initialize and there are no
-        // remaining initialized upstreams, drop the cached init result. Otherwise, new downstream
-        // initialize requests would get an immediate cached response and then fail/hang because
-        // there's no initialized upstream to serve subsequent requests.
+        // If an upstream dies after a successful global initialize and there are no remaining
+        // initialized upstreams, drop the cached init result. Otherwise, new downstream initialize
+        // requests would get an immediate cached response and then fail/hang because there's no
+        // initialized upstream to serve subsequent requests.
         let shouldResetGlobalInit: Bool
-        if upstreamIndex == 0 && globalInit.hadGlobalInit {
+        if globalInit.hadGlobalInit {
             let anyInitialized = upstreamState.withLockedValue { state in
                 state.upstreamStates.contains { $0.isInitialized }
             }

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -57,6 +57,9 @@ final class SessionManager: Sendable, SessionManaging {
         var isShuttingDown = false
         var didWarmSecondary = false
         var primaryInitUpstreamId: Int64?
+        // If we drop the cached global init result while the primary is already performing a warm init,
+        // retry the eager/global init once that warm init finishes unsuccessfully (error/timeout).
+        var shouldRetryEagerInitializePrimaryAfterWarmInitFailure = false
     }
 
     private let sessionsState = NIOLockedValueBox(SessionState())
@@ -418,7 +421,14 @@ final class SessionManager: Sendable, SessionManaging {
                         guard !state.upstreamStates.isEmpty else { return false }
                         return state.upstreamStates[0].initInFlight
                     }
-                    if !primaryInitInFlight {
+                    if primaryInitInFlight {
+                        initState.withLockedValue { state in
+                            state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure = true
+                        }
+                    } else {
+                        initState.withLockedValue { state in
+                            state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure = false
+                        }
                         startEagerInitializePrimary()
                     }
                 }
@@ -516,6 +526,7 @@ final class SessionManager: Sendable, SessionManaging {
                 state.initResult = result
             }
             state.initInFlight = false
+            state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure = false
             let timeout = state.initTimeout
             state.initTimeout = nil
             let pending = state.initPending
@@ -599,9 +610,13 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func failInitPending(error: Error) {
-        let result = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?, upstreamId: Int64?)? in
+        let result = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?, upstreamId: Int64?, shouldRetryEagerInit: Bool)? in
             if state.isShuttingDown {
                 return nil
+            }
+            let shouldRetryEagerInit = state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure && state.initResult == nil
+            if shouldRetryEagerInit {
+                state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure = false
             }
             state.initInFlight = false
             let timeout = state.initTimeout
@@ -610,7 +625,7 @@ final class SessionManager: Sendable, SessionManaging {
             state.initPending.removeAll()
             let upstreamId = state.primaryInitUpstreamId
             state.primaryInitUpstreamId = nil
-            return (pending, timeout, upstreamId)
+            return (pending, timeout, upstreamId, shouldRetryEagerInit)
         }
         guard let result else { return }
         result.timeout?.cancel()
@@ -622,6 +637,10 @@ final class SessionManager: Sendable, SessionManaging {
             item.eventLoop.execute {
                 item.promise.fail(error)
             }
+        }
+
+        if result.shouldRetryEagerInit, config.eagerInitialize {
+            startEagerInitializePrimary()
         }
     }
 
@@ -736,6 +755,18 @@ final class SessionManager: Sendable, SessionManaging {
         }
         guard shouldClear else { return }
         idMapper.remove(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
+
+        guard upstreamIndex == 0, config.eagerInitialize else { return }
+        let shouldRetryEagerInit = initState.withLockedValue { state -> Bool in
+            let shouldRetry = state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure && state.initResult == nil
+            if shouldRetry {
+                state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure = false
+            }
+            return shouldRetry
+        }
+        if shouldRetryEagerInit {
+            startEagerInitializePrimary()
+        }
     }
 
     private func makeInternalInitializeRequest(id: Int64) -> [String: Any] {

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -33,8 +33,9 @@ protocol SessionManaging: Sendable {
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer>
-    func assignUpstreamId(sessionId: String, originalId: RPCId) -> Int64
-    func sendUpstream(_ data: Data)
+    func chooseUpstreamIndex(sessionId: String) -> Int
+    func assignUpstreamId(sessionId: String, originalId: RPCId, upstreamIndex: Int) -> Int64
+    func sendUpstream(_ data: Data, upstreamIndex: Int)
 }
 
 final class SessionManager: Sendable, SessionManaging {
@@ -53,46 +54,77 @@ final class SessionManager: Sendable, SessionManaging {
         var initPending: [InitPending] = []
         var initInFlight = false
         var initTimeout: Scheduled<Void>?
-        var didSendInitialized = false
         var isShuttingDown = false
+        var didWarmSecondary = false
+        var primaryInitUpstreamId: Int64?
     }
 
     private let sessionsState = NIOLockedValueBox(SessionState())
     private let initState = NIOLockedValueBox(InitState())
-    private let upstreamTaskBox = NIOLockedValueBox<Task<Void, Never>?>(nil)
+    private let upstreamTaskBox = NIOLockedValueBox<[Task<Void, Never>]>([])
     private let eventLoop: EventLoop
-    private let idMapper = UpstreamIdMapper()
+    private let idMapper: UpstreamIdMapper
     private let config: ProxyConfig
-    let upstream: any UpstreamClient
+    let upstreams: [any UpstreamClient]
 
-    convenience init(config: ProxyConfig, eventLoop: EventLoop) {
-        let upstream = Self.makeDefaultUpstream(config: config)
-        self.init(config: config, eventLoop: eventLoop, upstream: upstream)
+    private struct UpstreamState: Sendable {
+        var isInitialized = false
+        var initInFlight = false
+        var initTimeout: Scheduled<Void>?
+        var didSendInitialized = false
+        var initUpstreamId: Int64?
     }
 
-    init(config: ProxyConfig, eventLoop: EventLoop, upstream: any UpstreamClient) {
+    private struct UpstreamPoolState: Sendable {
+        var upstreamStates: [UpstreamState] = []
+        var nextPick: Int = 0
+    }
+
+    private let upstreamState = NIOLockedValueBox(UpstreamPoolState())
+
+    convenience init(config: ProxyConfig, eventLoop: EventLoop) {
+        let count = max(1, min(config.upstreamProcessCount, 10))
+        let sharedSessionID = config.upstreamSessionID ?? UUID().uuidString
+        let upstreams = Self.makeDefaultUpstreams(config: config, sharedSessionID: sharedSessionID, count: count)
+        self.init(config: config, eventLoop: eventLoop, upstreams: upstreams)
+    }
+
+    init(config: ProxyConfig, eventLoop: EventLoop, upstreams: [any UpstreamClient]) {
+        precondition(!upstreams.isEmpty, "upstreams must not be empty")
         self.config = config
         self.eventLoop = eventLoop
-        self.upstream = upstream
-        let task = Task { [weak self] in
-            guard let self else { return }
-            for await event in upstream.events {
-                switch event {
-                case .message(let data):
-                    self.routeUpstreamMessage(data)
-                case .exit(let status):
-                    self.handleUpstreamExit(status)
+        self.upstreams = upstreams
+        self.idMapper = UpstreamIdMapper(upstreamCount: upstreams.count)
+        upstreamState.withLockedValue { state in
+            state.upstreamStates = Array(repeating: UpstreamState(), count: upstreams.count)
+            state.nextPick = 0
+        }
+
+        var tasks: [Task<Void, Never>] = []
+        tasks.reserveCapacity(upstreams.count)
+        for (upstreamIndex, upstream) in upstreams.enumerated() {
+            let task = Task { [weak self] in
+                guard let self else { return }
+                for await event in upstream.events {
+                    switch event {
+                    case .message(let data):
+                        self.routeUpstreamMessage(data, upstreamIndex: upstreamIndex)
+                    case .exit(let status):
+                        self.handleUpstreamExit(status, upstreamIndex: upstreamIndex)
+                    }
                 }
+            }
+            tasks.append(task)
+            Task {
+                await upstream.start()
             }
         }
         upstreamTaskBox.withLockedValue { taskBox in
-            taskBox = task
+            taskBox = tasks
         }
-        Task {
-            await upstream.start()
-        }
+
         if config.eagerInitialize {
-            startEagerInitialize()
+            startEagerInitializePrimary()
         }
     }
 
@@ -121,7 +153,7 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     func shutdown() {
-        let timeout = initState.withLockedValue { state -> Scheduled<Void>? in
+        let globalTimeout = initState.withLockedValue { state -> Scheduled<Void>? in
             state.isShuttingDown = true
             state.initInFlight = false
             let existing = state.initTimeout
@@ -129,20 +161,58 @@ final class SessionManager: Sendable, SessionManaging {
             state.initPending.removeAll()
             return existing
         }
-        timeout?.cancel()
-        let task = upstreamTaskBox.withLockedValue { taskBox -> Task<Void, Never>? in
+        globalTimeout?.cancel()
+
+        let upstreamTimeouts = upstreamState.withLockedValue { state -> [Scheduled<Void>?] in
+            var timeouts: [Scheduled<Void>?] = []
+            timeouts.reserveCapacity(state.upstreamStates.count)
+            for index in 0..<state.upstreamStates.count {
+                timeouts.append(state.upstreamStates[index].initTimeout)
+                state.upstreamStates[index].initTimeout = nil
+                state.upstreamStates[index].initInFlight = false
+                state.upstreamStates[index].initUpstreamId = nil
+            }
+            return timeouts
+        }
+        for timeout in upstreamTimeouts {
+            timeout?.cancel()
+        }
+
+        let tasks = upstreamTaskBox.withLockedValue { taskBox -> [Task<Void, Never>] in
             let current = taskBox
-            taskBox = nil
+            taskBox = []
             return current
         }
-        task?.cancel()
-        Task {
-            await upstream.stop()
+        for task in tasks {
+            task.cancel()
+        }
+        for upstream in upstreams {
+            Task {
+                await upstream.stop()
+            }
         }
     }
 
     func isInitialized() -> Bool {
         initState.withLockedValue { $0.initResult != nil }
+    }
+
+    func chooseUpstreamIndex(sessionId _: String) -> Int {
+        upstreamState.withLockedValue { state in
+            let count = state.upstreamStates.count
+            guard count > 0 else { return 0 }
+
+            let rawStart = state.nextPick % count
+            let start = rawStart >= 0 ? rawStart : rawStart + count
+            state.nextPick &+= 1
+            for offset in 0..<count {
+                let candidate = (start + offset) % count
+                if state.upstreamStates[candidate].isInitialized {
+                    return candidate
+                }
+            }
+            return 0
+        }
     }
 
     func registerInitialize(
@@ -199,10 +269,14 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         if shouldSend, var initRequest {
-            let upstreamId = idMapper.assignInitialize()
+            let upstreamId = idMapper.assignInitialize(upstreamIndex: 0)
+            initState.withLockedValue { state in
+                state.primaryInitUpstreamId = upstreamId
+            }
+            markUpstreamInitInFlight(upstreamIndex: 0, upstreamId: upstreamId)
             initRequest["id"] = upstreamId
             if let data = try? JSONSerialization.data(withJSONObject: initRequest, options: []) {
-                sendUpstream(data)
+                sendUpstream(data, upstreamIndex: 0)
             } else {
                 failInitPending(error: TimeoutError())
             }
@@ -214,7 +288,7 @@ final class SessionManager: Sendable, SessionManaging {
         return promise.futureResult
     }
 
-    private func routeUpstreamMessage(_ data: Data) {
+    private func routeUpstreamMessage(_ data: Data, upstreamIndex: Int) {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
             broadcastToAllSessions(data)
             return
@@ -222,9 +296,9 @@ final class SessionManager: Sendable, SessionManaging {
 
         if var object = json as? [String: Any],
            let upstreamId = upstreamId(from: object["id"]),
-           let mapping = idMapper.consume(upstreamId) {
+           let mapping = idMapper.consume(upstreamIndex: upstreamIndex, upstreamId: upstreamId) {
             if mapping.isInitialize {
-                handleInitializeResponse(object)
+                handleInitializeResponse(object, upstreamIndex: upstreamIndex)
                 return
             }
             if let sessionId = mapping.sessionId, let originalId = mapping.originalId {
@@ -244,12 +318,12 @@ final class SessionManager: Sendable, SessionManaging {
             for item in array {
                 guard var object = item as? [String: Any],
                       let upstreamId = upstreamId(from: object["id"]),
-                      let mapping = idMapper.consume(upstreamId) else {
+                      let mapping = idMapper.consume(upstreamIndex: upstreamIndex, upstreamId: upstreamId) else {
                     transformed.append(item)
                     continue
                 }
                 if mapping.isInitialize {
-                    handleInitializeResponse(object)
+                    handleInitializeResponse(object, upstreamIndex: upstreamIndex)
                     continue
                 }
                 guard let originalId = mapping.originalId else {
@@ -271,45 +345,86 @@ final class SessionManager: Sendable, SessionManaging {
         broadcastToAllSessions(data)
     }
 
-    private func handleUpstreamExit(_ status: Int32) {
-        let result = initState.withLockedValue { state -> (pending: [InitPending], shouldEagerInitialize: Bool, timeout: Scheduled<Void>?)? in
+    private func handleUpstreamExit(_ status: Int32, upstreamIndex: Int) {
+        let globalInit = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?, hadGlobalInit: Bool, wasInFlight: Bool, primaryInitUpstreamId: Int64?)? in
             if state.isShuttingDown {
                 return nil
             }
-            state.initResult = nil
-            state.initInFlight = false
-            state.didSendInitialized = false
-            let timeout = state.initTimeout
-            state.initTimeout = nil
+            let wasInFlight = state.initInFlight
+            let hadGlobalInit = state.initResult != nil
             let pending = state.initPending
-            state.initPending.removeAll()
-            return (pending, config.eagerInitialize, timeout)
+            let timeout = state.initTimeout
+            let primaryId = state.primaryInitUpstreamId
+
+            if upstreamIndex == 0 && wasInFlight {
+                state.initInFlight = false
+                state.initTimeout = nil
+                state.initPending.removeAll()
+                state.primaryInitUpstreamId = nil
+            }
+
+            return (pending, timeout, hadGlobalInit, wasInFlight, primaryId)
         }
-        guard let result else { return }
-        result.timeout?.cancel()
-        let pending = result.pending
-        let shouldEagerInitialize = result.shouldEagerInitialize
+        guard let globalInit else { return }
 
-        idMapper.reset()
-
-        for item in pending {
-            item.eventLoop.execute {
-                item.promise.fail(TimeoutError())
+        if upstreamIndex == 0 && globalInit.wasInFlight {
+            globalInit.timeout?.cancel()
+            if let upstreamId = globalInit.primaryInitUpstreamId {
+                idMapper.remove(upstreamIndex: 0, upstreamId: upstreamId)
+            }
+            for item in globalInit.pending {
+                item.eventLoop.execute {
+                    item.promise.fail(TimeoutError())
+                }
             }
         }
 
-        if shouldEagerInitialize {
-            startEagerInitialize()
+        clearUpstreamState(upstreamIndex: upstreamIndex)
+        idMapper.reset(upstreamIndex: upstreamIndex)
+
+        // If the primary upstream dies after a successful global initialize and there are no
+        // remaining initialized upstreams, drop the cached init result. Otherwise, new downstream
+        // initialize requests would get an immediate cached response and then fail/hang because
+        // there's no initialized upstream to serve subsequent requests.
+        let shouldResetGlobalInit: Bool
+        if upstreamIndex == 0 && globalInit.hadGlobalInit {
+            let anyInitialized = upstreamState.withLockedValue { state in
+                state.upstreamStates.contains { $0.isInitialized }
+            }
+            shouldResetGlobalInit = !anyInitialized
+        } else {
+            shouldResetGlobalInit = false
+        }
+        if shouldResetGlobalInit {
+            initState.withLockedValue { state in
+                state.initResult = nil
+                state.didWarmSecondary = false
+            }
+        }
+
+        if config.eagerInitialize {
+            if upstreamIndex == 0 {
+                if shouldResetGlobalInit || !globalInit.hadGlobalInit {
+                    startEagerInitializePrimary()
+                } else {
+                    startUpstreamWarmInitialize(upstreamIndex: 0)
+                }
+            } else if globalInit.hadGlobalInit {
+                startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+            }
         }
     }
 
-    func assignUpstreamId(sessionId: String, originalId: RPCId) -> Int64 {
-        idMapper.assign(sessionId: sessionId, originalId: originalId, isInitialize: false)
+    func assignUpstreamId(sessionId: String, originalId: RPCId, upstreamIndex: Int) -> Int64 {
+        idMapper.assign(upstreamIndex: upstreamIndex, sessionId: sessionId, originalId: originalId, isInitialize: false)
     }
 
-    func sendUpstream(_ data: Data) {
+    func sendUpstream(_ data: Data, upstreamIndex: Int) {
+        guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
+            return
+        }
         Task {
-            await upstream.send(data)
+            await upstreams[upstreamIndex].send(data)
         }
     }
 
@@ -332,9 +447,10 @@ final class SessionManager: Sendable, SessionManaging {
         }
     }
 
-    private func startEagerInitialize() {
+    private func startEagerInitializePrimary() {
         var shouldSend = false
         var shouldScheduleTimeout = false
+        var upstreamId: Int64?
         initState.withLockedValue { state in
             if state.initResult == nil && !state.initInFlight {
                 state.initInFlight = true
@@ -347,34 +463,40 @@ final class SessionManager: Sendable, SessionManaging {
         }
         guard shouldSend else { return }
 
-        let upstreamId = idMapper.assignInitialize()
-        let request: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": upstreamId,
-            "method": "initialize",
-            "params": [
-                "protocolVersion": "2025-03-26",
-                "capabilities": [:],
-                "clientInfo": [
-                    "name": "xcode-mcp-proxy",
-                    "version": "0.0",
-                ],
-            ],
-        ]
+        upstreamId = idMapper.assignInitialize(upstreamIndex: 0)
+        if let upstreamId {
+            initState.withLockedValue { state in
+                state.primaryInitUpstreamId = upstreamId
+            }
+            markUpstreamInitInFlight(upstreamIndex: 0, upstreamId: upstreamId)
+        }
+
+        let request = makeInternalInitializeRequest(id: upstreamId ?? 1)
         if let data = try? JSONSerialization.data(withJSONObject: request, options: []) {
-            sendUpstream(data)
+            sendUpstream(data, upstreamIndex: 0)
         } else {
             failInitPending(error: TimeoutError())
         }
     }
 
-    private func handleInitializeResponse(_ object: [String: Any]) {
+    private func handleInitializeResponse(_ object: [String: Any], upstreamIndex: Int) {
         guard let resultValue = object["result"], let result = JSONValue(any: resultValue) else {
-            failInitPending(error: TimeoutError())
+            if upstreamIndex == 0 {
+                failInitPending(error: TimeoutError())
+            } else {
+                clearUpstreamState(upstreamIndex: upstreamIndex)
+            }
             return
         }
 
-        let update = initState.withLockedValue { state -> (pending: [InitPending], shouldSendInitialized: Bool, timeout: Scheduled<Void>?)? in
+        markUpstreamInitialized(upstreamIndex: upstreamIndex)
+        sendInitializedNotificationIfNeeded(upstreamIndex: upstreamIndex)
+
+        if upstreamIndex != 0 {
+            return
+        }
+
+        let update = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?, shouldWarmSecondary: Bool)? in
             if state.isShuttingDown {
                 return nil
             }
@@ -386,18 +508,15 @@ final class SessionManager: Sendable, SessionManaging {
             state.initTimeout = nil
             let pending = state.initPending
             state.initPending.removeAll()
-            let shouldSendInitialized = !state.didSendInitialized
-            if shouldSendInitialized {
-                state.didSendInitialized = true
+            state.primaryInitUpstreamId = nil
+            let shouldWarmSecondary = !state.didWarmSecondary
+            if shouldWarmSecondary {
+                state.didWarmSecondary = true
             }
-            return (pending, shouldSendInitialized, timeout)
+            return (pending, timeout, shouldWarmSecondary)
         }
         guard let update else { return }
         update.timeout?.cancel()
-
-        if update.shouldSendInitialized {
-            sendInitializedNotification()
-        }
 
         for item in update.pending {
             if let buffer = encodeInitializeResponse(originalId: item.originalId, result: result) {
@@ -409,6 +528,10 @@ final class SessionManager: Sendable, SessionManaging {
                     item.promise.fail(TimeoutError())
                 }
             }
+        }
+
+        if update.shouldWarmSecondary {
+            warmUpSecondaryUpstreams()
         }
     }
 
@@ -427,13 +550,23 @@ final class SessionManager: Sendable, SessionManaging {
         return buffer
     }
 
-    private func sendInitializedNotification() {
+    private func sendInitializedNotificationIfNeeded(upstreamIndex: Int) {
+        let shouldSend = upstreamState.withLockedValue { state -> Bool in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return false }
+            if state.upstreamStates[upstreamIndex].didSendInitialized {
+                return false
+            }
+            state.upstreamStates[upstreamIndex].didSendInitialized = true
+            return true
+        }
+        guard shouldSend else { return }
+
         let notification: [String: Any] = [
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
         ]
         if let data = try? JSONSerialization.data(withJSONObject: notification, options: []) {
-            sendUpstream(data)
+            sendUpstream(data, upstreamIndex: upstreamIndex)
         }
     }
 
@@ -454,7 +587,7 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func failInitPending(error: Error) {
-        let result = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?)? in
+        let result = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?, upstreamId: Int64?)? in
             if state.isShuttingDown {
                 return nil
             }
@@ -463,15 +596,150 @@ final class SessionManager: Sendable, SessionManaging {
             state.initTimeout = nil
             let pending = state.initPending
             state.initPending.removeAll()
-            return (pending, timeout)
+            let upstreamId = state.primaryInitUpstreamId
+            state.primaryInitUpstreamId = nil
+            return (pending, timeout, upstreamId)
         }
         guard let result else { return }
         result.timeout?.cancel()
+        if let upstreamId = result.upstreamId {
+            idMapper.remove(upstreamIndex: 0, upstreamId: upstreamId)
+        }
+        clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
             item.eventLoop.execute {
                 item.promise.fail(error)
             }
         }
+    }
+
+    private func markUpstreamInitInFlight(upstreamIndex: Int, upstreamId: Int64) {
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            state.upstreamStates[upstreamIndex].initInFlight = true
+            state.upstreamStates[upstreamIndex].initUpstreamId = upstreamId
+            state.upstreamStates[upstreamIndex].isInitialized = false
+        }
+    }
+
+    private func clearUpstreamInitInFlight(upstreamIndex: Int) {
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            state.upstreamStates[upstreamIndex].initInFlight = false
+            state.upstreamStates[upstreamIndex].initUpstreamId = nil
+            state.upstreamStates[upstreamIndex].initTimeout = nil
+        }
+    }
+
+    private func clearUpstreamState(upstreamIndex: Int) {
+        let timeout = upstreamState.withLockedValue { state -> Scheduled<Void>? in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
+            let timeout = state.upstreamStates[upstreamIndex].initTimeout
+            state.upstreamStates[upstreamIndex].initTimeout = nil
+            state.upstreamStates[upstreamIndex].isInitialized = false
+            state.upstreamStates[upstreamIndex].initInFlight = false
+            state.upstreamStates[upstreamIndex].didSendInitialized = false
+            state.upstreamStates[upstreamIndex].initUpstreamId = nil
+            return timeout
+        }
+        timeout?.cancel()
+    }
+
+    private func markUpstreamInitialized(upstreamIndex: Int) {
+        let timeout = upstreamState.withLockedValue { state -> Scheduled<Void>? in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
+            state.upstreamStates[upstreamIndex].isInitialized = true
+            state.upstreamStates[upstreamIndex].initInFlight = false
+            state.upstreamStates[upstreamIndex].initUpstreamId = nil
+            let timeout = state.upstreamStates[upstreamIndex].initTimeout
+            state.upstreamStates[upstreamIndex].initTimeout = nil
+            return timeout
+        }
+        timeout?.cancel()
+    }
+
+    private func warmUpSecondaryUpstreams() {
+        guard upstreams.count > 1 else { return }
+        for upstreamIndex in 1..<upstreams.count {
+            startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+        }
+    }
+
+    private func startUpstreamWarmInitialize(upstreamIndex: Int) {
+        var shouldSend = false
+        var upstreamId: Int64?
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            if state.upstreamStates[upstreamIndex].isInitialized || state.upstreamStates[upstreamIndex].initInFlight {
+                return
+            }
+            state.upstreamStates[upstreamIndex].initInFlight = true
+            shouldSend = true
+        }
+        guard shouldSend else { return }
+
+        upstreamId = idMapper.assignInitialize(upstreamIndex: upstreamIndex)
+        if let upstreamId {
+            upstreamState.withLockedValue { state in
+                guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+                state.upstreamStates[upstreamIndex].initUpstreamId = upstreamId
+            }
+            scheduleUpstreamInitTimeout(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
+        }
+
+        let request = makeInternalInitializeRequest(id: upstreamId ?? 1)
+        if let data = try? JSONSerialization.data(withJSONObject: request, options: []) {
+            sendUpstream(data, upstreamIndex: upstreamIndex)
+        } else {
+            clearUpstreamState(upstreamIndex: upstreamIndex)
+        }
+    }
+
+    private func scheduleUpstreamInitTimeout(upstreamIndex: Int, upstreamId: Int64) {
+        guard let timeoutAmount = makeRequestTimeout(config.requestTimeout) else {
+            return
+        }
+        let timeout = eventLoop.scheduleTask(in: timeoutAmount) { [weak self] in
+            guard let self else { return }
+            self.handleUpstreamInitTimeout(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
+        }
+        let previous = upstreamState.withLockedValue { state -> Scheduled<Void>? in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
+            let existing = state.upstreamStates[upstreamIndex].initTimeout
+            state.upstreamStates[upstreamIndex].initTimeout = timeout
+            return existing
+        }
+        previous?.cancel()
+    }
+
+    private func handleUpstreamInitTimeout(upstreamIndex: Int, upstreamId: Int64) {
+        let shouldClear = upstreamState.withLockedValue { state -> Bool in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return false }
+            guard state.upstreamStates[upstreamIndex].initUpstreamId == upstreamId else { return false }
+            state.upstreamStates[upstreamIndex].initTimeout = nil
+            state.upstreamStates[upstreamIndex].initInFlight = false
+            state.upstreamStates[upstreamIndex].isInitialized = false
+            state.upstreamStates[upstreamIndex].initUpstreamId = nil
+            return true
+        }
+        guard shouldClear else { return }
+        idMapper.remove(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
+    }
+
+    private func makeInternalInitializeRequest(id: Int64) -> [String: Any] {
+        [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": "2025-03-26",
+                "capabilities": [:],
+                "clientInfo": [
+                    "name": "xcode-mcp-proxy",
+                    "version": "0.0",
+                ],
+            ],
+        ]
     }
 }
 
@@ -482,16 +750,16 @@ private func makeRequestTimeout(_ seconds: TimeInterval) -> TimeAmount? {
 }
 
 private extension SessionManager {
-    static func makeDefaultUpstream(config: ProxyConfig) -> UpstreamProcess {
+    static func makeDefaultUpstreams(
+        config: ProxyConfig,
+        sharedSessionID: String,
+        count: Int
+    ) -> [UpstreamProcess] {
         var environment = ProcessInfo.processInfo.environment
         if let pid = config.xcodePID {
             environment["MCP_XCODE_PID"] = String(pid)
         }
-        if let override = config.upstreamSessionID {
-            environment["MCP_XCODE_SESSION_ID"] = override
-        } else {
-            environment["MCP_XCODE_SESSION_ID"] = UUID().uuidString
-        }
+        environment["MCP_XCODE_SESSION_ID"] = sharedSessionID
         let upstreamConfig = UpstreamProcess.Config(
             command: config.upstreamCommand,
             args: config.upstreamArgs,
@@ -499,23 +767,38 @@ private extension SessionManager {
             restartInitialDelay: 1,
             restartMaxDelay: 30
         )
-        return UpstreamProcess(config: upstreamConfig)
+        if count <= 1 {
+            return [UpstreamProcess(config: upstreamConfig)]
+        }
+        var upstreams: [UpstreamProcess] = []
+        upstreams.reserveCapacity(count)
+        for _ in 0..<count {
+            upstreams.append(UpstreamProcess(config: upstreamConfig))
+        }
+        return upstreams
     }
 }
 
 private final class UpstreamIdMapper: Sendable {
     private struct State: Sendable {
         var nextId: Int64 = 1
-        var mapping: [Int64: UpstreamMapping] = [:]
+        var mappingsByUpstream: [[Int64: UpstreamMapping]] = []
     }
 
     private let state = NIOLockedValueBox(State())
 
-    func assign(sessionId: String, originalId: RPCId, isInitialize: Bool) -> Int64 {
+    init(upstreamCount: Int) {
         state.withLockedValue { state in
+            state.mappingsByUpstream = Array(repeating: [:], count: upstreamCount)
+        }
+    }
+
+    func assign(upstreamIndex: Int, sessionId: String, originalId: RPCId, isInitialize: Bool) -> Int64 {
+        state.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return 0 }
             let id = state.nextId
             state.nextId += 1
-            state.mapping[id] = UpstreamMapping(
+            state.mappingsByUpstream[upstreamIndex][id] = UpstreamMapping(
                 sessionId: sessionId,
                 originalId: originalId,
                 isInitialize: isInitialize
@@ -524,11 +807,12 @@ private final class UpstreamIdMapper: Sendable {
         }
     }
 
-    func assignInitialize() -> Int64 {
+    func assignInitialize(upstreamIndex: Int) -> Int64 {
         state.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return 0 }
             let id = state.nextId
             state.nextId += 1
-            state.mapping[id] = UpstreamMapping(
+            state.mappingsByUpstream[upstreamIndex][id] = UpstreamMapping(
                 sessionId: nil,
                 originalId: nil,
                 isInitialize: true
@@ -537,15 +821,24 @@ private final class UpstreamIdMapper: Sendable {
         }
     }
 
-    func consume(_ upstreamId: Int64) -> UpstreamMapping? {
+    func consume(upstreamIndex: Int, upstreamId: Int64) -> UpstreamMapping? {
         state.withLockedValue { state in
-            state.mapping.removeValue(forKey: upstreamId)
+            guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return nil }
+            return state.mappingsByUpstream[upstreamIndex].removeValue(forKey: upstreamId)
         }
     }
 
-    func reset() {
+    func remove(upstreamIndex: Int, upstreamId: Int64) {
         state.withLockedValue { state in
-            state.mapping.removeAll()
+            guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return }
+            state.mappingsByUpstream[upstreamIndex].removeValue(forKey: upstreamId)
+        }
+    }
+
+    func reset(upstreamIndex: Int) {
+        state.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return }
+            state.mappingsByUpstream[upstreamIndex].removeAll()
         }
     }
 }

--- a/Sources/XcodeMCPProxyInstall/main.swift
+++ b/Sources/XcodeMCPProxyInstall/main.swift
@@ -109,10 +109,10 @@ private func install(options: InstallOptions) throws {
     }
 
     try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
-    let repoRoot = repositoryRoot(from: selfURL)
-        ?? URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
     // Always build the installed products when possible, so users get the latest binary after pulling updates.
-    if fileManager.fileExists(atPath: repoRoot.appendingPathComponent("Package.swift").path) {
+    // Only do this when we can confidently locate the repo root from the installer path (typically `.build/...`).
+    if let repoRoot = repositoryRoot(from: selfURL),
+       fileManager.fileExists(atPath: repoRoot.appendingPathComponent("Package.swift").path) {
         try buildProducts(binaries, in: repoRoot)
     }
 

--- a/Sources/XcodeMCPProxyInstall/main.swift
+++ b/Sources/XcodeMCPProxyInstall/main.swift
@@ -109,13 +109,11 @@ private func install(options: InstallOptions) throws {
     }
 
     try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
-    let missing = binaries.filter { name in
-        !fileManager.fileExists(atPath: baseURL.appendingPathComponent(name).path)
-    }
-    if !missing.isEmpty {
-        let repoRoot = repositoryRoot(from: selfURL)
-            ?? URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
-        try buildProducts(missing, in: repoRoot)
+    let repoRoot = repositoryRoot(from: selfURL)
+        ?? URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+    // Always build the installed products when possible, so users get the latest binary after pulling updates.
+    if fileManager.fileExists(atPath: repoRoot.appendingPathComponent("Package.swift").path) {
+        try buildProducts(binaries, in: repoRoot)
     }
 
     for name in binaries {
@@ -145,21 +143,19 @@ private func repositoryRoot(from executableURL: URL) -> URL? {
 }
 
 private func buildProducts(_ products: [String], in directory: URL) throws {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    var arguments = ["swift", "build", "-c", "release"]
     for product in products {
-        arguments += ["--product", product]
-    }
-    process.arguments = arguments
-    process.currentDirectoryURL = directory
-    process.standardOutput = FileHandle.standardOutput
-    process.standardError = FileHandle.standardError
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["swift", "build", "-c", "release", "--product", product]
+        process.currentDirectoryURL = directory
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
 
-    try process.run()
-    process.waitUntilExit()
-    guard process.terminationStatus == 0 else {
-        throw InstallError.message("swift build failed; run from the repo root and try again")
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw InstallError.message("swift build failed; run from the repo root and try again")
+        }
     }
 }
 

--- a/Sources/XcodeMCPProxyServer/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyServer/XcodeMCPProxyServer.swift
@@ -79,6 +79,7 @@ private func parseOptions(args: [String], environment: [String: String]) throws 
         "--upstream-command",
         "--upstream-args",
         "--upstream-arg",
+        "--upstream-processes",
         "--xcode-pid",
         "--session-id",
         "--max-body-bytes",
@@ -220,6 +221,7 @@ private func printUsage() {
       --listen host:port
       --host host
       --port port
+      --upstream-processes n
       --xcode-pid pid
       --lazy-init
       --dry-run

--- a/Tests/XcodeMCPProxyTests/CLIParserTests.swift
+++ b/Tests/XcodeMCPProxyTests/CLIParserTests.swift
@@ -44,6 +44,40 @@ private func makeTempDiscoveryURL() -> URL {
     #expect(config.eagerInitialize == false)
 }
 
+@Test func cliParsesUpstreamProcesses() async throws {
+    let config = try CLIParser.parse(
+        args: ["xcode-mcp-proxy", "--upstream-processes", "10"],
+        environment: [:]
+    )
+    #expect(config.upstreamProcessCount == 10)
+}
+
+@Test func cliRejectsInvalidUpstreamProcesses() async throws {
+    do {
+        _ = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--upstream-processes", "0"],
+            environment: [:]
+        )
+        #expect(Bool(false))
+    } catch {}
+
+    do {
+        _ = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--upstream-processes", "11"],
+            environment: [:]
+        )
+        #expect(Bool(false))
+    } catch {}
+
+    do {
+        _ = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--upstream-processes", "abc"],
+            environment: [:]
+        )
+        #expect(Bool(false))
+    } catch {}
+}
+
 @Test func cliUsesEnvironmentOverrides() async throws {
     let config = try CLIParser.parse(
         args: ["xcode-mcp-proxy"],

--- a/Tests/XcodeMCPProxyTests/HTTPConcurrencyTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPConcurrencyTests.swift
@@ -128,7 +128,7 @@ private struct TestHTTPServer {
             eagerInitialize: false
         )
         let upstream = EchoUpstreamClient()
-        let sessionManager = SessionManager(config: config, eventLoop: group.next(), upstream: upstream)
+        let sessionManager = SessionManager(config: config, eventLoop: group.next(), upstreams: [upstream])
 
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -295,7 +295,9 @@ private final class TestSessionManager: SessionManaging {
         return eventLoop.makeSucceededFuture(buffer)
     }
 
-    func assignUpstreamId(sessionId: String, originalId: RPCId) -> Int64 {
+    func chooseUpstreamIndex(sessionId _: String) -> Int { 0 }
+
+    func assignUpstreamId(sessionId: String, originalId: RPCId, upstreamIndex _: Int) -> Int64 {
         state.withLockedValue { state in
             let id = state.nextUpstreamId
             state.nextUpstreamId += 1
@@ -303,7 +305,7 @@ private final class TestSessionManager: SessionManaging {
         }
     }
 
-    func sendUpstream(_ data: Data) {}
+    func sendUpstream(_ data: Data, upstreamIndex _: Int) {}
 }
 
 private func makeConfig(maxBodyBytes: Int = 1024, requestTimeout: TimeInterval = 1) -> ProxyConfig {

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -9,7 +9,7 @@ import Testing
     let eventLoop = group.next()
     let upstream = TestUpstreamClient()
     let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
-    let manager = SessionManager(config: config, eventLoop: eventLoop, upstream: upstream)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
 
     let request1 = makeInitializeRequest(id: 1)
     let request2 = makeInitializeRequest(id: 2)
@@ -46,7 +46,7 @@ import Testing
     let eventLoop = group.next()
     let upstream = TestUpstreamClient()
     let config = makeConfig(eagerInitialize: false, requestTimeout: 1)
-    let manager = SessionManager(config: config, eventLoop: eventLoop, upstream: upstream)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
 
     let request = makeInitializeRequest(id: 1)
     let future = manager.registerInitialize(
@@ -81,7 +81,7 @@ import Testing
     let eventLoop = group.next()
     let upstream = TestUpstreamClient()
     let config = makeConfig(eagerInitialize: true, requestTimeout: 5)
-    let manager = SessionManager(config: config, eventLoop: eventLoop, upstream: upstream)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
     #expect(manager.isInitialized() == false)
 
     await Task.yield()
@@ -98,7 +98,7 @@ import Testing
     let eventLoop = group.next()
     let upstream = TestUpstreamClient()
     let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
-    let manager = SessionManager(config: config, eventLoop: eventLoop, upstream: upstream)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
 
     let request = makeInitializeRequest(id: 1)
     let future = manager.registerInitialize(
@@ -128,6 +128,165 @@ import Testing
     let cachedId = (cachedResponse["id"] as? NSNumber)?.intValue
     #expect(cachedId == 2)
     #expect((await upstream.sent()).count == 2)
+}
+
+@Test func sessionManagerPrimaryExitClearsCachedInitializeResult() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+    // First init establishes the cached init result.
+    let init1 = manager.registerInitialize(
+        originalId: RPCId(any: NSNumber(value: 1))!,
+        requestObject: makeInitializeRequest(id: 1),
+        on: eventLoop
+    )
+    await Task.yield()
+    #expect((await upstream.sent()).count == 1)
+    let upstreamId1 = try extractUpstreamId(from: (await upstream.sent())[0])
+    await upstream.yield(.message(try makeInitializeResponse(id: upstreamId1)))
+    _ = try await init1.get()
+
+    // Wait for notifications/initialized.
+    try await waitForSentCount(upstream, count: 2, timeoutSeconds: 1)
+
+    // Simulate primary upstream dying after init succeeded.
+    await upstream.yield(.exit(1))
+    await Task.yield()
+
+    // A new downstream initialize must trigger a new upstream initialize (no cached response).
+    let init2 = manager.registerInitialize(
+        originalId: RPCId(any: NSNumber(value: 2))!,
+        requestObject: makeInitializeRequest(id: 2),
+        on: eventLoop
+    )
+    try await waitForSentCount(upstream, count: 3, timeoutSeconds: 1)
+    let upstreamId2 = try extractUpstreamId(from: (await upstream.sent())[2])
+    await upstream.yield(.message(try makeInitializeResponse(id: upstreamId2)))
+    _ = try await init2.get()
+}
+
+@Test func sessionManagerRoutesRequestsRoundRobinAcrossUpstreams() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Eager init -> upstream0
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 1)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    // Warm init -> upstream1
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 1)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    // Wait for per-upstream notifications/initialized.
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 1)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 1)
+
+    let sessionId = "session-1"
+    let session = manager.session(id: sessionId)
+
+    let originalA = RPCId(any: NSNumber(value: 100))!
+    let originalB = RPCId(any: NSNumber(value: 101))!
+
+    let upstreamIndexA = manager.chooseUpstreamIndex(sessionId: sessionId)
+    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionId)
+    #expect(upstreamIndexA != upstreamIndexB)
+
+    let futureA = session.router.registerRequest(idKey: originalA.key, on: eventLoop)
+    let upstreamIdA = manager.assignUpstreamId(
+        sessionId: sessionId,
+        originalId: originalA,
+        upstreamIndex: upstreamIndexA
+    )
+    manager.sendUpstream(try makeToolListRequest(id: upstreamIdA), upstreamIndex: upstreamIndexA)
+
+    let futureB = session.router.registerRequest(idKey: originalB.key, on: eventLoop)
+    let upstreamIdB = manager.assignUpstreamId(
+        sessionId: sessionId,
+        originalId: originalB,
+        upstreamIndex: upstreamIndexB
+    )
+    manager.sendUpstream(try makeToolListRequest(id: upstreamIdB), upstreamIndex: upstreamIndexB)
+
+    await yieldMessage(
+        try makeToolListResponse(id: upstreamIdA),
+        to: upstreamIndexA == 0 ? upstream0 : upstream1
+    )
+    await yieldMessage(
+        try makeToolListResponse(id: upstreamIdB),
+        to: upstreamIndexB == 0 ? upstream0 : upstream1
+    )
+
+    _ = try await futureA.get()
+    _ = try await futureB.get()
+
+    let methods0 = await upstream0.sent().compactMap(methodName(from:))
+    let methods1 = await upstream1.sent().compactMap(methodName(from:))
+    #expect(methods0.filter { $0 == "tools/list" }.count == 1)
+    #expect(methods1.filter { $0 == "tools/list" }.count == 1)
+}
+
+@Test func sessionManagerExitClearsMappingsAndKeepsServingOnOtherUpstreams() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Initialize both upstreams.
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 1)
+    let init0 = await upstream0.sent()
+    await upstream0.yield(.message(try makeInitializeResponse(id: try extractUpstreamId(from: init0[0]))))
+
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 1)
+    let init1 = await upstream1.sent()
+    await upstream1.yield(.message(try makeInitializeResponse(id: try extractUpstreamId(from: init1[0]))))
+
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 1)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 1)
+
+    let sessionId = "session-1"
+    let session = manager.session(id: sessionId)
+
+    // Send a request to upstream1, then kill upstream1 before it can respond.
+    let originalA = RPCId(any: NSNumber(value: 200))!
+    let futureA = session.router.registerRequest(idKey: originalA.key, on: eventLoop)
+    let upstreamIdA = manager.assignUpstreamId(sessionId: sessionId, originalId: originalA, upstreamIndex: 1)
+    manager.sendUpstream(try makeToolListRequest(id: upstreamIdA), upstreamIndex: 1)
+
+    await upstream1.yield(.exit(1))
+
+    // The proxy should continue serving on upstream0.
+    let originalB = RPCId(any: NSNumber(value: 201))!
+    let futureB = session.router.registerRequest(idKey: originalB.key, on: eventLoop)
+    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionId)
+    #expect(upstreamIndexB == 0)
+    let upstreamIdB = manager.assignUpstreamId(sessionId: sessionId, originalId: originalB, upstreamIndex: upstreamIndexB)
+    manager.sendUpstream(try makeToolListRequest(id: upstreamIdB), upstreamIndex: upstreamIndexB)
+    await upstream0.yield(.message(try makeToolListResponse(id: upstreamIdB)))
+    _ = try await futureB.get()
+
+    // A should time out (mapping is cleared on exit, and no response arrives).
+    do {
+        _ = try await futureA.get()
+        #expect(Bool(false))
+    } catch {
+        #expect(error is TimeoutError)
+    }
 }
 
 private func makeConfig(eagerInitialize: Bool, requestTimeout: TimeInterval) -> ProxyConfig {
@@ -204,4 +363,37 @@ private func waitForSentCount(
         }
         try await Task.sleep(nanoseconds: 50_000_000)
     }
+}
+
+private func methodName(from data: Data) -> String? {
+    guard let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+        return nil
+    }
+    return object["method"] as? String
+}
+
+private func makeToolListRequest(id: Int64) throws -> Data {
+    try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/list",
+        ],
+        options: []
+    )
+}
+
+private func makeToolListResponse(id: Int64) throws -> Data {
+    try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [:],
+        ],
+        options: []
+    )
+}
+
+private func yieldMessage(_ data: Data, to upstream: TestUpstreamClient) async {
+    await upstream.yield(.message(data))
 }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -169,6 +169,57 @@ import Testing
     _ = try await init2.get()
 }
 
+@Test func sessionManagerSecondaryExitClearsCachedInitializeResultWhenPrimaryAlreadyDown() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // First init establishes the cached init result (primary only).
+    let init1 = manager.registerInitialize(
+        originalId: RPCId(any: NSNumber(value: 1))!,
+        requestObject: makeInitializeRequest(id: 1),
+        on: eventLoop
+    )
+    await Task.yield()
+    #expect((await upstream0.sent()).count == 1)
+    let upstreamId0 = try extractUpstreamId(from: (await upstream0.sent())[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: upstreamId0)))
+    _ = try await init1.get()
+
+    // Warm init -> upstream1
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 1)
+    let init1Messages = await upstream1.sent()
+    let upstreamId1 = try extractUpstreamId(from: init1Messages[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: upstreamId1)))
+
+    // Wait for per-upstream notifications/initialized.
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 1)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 1)
+
+    // Simulate primary dying first (cached init result should remain because upstream1 is still initialized).
+    await upstream0.yield(.exit(1))
+    await Task.yield()
+
+    // Now simulate the last initialized upstream dying too.
+    await upstream1.yield(.exit(1))
+    await Task.yield()
+
+    // A new downstream initialize must trigger a new upstream initialize (no cached response).
+    let init2 = manager.registerInitialize(
+        originalId: RPCId(any: NSNumber(value: 2))!,
+        requestObject: makeInitializeRequest(id: 2),
+        on: eventLoop
+    )
+    try await waitForSentCount(upstream0, count: 3, timeoutSeconds: 1)
+    let upstreamId2 = try extractUpstreamId(from: (await upstream0.sent())[2])
+    await upstream0.yield(.message(try makeInitializeResponse(id: upstreamId2)))
+    _ = try await init2.get()
+}
+
 @Test func sessionManagerRoutesRequestsRoundRobinAcrossUpstreams() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -220,6 +220,53 @@ import Testing
     _ = try await init2.get()
 }
 
+@Test func sessionManagerEagerInitializeRerunsPrimaryInitWhenLastInitializedUpstreamExits() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
+    let _ = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Initialize both upstreams.
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 1)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 1)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    // Wait for per-upstream notifications/initialized.
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 1)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 1)
+
+    // Simulate primary dying first (cached init result should remain because upstream1 is still initialized).
+    await upstream0.yield(.exit(1))
+
+    // Primary warm init should be attempted, but we simulate it failing.
+    try await waitForSentCount(upstream0, count: 3, timeoutSeconds: 1)
+    let retry = await upstream0.sent()
+    let retryId = try extractUpstreamId(from: retry[2])
+    let errorResponse: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": retryId,
+        "error": [
+            "code": -1,
+            "message": "warm init failed",
+        ],
+    ]
+    await upstream0.yield(.message(try JSONSerialization.data(withJSONObject: errorResponse, options: [])))
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    // Now simulate the last initialized upstream dying too. Eager init should kick the global init path again.
+    await upstream1.yield(.exit(1))
+    try await waitForSentCount(upstream0, count: 4, timeoutSeconds: 1)
+}
+
 @Test func sessionManagerRoutesRequestsRoundRobinAcrossUpstreams() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }


### PR DESCRIPTION
Summary:
- Add --upstream-processes (1..10) to start multiple upstream mcpbridge processes and route requests across them
- Update session handling/ID mapping to support multiple upstreams and recovery
- Add tests for CLI parsing, round-robin routing, and upstream exit handling
- Refresh benchmark notes comparing upstream=1 vs upstream=4 (with line charts)

Testing:
- swift test