### PR TITLE
fix: normalize resources list compatibility responses

### DIFF
--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -599,19 +599,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return upstreamData
         }
 
-        // Happy path: upstream already returned a valid Resources result shape.
-        if let result = object["result"] {
-            if let resultObject = result as? [String: Any], resultObject[expectedKey] is [Any] {
-                return upstreamData
-            }
+        let result = object["result"]
 
-            // Xcode MCP may return non-standard "tool-style" error payloads via `result`,
-            // for example:
-            //   {"result":{"content":[...],"isError":true}, ...}
-            // Normalize any non-conforming `result` to an empty Resources list.
-            if let empty = emptyResourcesListResponseData(method: method, originalId: originalId) {
-                return empty
-            }
+        // Happy path: upstream already returned a valid Resources result shape.
+        if let resultObject = result as? [String: Any], resultObject[expectedKey] is [Any] {
             return upstreamData
         }
 
@@ -622,14 +613,50 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             guard code == -32601 else {
                 return upstreamData
             }
-        } else {
-            return upstreamData
+            if let result,
+               isNonStandardUnsupportedResourcesResult(result, method: method),
+               let empty = emptyResourcesListResponseData(method: method, originalId: originalId) {
+                return empty
+            }
+            return emptyResourcesListResponseData(method: method, originalId: originalId) ?? upstreamData
         }
 
-        guard let empty = emptyResourcesListResponseData(method: method, originalId: originalId) else {
-            return upstreamData
+        // Xcode MCP may return non-standard "tool-style" error payloads via `result`,
+        // for example:
+        //   {"result":{"content":[...],"isError":true}, ...}
+        // Only rewrite this specific "unknown method" shape to avoid masking real errors.
+        if let result,
+           isNonStandardUnsupportedResourcesResult(result, method: method),
+           let empty = emptyResourcesListResponseData(method: method, originalId: originalId) {
+            return empty
         }
-        return empty
+
+        return upstreamData
+    }
+
+    private func isNonStandardUnsupportedResourcesResult(_ result: Any, method: String) -> Bool {
+        guard let resultObject = result as? [String: Any] else {
+            return false
+        }
+        guard let isError = resultObject["isError"] as? Bool, isError else {
+            return false
+        }
+        guard let content = resultObject["content"] as? [Any], !content.isEmpty else {
+            return false
+        }
+
+        let methodToken = method.lowercased()
+        for item in content {
+            guard let contentObject = item as? [String: Any],
+                  let text = contentObject["text"] as? String else {
+                continue
+            }
+            let normalized = text.lowercased()
+            if normalized.contains("unknown method"), normalized.contains(methodToken) {
+                return true
+            }
+        }
+        return false
     }
 
     private func emptyResourcesListResponseData(method: String, originalId: RPCId) -> Data? {

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -599,8 +599,19 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return upstreamData
         }
 
-        if let result = object["result"] as? [String: Any],
-           result[expectedKey] is [Any] {
+        // Happy path: upstream already returned a valid Resources result shape.
+        if let result = object["result"] {
+            if let resultObject = result as? [String: Any], resultObject[expectedKey] is [Any] {
+                return upstreamData
+            }
+
+            // Xcode MCP may return non-standard "tool-style" error payloads via `result`,
+            // for example:
+            //   {"result":{"content":[...],"isError":true}, ...}
+            // Normalize any non-conforming `result` to an empty Resources list.
+            if let empty = emptyResourcesListResponseData(method: method, originalId: originalId) {
+                return empty
+            }
             return upstreamData
         }
 
@@ -615,6 +626,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return upstreamData
         }
 
+        guard let empty = emptyResourcesListResponseData(method: method, originalId: originalId) else {
+            return upstreamData
+        }
+        return empty
+    }
+
+    private func emptyResourcesListResponseData(method: String, originalId: RPCId) -> Data? {
         let result: [String: Any] = (method == "resources/list")
             ? ["resources": [Any]()]
             : ["resourceTemplates": [Any]()]
@@ -623,11 +641,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             "id": originalId.value.foundationObject,
             "result": result,
         ]
-        guard JSONSerialization.isValidJSONObject(response),
-              let data = try? JSONSerialization.data(withJSONObject: response, options: []) else {
-            return upstreamData
+        guard JSONSerialization.isValidJSONObject(response) else {
+            return nil
         }
-        return data
+        return try? JSONSerialization.data(withJSONObject: response, options: [])
     }
 
     private func sendJSON(on channel: Channel, buffer: ByteBuffer, keepAlive: Bool, sessionId: String, requestLog: RequestLogContext) {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -695,6 +695,81 @@ import Testing
     #expect(resources?.isEmpty == true)
 }
 
+@Test func httpResourcesListRewritesNonStandardErrorResultToEmptyArrayAfterInit() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config) { method, originalId in
+        #expect(method == "resources/list")
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "result": [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "The message contained an unknown method 'resources/list'",
+                    ],
+                ],
+                "isError": true,
+            ],
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [])
+    }
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    // Initialize to establish a session id.
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = initResponse.head.headers.first(name: "Mcp-Session-Id")
+    #expect(sessionId?.isEmpty == false)
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 456,
+        "method": "resources/list",
+        "params": [String: Any](),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId!)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    #expect(object?["error"] == nil)
+    let result = object?["result"] as? [String: Any]
+    let resources = result?["resources"] as? [Any]
+    #expect(resources?.isEmpty == true)
+}
+
 @Test func httpResourcesListDoesNotMaskNonMethodNotFoundErrorsAfterInit() async throws {
     let config = makeConfig()
     let channel = EmbeddedChannel()

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -839,6 +839,151 @@ import Testing
     #expect(object?["result"] == nil)
 }
 
+@Test func httpResourcesListDoesNotMaskNonMethodNotFoundErrorsWhenNullResultIsPresentAfterInit() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config) { method, originalId in
+        #expect(method == "resources/list")
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "result": NSNull(),
+            "error": [
+                "code": -32000,
+                "message": "permission denied",
+            ],
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [])
+    }
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    // Initialize to establish a session id.
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = initResponse.head.headers.first(name: "Mcp-Session-Id")
+    #expect(sessionId?.isEmpty == false)
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 124,
+        "method": "resources/list",
+        "params": [String: Any](),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId!)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let error = object?["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32000)
+    #expect(object?["result"] is NSNull)
+}
+
+@Test func httpResourcesListDoesNotRewriteNonStandardErrorResultWithoutUnknownMethodAfterInit() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config) { method, originalId in
+        #expect(method == "resources/list")
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "result": [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "permission denied",
+                    ],
+                ],
+                "isError": true,
+            ],
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [])
+    }
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    // Initialize to establish a session id.
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = initResponse.head.headers.first(name: "Mcp-Session-Id")
+    #expect(sessionId?.isEmpty == false)
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 457,
+        "method": "resources/list",
+        "params": [String: Any](),
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId!)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    #expect(object?["error"] == nil)
+    let result = object?["result"] as? [String: Any]
+    #expect((result?["isError"] as? Bool) == true)
+    #expect(result?["resources"] == nil)
+}
+
 private enum HTTPTestError: Error {
     case missingResponseHead
 }


### PR DESCRIPTION
Summary:
- Normalize non-standard `resources/list` and `resources/templates/list` result payloads to MCP-compatible empty list responses in the compatibility shim.
- Extract empty-resources response construction into a shared helper to keep rewrite behavior consistent.
- Add regression coverage for the non-standard `result.isError` shape returned by Xcode MCP.

Testing:
- swift test
- codex review --uncommitted