### PR TITLE
Pin sessions to upstream to reduce cross-talk

### DIFF
--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -404,7 +404,29 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        let upstreamIndex = sessionManager.chooseUpstreamIndex(sessionId: sessionId)
+        let shouldPinUpstream: Bool = {
+            guard let any = try? JSONSerialization.jsonObject(with: bodyData, options: []) else {
+                return false
+            }
+            if let object = any as? [String: Any] {
+                guard let method = object["method"] as? String, method != "initialize" else {
+                    return false
+                }
+                return object["id"] != nil && !(object["id"] is NSNull)
+            }
+            if let array = any as? [Any] {
+                for item in array {
+                    guard let object = item as? [String: Any] else { continue }
+                    guard let method = object["method"] as? String, method != "initialize" else { continue }
+                    if let id = object["id"], !(id is NSNull) {
+                        return true
+                    }
+                }
+            }
+            return false
+        }()
+
+        let upstreamIndex = sessionManager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: shouldPinUpstream)
 
         let transform: RequestTransform
         do {

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -367,6 +367,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 if headerSessionExists == false {
                     _ = sessionManager.session(id: headerSessionId)
                 }
+                // Even when tools/list is served from cache, pin the session so later upstream messages
+                // route consistently instead of fanning out across unpinned sessions.
+                _ = sessionManager.chooseUpstreamIndex(sessionId: headerSessionId, shouldPin: true)
                 let response: [String: Any] = [
                     "jsonrpc": "2.0",
                     "id": originalId.value.foundationObject,

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import NIO
 import NIOConcurrencyHelpers
 
@@ -35,7 +36,7 @@ protocol SessionManaging: Sendable {
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer>
-    func chooseUpstreamIndex(sessionId: String) -> Int
+    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int
     func assignUpstreamId(sessionId: String, originalId: RPCId, upstreamIndex: Int) -> Int64
     func sendUpstream(_ data: Data, upstreamIndex: Int)
 }
@@ -54,7 +55,12 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private struct SessionState: Sendable {
-        var sessions: [String: SessionContext] = [:]
+        struct SessionRecord: Sendable {
+            let context: SessionContext
+            var pinnedUpstreamIndex: Int?
+        }
+
+        var sessions: [String: SessionRecord] = [:]
     }
 
     private struct InitState: Sendable {
@@ -76,6 +82,7 @@ final class SessionManager: Sendable, SessionManaging {
     private let eventLoop: EventLoop
     private let idMapper: UpstreamIdMapper
     private let config: ProxyConfig
+    private let logger: Logger = ProxyLogging.make("session")
     let upstreams: [any UpstreamClient]
     private let toolsListState = NIOLockedValueBox(ToolsListState())
 
@@ -148,10 +155,10 @@ final class SessionManager: Sendable, SessionManaging {
     func session(id: String) -> SessionContext {
         sessionsState.withLockedValue { state in
             if let existing = state.sessions[id] {
-                return existing
+                return existing.context
             }
             let context = SessionContext(id: id, config: config)
-            state.sessions[id] = context
+            state.sessions[id] = SessionState.SessionRecord(context: context, pinnedUpstreamIndex: nil)
             return context
         }
     }
@@ -164,7 +171,7 @@ final class SessionManager: Sendable, SessionManaging {
 
     func removeSession(id: String) {
         let context = sessionsState.withLockedValue { state in
-            state.sessions.removeValue(forKey: id)
+            state.sessions.removeValue(forKey: id)?.context
         }
         context?.notificationHub.closeAll()
     }
@@ -237,8 +244,29 @@ final class SessionManager: Sendable, SessionManaging {
         Task.detached { ToolsListCache.write(result) }
     }
 
-    func chooseUpstreamIndex(sessionId _: String) -> Int {
-        upstreamState.withLockedValue { state in
+    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int {
+        // If we already pinned this session to an initialized upstream, always stick to it.
+        // This reduces cross-talk between multiple concurrent clients sharing the same proxy.
+        var pinned = sessionsState.withLockedValue { state in
+            state.sessions[sessionId]?.pinnedUpstreamIndex
+        }
+        if let pinnedIndex = pinned {
+            let isInitialized = upstreamState.withLockedValue { state in
+                guard pinnedIndex >= 0, pinnedIndex < state.upstreamStates.count else { return false }
+                return state.upstreamStates[pinnedIndex].isInitialized
+            }
+            if isInitialized {
+                return pinnedIndex
+            }
+
+            // Upstream is no longer usable; clear the pin so we can re-pick.
+            sessionsState.withLockedValue { state in
+                state.sessions[sessionId]?.pinnedUpstreamIndex = nil
+            }
+            pinned = nil
+        }
+
+        let chosen = upstreamState.withLockedValue { state in
             let count = state.upstreamStates.count
             guard count > 0 else { return 0 }
 
@@ -253,6 +281,16 @@ final class SessionManager: Sendable, SessionManaging {
             }
             return 0
         }
+
+        // Only persist the pin when asked. We typically pin on the first non-initialize JSON-RPC request
+        // (method + id), not on notifications.
+        if pinned == nil, shouldPin {
+            sessionsState.withLockedValue { state in
+                state.sessions[sessionId]?.pinnedUpstreamIndex = chosen
+            }
+        }
+
+        return chosen
     }
 
     func registerInitialize(
@@ -330,7 +368,7 @@ final class SessionManager: Sendable, SessionManaging {
 
     private func routeUpstreamMessage(_ data: Data, upstreamIndex: Int) {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
-            broadcastToAllSessions(data)
+            routeUnmappedUpstreamMessage(data, upstreamIndex: upstreamIndex)
             return
         }
 
@@ -382,7 +420,7 @@ final class SessionManager: Sendable, SessionManaging {
             }
         }
 
-        broadcastToAllSessions(data)
+        routeUnmappedUpstreamMessage(data, upstreamIndex: upstreamIndex)
     }
 
     private func handleUpstreamExit(_ status: Int32, upstreamIndex: Int) {
@@ -421,6 +459,23 @@ final class SessionManager: Sendable, SessionManaging {
 
         clearUpstreamState(upstreamIndex: upstreamIndex)
         idMapper.reset(upstreamIndex: upstreamIndex)
+
+        // Any sessions pinned to this upstream can no longer rely on it. Clear their pin so the next
+        // request will re-pick a live upstream.
+        let clearedPins = sessionsState.withLockedValue { state -> Int in
+            let keys = Array(state.sessions.keys)
+            var cleared = 0
+            for key in keys {
+                if state.sessions[key]?.pinnedUpstreamIndex == upstreamIndex {
+                    state.sessions[key]?.pinnedUpstreamIndex = nil
+                    cleared += 1
+                }
+            }
+            return cleared
+        }
+        if clearedPins > 0 {
+            logger.debug("Cleared pinned sessions for exited upstream", metadata: ["upstream": .string("\(upstreamIndex)"), "cleared": .string("\(clearedPins)")])
+        }
 
         // If an upstream dies after a successful global initialize and there are no remaining
         // initialized upstreams, drop the cached init result. Otherwise, new downstream initialize
@@ -497,11 +552,26 @@ final class SessionManager: Sendable, SessionManaging {
         return nil
     }
 
-    private func broadcastToAllSessions(_ data: Data) {
-        let snapshot = sessionsState.withLockedValue { state in
-            Array(state.sessions.values)
+    private func routeUnmappedUpstreamMessage(_ data: Data, upstreamIndex: Int) {
+        // We have no id-based mapping for this upstream message, so we can't unambiguously route it to a
+        // single session. To reduce cross-talk across multiple concurrent agents, only deliver it to
+        // sessions pinned to the same upstream.
+        let targets = sessionsState.withLockedValue { state in
+            state.sessions.values.compactMap { record in
+                record.pinnedUpstreamIndex == upstreamIndex ? record.context : nil
+            }
         }
-        for session in snapshot {
+        guard !targets.isEmpty else {
+            logger.debug(
+                "Dropping unmapped upstream message (no pinned sessions)",
+                metadata: [
+                    "upstream": .string("\(upstreamIndex)"),
+                    "bytes": .string("\(data.count)"),
+                ]
+            )
+            return
+        }
+        for session in targets {
             session.router.handleIncoming(data)
         }
     }

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -552,28 +552,71 @@ final class SessionManager: Sendable, SessionManaging {
         return nil
     }
 
+    private func isServerInitiatedMessage(_ value: Any) -> Bool {
+        if let object = value as? [String: Any] {
+            return object["method"] is String
+        }
+        if let array = value as? [Any] {
+            return array.contains { item in
+                guard let object = item as? [String: Any] else { return false }
+                return object["method"] is String
+            }
+        }
+        return false
+    }
+
     private func routeUnmappedUpstreamMessage(_ data: Data, upstreamIndex: Int) {
         // We have no id-based mapping for this upstream message, so we can't unambiguously route it to a
         // single session. To reduce cross-talk across multiple concurrent agents, only deliver it to
-        // sessions pinned to the same upstream.
-        let targets = sessionsState.withLockedValue { state in
-            state.sessions.values.compactMap { record in
-                record.pinnedUpstreamIndex == upstreamIndex ? record.context : nil
+        // sessions pinned to the same upstream. If no session is pinned to this upstream yet, still
+        // deliver server-initiated notifications/requests to unpinned sessions so they don't miss
+        // pre-pin messages.
+        let (pinnedTargets, unpinnedTargets) = sessionsState.withLockedValue { state -> ([SessionContext], [SessionContext]) in
+            var pinned: [SessionContext] = []
+            var unpinned: [SessionContext] = []
+            pinned.reserveCapacity(state.sessions.count)
+            unpinned.reserveCapacity(state.sessions.count)
+            for record in state.sessions.values {
+                if record.pinnedUpstreamIndex == upstreamIndex {
+                    pinned.append(record.context)
+                } else if record.pinnedUpstreamIndex == nil {
+                    unpinned.append(record.context)
+                }
             }
+            return (pinned, unpinned)
         }
-        guard !targets.isEmpty else {
+
+        if !pinnedTargets.isEmpty {
+            for session in pinnedTargets {
+                session.router.handleIncoming(data)
+            }
+            return
+        }
+
+        if let any = try? JSONSerialization.jsonObject(with: data, options: []),
+           isServerInitiatedMessage(any),
+           !unpinnedTargets.isEmpty {
             logger.debug(
-                "Dropping unmapped upstream message (no pinned sessions)",
+                "Routing unmapped upstream message to unpinned sessions",
                 metadata: [
                     "upstream": .string("\(upstreamIndex)"),
                     "bytes": .string("\(data.count)"),
+                    "targets": .string("\(unpinnedTargets.count)"),
                 ]
             )
+            for session in unpinnedTargets {
+                session.router.handleIncoming(data)
+            }
             return
         }
-        for session in targets {
-            session.router.handleIncoming(data)
-        }
+
+        logger.debug(
+            "Dropping unmapped upstream message (no pinned sessions)",
+            metadata: [
+                "upstream": .string("\(upstreamIndex)"),
+                "bytes": .string("\(data.count)"),
+            ]
+        )
     }
 
     private func startEagerInitializePrimary() {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -325,6 +325,8 @@ import Testing
 
     #expect(sessionManager.sentUpstreamCount() == 0)
     #expect(sessionManager.assignedUpstreamIdCount() == 0)
+    #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+    #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
 }
 
 @Test func httpToolsListForwardsWhenParamsArePresentEvenIfCacheExists() async throws {
@@ -665,6 +667,11 @@ private final class TestSessionManager: SessionManaging {
         let originalId: RPCId
     }
 
+    private struct ChooseUpstreamCall: Sendable {
+        let sessionId: String
+        let shouldPin: Bool
+    }
+
     private struct State: Sendable {
         var sessions: [String: SessionContext] = [:]
         var nextUpstreamId: Int64 = 1
@@ -673,6 +680,7 @@ private final class TestSessionManager: SessionManaging {
         var cachedToolsList: JSONValue?
         var upstreamSendCount = 0
         var upstreamIdMapping: [Int64: UpstreamMapping] = [:]
+        var chooseUpstreamCalls: [ChooseUpstreamCall] = []
     }
 
     private let state = NIOLockedValueBox(State())
@@ -750,7 +758,14 @@ private final class TestSessionManager: SessionManaging {
         return eventLoop.makeSucceededFuture(buffer)
     }
 
-    func chooseUpstreamIndex(sessionId _: String, shouldPin _: Bool) -> Int { 0 }
+    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int {
+        state.withLockedValue { state in
+            state.chooseUpstreamCalls.append(
+                ChooseUpstreamCall(sessionId: sessionId, shouldPin: shouldPin)
+            )
+        }
+        return 0
+    }
 
     func assignUpstreamId(sessionId: String, originalId: RPCId, upstreamIndex _: Int) -> Int64 {
         state.withLockedValue { state in
@@ -790,6 +805,14 @@ private final class TestSessionManager: SessionManaging {
 
     func assignedUpstreamIdCount() -> Int {
         state.withLockedValue { $0.assignUpstreamIdCount }
+    }
+
+    func chooseUpstreamIndexCallCount() -> Int {
+        state.withLockedValue { $0.chooseUpstreamCalls.count }
+    }
+
+    func lastChooseUpstreamShouldPin() -> Bool {
+        state.withLockedValue { $0.chooseUpstreamCalls.last?.shouldPin ?? false }
     }
 }
 

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -750,7 +750,7 @@ private final class TestSessionManager: SessionManaging {
         return eventLoop.makeSucceededFuture(buffer)
     }
 
-    func chooseUpstreamIndex(sessionId _: String) -> Int { 0 }
+    func chooseUpstreamIndex(sessionId _: String, shouldPin _: Bool) -> Int { 0 }
 
     func assignUpstreamId(sessionId: String, originalId: RPCId, upstreamIndex _: Int) -> Int64 {
         state.withLockedValue { state in

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -211,6 +211,13 @@ import Testing
     await upstream1.yield(.exit(1))
     await Task.yield()
 
+    // Ensure the cached init result is cleared before asserting that a new downstream initialize
+    // triggers a fresh upstream initialize. This avoids race/flakiness where the exit event hasn't
+    // been processed yet on the event loop.
+    try await waitForCondition(timeoutSeconds: 2) {
+        manager.isInitialized() == false
+    }
+
     // A new downstream initialize must trigger a new upstream initialize (no cached response).
     let init2 = manager.registerInitialize(
         originalId: RPCId(any: NSNumber(value: 2))!,
@@ -270,7 +277,7 @@ import Testing
     try await waitForSentCount(upstream0, count: 4, timeoutSeconds: 2)
 }
 
-@Test func sessionManagerRoutesRequestsRoundRobinAcrossUpstreams() async throws {
+@Test func sessionManagerPinsSessionsRoundRobinAcrossUpstreams() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }
     let eventLoop = group.next()
@@ -295,27 +302,29 @@ import Testing
     try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
     try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
 
-    let sessionId = "session-1"
-    let session = manager.session(id: sessionId)
+    let sessionIdA = "session-A"
+    let sessionIdB = "session-B"
+    let sessionA = manager.session(id: sessionIdA)
+    let sessionB = manager.session(id: sessionIdB)
 
     let originalA = RPCId(any: NSNumber(value: 100))!
     let originalB = RPCId(any: NSNumber(value: 101))!
 
-    let upstreamIndexA = manager.chooseUpstreamIndex(sessionId: sessionId)
-    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionId)
+    let upstreamIndexA = manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true)
+    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true)
     #expect(upstreamIndexA != upstreamIndexB)
 
-    let futureA = session.router.registerRequest(idKey: originalA.key, on: eventLoop)
+    let futureA = sessionA.router.registerRequest(idKey: originalA.key, on: eventLoop)
     let upstreamIdA = manager.assignUpstreamId(
-        sessionId: sessionId,
+        sessionId: sessionIdA,
         originalId: originalA,
         upstreamIndex: upstreamIndexA
     )
     manager.sendUpstream(try makeToolListRequest(id: upstreamIdA), upstreamIndex: upstreamIndexA)
 
-    let futureB = session.router.registerRequest(idKey: originalB.key, on: eventLoop)
+    let futureB = sessionB.router.registerRequest(idKey: originalB.key, on: eventLoop)
     let upstreamIdB = manager.assignUpstreamId(
-        sessionId: sessionId,
+        sessionId: sessionIdB,
         originalId: originalB,
         upstreamIndex: upstreamIndexB
     )
@@ -337,6 +346,108 @@ import Testing
     let methods1 = await upstream1.sent().compactMap(methodName(from:))
     #expect(methods0.filter { $0 == "tools/list" }.count == 1)
     #expect(methods1.filter { $0 == "tools/list" }.count == 1)
+}
+
+@Test func sessionManagerRoutesUnmappedNotificationsToPinnedSessionsOnly() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Initialize both upstreams.
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+    // Create two sessions and pin them to different upstreams.
+    let sessionIdA = "session-A"
+    let sessionIdB = "session-B"
+    let sessionA = manager.session(id: sessionIdA)
+    let sessionB = manager.session(id: sessionIdB)
+
+    let upstreamIndexA = manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true)
+    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true)
+    #expect(upstreamIndexA != upstreamIndexB)
+
+    // Ensure we're starting from a clean buffer state.
+    _ = sessionA.router.drainBufferedNotifications()
+    _ = sessionB.router.drainBufferedNotifications()
+
+    let notification = try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "method": "notifications/test",
+            "params": ["value": 1],
+        ],
+        options: []
+    )
+
+    await yieldMessage(notification, to: upstream0)
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let pinnedTo0 = upstreamIndexA == 0 ? sessionA : sessionB
+    let notPinnedTo0 = upstreamIndexA == 0 ? sessionB : sessionA
+
+    let receivedPinned = pinnedTo0.router.drainBufferedNotifications()
+    let receivedOther = notPinnedTo0.router.drainBufferedNotifications()
+    #expect(receivedPinned.count == 1)
+    #expect(receivedPinned.first == notification)
+    #expect(receivedOther.isEmpty)
+}
+
+@Test func sessionManagerRepinsAfterUpstreamExit() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Initialize both upstreams.
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+    // Pin two sessions to different upstreams.
+    let sessionIdA = "session-A"
+    let sessionIdB = "session-B"
+    _ = manager.session(id: sessionIdA)
+    _ = manager.session(id: sessionIdB)
+
+    let upstreamIndexA = manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true)
+    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true)
+    #expect(upstreamIndexA != upstreamIndexB)
+
+    let pinnedTo1SessionId = upstreamIndexA == 1 ? sessionIdA : sessionIdB
+    #expect(manager.chooseUpstreamIndex(sessionId: pinnedTo1SessionId, shouldPin: true) == 1)
+
+    await upstream1.yield(.exit(1))
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let repinned = manager.chooseUpstreamIndex(sessionId: pinnedTo1SessionId, shouldPin: true)
+    #expect(repinned == 0)
 }
 
 @Test func sessionManagerExitClearsMappingsAndKeepsServingOnOtherUpstreams() async throws {
@@ -374,7 +485,7 @@ import Testing
     // The proxy should continue serving on upstream0.
     let originalB = RPCId(any: NSNumber(value: 201))!
     let futureB = session.router.registerRequest(idKey: originalB.key, on: eventLoop)
-    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionId)
+    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true)
     #expect(upstreamIndexB == 0)
     let upstreamIdB = manager.assignUpstreamId(sessionId: sessionId, originalId: originalB, upstreamIndex: upstreamIndexB)
     manager.sendUpstream(try makeToolListRequest(id: upstreamIdB), upstreamIndex: upstreamIndexB)

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -407,6 +407,53 @@ import Testing
     #expect(receivedOther.isEmpty)
 }
 
+@Test func sessionManagerRoutesUnmappedNotificationsToUnpinnedSessionsWhenNoPinnedTargetsExist() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Initialize both upstreams.
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+    // Create a session, but do not pin it yet.
+    let sessionId = "session-A"
+    let session = manager.session(id: sessionId)
+
+    // Ensure we're starting from a clean buffer state.
+    _ = session.router.drainBufferedNotifications()
+
+    let notification = try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "method": "notifications/test",
+            "params": ["value": 1],
+        ],
+        options: []
+    )
+
+    await yieldMessage(notification, to: upstream0)
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let received = session.router.drainBufferedNotifications()
+    #expect(received.count == 1)
+    #expect(received.first == notification)
+}
+
 @Test func sessionManagerRepinsAfterUpstreamExit() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }


### PR DESCRIPTION
Summary:
- Add session-level upstream pinning keyed by Mcp-Session-Id.
- Route upstream messages without id mapping only to sessions pinned to the same upstream (drop when none).
- Clear pins for sessions when an upstream exits to allow repinning on the next request.
- Compute pin eligibility in the HTTP handler based on the first non-initialize JSON-RPC request with an id.
- Add tests for pinned routing and repinning, and harden an upstream-exit initialize-cache test against flakiness.

Testing:
- swift test