### PR TITLE
fix: stabilize tools/list handshake

### DIFF
--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -16,8 +16,9 @@ If you see an error like:
 
 it’s usually because the upstream (`xcrun mcpbridge` / Xcode) was slow on the first `tools/list`.
 
-- `xcode-mcp-proxy-server` prewarms and caches `tools/list` once it’s ready.
-- The cached tool list is stored at `~/Library/Caches/XcodeMCPProxy/tools-list.json` and reused on next startup.
+- `xcode-mcp-proxy-server` prewarms and caches `tools/list` **in memory** once it’s ready, and serves it immediately on subsequent requests (stale-while-revalidate).
+- The tool list cache is **not persisted to disk**. It survives repeated Codex restarts as long as the proxy server stays running.
+- When using `--upstream-processes > 1`, the proxy quarantines upstreams that fail `tools/list` refreshes (30s) and may request an upstream restart after consecutive failures.
 
 ## HTTP/SSE client cannot connect
 - Ensure `xcode-mcp-proxy-server` is running.

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -16,9 +16,9 @@ If you see an error like:
 
 it’s usually because the upstream (`xcrun mcpbridge` / Xcode) was slow on the first `tools/list`.
 
-- `xcode-mcp-proxy-server` prewarms and caches `tools/list` **in memory** once it’s ready, and serves it immediately on subsequent requests (stale-while-revalidate).
+- `xcode-mcp-proxy-server` prewarms and caches `tools/list` **in memory** once it’s ready, and serves it immediately on subsequent requests.
 - The tool list cache is **not persisted to disk**. It survives repeated Codex restarts as long as the proxy server stays running.
-- When using `--upstream-processes > 1`, the proxy quarantines upstreams that fail `tools/list` refreshes (30s) and may request an upstream restart after consecutive failures.
+- `tools/list` is intentionally treated as stable for the lifetime of the proxy process (no background refresh), to avoid upstream churn and surprise Xcode permission dialogs.
 
 ## HTTP/SSE client cannot connect
 - Ensure `xcode-mcp-proxy-server` is running.

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -779,8 +779,9 @@ enum RequestInspector {
         let json = try JSONSerialization.jsonObject(with: data, options: [])
         if var object = json as? [String: Any] {
             let method = object["method"] as? String
+            // We intentionally treat tools/list as stable and cache it regardless of params.
+            // Some clients attach pagination-like params even when they expect the full list.
             let isCacheableToolsListRequest = (method == "tools/list")
-                && ToolsListCachePolicy.isCacheableParams(object["params"])
             if let id = object["id"], let rpcId = RPCId(any: id) {
                 let upstreamId = mapId(sessionId, rpcId)
                 object["id"] = upstreamId
@@ -843,15 +844,5 @@ enum RequestInspector {
             originalId: nil,
             isCacheableToolsListRequest: false
         )
-    }
-}
-
-fileprivate enum ToolsListCachePolicy {
-    static func isCacheableParams(_ params: Any?) -> Bool {
-        guard let params else { return true }
-        if params is NSNull { return true }
-        if let object = params as? [String: Any] { return object.isEmpty }
-        if let array = params as? [Any] { return array.isEmpty }
-        return false
     }
 }

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -381,8 +381,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         "pinned_upstream": .string("\(pinnedUpstreamIndex)"),
                     ]
                 )
-                // Refresh in the background (stale-while-revalidate).
-                sessionManager.refreshToolsListIfNeeded()
+                // Intentionally do not refresh tools/list in the background.
+                // Once we have a valid tool list, keeping it stable for the lifetime of the proxy
+                // avoids upstream churn (and Xcode permission prompts) caused by best-effort refreshes.
                 let response: [String: Any] = [
                     "jsonrpc": "2.0",
                     "id": originalId.value.foundationObject,

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -355,10 +355,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 }
             }
 
-            // Serve cached tools/list only for the canonical no-params request.
-            // Some clients use params for pagination; serving a cached first page would be incorrect.
+            // Serve cached tools/list regardless of params. Some clients attach pagination-like params,
+            // but Codex startup expects a full tool list quickly; stability wins over strict pagination.
             if method == "tools/list",
-               ToolsListCachePolicy.isCacheableParams(object["params"]),
                let headerSessionId,
                sessionManager.isInitialized(),
                let cachedResult = sessionManager.cachedToolsListResult(),
@@ -367,9 +366,23 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 if headerSessionExists == false {
                     _ = sessionManager.session(id: headerSessionId)
                 }
+                let hasParams: Bool = {
+                    guard let params = object["params"] else { return false }
+                    return !(params is NSNull)
+                }()
                 // Even when tools/list is served from cache, pin the session so later upstream messages
                 // route consistently instead of fanning out across unpinned sessions.
