### PR TITLE
fix: stub mcp resources

### DIFF
--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -310,6 +310,50 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return
             }
 
+            // Xcode MCP (via `xcrun mcpbridge`) currently doesn't implement the MCP Resources APIs.
+            // Some clients still probe `resources/list` and `resources/templates/list` unconditionally,
+            // and Xcode returns a tool-style error payload that doesn't match the expected schema.
+            // To keep clients happy, serve an empty list response locally.
+            if method == "resources/list" || method == "resources/templates/list" {
+                guard let originalIdValue = object["id"], let originalId = RPCId(any: originalIdValue) else {
+                    sendPlain(on: context.channel, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: nil, requestLog: requestLog)
+                    return
+                }
+
+                let sessionId = headerSessionId ?? UUID().uuidString
+                if let headerSessionId, headerSessionExists == false {
+                    _ = sessionManager.session(id: headerSessionId)
+                }
+
+                let result: [String: Any]
+                if method == "resources/list" {
+                    result = [
+                        "resources": [Any](),
+                    ]
+                } else {
+                    result = [
+                        "resourceTemplates": [Any](),
+                    ]
+                }
+
+                let response: [String: Any] = [
+                    "jsonrpc": "2.0",
+                    "id": originalId.value.foundationObject,
+                    "result": result,
+                ]
+                if JSONSerialization.isValidJSONObject(response),
+                   let data = try? JSONSerialization.data(withJSONObject: response, options: []) {
+                    if prefersEventStream {
+                        sendSingleSSE(on: context.channel, data: data, keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
+                    } else {
+                        var out = context.channel.allocator.buffer(capacity: data.count)
+                        out.writeBytes(data)
+                        sendJSON(on: context.channel, buffer: out, keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
+                    }
+                    return
+                }
+            }
+
             // Serve cached tools/list only for the canonical no-params request.
             // Some clients use params for pagination; serving a cached first page would be incorrect.
             if method == "tools/list",

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -311,10 +311,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             }
 
             // Xcode MCP (via `xcrun mcpbridge`) currently doesn't implement the MCP Resources APIs.
-            // Some clients still probe `resources/list` and `resources/templates/list` unconditionally,
-            // and Xcode returns a tool-style error payload that doesn't match the expected schema.
-            // To keep clients happy, serve an empty list response locally.
-            if method == "resources/list" || method == "resources/templates/list" {
+            // Some clients still probe `resources/list` and `resources/templates/list` unconditionally.
+            //
+            // If the proxy hasn't been initialized yet, we can't reliably forward these requests. Serve an
+            // empty list response locally so clients don't choke on unsupported-method errors.
+            if (method == "resources/list" || method == "resources/templates/list") && sessionManager.isInitialized() == false {
                 guard let originalIdValue = object["id"], let originalId = RPCId(any: originalIdValue) else {
                     sendPlain(on: context.channel, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: nil, requestLog: requestLog)
                     return
@@ -462,17 +463,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
                         return
                     }
+                    let responseData = self.rewriteUnsupportedResourcesListResponseIfNeeded(
+                        method: transform.method,
+                        originalId: transform.originalId,
+                        upstreamData: data
+                    )
                     if transform.isCacheableToolsListRequest,
-                       let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                       let object = try? JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any],
                        let resultAny = object["result"],
                        let result = JSONValue(any: resultAny) {
                         self.sessionManager.setCachedToolsListResult(result)
                     }
                     if prefersEventStream {
-                        self.sendSingleSSE(on: channel, data: data, keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
+                        self.sendSingleSSE(on: channel, data: responseData, keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
                     } else {
-                        var out = channel.allocator.buffer(capacity: data.count)
-                        out.writeBytes(data)
+                        var out = channel.allocator.buffer(capacity: responseData.count)
+                        out.writeBytes(responseData)
                         self.sendJSON(on: channel, buffer: out, keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
                     }
                 case .failure:
@@ -519,6 +525,40 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         if !keepAlive {
             channel.close(promise: nil)
         }
+    }
+
+    private func rewriteUnsupportedResourcesListResponseIfNeeded(
+        method: String?,
+        originalId: RPCId?,
+        upstreamData: Data
+    ) -> Data {
+        guard let method,
+              method == "resources/list" || method == "resources/templates/list" else {
+            return upstreamData
+        }
+        guard let originalId else { return upstreamData }
+
+        let expectedKey = (method == "resources/list") ? "resources" : "resourceTemplates"
+
+        if let object = try? JSONSerialization.jsonObject(with: upstreamData, options: []) as? [String: Any],
+           let result = object["result"] as? [String: Any],
+           result[expectedKey] is [Any] {
+            return upstreamData
+        }
+
+        let result: [String: Any] = (method == "resources/list")
+            ? ["resources": [Any]()]
+            : ["resourceTemplates": [Any]()]
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "result": result,
+        ]
+        guard JSONSerialization.isValidJSONObject(response),
+              let data = try? JSONSerialization.data(withJSONObject: response, options: []) else {
+            return upstreamData
+        }
+        return data
     }
 
     private func sendJSON(on channel: Channel, buffer: ByteBuffer, keepAlive: Bool, sessionId: String, requestLog: RequestLogContext) {

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -540,9 +540,23 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         let expectedKey = (method == "resources/list") ? "resources" : "resourceTemplates"
 
-        if let object = try? JSONSerialization.jsonObject(with: upstreamData, options: []) as? [String: Any],
-           let result = object["result"] as? [String: Any],
+        guard let object = try? JSONSerialization.jsonObject(with: upstreamData, options: []) as? [String: Any] else {
+            return upstreamData
+        }
+
+        if let result = object["result"] as? [String: Any],
            result[expectedKey] is [Any] {
+            return upstreamData
+        }
+
+        // Only rewrite the standard JSON-RPC "Method not found" error (-32601).
+        // Any other upstream error should pass through unchanged.
+        if let error = object["error"] as? [String: Any] {
+            let code = (error["code"] as? NSNumber)?.intValue ?? (error["code"] as? Int)
+            guard code == -32601 else {
+                return upstreamData
+            }
+        } else {
             return upstreamData
         }
 

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -516,11 +516,155 @@ import Testing
     #expect(templates?.isEmpty == true)
 }
 
+@Test func httpResourcesListRewritesMethodNotFoundErrorToEmptyArrayAfterInit() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config) { method, originalId in
+        #expect(method == "resources/list")
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "error": [
+                "code": -32601,
+                "message": "Method not found",
+            ],
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [])
+    }
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    // Initialize to establish a session id.
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = initResponse.head.headers.first(name: "Mcp-Session-Id")
+    #expect(sessionId?.isEmpty == false)
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 123,
+        "method": "resources/list",
+        "params": [String: Any](),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId!)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    #expect(object?["error"] == nil)
+    let result = object?["result"] as? [String: Any]
+    let resources = result?["resources"] as? [Any]
+    #expect(resources?.isEmpty == true)
+}
+
+@Test func httpResourcesListDoesNotMaskNonMethodNotFoundErrorsAfterInit() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config) { method, originalId in
+        #expect(method == "resources/list")
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "error": [
+                "code": -32000,
+                "message": "permission denied",
+            ],
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [])
+    }
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    // Initialize to establish a session id.
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = initResponse.head.headers.first(name: "Mcp-Session-Id")
+    #expect(sessionId?.isEmpty == false)
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 123,
+        "method": "resources/list",
+        "params": [String: Any](),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId!)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let error = object?["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32000)
+    #expect(object?["result"] == nil)
+}
+
 private enum HTTPTestError: Error {
     case missingResponseHead
 }
 
 private final class TestSessionManager: SessionManaging {
+    private struct UpstreamMapping: Sendable {
+        let sessionId: String
+        let originalId: RPCId
+    }
+
     private struct State: Sendable {
         var sessions: [String: SessionContext] = [:]
         var nextUpstreamId: Int64 = 1
@@ -528,13 +672,19 @@ private final class TestSessionManager: SessionManaging {
         var initialized = false
         var cachedToolsList: JSONValue?
         var upstreamSendCount = 0
+        var upstreamIdMapping: [Int64: UpstreamMapping] = [:]
     }
 
     private let state = NIOLockedValueBox(State())
     private let config: ProxyConfig
+    private let upstreamResponder: (@Sendable (_ method: String, _ originalId: RPCId) throws -> Data)?
 
-    init(config: ProxyConfig) {
+    init(
+        config: ProxyConfig,
+        upstreamResponder: (@Sendable (_ method: String, _ originalId: RPCId) throws -> Data)? = nil
+    ) {
         self.config = config
+        self.upstreamResponder = upstreamResponder
     }
 
     func session(id: String) -> SessionContext {
@@ -607,6 +757,7 @@ private final class TestSessionManager: SessionManaging {
             state.assignUpstreamIdCount += 1
             let id = state.nextUpstreamId
             state.nextUpstreamId += 1
+            state.upstreamIdMapping[id] = UpstreamMapping(sessionId: sessionId, originalId: originalId)
             return id
         }
     }
@@ -615,6 +766,22 @@ private final class TestSessionManager: SessionManaging {
         state.withLockedValue { state in
             state.upstreamSendCount += 1
         }
+
+        guard let upstreamResponder else { return }
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+              let method = object["method"] as? String,
+              let upstreamIdValue = object["id"] else {
+            return
+        }
+        let upstreamId = (upstreamIdValue as? NSNumber)?.int64Value ?? (upstreamIdValue as? Int64)
+        guard let upstreamId,
+              let mapping = state.withLockedValue({ $0.upstreamIdMapping[upstreamId] }),
+              let responseData = try? upstreamResponder(method, mapping.originalId) else {
+            return
+        }
+
+        let session = self.session(id: mapping.sessionId)
+        session.router.handleIncoming(responseData)
     }
 
     func sentUpstreamCount() -> Int {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -442,6 +442,80 @@ import Testing
     #expect(toolsResponse.head.headers.first(name: "Content-Type") == "application/json")
 }
 
+@Test func httpResourcesListReturnsEmptyArray() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "resources/list",
+        "params": [String: Any](),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: "session-1")
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    #expect(response.head.headers.first(name: "Content-Type") == "application/json")
+
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let responseId = (object?["id"] as? NSNumber)?.intValue
+    #expect(responseId == 1)
+    let result = object?["result"] as? [String: Any]
+    let resources = result?["resources"] as? [Any]
+    #expect(resources?.isEmpty == true)
+}
+
+@Test func httpResourceTemplatesListReturnsEmptyArray() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "resources/templates/list",
+        "params": [String: Any](),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: "session-1")
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    #expect(response.head.headers.first(name: "Content-Type") == "application/json")
+
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let responseId = (object?["id"] as? NSNumber)?.intValue
+    #expect(responseId == 1)
+    let result = object?["result"] as? [String: Any]
+    let templates = result?["resourceTemplates"] as? [Any]
+    #expect(templates?.isEmpty == true)
+}
+
 private enum HTTPTestError: Error {
     case missingResponseHead
 }


### PR DESCRIPTION
Summary:
- Return empty results for `resources/list` and `resources/templates/list` to avoid client decode errors when upstream doesn't implement Resources APIs.
- Add HTTP handler tests for both methods.

Testing:
- swift test