### PR TITLE
fix: transport closed hang

### DIFF
--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -31,6 +31,19 @@ args = ["--stdio"]
 tool_timeout_sec = 300
 ```
 
+## Codex shows `Transport closed` (then hangs)
+If you see an error like:
+
+- `tools/call failed: Transport closed`
+
+it usually means the MCP server process (`xcode-mcp-proxy --stdio`) was terminated while Codex was waiting (often due to the default `tool_timeout_sec` being too short for slow Xcode operations).
+
+- Set `tool_timeout_sec` (see above) to a value that covers the slowest Xcode tool calls you expect.
+- Ensure the central proxy (`xcode-mcp-proxy-server`) is running and the discovery file is fresh: `~/Library/Caches/XcodeMCPProxy/endpoint.json`.
+- If it keeps happening, restart the local processes:
+  - `pkill -f xcode-mcp-proxy`
+  - `pkill -f mcpbridge`
+
 ## Xcode dialog does not appear
 Make sure `--lazy-init` is not set (when enabled, the dialog appears on the first request instead of at startup).
 

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -407,6 +407,18 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private func sendSingleSSE(on channel: Channel, data: Data, keepAlive: Bool, sessionId: String, requestLog: RequestLogContext) {
+        guard let payload = SSECodec.encodeDataEvent(data) else {
+            sendPlain(
+                on: channel,
+                status: .badGateway,
+                body: "invalid upstream response",
+                keepAlive: keepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
+            return
+        }
+
         logResponse(requestLog, status: .ok, sessionId: sessionId)
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "text/event-stream")
@@ -417,10 +429,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         head.headers.add(name: "Connection", value: keepAlive ? "keep-alive" : "close")
         channel.write(HTTPServerResponsePart.head(head), promise: nil)
 
-        var buffer = channel.allocator.buffer(capacity: data.count + 16)
-        buffer.writeString("data: ")
-        buffer.writeBytes(data)
-        buffer.writeString("\n\n")
+        var buffer = channel.allocator.buffer(capacity: payload.utf8.count)
+        buffer.writeString(payload)
         channel.write(HTTPServerResponsePart.body(.byteBuffer(buffer)), promise: nil)
         channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
         if !keepAlive {
@@ -482,7 +492,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private func sendSSE(to channel: Channel, data: Data) {
-        let payload = "data: \(String(decoding: data, as: UTF8.self))\n\n"
+        guard let payload = SSECodec.encodeDataEvent(data) else {
+            logger.warning("Dropping non-UTF8 SSE payload", metadata: ["bytes": "\(data.count)"])
+            return
+        }
         channel.eventLoop.execute {
             guard channel.isActive else { return }
             var buffer = channel.allocator.buffer(capacity: payload.utf8.count)

--- a/Sources/XcodeMCPProxy/SSECodec.swift
+++ b/Sources/XcodeMCPProxy/SSECodec.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+enum SSECodec {
+    /// Encodes a single SSE event containing one logical `data` payload.
+    ///
+    /// If the payload contains newlines, they are emitted as multiple `data:` lines per the SSE spec.
+    /// Returns `nil` if the payload is not valid UTF-8.
+    static func encodeDataEvent(_ data: Data) -> String? {
+        guard let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        // Rough over-allocation: "data: " prefix + "\n" per line + final "\n".
+        var out = String()
+        out.reserveCapacity(text.utf8.count + 16)
+
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        for line in lines {
+            out += "data: "
+            out += line
+            out += "\n"
+        }
+        out += "\n"
+        return out
+    }
+}
+
+struct SSEDecoder {
+    private var dataLines: [String] = []
+
+    mutating func feed(line: String) -> Data? {
+        let normalized: Substring
+        if line.last == "\r" {
+            normalized = line.dropLast()
+        } else {
+            normalized = Substring(line)
+        }
+
+        // Empty line ends the current event.
+        if normalized.isEmpty {
+            return flushIfNeeded()
+        }
+
+        // Comment line.
+        if normalized.first == ":" {
+            return nil
+        }
+
+        guard normalized.hasPrefix("data:") else {
+            return nil
+        }
+
+        var payload = normalized.dropFirst(5)
+        if payload.first == " " {
+            payload = payload.dropFirst()
+        }
+        dataLines.append(String(payload))
+        return nil
+    }
+
+    mutating func flushIfNeeded() -> Data? {
+        guard !dataLines.isEmpty else { return nil }
+        let payload = dataLines.joined(separator: "\n")
+        dataLines.removeAll(keepingCapacity: true)
+        return Data(payload.utf8)
+    }
+}
+

--- a/Sources/XcodeMCPProxy/SSEHub.swift
+++ b/Sources/XcodeMCPProxy/SSEHub.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import NIO
 import NIOHTTP1
 import NIOConcurrencyHelpers
@@ -9,6 +10,7 @@ final class SSEHub: Sendable {
     }
 
     private let state = NIOLockedValueBox(State())
+    private let logger: Logger = ProxyLogging.make("sse")
 
     var hasClients: Bool {
         state.withLockedValue { !$0.clients.isEmpty }
@@ -27,7 +29,10 @@ final class SSEHub: Sendable {
     }
 
     func broadcast(_ data: Data) {
-        let payload = "data: \(String(decoding: data, as: UTF8.self))\n\n"
+        guard let payload = SSECodec.encodeDataEvent(data) else {
+            logger.warning("Dropping non-UTF8 SSE payload", metadata: ["bytes": "\(data.count)"])
+            return
+        }
         let channels = state.withLockedValue { Array($0.clients.values) }
         for channel in channels {
             channel.eventLoop.execute {

--- a/Sources/XcodeMCPProxy/StdioAdapter.swift
+++ b/Sources/XcodeMCPProxy/StdioAdapter.swift
@@ -182,10 +182,20 @@ public actor StdioAdapter {
             throw AdapterError.httpStatus(http.statusCode)
         }
 
+        var decoder = SSEDecoder()
         for try await line in bytes.lines {
             if Task.isCancelled { break }
-            guard let payload = parseSSELine(line) else { continue }
+            guard let payload = decoder.feed(line: line) else { continue }
+            guard isValidJSONPayload(payload) else {
+                logger.warning("Dropping invalid SSE payload", metadata: ["bytes": "\(payload.count)"])
+                continue
+            }
             await outputWriter.send(payload)
+        }
+
+        // If the stream ends without a terminating blank line, flush any buffered event.
+        if let tail = decoder.flushIfNeeded(), isValidJSONPayload(tail) {
+            await outputWriter.send(tail)
         }
     }
 
@@ -199,17 +209,6 @@ public actor StdioAdapter {
         } else {
             request.timeoutInterval = .infinity
         }
-    }
-
-    private func parseSSELine(_ line: String) -> Data? {
-        guard line.hasPrefix("data:") else { return nil }
-        let index = line.index(line.startIndex, offsetBy: 5)
-        var payload = line[index...]
-        if payload.first == " " {
-            payload = payload.dropFirst()
-        }
-        guard !payload.isEmpty else { return nil }
-        return Data(payload.utf8)
     }
 
     private func isValidJSONPayload(_ data: Data) -> Bool {

--- a/Sources/XcodeMCPProxy/UpstreamProcess.swift
+++ b/Sources/XcodeMCPProxy/UpstreamProcess.swift
@@ -125,8 +125,27 @@ actor UpstreamProcess: UpstreamClient {
     private func handleStdoutData(_ data: Data) {
         let messages = framer.append(data)
         for message in messages {
+            guard isValidJSONPayload(message) else {
+                if let text = String(data: message, encoding: .utf8) {
+                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        let preview = String(trimmed.prefix(200))
+                        logger.warning("Dropping non-JSON upstream stdout", metadata: ["preview": "\(preview)"])
+                    }
+                } else {
+                    logger.warning("Dropping non-UTF8 upstream stdout", metadata: ["bytes": "\(message.count)"])
+                }
+                continue
+            }
             continuation.yield(.message(message))
         }
+    }
+
+    private func isValidJSONPayload(_ data: Data) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            return false
+        }
+        return json is [String: Any] || json is [Any]
     }
 
     private func handleTermination(status: Int32) {

--- a/Tests/XcodeMCPProxyTests/SSECodecTests.swift
+++ b/Tests/XcodeMCPProxyTests/SSECodecTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import XcodeMCPProxy
+
+@Test func sseCodecEncodesSingleLineDataEvent() async throws {
+    let json = #"{"jsonrpc":"2.0","method":"ping"}"#
+    let data = Data(json.utf8)
+    let encoded = SSECodec.encodeDataEvent(data)
+    #expect(encoded == "data: \(json)\n\n")
+}
+
+@Test func sseCodecRoundTripsMultiLinePayload() async throws {
+    let payload = "{\n\"a\": 1\n}"
+    let data = Data(payload.utf8)
+    let encoded = SSECodec.encodeDataEvent(data)
+    #expect(encoded == "data: {\ndata: \"a\": 1\ndata: }\n\n")
+
+    var decoder = SSEDecoder()
+    var decodedEvents: [String] = []
+    for line in (encoded ?? "").split(separator: "\n", omittingEmptySubsequences: false) {
+        if let event = decoder.feed(line: String(line)) {
+            decodedEvents.append(String(decoding: event, as: UTF8.self))
+        }
+    }
+    if let tail = decoder.flushIfNeeded() {
+        decodedEvents.append(String(decoding: tail, as: UTF8.self))
+    }
+
+    #expect(decodedEvents == [payload])
+}
+
+@Test func sseDecoderIgnoresCommentsAndHandlesCRLF() async throws {
+    var decoder = SSEDecoder()
+
+    // Comment line should not produce an event.
+    #expect(decoder.feed(line: ": ok") == nil)
+    #expect(decoder.feed(line: "") == nil)
+
+    // CR should be stripped from the line.
+    let json = #"{"a":1}"#
+    #expect(decoder.feed(line: "data: \(json)\r") == nil)
+    let event = decoder.feed(line: "")
+    #expect(event != nil)
+    #expect(String(decoding: event ?? Data(), as: UTF8.self) == json)
+}
+


### PR DESCRIPTION
Summary:
- Encode SSE events per spec (multi-line `data:`) and drop non-UTF8 payloads
- Assemble SSE events in the STDIO adapter and drop invalid JSON
- Drop non-JSON upstream stdout to avoid breaking downstream transports
- Document `Transport closed` troubleshooting; add SSE codec tests

Testing:
- swift test