-                _ = sessionManager.chooseUpstreamIndex(sessionId: headerSessionId, shouldPin: true)
+                let pinnedUpstreamIndex = sessionManager.chooseUpstreamIndex(sessionId: headerSessionId, shouldPin: true)
+                logger.debug(
+                    "tools/list cache hit",
+                    metadata: [
+                        "session": .string(headerSessionId),
+                        "has_params": .string(hasParams ? "true" : "false"),
+                        "pinned_upstream": .string("\(pinnedUpstreamIndex)"),
+                    ]
+                )
+                // Refresh in the background (stale-while-revalidate).
+                sessionManager.refreshToolsListIfNeeded()
                 let response: [String: Any] = [
                     "jsonrpc": "2.0",
                     "id": originalId.value.foundationObject,
@@ -447,6 +460,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         } catch {
             sendPlain(on: context.channel, status: .badRequest, body: "invalid json", keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
             return
+        }
+
+        if transform.method == "tools/list" {
+            let hasCache = sessionManager.cachedToolsListResult() != nil
+            let params = (try? JSONSerialization.jsonObject(with: bodyData, options: []))
+                .flatMap { $0 as? [String: Any] }?["params"]
+            let hasParams = params != nil && !(params is NSNull)
+            logger.debug(
+                "tools/list cache miss; forwarding upstream",
+                metadata: [
+                    "session": .string(sessionId),
+                    "has_cache": .string(hasCache ? "true" : "false"),
+                    "has_params": .string(hasParams ? "true" : "false"),
+                    "upstream": .string("\(upstreamIndex)"),
+                ]
+            )
         }
 
         if headerSessionId == nil {

--- a/Sources/XcodeMCPProxy/ProxyRouter.swift
+++ b/Sources/XcodeMCPProxy/ProxyRouter.swift
@@ -32,9 +32,14 @@ final class ProxyRouter: Sendable {
         self.sendNotification = sendNotification
     }
 
-    func registerRequest(idKey: String, on eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
+    func registerRequest(
+        idKey: String,
+        on eventLoop: EventLoop,
+        timeout: TimeAmount? = nil
+    ) -> EventLoopFuture<ByteBuffer> {
         let promise = eventLoop.makePromise(of: ByteBuffer.self)
-        let timeout = requestTimeout.map { timeout in
+        let effectiveTimeout = timeout ?? requestTimeout
+        let timeout = effectiveTimeout.map { timeout in
             eventLoop.scheduleTask(in: timeout) { [weak self] in
                 guard let self else { return }
                 self.failTimeout(idKey: idKey)

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -326,7 +326,11 @@ final class SessionManager: Sendable, SessionManaging {
 
         // Only persist the pin when asked. We typically pin on the first non-initialize JSON-RPC request
         // (method + id), not on notifications.
-        if pinned == nil, shouldPin, chosen.isHealthy {
+        //
+        // Even if the chosen upstream is temporarily marked unhealthy (for example, after a best-effort
+        // tools/list warmup failure), pinning still improves session affinity for unmapped upstream
+        // messages and avoids broadcasting server-initiated traffic to unrelated unpinned sessions.
+        if pinned == nil, shouldPin {
             sessionsState.withLockedValue { state in
                 state.sessions[sessionId]?.pinnedUpstreamIndex = chosen.index
             }

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -31,6 +31,7 @@ protocol SessionManaging: Sendable {
     func isInitialized() -> Bool
     func cachedToolsListResult() -> JSONValue?
     func setCachedToolsListResult(_ result: JSONValue)
+    func refreshToolsListIfNeeded()
     func registerInitialize(
         originalId: RPCId,
         requestObject: [String: Any],
@@ -50,8 +51,10 @@ final class SessionManager: Sendable, SessionManaging {
 
     private struct ToolsListState: Sendable {
         var cachedResult: JSONValue?
+        // Used for both the post-initialize warmup and stale-while-revalidate refreshes triggered
+        // by HTTP cache hits.
         var warmupInFlight = false
-        var didRefreshThisProcess = false
+        var internalSessionId: String?
     }
 
     private struct SessionState: Sendable {
@@ -92,6 +95,9 @@ final class SessionManager: Sendable, SessionManaging {
         var initTimeout: Scheduled<Void>?
         var didSendInitialized = false
         var initUpstreamId: Int64?
+        var unhealthyUntilUptimeNs: UInt64?
+        var consecutiveToolsListFailures: Int = 0
+        var lastToolsListSuccessUptimeNs: UInt64?
     }
 
     private struct UpstreamPoolState: Sendable {
@@ -114,11 +120,6 @@ final class SessionManager: Sendable, SessionManaging {
         self.eventLoop = eventLoop
         self.upstreams = upstreams
         self.idMapper = UpstreamIdMapper(upstreamCount: upstreams.count)
-        if let cached = ToolsListCache.read() {
-            toolsListState.withLockedValue { state in
-                state.cachedResult = cached
-            }
-        }
         upstreamState.withLockedValue { state in
             state.upstreamStates = Array(repeating: UpstreamState(), count: upstreams.count)
             state.nextPick = 0
@@ -223,39 +224,53 @@ final class SessionManager: Sendable, SessionManaging {
 
     func cachedToolsListResult() -> JSONValue? {
         toolsListState.withLockedValue { state in
-            // We seed the cache from disk, but treat it as stale until we've successfully refreshed
-            // tools/list at least once in the current process.
-            guard state.didRefreshThisProcess else { return nil }
             return state.cachedResult
         }
     }
 
     func setCachedToolsListResult(_ result: JSONValue) {
-        let isValid = ToolsListCache.isValidToolsListResult(result)
+        guard isValidToolsListResult(result) else { return }
         toolsListState.withLockedValue { state in
-            if isValid {
-                state.cachedResult = result
-                state.didRefreshThisProcess = true
-            }
-            state.warmupInFlight = false
+            state.cachedResult = result
         }
+    }
 
-        guard isValid else { return }
-        Task.detached { ToolsListCache.write(result) }
+    func refreshToolsListIfNeeded() {
+        guard config.prewarmToolsList else { return }
+        guard isInitialized() else { return }
+
+        let shouldStart = toolsListState.withLockedValue { state -> Bool in
+            if state.warmupInFlight {
+                return false
+            }
+            state.warmupInFlight = true
+            return true
+        }
+        guard shouldStart else { return }
+
+        Task { [weak self] in
+            guard let self else { return }
+            await self.refreshToolsList()
+        }
     }
 
     func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int {
         // If we already pinned this session to an initialized upstream, always stick to it.
         // This reduces cross-talk between multiple concurrent clients sharing the same proxy.
+        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
         var pinned = sessionsState.withLockedValue { state in
             state.sessions[sessionId]?.pinnedUpstreamIndex
         }
         if let pinnedIndex = pinned {
-            let isInitialized = upstreamState.withLockedValue { state in
+            let isUsable = upstreamState.withLockedValue { state in
                 guard pinnedIndex >= 0, pinnedIndex < state.upstreamStates.count else { return false }
-                return state.upstreamStates[pinnedIndex].isInitialized
+                if let until = state.upstreamStates[pinnedIndex].unhealthyUntilUptimeNs, until <= nowUptimeNs {
+                    state.upstreamStates[pinnedIndex].unhealthyUntilUptimeNs = nil
+                }
+                let upstream = state.upstreamStates[pinnedIndex]
+                return upstream.isInitialized && upstream.unhealthyUntilUptimeNs == nil
             }
-            if isInitialized {
+            if isUsable {
                 return pinnedIndex
             }
 
@@ -266,31 +281,53 @@ final class SessionManager: Sendable, SessionManaging {
             pinned = nil
         }
 
-        let chosen = upstreamState.withLockedValue { state in
+        let chosen = upstreamState.withLockedValue { state -> (index: Int, isHealthy: Bool) in
             let count = state.upstreamStates.count
-            guard count > 0 else { return 0 }
+            guard count > 0 else { return (0, true) }
 
             let rawStart = state.nextPick % count
             let start = rawStart >= 0 ? rawStart : rawStart + count
             state.nextPick &+= 1
+
+            // Prefer initialized and healthy upstreams.
             for offset in 0..<count {
                 let candidate = (start + offset) % count
-                if state.upstreamStates[candidate].isInitialized {
-                    return candidate
+                if !state.upstreamStates[candidate].isInitialized {
+                    continue
+                }
+                if let until = state.upstreamStates[candidate].unhealthyUntilUptimeNs, until <= nowUptimeNs {
+                    state.upstreamStates[candidate].unhealthyUntilUptimeNs = nil
+                }
+                if state.upstreamStates[candidate].unhealthyUntilUptimeNs == nil {
+                    return (candidate, true)
                 }
             }
-            return 0
+
+            // Fall back to any initialized upstream, even if temporarily unhealthy.
+            for offset in 0..<count {
+                let candidate = (start + offset) % count
+                if !state.upstreamStates[candidate].isInitialized {
+                    continue
+                }
+                if let until = state.upstreamStates[candidate].unhealthyUntilUptimeNs, until <= nowUptimeNs {
+                    state.upstreamStates[candidate].unhealthyUntilUptimeNs = nil
+                }
+                let healthy = state.upstreamStates[candidate].unhealthyUntilUptimeNs == nil
+                return (candidate, healthy)
+            }
+
+            return (0, true)
         }
 
         // Only persist the pin when asked. We typically pin on the first non-initialize JSON-RPC request
         // (method + id), not on notifications.
-        if pinned == nil, shouldPin {
+        if pinned == nil, shouldPin, chosen.isHealthy {
             sessionsState.withLockedValue { state in
-                state.sessions[sessionId]?.pinnedUpstreamIndex = chosen
+                state.sessions[sessionId]?.pinnedUpstreamIndex = chosen.index
             }
         }
 
-        return chosen
+        return chosen.index
     }
 
     func registerInitialize(
@@ -708,7 +745,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         // Warm tools/list once so HTTP clients (Codex startup) don't pay the first-hit penalty.
-        startToolsListWarmupIfNeeded()
+        refreshToolsListIfNeeded()
     }
 
     private func encodeInitializeResponse(originalId: RPCId, result: JSONValue) -> ByteBuffer? {
@@ -824,6 +861,9 @@ final class SessionManager: Sendable, SessionManaging {
             state.upstreamStates[upstreamIndex].initInFlight = false
             state.upstreamStates[upstreamIndex].didSendInitialized = false
             state.upstreamStates[upstreamIndex].initUpstreamId = nil
+            state.upstreamStates[upstreamIndex].unhealthyUntilUptimeNs = nil
+            state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
+            state.upstreamStates[upstreamIndex].lastToolsListSuccessUptimeNs = nil
             return timeout
         }
         timeout?.cancel()
@@ -849,48 +889,114 @@ final class SessionManager: Sendable, SessionManaging {
         }
     }
 
-    private func startToolsListWarmupIfNeeded() {
-        guard config.prewarmToolsList else { return }
-
-        let shouldStart = toolsListState.withLockedValue { state -> Bool in
-            // Even when we have a persisted cache from a previous run, warm once per process start so the
-            // cache can be refreshed after Xcode upgrades or tool changes.
-            if state.warmupInFlight {
-                return false
-            }
-            state.warmupInFlight = true
-            return true
+    private func toolsListInternalSessionId() -> String {
+        if let existing = toolsListState.withLockedValue({ $0.internalSessionId }) {
+            return existing
         }
-        guard shouldStart else { return }
 
-        Task { [weak self] in
-            guard let self else { return }
-            await self.warmToolsList()
-        }
-    }
-
-    private func makeUniqueToolsListWarmupSessionId() -> String {
         // Clients can provide arbitrary Mcp-Session-Id values. Use a UUID-backed internal ID
         // and ensure it doesn't match any active session so warmup can't evict real client state.
         var candidate: String
         repeat {
             candidate = "__tools_list_warmup__:" + UUID().uuidString
         } while hasSession(id: candidate)
-        return candidate
+
+        return toolsListState.withLockedValue { state in
+            if let existing = state.internalSessionId {
+                return existing
+            }
+            state.internalSessionId = candidate
+            return candidate
+        }
     }
 
-    private func warmToolsList() async {
-        let upstreamIndex = 0
-        let internalSessionId = makeUniqueToolsListWarmupSessionId()
+    private func clearPinnedSessions(forUpstreamIndex upstreamIndex: Int) -> Int {
+        sessionsState.withLockedValue { state -> Int in
+            let keys = Array(state.sessions.keys)
+            var cleared = 0
+            for key in keys {
+                if state.sessions[key]?.pinnedUpstreamIndex == upstreamIndex {
+                    state.sessions[key]?.pinnedUpstreamIndex = nil
+                    cleared += 1
+                }
+            }
+            return cleared
+        }
+    }
 
-        guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
+    private func markToolsListRefreshSucceeded(upstreamIndex: Int, nowUptimeNs: UInt64) {
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            state.upstreamStates[upstreamIndex].unhealthyUntilUptimeNs = nil
+            state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
+            state.upstreamStates[upstreamIndex].lastToolsListSuccessUptimeNs = nowUptimeNs
+        }
+    }
+
+    private func markToolsListRefreshFailed(upstreamIndex: Int, nowUptimeNs: UInt64, reason: String) {
+        let quarantineNs: UInt64 = 30 * 1_000_000_000
+        let quarantineUntil = nowUptimeNs &+ quarantineNs
+
+        var failures = 0
+        var shouldRestart = false
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            state.upstreamStates[upstreamIndex].unhealthyUntilUptimeNs = quarantineUntil
+            state.upstreamStates[upstreamIndex].consecutiveToolsListFailures += 1
+            failures = state.upstreamStates[upstreamIndex].consecutiveToolsListFailures
+            shouldRestart = failures >= 3
+            if shouldRestart {
+                // Reset so we don't spam restarts while the process is still terminating.
+                state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
+            }
+        }
+
+        let clearedPins = clearPinnedSessions(forUpstreamIndex: upstreamIndex)
+        logger.debug(
+            "tools/list refresh failed; quarantining upstream",
+            metadata: [
+                "upstream": .string("\(upstreamIndex)"),
+                "reason": .string(reason),
+                "failures": .string("\(failures)"),
+                "quarantine_until_uptime_ns": .string("\(quarantineUntil)"),
+                "cleared_pins": .string("\(clearedPins)"),
+            ]
+        )
+
+        guard shouldRestart, upstreamIndex >= 0, upstreamIndex < upstreams.count else { return }
+        guard let process = upstreams[upstreamIndex] as? UpstreamProcess else { return }
+        logger.debug(
+            "Requesting upstream restart due to consecutive tools/list failures",
+            metadata: ["upstream": .string("\(upstreamIndex)")]
+        )
+        Task {
+            await process.requestRestart()
+        }
+    }
+
+    private func refreshToolsList() async {
+        defer {
             toolsListState.withLockedValue { $0.warmupInFlight = false }
+        }
+
+        let refreshTimeout: TimeAmount = .seconds(5)
+        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        let internalSessionId = toolsListInternalSessionId()
+        _ = session(id: internalSessionId)
+
+        let upstreamIndex = chooseUpstreamIndex(sessionId: internalSessionId, shouldPin: false)
+        guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
+            logger.debug("tools/list refresh: invalid upstream index", metadata: ["upstream": .string("\(upstreamIndex)")])
             return
         }
 
         let originalId = RPCId(any: NSNumber(value: 1))!
-        let warmupSession = session(id: internalSessionId)
-        let future = warmupSession.router.registerRequest(idKey: originalId.key, on: eventLoop)
+        let refreshSession = session(id: internalSessionId)
+        let future = refreshSession.router.registerRequest(
+            idKey: originalId.key,
+            on: eventLoop,
+            timeout: refreshTimeout
+        )
         let upstreamId = assignUpstreamId(
             sessionId: internalSessionId,
             originalId: originalId,
@@ -904,11 +1010,17 @@ final class SessionManager: Sendable, SessionManaging {
         ]
         guard JSONSerialization.isValidJSONObject(request),
               let requestData = try? JSONSerialization.data(withJSONObject: request, options: []) else {
-            toolsListState.withLockedValue { $0.warmupInFlight = false }
-            removeSession(id: internalSessionId)
+            markToolsListRefreshFailed(upstreamIndex: upstreamIndex, nowUptimeNs: nowUptimeNs, reason: "encode_request_failed")
             return
         }
 
+        logger.debug(
+            "tools/list refresh started",
+            metadata: [
+                "upstream": .string("\(upstreamIndex)"),
+                "timeout": .string("\(refreshTimeout.nanoseconds)ns"),
+            ]
+        )
         sendUpstream(requestData, upstreamIndex: upstreamIndex)
 
         do {
@@ -916,18 +1028,30 @@ final class SessionManager: Sendable, SessionManaging {
             guard let responseData = buffer.readData(length: buffer.readableBytes),
                   let response = try JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any],
                   let resultAny = response["result"],
-                  let result = JSONValue(any: resultAny) else {
-                toolsListState.withLockedValue { $0.warmupInFlight = false }
-                removeSession(id: internalSessionId)
+                  let result = JSONValue(any: resultAny),
+                  isValidToolsListResult(result) else {
+                markToolsListRefreshFailed(upstreamIndex: upstreamIndex, nowUptimeNs: nowUptimeNs, reason: "invalid_response")
                 return
             }
 
+            markToolsListRefreshSucceeded(upstreamIndex: upstreamIndex, nowUptimeNs: nowUptimeNs)
             setCachedToolsListResult(result)
+            logger.debug(
+                "tools/list refresh succeeded",
+                metadata: ["upstream": .string("\(upstreamIndex)"), "bytes": .string("\(responseData.count)")]
+            )
         } catch {
-            toolsListState.withLockedValue { $0.warmupInFlight = false }
+            markToolsListRefreshFailed(upstreamIndex: upstreamIndex, nowUptimeNs: nowUptimeNs, reason: "timeout")
         }
+    }
 
-        removeSession(id: internalSessionId)
+    private func isValidToolsListResult(_ value: JSONValue) -> Bool {
+        guard case .object(let object) = value else { return false }
+        guard let toolsValue = object["tools"] else { return false }
+        if case .array = toolsValue {
+            return true
+        }
+        return false
     }
 
     private func startUpstreamWarmInitialize(upstreamIndex: Int) {
@@ -1124,51 +1248,4 @@ private struct UpstreamMapping: Sendable {
     let sessionId: String?
     let originalId: RPCId?
     let isInitialize: Bool
-}
-
-private enum ToolsListCache {
-    static var fileURL: URL {
-        let base = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        return (base ?? FileManager.default.temporaryDirectory)
-            .appendingPathComponent("XcodeMCPProxy", isDirectory: true)
-            .appendingPathComponent("tools-list.json")
-    }
-
-    static func read() -> JSONValue? {
-        guard let data = try? Data(contentsOf: fileURL) else {
-            return nil
-        }
-        guard let any = try? JSONSerialization.jsonObject(with: data, options: []) else {
-            return nil
-        }
-        guard let value = JSONValue(any: any), isValidToolsListResult(value) else {
-            return nil
-        }
-        return value
-    }
-
-    static func isValidToolsListResult(_ value: JSONValue) -> Bool {
-        guard case .object(let object) = value else { return false }
-        guard let toolsValue = object["tools"] else { return false }
-        if case .array = toolsValue {
-            return true
-        }
-        return false
-    }
-
-    static func write(_ result: JSONValue) {
-        let object = result.foundationObject
-        guard JSONSerialization.isValidJSONObject(object) else {
-            return
-        }
-
-        do {
-            let directory = fileURL.deletingLastPathComponent()
-            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-            let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
-            try data.write(to: fileURL, options: [.atomic])
-        } catch {
-            // Best-effort cache; ignore failures.
-        }
-    }
 }

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -979,6 +979,13 @@ final class SessionManager: Sendable, SessionManaging {
             toolsListState.withLockedValue { $0.warmupInFlight = false }
         }
 
+        // Intentionally keep the background tools/list refresh fail-fast.
+        //
+        // This code path is stale-while-revalidate: callers already got a cached tools/list response.
+        // Using a long `config.requestTimeout` here would let slow/hung upstreams hold refresh (and
+        // upstream health feedback) hostage, increasing startup latency and routing churn.
+        //
+        // Forwarded client requests still use `config.requestTimeout`; this refresh is best-effort.
         let refreshTimeout: TimeAmount = .seconds(5)
         let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
         let internalSessionId = toolsListInternalSessionId()

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -939,11 +939,24 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func markToolsListRefreshFailed(upstreamIndex: Int, nowUptimeNs: UInt64, reason: String) {
+        let quarantineNs: UInt64 = 30 * 1_000_000_000
+        let quarantineUntil = nowUptimeNs &+ quarantineNs
+
+        var failures = 0
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            state.upstreamStates[upstreamIndex].unhealthyUntilUptimeNs = quarantineUntil
+            state.upstreamStates[upstreamIndex].consecutiveToolsListFailures += 1
+            failures = state.upstreamStates[upstreamIndex].consecutiveToolsListFailures
+        }
+
         logger.debug(
             "tools/list warmup failed (best-effort)",
             metadata: [
                 "upstream": .string("\(upstreamIndex)"),
                 "reason": .string(reason),
+                "failures": .string("\(failures)"),
+                "quarantine_until_uptime_ns": .string("\(quarantineUntil)"),
                 "uptime_ns": .string("\(nowUptimeNs)"),
             ]
         )

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -1010,6 +1010,7 @@ final class SessionManager: Sendable, SessionManaging {
         ]
         guard JSONSerialization.isValidJSONObject(request),
               let requestData = try? JSONSerialization.data(withJSONObject: request, options: []) else {
+            idMapper.remove(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
             markToolsListRefreshFailed(upstreamIndex: upstreamIndex, nowUptimeNs: nowUptimeNs, reason: "encode_request_failed")
             return
         }
@@ -1030,6 +1031,7 @@ final class SessionManager: Sendable, SessionManaging {
                   let resultAny = response["result"],
                   let result = JSONValue(any: resultAny),
                   isValidToolsListResult(result) else {
+                idMapper.remove(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
                 markToolsListRefreshFailed(upstreamIndex: upstreamIndex, nowUptimeNs: nowUptimeNs, reason: "invalid_response")
                 return
             }
@@ -1041,6 +1043,7 @@ final class SessionManager: Sendable, SessionManaging {
                 metadata: ["upstream": .string("\(upstreamIndex)"), "bytes": .string("\(responseData.count)")]
             )
         } catch {
+            idMapper.remove(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
             markToolsListRefreshFailed(upstreamIndex: upstreamIndex, nowUptimeNs: nowUptimeNs, reason: "timeout")
         }
     }

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -617,6 +617,54 @@ final class SessionManager: Sendable, SessionManaging {
         // sessions pinned to the same upstream. If no session is pinned to this upstream yet, still
         // deliver server-initiated notifications/requests to unpinned sessions so they don't miss
         // pre-pin messages.
+        //
+        // Never forward unmapped JSON-RPC responses (no `method`) to sessions: if we dropped a mapping
+        // due to timeouts (e.g. a best-effort tools/list warmup) then a late response must not leak
+        // into active client streams.
+        guard let any = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            logger.debug(
+                "Dropping unmapped upstream message (invalid JSON)",
+                metadata: [
+                    "upstream": .string("\(upstreamIndex)"),
+                    "bytes": .string("\(data.count)"),
+                ]
+            )
+            return
+        }
+
+        let serverInitiatedPayloads: [Data] = {
+            if let object = any as? [String: Any] {
+                guard object["method"] is String else { return [] }
+                return [data]
+            }
+            if let array = any as? [Any] {
+                var payloads: [Data] = []
+                payloads.reserveCapacity(array.count)
+                for item in array {
+                    guard let object = item as? [String: Any],
+                          object["method"] is String,
+                          JSONSerialization.isValidJSONObject(object),
+                          let encoded = try? JSONSerialization.data(withJSONObject: object, options: []) else {
+                        continue
+                    }
+                    payloads.append(encoded)
+                }
+                return payloads
+            }
+            return []
+        }()
+
+        guard !serverInitiatedPayloads.isEmpty else {
+            logger.debug(
+                "Dropping unmapped upstream response",
+                metadata: [
+                    "upstream": .string("\(upstreamIndex)"),
+                    "bytes": .string("\(data.count)"),
+                ]
+            )
+            return
+        }
+
         let (pinnedTargets, unpinnedTargets) = sessionsState.withLockedValue { state -> ([SessionContext], [SessionContext]) in
             var pinned: [SessionContext] = []
             var unpinned: [SessionContext] = []
@@ -633,15 +681,15 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         if !pinnedTargets.isEmpty {
-            for session in pinnedTargets {
-                session.router.handleIncoming(data)
+            for payload in serverInitiatedPayloads {
+                for session in pinnedTargets {
+                    session.router.handleIncoming(payload)
+                }
             }
             return
         }
 
-        if let any = try? JSONSerialization.jsonObject(with: data, options: []),
-           isServerInitiatedMessage(any),
-           !unpinnedTargets.isEmpty {
+        if !unpinnedTargets.isEmpty {
             logger.debug(
                 "Routing unmapped upstream message to unpinned sessions",
                 metadata: [
@@ -650,14 +698,16 @@ final class SessionManager: Sendable, SessionManaging {
                     "targets": .string("\(unpinnedTargets.count)"),
                 ]
             )
-            for session in unpinnedTargets {
-                session.router.handleIncoming(data)
+            for payload in serverInitiatedPayloads {
+                for session in unpinnedTargets {
+                    session.router.handleIncoming(payload)
+                }
             }
             return
         }
 
         logger.debug(
-            "Dropping unmapped upstream message (no pinned sessions)",
+            "Dropping unmapped upstream message (no target sessions)",
             metadata: [
                 "upstream": .string("\(upstreamIndex)"),
                 "bytes": .string("\(data.count)"),

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -51,8 +51,7 @@ final class SessionManager: Sendable, SessionManaging {
 
     private struct ToolsListState: Sendable {
         var cachedResult: JSONValue?
-        // Used for both the post-initialize warmup and stale-while-revalidate refreshes triggered
-        // by HTTP cache hits.
+        // Tracks a best-effort warmup to populate the in-memory tools/list cache once.
         var warmupInFlight = false
         var internalSessionId: String?
     }
@@ -240,6 +239,12 @@ final class SessionManager: Sendable, SessionManaging {
         guard isInitialized() else { return }
 
         let shouldStart = toolsListState.withLockedValue { state -> Bool in
+            // If we already cached a valid tool list, keep it stable for the lifetime of this proxy process.
+            // tools/list is not expected to change during normal operation, and background refreshes can cause
+            // upstream churn (including Xcode permission dialogs) when upstreams are slow or flaky.
+            if state.cachedResult != nil {
+                return false
+            }
             if state.warmupInFlight {
                 return false
             }
@@ -934,44 +939,14 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func markToolsListRefreshFailed(upstreamIndex: Int, nowUptimeNs: UInt64, reason: String) {
-        let quarantineNs: UInt64 = 30 * 1_000_000_000
-        let quarantineUntil = nowUptimeNs &+ quarantineNs
-
-        var failures = 0
-        var shouldRestart = false
-        upstreamState.withLockedValue { state in
-            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
-            state.upstreamStates[upstreamIndex].unhealthyUntilUptimeNs = quarantineUntil
-            state.upstreamStates[upstreamIndex].consecutiveToolsListFailures += 1
-            failures = state.upstreamStates[upstreamIndex].consecutiveToolsListFailures
-            shouldRestart = failures >= 3
-            if shouldRestart {
-                // Reset so we don't spam restarts while the process is still terminating.
-                state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
-            }
-        }
-
-        let clearedPins = clearPinnedSessions(forUpstreamIndex: upstreamIndex)
         logger.debug(
-            "tools/list refresh failed; quarantining upstream",
+            "tools/list warmup failed (best-effort)",
             metadata: [
                 "upstream": .string("\(upstreamIndex)"),
                 "reason": .string(reason),
-                "failures": .string("\(failures)"),
-                "quarantine_until_uptime_ns": .string("\(quarantineUntil)"),
-                "cleared_pins": .string("\(clearedPins)"),
+                "uptime_ns": .string("\(nowUptimeNs)"),
             ]
         )
-
-        guard shouldRestart, upstreamIndex >= 0, upstreamIndex < upstreams.count else { return }
-        guard let process = upstreams[upstreamIndex] as? UpstreamProcess else { return }
-        logger.debug(
-            "Requesting upstream restart due to consecutive tools/list failures",
-            metadata: ["upstream": .string("\(upstreamIndex)")]
-        )
-        Task {
-            await process.requestRestart()
-        }
     }
 
     private func refreshToolsList() async {
@@ -979,13 +954,11 @@ final class SessionManager: Sendable, SessionManaging {
             toolsListState.withLockedValue { $0.warmupInFlight = false }
         }
 
-        // Intentionally keep the background tools/list refresh fail-fast.
+        // Intentionally keep the tools/list warmup fail-fast.
         //
-        // This code path is stale-while-revalidate: callers already got a cached tools/list response.
-        // Using a long `config.requestTimeout` here would let slow/hung upstreams hold refresh (and
-        // upstream health feedback) hostage, increasing startup latency and routing churn.
-        //
-        // Forwarded client requests still use `config.requestTimeout`; this refresh is best-effort.
+        // We only use this to populate the in-memory tools/list cache once. A long `config.requestTimeout`
+        // here would unnecessarily block warmup on slow/hung upstreams and can contribute to churn (and
+        // Xcode permission prompts) if callers retry aggressively.
         let refreshTimeout: TimeAmount = .seconds(5)
         let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
         let internalSessionId = toolsListInternalSessionId()

--- a/Sources/XcodeMCPProxy/StdioFramer.swift
+++ b/Sources/XcodeMCPProxy/StdioFramer.swift
@@ -135,8 +135,38 @@ final class StdioFramer {
         guard !buffer.isEmpty else { return false }
 
         // If we're at the start of a (possibly partial) Content-Length header, wait for more bytes.
+        // NOTE: Upstreams sometimes print newline-delimited log lines that begin with "Content-Length".
+        // We must avoid stalling forever on such junk, but also preserve correct framing when a real
+        // Content-Length header arrives split across multiple writes.
         if isPotentialContentLengthHeaderPrefix() {
-            return false
+            let delimiterCRLF = Data("\r\n\r\n".utf8)
+            let delimiterLF = Data("\n\n".utf8)
+
+            // If we already have the header/body delimiter, this is a legitimate header; wait for the body.
+            if buffer.range(of: delimiterCRLF) != nil || buffer.range(of: delimiterLF) != nil {
+                return false
+            }
+
+            // No delimiter yet: if we haven't received even a newline, we're still in a partial line.
+            guard let firstNewlineIndex = buffer.firstIndex(of: 0x0A) else {
+                return false
+            }
+
+            // If we only have the first header line so far, keep waiting for the rest.
+            let afterNewline = buffer.index(after: firstNewlineIndex)
+            if afterNewline == buffer.endIndex {
+                return false
+            }
+
+            // If JSON appears before any delimiter, treat the leading line as junk and drop it so parsing can continue.
+            let hasJSONStartAfterNewline = buffer[afterNewline...].contains { $0 == 0x7B || $0 == 0x5B }
+            if !hasJSONStartAfterNewline {
+                // Otherwise, assume the header may still be arriving in pieces. This is bounded so we don't
+                // keep buffering unbounded junk forever.
+                if buffer.count < 8 * 1024 {
+                    return false
+                }
+            }
         }
 
         // If the first non-whitespace token looks like JSON, don't drop anything; we might just be

--- a/Sources/XcodeMCPProxy/StdioFramer.swift
+++ b/Sources/XcodeMCPProxy/StdioFramer.swift
@@ -43,26 +43,27 @@ final class StdioFramer {
         guard let headerRange = headerEndRange else { return nil }
         let headerEndIndex = headerRange.upperBound
         let headerData = buffer.subdata(in: 0..<headerRange.lowerBound)
-        guard let headerText = String(data: headerData, encoding: .utf8) else { return nil }
-
-        var contentLength: Int?
-        for line in headerText.split(separator: "\n") {
-            let parts = line.split(separator: ":", maxSplits: 1)
-            guard parts.count == 2 else { continue }
-            if parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-                .caseInsensitiveCompare("Content-Length") == .orderedSame {
-                contentLength = Int(parts[1].trimmingCharacters(in: .whitespacesAndNewlines))
-                break
-            }
-        }
-
-        guard let length = contentLength, length >= 0 else { return nil }
+        guard let headerText = String(data: headerData, encoding: .utf8),
+              let length = parseContentLength(from: headerText) else { return nil }
         guard buffer.count >= headerEndIndex + length else { return nil }
 
-        let bodyRange = headerEndIndex..<(headerEndIndex + length)
-        let message = buffer.subdata(in: bodyRange)
-        buffer.removeSubrange(0..<(headerEndIndex + length))
-        return message
+        let bodyEndIndex = headerEndIndex + length
+        let bodyRange = headerEndIndex..<bodyEndIndex
+
+        // Validate that the framed body looks like a single JSON value. If it doesn't, treat the
+        // Content-Length header as junk (e.g. upstream log output) and resync by dropping the header.
+        if let jsonStart = firstNonWhitespaceIndex(in: bodyRange),
+           buffer[jsonStart] == 0x7B || buffer[jsonStart] == 0x5B,
+           let jsonEndIndex = jsonValueEndIndex(from: jsonStart),
+           jsonEndIndex <= bodyEndIndex,
+           buffer[jsonEndIndex..<bodyEndIndex].allSatisfy({ isWhitespace($0) }) {
+            let message = buffer.subdata(in: bodyRange)
+            buffer.removeSubrange(0..<bodyEndIndex)
+            return message
+        }
+
+        buffer.removeSubrange(0..<headerEndIndex)
+        return nil
     }
 
     private func nextJSONValueMessage() -> Data? {
@@ -142,9 +143,36 @@ final class StdioFramer {
             let delimiterCRLF = Data("\r\n\r\n".utf8)
             let delimiterLF = Data("\n\n".utf8)
 
-            // If we already have the header/body delimiter, this is a legitimate header; wait for the body.
-            if buffer.range(of: delimiterCRLF) != nil || buffer.range(of: delimiterLF) != nil {
-                return false
+            if let headerRange = buffer.range(of: delimiterCRLF) ?? buffer.range(of: delimiterLF) {
+                let headerEndIndex = headerRange.upperBound
+                let headerData = buffer.subdata(in: 0..<headerRange.lowerBound)
+
+                if let headerText = String(data: headerData, encoding: .utf8),
+                   let length = parseContentLength(from: headerText) {
+                    if let bodyStart = firstNonWhitespaceIndex(from: headerEndIndex) {
+                        // If we have any bytes after the delimiter and it doesn't look like JSON,
+                        // treat the header as junk framing and resync.
+                        if buffer[bodyStart] != 0x7B && buffer[bodyStart] != 0x5B {
+                            buffer.removeSubrange(0..<headerEndIndex)
+                            return true
+                        }
+
+                        // If a full JSON value is already present after the delimiter, but it doesn't match
+                        // the declared Content-Length, treat this as junk framing and resync.
+                        if let jsonEndIndex = jsonValueEndIndex(from: bodyStart) {
+                            let observedLength = buffer.distance(from: headerEndIndex, to: jsonEndIndex)
+                            if observedLength != length {
+                                buffer.removeSubrange(0..<headerEndIndex)
+                                return true
+                            }
+                        }
+                    }
+
+                    // Otherwise, assume this is legitimate framing; wait for the body bytes.
+                    return false
+                }
+
+                // Delimiter is present but the header isn't parseable: fall back to line dropping below.
             }
 
             // No delimiter yet: if we haven't received even a newline, we're still in a partial line.
@@ -189,6 +217,80 @@ final class StdioFramer {
         }
         guard index < buffer.endIndex else { return nil }
         return buffer[index]
+    }
+
+    private func firstNonWhitespaceIndex(from startIndex: Data.Index) -> Data.Index? {
+        var index = startIndex
+        while index < buffer.endIndex, isWhitespace(buffer[index]) {
+            index = buffer.index(after: index)
+        }
+        guard index < buffer.endIndex else { return nil }
+        return index
+    }
+
+    private func firstNonWhitespaceIndex(in range: Range<Data.Index>) -> Data.Index? {
+        var index = range.lowerBound
+        while index < range.upperBound, isWhitespace(buffer[index]) {
+            index = buffer.index(after: index)
+        }
+        guard index < range.upperBound else { return nil }
+        return index
+    }
+
+    private func jsonValueEndIndex(from startIndex: Data.Index) -> Data.Index? {
+        var index = startIndex
+        guard index < buffer.endIndex else { return nil }
+        let first = buffer[index]
+        guard first == 0x7B || first == 0x5B else { return nil }
+
+        var depth = 0
+        var inString = false
+        var isEscaped = false
+        var endIndex: Data.Index?
+
+        while index < buffer.endIndex {
+            let byte = buffer[index]
+            if inString {
+                if isEscaped {
+                    isEscaped = false
+                } else if byte == 0x5C {
+                    isEscaped = true
+                } else if byte == 0x22 {
+                    inString = false
+                }
+            } else {
+                if byte == 0x22 {
+                    inString = true
+                } else if byte == 0x7B || byte == 0x5B {
+                    depth += 1
+                } else if byte == 0x7D || byte == 0x5D {
+                    depth -= 1
+                    if depth == 0 {
+                        endIndex = index
+                        break
+                    }
+                }
+            }
+            index = buffer.index(after: index)
+        }
+
+        guard let endIndex, depth == 0, !inString else { return nil }
+        return buffer.index(after: endIndex)
+    }
+
+    private func parseContentLength(from headerText: String) -> Int? {
+        for line in headerText.split(separator: "\n") {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+            if parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+                .caseInsensitiveCompare("Content-Length") == .orderedSame {
+                guard let length = Int(parts[1].trimmingCharacters(in: .whitespacesAndNewlines)), length >= 0 else {
+                    return nil
+                }
+                return length
+            }
+        }
+        return nil
     }
 
     private func isPotentialContentLengthHeaderPrefix() -> Bool {

--- a/Sources/XcodeMCPProxy/StdioFramer.swift
+++ b/Sources/XcodeMCPProxy/StdioFramer.swift
@@ -13,15 +13,17 @@ final class StdioFramer {
                 messages.append(message)
                 continue
             }
-            let lines = nextNDJSONMessages()
-            if lines.isEmpty {
-                if let message = nextJSONValueMessage() {
-                    messages.append(message)
-                    continue
-                }
-                break
+            if let message = nextJSONValueMessage() {
+                messages.append(message)
+                continue
             }
-            messages.append(contentsOf: lines)
+            if trimLeadingWhitespace() {
+                continue
+            }
+            if dropLeadingNonJSONLine() {
+                continue
+            }
+            break
         }
 
         return messages
@@ -61,29 +63,6 @@ final class StdioFramer {
         let message = buffer.subdata(in: bodyRange)
         buffer.removeSubrange(0..<(headerEndIndex + length))
         return message
-    }
-
-    private func nextNDJSONMessages() -> [Data] {
-        guard let lastNewline = buffer.lastIndex(of: 0x0A) else { return [] }
-        let endIndex = buffer.index(after: lastNewline)
-        let completeData = buffer.subdata(in: 0..<endIndex)
-        buffer.removeSubrange(0..<endIndex)
-
-        var messages: [Data] = []
-        var startIndex = completeData.startIndex
-        for index in completeData.indices where completeData[index] == 0x0A {
-            let lineData = completeData.subdata(in: startIndex..<index)
-            startIndex = completeData.index(after: index)
-            let trimmed = trimTrailingCR(lineData)
-            if trimmed.isEmpty { continue }
-            messages.append(trimmed)
-        }
-        return messages
-    }
-
-    private func trimTrailingCR(_ data: Data) -> Data {
-        guard let last = data.last, last == 0x0D else { return data }
-        return data.dropLast()
     }
 
     private func nextJSONValueMessage() -> Data? {
@@ -133,6 +112,61 @@ final class StdioFramer {
         let message = buffer.subdata(in: startIndex..<messageEnd)
         buffer.removeSubrange(0..<messageEnd)
         return message
+    }
+
+    private func trimLeadingWhitespace() -> Bool {
+        guard !buffer.isEmpty else { return false }
+        var index = buffer.startIndex
+        while index < buffer.endIndex, isWhitespace(buffer[index]) {
+            index = buffer.index(after: index)
+        }
+        if index == buffer.startIndex {
+            return false
+        }
+        if index == buffer.endIndex {
+            buffer.removeAll(keepingCapacity: true)
+            return true
+        }
+        buffer.removeSubrange(0..<index)
+        return true
+    }
+
+    private func dropLeadingNonJSONLine() -> Bool {
+        guard !buffer.isEmpty else { return false }
+
+        // If we're at the start of a (possibly partial) Content-Length header, wait for more bytes.
+        if isPotentialContentLengthHeaderPrefix() {
+            return false
+        }
+
+        // If the first non-whitespace token looks like JSON, don't drop anything; we might just be
+        // waiting for the rest of a multi-line JSON value.
+        if let first = firstNonWhitespaceByte(), first == 0x7B || first == 0x5B {
+            return false
+        }
+
+        // Drop exactly one line of non-JSON stdout so we don't get stuck on accidental log output.
+        guard let newlineIndex = buffer.firstIndex(of: 0x0A) else { return false }
+        let dropEnd = buffer.index(after: newlineIndex)
+        buffer.removeSubrange(0..<dropEnd)
+        return true
+    }
+
+    private func firstNonWhitespaceByte() -> UInt8? {
+        var index = buffer.startIndex
+        while index < buffer.endIndex, isWhitespace(buffer[index]) {
+            index = buffer.index(after: index)
+        }
+        guard index < buffer.endIndex else { return nil }
+        return buffer[index]
+    }
+
+    private func isPotentialContentLengthHeaderPrefix() -> Bool {
+        let headerPrefix = "Content-Length"
+        let count = min(buffer.count, headerPrefix.utf8.count)
+        guard count > 0 else { return false }
+        guard let prefix = String(data: buffer.prefix(count), encoding: .utf8) else { return false }
+        return headerPrefix.lowercased().hasPrefix(prefix.lowercased())
     }
 
     private func isWhitespace(_ byte: UInt8) -> Bool {

--- a/Sources/XcodeMCPProxy/UpstreamProcess.swift
+++ b/Sources/XcodeMCPProxy/UpstreamProcess.swift
@@ -184,6 +184,15 @@ actor UpstreamProcess: UpstreamClient {
         guard !isStopping else {
             return
         }
+
+        // If we're terminating an old process (e.g. via requestRestart) and a replacement process is
+        // already running, suppress the exit event. Otherwise, SessionManager will treat this as an
+        // upstream outage and clear pins/mappings for an upstream that is actually healthy.
+        if wasTerminating, process != nil {
+            logger.debug("Upstream process exited (superseded)", metadata: ["status": "\(status)"])
+            return
+        }
+
         logger.warning("Upstream process exited", metadata: ["status": "\(status)"])
         continuation.yield(.exit(status))
         // If a replacement process is already running, don't schedule another restart.

--- a/Sources/XcodeMCPProxy/UpstreamProcess.swift
+++ b/Sources/XcodeMCPProxy/UpstreamProcess.swift
@@ -49,6 +49,23 @@ actor UpstreamProcess: UpstreamClient {
         continuation.finish()
     }
 
+    func requestRestart() async {
+        guard !isStopping else { return }
+        restartTask?.cancel()
+        restartTask = nil
+
+        // If we're already down (or never started), just start immediately.
+        if process == nil {
+            startLocked()
+            return
+        }
+
+        logger.warning("Upstream restart requested")
+        restartDelay = config.restartInitialDelay
+        stopLocked()
+        // The termination handler will emit an .exit event and schedule a restart.
+    }
+
     func send(_ data: Data) async {
         if process == nil {
             startLocked()

--- a/Sources/XcodeMCPProxy/UpstreamProcess.swift
+++ b/Sources/XcodeMCPProxy/UpstreamProcess.swift
@@ -17,6 +17,7 @@ actor UpstreamProcess: UpstreamClient {
 
     private let config: Config
     private var process: Process?
+    private var terminatingProcess: Process?
     private var stdinPipe = Pipe()
     private var stdoutPipe = Pipe()
     private var stderrPipe = Pipe()
@@ -46,6 +47,7 @@ actor UpstreamProcess: UpstreamClient {
         restartTask?.cancel()
         restartTask = nil
         stopLocked()
+        terminatingProcess = nil
         continuation.finish()
     }
 
@@ -116,7 +118,7 @@ actor UpstreamProcess: UpstreamClient {
 
         process.terminationHandler = { [weak self] proc in
             Task {
-                await self?.handleTermination(status: proc.terminationStatus)
+                await self?.handleTermination(process: proc, status: proc.terminationStatus)
             }
         }
 
@@ -134,6 +136,7 @@ actor UpstreamProcess: UpstreamClient {
         stdoutPipe.fileHandleForReading.readabilityHandler = nil
         stderrPipe.fileHandleForReading.readabilityHandler = nil
         if let process = process {
+            terminatingProcess = process
             process.terminate()
         }
         process = nil
@@ -165,14 +168,28 @@ actor UpstreamProcess: UpstreamClient {
         return json is [String: Any] || json is [Any]
     }
 
-    private func handleTermination(status: Int32) {
-        process = nil
+    private func handleTermination(process terminated: Process, status: Int32) {
+        let wasCurrent = process.map { terminated === $0 } ?? false
+        let wasTerminating = terminatingProcess.map { terminated === $0 } ?? false
+
+        if wasCurrent {
+            process = nil
+        } else if wasTerminating {
+            terminatingProcess = nil
+        } else {
+            // Stale termination for an older process we no longer track.
+            return
+        }
+
         guard !isStopping else {
             return
         }
         logger.warning("Upstream process exited", metadata: ["status": "\(status)"])
         continuation.yield(.exit(status))
-        scheduleRestart()
+        // If a replacement process is already running, don't schedule another restart.
+        if process == nil {
+            scheduleRestart()
+        }
     }
 
     private func handleStderrData(_ data: Data) {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -327,9 +327,10 @@ import Testing
     #expect(sessionManager.assignedUpstreamIdCount() == 0)
     #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
     #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
+    #expect(sessionManager.refreshToolsListCallCount() == 1)
 }
 
-@Test func httpToolsListForwardsWhenParamsArePresentEvenIfCacheExists() async throws {
+@Test func httpToolsListUsesCachedResultWhenParamsArePresent() async throws {
     let config = makeConfig()
     let channel = EmbeddedChannel()
     defer { _ = try? channel.finish() }
@@ -363,7 +364,7 @@ import Testing
     let sessionId = initResponse.head.headers.first(name: "Mcp-Session-Id")
     #expect(sessionId?.isEmpty == false)
 
-    // tools/list with params should not be served from cache.
+    // tools/list with params should still be served from cache (Codex startup stability).
     let toolsPayload: [String: Any] = [
         "jsonrpc": "2.0",
         "id": 2,
@@ -384,8 +385,22 @@ import Testing
     try channel.writeInbound(HTTPServerRequestPart.body(toolsBody))
     try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-    #expect(sessionManager.sentUpstreamCount() == 1)
-    #expect(sessionManager.assignedUpstreamIdCount() == 1)
+    let toolsResponse = try collectResponse(from: channel)
+    #expect(toolsResponse.head.status == .ok)
+
+    let responseObject = try JSONSerialization.jsonObject(with: Data(toolsResponse.body.utf8), options: []) as? [String: Any]
+    let responseId = (responseObject?["id"] as? NSNumber)?.intValue
+    #expect(responseId == 2)
+
+    let result = responseObject?["result"] as? [String: Any]
+    let tools = result?["tools"] as? [Any]
+    #expect(tools?.count == 0)
+
+    #expect(sessionManager.sentUpstreamCount() == 0)
+    #expect(sessionManager.assignedUpstreamIdCount() == 0)
+    #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+    #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
+    #expect(sessionManager.refreshToolsListCallCount() == 1)
 }
 
 @Test func httpToolsListPrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {
@@ -678,6 +693,7 @@ private final class TestSessionManager: SessionManaging {
         var assignUpstreamIdCount = 0
         var initialized = false
         var cachedToolsList: JSONValue?
+        var refreshToolsListCalls = 0
         var upstreamSendCount = 0
         var upstreamIdMapping: [Int64: UpstreamMapping] = [:]
         var chooseUpstreamCalls: [ChooseUpstreamCall] = []
@@ -734,6 +750,12 @@ private final class TestSessionManager: SessionManaging {
     func setCachedToolsListResult(_ result: JSONValue) {
         state.withLockedValue { state in
             state.cachedToolsList = result
+        }
+    }
+
+    func refreshToolsListIfNeeded() {
+        state.withLockedValue { state in
+            state.refreshToolsListCalls += 1
         }
     }
 
@@ -813,6 +835,10 @@ private final class TestSessionManager: SessionManaging {
 
     func lastChooseUpstreamShouldPin() -> Bool {
         state.withLockedValue { $0.chooseUpstreamCalls.last?.shouldPin ?? false }
+    }
+
+    func refreshToolsListCallCount() -> Int {
+        state.withLockedValue { $0.refreshToolsListCalls }
     }
 }
 

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -327,7 +327,7 @@ import Testing
     #expect(sessionManager.assignedUpstreamIdCount() == 0)
     #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
     #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
-    #expect(sessionManager.refreshToolsListCallCount() == 1)
+    #expect(sessionManager.refreshToolsListCallCount() == 0)
 }
 
 @Test func httpToolsListUsesCachedResultWhenParamsArePresent() async throws {
@@ -400,7 +400,7 @@ import Testing
     #expect(sessionManager.assignedUpstreamIdCount() == 0)
     #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
     #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
-    #expect(sessionManager.refreshToolsListCallCount() == 1)
+    #expect(sessionManager.refreshToolsListCallCount() == 0)
 }
 
 @Test func httpToolsListPrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -403,6 +403,98 @@ import Testing
     #expect(sessionManager.refreshToolsListCallCount() == 0)
 }
 
+@Test func httpToolsListCachesResultOnMissWhenParamsArePresent() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config) { method, originalId in
+        #expect(method == "tools/list")
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "result": [
+                "tools": [Any](),
+            ],
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [])
+    }
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    // Initialize to establish a session id.
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = initResponse.head.headers.first(name: "Mcp-Session-Id")
+    #expect(sessionId?.isEmpty == false)
+
+    // tools/list should be forwarded on the first miss, then cached even with params.
+    let toolsPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": [
+            "cursor": "cursor-1",
+        ],
+    ]
+    let toolsData = try JSONSerialization.data(withJSONObject: toolsPayload, options: [])
+
+    var toolsHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    toolsHead.headers.add(name: "Accept", value: "application/json")
+    toolsHead.headers.add(name: "Content-Type", value: "application/json")
+    toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionId!)
+    var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
+    toolsBody.writeBytes(toolsData)
+    try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(toolsBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let toolsResponse = try collectResponse(from: channel)
+    #expect(toolsResponse.head.status == .ok)
+    #expect(sessionManager.cachedToolsListResult() != nil)
+    #expect(sessionManager.sentUpstreamCount() == 1)
+
+    // Second call should be served from cache (no upstream send).
+    let toolsPayload2: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/list",
+        "params": [
+            "cursor": "cursor-2",
+        ],
+    ]
+    let toolsData2 = try JSONSerialization.data(withJSONObject: toolsPayload2, options: [])
+    var toolsHead2 = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    toolsHead2.headers.add(name: "Accept", value: "application/json")
+    toolsHead2.headers.add(name: "Content-Type", value: "application/json")
+    toolsHead2.headers.add(name: "Mcp-Session-Id", value: sessionId!)
+    var toolsBody2 = channel.allocator.buffer(capacity: toolsData2.count)
+    toolsBody2.writeBytes(toolsData2)
+    try channel.writeInbound(HTTPServerRequestPart.head(toolsHead2))
+    try channel.writeInbound(HTTPServerRequestPart.body(toolsBody2))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let toolsResponse2 = try collectResponse(from: channel)
+    #expect(toolsResponse2.head.status == .ok)
+    #expect(sessionManager.sentUpstreamCount() == 1)
+}
+
 @Test func httpToolsListPrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {
     let config = makeConfig()
     let channel = EmbeddedChannel()

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -454,6 +454,27 @@ import Testing
     #expect(received.first == notification)
 }
 
+@Test func sessionManagerDropsUnmappedResponsesEvenWhenPinnedTargetsExist() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+    let sessionId = "session-A"
+    let session = manager.session(id: sessionId)
+    _ = manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true)
+
+    _ = session.router.drainBufferedNotifications()
+
+    // Unmapped JSON-RPC response (no `method`) must never be routed to sessions.
+    await yieldMessage(try makeToolListResponse(id: 9_999_999), to: upstream)
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    #expect(session.router.drainBufferedNotifications().isEmpty)
+}
+
 @Test func sessionManagerPinsFallbackUpstreamEvenWhenUnhealthy() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -454,6 +454,109 @@ import Testing
     #expect(received.first == notification)
 }
 
+@Test func sessionManagerPinsFallbackUpstreamEvenWhenUnhealthy() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    var config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+    config.prewarmToolsList = true
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Initialize primary upstream0.
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    // Warm init -> upstream1.
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    // Wait for per-upstream notifications/initialized.
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+    // Fail tools/list warmup on upstream0 to mark it unhealthy.
+    var warmup0: Data?
+    let warmupDeadline0 = Date().addingTimeInterval(2)
+    while Date() < warmupDeadline0 {
+        manager.refreshToolsListIfNeeded()
+        if let req = (await upstream0.sent()).first(where: { methodName(from: $0) == "tools/list" }) {
+            warmup0 = req
+            break
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+    }
+    #expect(warmup0 != nil)
+    if let warmup0 {
+        let id = try extractUpstreamId(from: warmup0)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [:], // invalid (no `tools` array) -> marks upstream unhealthy
+        ]
+        await upstream0.yield(.message(try JSONSerialization.data(withJSONObject: response, options: [])))
+    }
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    // Trigger another warmup; it should prefer upstream1 and fail there too so no healthy upstream exists.
+    var warmup1: Data?
+    let warmupDeadline1 = Date().addingTimeInterval(2)
+    while Date() < warmupDeadline1 {
+        manager.refreshToolsListIfNeeded()
+        if let req = (await upstream1.sent()).first(where: { methodName(from: $0) == "tools/list" }) {
+            warmup1 = req
+            break
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+    }
+    #expect(warmup1 != nil)
+    if let warmup1 {
+        let id = try extractUpstreamId(from: warmup1)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [:],
+        ]
+        await upstream1.yield(.message(try JSONSerialization.data(withJSONObject: response, options: [])))
+    }
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let sessionIdA = "session-A"
+    let sessionIdB = "session-B"
+    let sessionA = manager.session(id: sessionIdA)
+    let sessionB = manager.session(id: sessionIdB)
+
+    _ = sessionA.router.drainBufferedNotifications()
+    _ = sessionB.router.drainBufferedNotifications()
+
+    // Pin session A even though the selected upstream is unhealthy, so unmapped messages don't broadcast
+    // to other unpinned sessions (session B).
+    let chosen = manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true)
+
+    let notification = try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "method": "notifications/test",
+            "params": ["value": 1],
+        ],
+        options: []
+    )
+
+    await yieldMessage(notification, to: chosen == 0 ? upstream0 : upstream1)
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let receivedA = sessionA.router.drainBufferedNotifications()
+    let receivedB = sessionB.router.drainBufferedNotifications()
+    #expect(receivedA.count == 1)
+    #expect(receivedA.first == notification)
+    #expect(receivedB.isEmpty)
+}
+
 @Test func sessionManagerRepinsAfterUpstreamExit() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }

--- a/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
+++ b/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
@@ -8,6 +8,7 @@ import Testing
     let payload = "Content-Length: \(json.utf8.count)\r\n\r\n\(json)"
     let parts = framer.append(Data(payload.utf8))
     #expect(parts.count == 1)
+    guard parts.count == 1 else { return }
     #expect(String(data: parts[0], encoding: .utf8) == json)
 }
 
@@ -18,6 +19,7 @@ import Testing
     let payload = "\(json1)\n\(json2)\n"
     let parts = framer.append(Data(payload.utf8))
     #expect(parts.count == 2)
+    guard parts.count == 2 else { return }
     #expect(String(data: parts[0], encoding: .utf8) == json1)
     #expect(String(data: parts[1], encoding: .utf8) == json2)
 }
@@ -27,5 +29,25 @@ import Testing
     let json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}"
     let parts = framer.append(Data(json.utf8))
     #expect(parts.count == 1)
+    guard parts.count == 1 else { return }
+    #expect(String(data: parts[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerMultilineJSON() async throws {
+    let framer = StdioFramer()
+    let json = "{\n\"jsonrpc\":\"2.0\",\n\"id\":1,\n\"result\":{\"ok\":true}\n}"
+    let parts = framer.append(Data(json.utf8))
+    #expect(parts.count == 1)
+    guard parts.count == 1 else { return }
+    #expect(String(data: parts[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerDropsLeadingNonJSONLineAndContinues() async throws {
+    let framer = StdioFramer()
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
+    let payload = "some log line\n\(json)"
+    let parts = framer.append(Data(payload.utf8))
+    #expect(parts.count == 1)
+    guard parts.count == 1 else { return }
     #expect(String(data: parts[0], encoding: .utf8) == json)
 }

--- a/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
+++ b/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
@@ -76,3 +76,33 @@ import Testing
     guard partsB.count == 1 else { return }
     #expect(String(data: partsB[0], encoding: .utf8) == json)
 }
+
+@Test func stdioFramerRecoversFromBogusContentLengthBlock() async throws {
+    let framer = StdioFramer()
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
+    let payload = "Content-Length: 123\n\nsome log line\n\(json)"
+    let parts = framer.append(Data(payload.utf8))
+    #expect(parts.count == 1)
+    guard parts.count == 1 else { return }
+    #expect(String(data: parts[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerRecoversFromBogusContentLengthShorterThanJSON() async throws {
+    let framer = StdioFramer()
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
+    let payload = "Content-Length: 5\r\n\r\n\(json)"
+    let parts = framer.append(Data(payload.utf8))
+    #expect(parts.count == 1)
+    guard parts.count == 1 else { return }
+    #expect(String(data: parts[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerRecoversFromBogusContentLengthLongerThanJSON() async throws {
+    let framer = StdioFramer()
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
+    let payload = "Content-Length: 123\n\n\(json)"
+    let parts = framer.append(Data(payload.utf8))
+    #expect(parts.count == 1)
+    guard parts.count == 1 else { return }
+    #expect(String(data: parts[0], encoding: .utf8) == json)
+}

--- a/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
+++ b/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
@@ -51,3 +51,28 @@ import Testing
     guard parts.count == 1 else { return }
     #expect(String(data: parts[0], encoding: .utf8) == json)
 }
+
+@Test func stdioFramerDoesNotStallOnContentLengthLookingLogLine() async throws {
+    let framer = StdioFramer()
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
+    let payload = "Content-Length: 123\n\(json)"
+    let parts = framer.append(Data(payload.utf8))
+    #expect(parts.count == 1)
+    guard parts.count == 1 else { return }
+    #expect(String(data: parts[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerKeepsWaitingForPartialContentLengthHeaderAcrossWrites() async throws {
+    let framer = StdioFramer()
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
+
+    let header = "Content-Length: \(json.utf8.count)\r\n"
+    let partsA = framer.append(Data(header.utf8))
+    #expect(partsA.isEmpty)
+
+    let rest = "\r\n\(json)"
+    let partsB = framer.append(Data(rest.utf8))
+    #expect(partsB.count == 1)
+    guard partsB.count == 1 else { return }
+    #expect(String(data: partsB[0], encoding: .utf8) == json)
+}


### PR DESCRIPTION
Summary:
- Serve cached `tools/list` even when params are present (Codex startup stability).
- Cache `tools/list` in memory and treat it as stable for the lifetime of the proxy process (no background refresh), to avoid upstream churn and surprise Xcode permission dialogs.
- Keep `tools/list` warmup best-effort and fail-fast without quarantining/forced restarts.
- Harden upstream STDIO framing to handle multiline JSON, stray non-JSON stdout, `Content-Length`-looking logs, and bogus `Content-Length` blocks.
- Update tests and troubleshooting docs for the current behavior.

Testing:
- swift test