### PR TITLE
fix: reliability first timeout recovery

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,9 +29,9 @@ swift run -c release xcode-mcp-proxy-install
 
 ```bash
 codex mcp remove xcode
-codex mcp add xcode --url http://localhost:8765/mcp
-# または
 codex mcp add xcode -- xcode-mcp-proxy
+# または
+codex mcp add xcode --url http://localhost:8765/mcp
 ```
 
 ### Claude Code

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Replace `xcrun mcpbridge` with one of the following:
 
 ```bash
 codex mcp remove xcode
-codex mcp add xcode --url http://localhost:8765/mcp
-# or
 codex mcp add xcode -- xcode-mcp-proxy
+# or
+codex mcp add xcode --url http://localhost:8765/mcp
 ```
 
 ### Claude Code

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -471,7 +471,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        let shouldPinUpstream = parsedRequestJSON.map(MCPMethodDispatcher.shouldPinUpstream(for:)) ?? false
+        guard let parsedRequestJSON else {
+            sendMCPError(
+                on: context.channel,
+                id: nil,
+                code: -32700,
+                message: "invalid json",
+                prefersEventStream: prefersEventStream,
+                keepAlive: head.isKeepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
+            return
+        }
+
+        let shouldPinUpstream = MCPMethodDispatcher.shouldPinUpstream(for: parsedRequestJSON)
         guard let upstreamIndex = sessionManager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: shouldPinUpstream) else {
             if requestIDs.isEmpty {
                 sendPlain(
@@ -602,13 +616,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             future.whenComplete { result in
                 switch result {
                 case .success(let buffer):
-                    for responseId in transform.responseIds {
-                        self.sessionManager.onRequestSucceeded(
-                            sessionId: sessionIdCopy,
-                            requestIdKey: responseId.key,
-                            upstreamIndex: upstreamIndex
-                        )
-                    }
                     var buffer = buffer
                     guard let data = buffer.readData(length: buffer.readableBytes) else {
                         self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
@@ -624,6 +631,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                        let resultAny = object["result"],
                        let result = JSONValue(any: resultAny) {
                         self.sessionManager.setCachedToolsListResult(result)
+                    }
+                    if self.shouldNotifyUpstreamSuccess(for: responseData) {
+                        for responseId in transform.responseIds {
+                            self.sessionManager.onRequestSucceeded(
+                                sessionId: sessionIdCopy,
+                                requestIdKey: responseId.key,
+                                upstreamIndex: upstreamIndex
+                            )
+                        }
                     }
                     if prefersEventStream {
                         self.sendSingleSSE(on: channel, data: responseData, keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
@@ -852,6 +868,44 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             buffer.writeBytes(data)
             sendJSON(on: channel, buffer: buffer, keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)
         }
+    }
+
+    private func shouldNotifyUpstreamSuccess(for responseData: Data) -> Bool {
+        guard let any = try? JSONSerialization.jsonObject(with: responseData, options: []) else {
+            return true
+        }
+
+        if let object = any as? [String: Any] {
+            return isUpstreamOverloadedErrorResponse(object) == false
+        }
+
+        if let array = any as? [Any] {
+            let objects = array.compactMap { $0 as? [String: Any] }
+            guard objects.isEmpty == false else {
+                return true
+            }
+            return objects.allSatisfy(isUpstreamOverloadedErrorResponse) == false
+        }
+
+        return true
+    }
+
+    private func isUpstreamOverloadedErrorResponse(_ object: [String: Any]) -> Bool {
+        guard let error = object["error"] as? [String: Any] else {
+            return false
+        }
+
+        let code: Int?
+        if let number = error["code"] as? NSNumber {
+            code = number.intValue
+        } else {
+            code = error["code"] as? Int
+        }
+        guard code == -32002 else {
+            return false
+        }
+
+        return (error["message"] as? String) == "upstream overloaded"
     }
 
     private func sendMCPError(

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -305,11 +305,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 future.whenComplete { result in
                     switch result {
                     case .success(let buffer):
-                        self.sessionManager.onRequestSucceeded(
-                            sessionId: sessionId,
-                            requestIdKey: originalId.key,
-                            upstreamIndex: 0
-                        )
                         var buffer = buffer
                         guard let data = buffer.readData(length: buffer.readableBytes) else {
                             self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -144,7 +144,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        guard acceptsEventStream(head.headers) else {
+        guard HTTPRequestValidator.acceptsEventStream(head.headers) else {
             sendPlain(
                 on: context.channel,
                 status: .notAcceptable,
@@ -156,7 +156,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        guard let sessionId = sessionIdFromHeaders(head.headers) else {
+        guard let sessionId = HTTPRequestValidator.sessionId(from: head.headers) else {
             sendPlain(
                 on: context.channel,
                 status: .unauthorized,
@@ -206,7 +206,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private func handleDelete(context: ChannelHandlerContext, head: HTTPRequestHead, requestLog: RequestLogContext) {
-        guard let sessionId = sessionIdFromHeaders(head.headers) else {
+        guard let sessionId = HTTPRequestValidator.sessionId(from: head.headers) else {
             sendPlain(
                 on: context.channel,
                 status: .unauthorized,
@@ -224,13 +224,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private func handlePost(context: ChannelHandlerContext, head: HTTPRequestHead, requestLog: RequestLogContext) {
-        let wantsEventStream = acceptsEventStream(head.headers)
-        let wantsJSON = acceptsJSON(head.headers)
-        // Prefer JSON when the client accepts both. Some MCP clients advertise
-        // `text/event-stream` but expect JSON for ordinary request/response calls
-        // such as `initialize` and `tools/list`.
-        let prefersEventStream = wantsEventStream && !wantsJSON
-        guard wantsEventStream || wantsJSON else {
+        let prefersEventStream: Bool
+        do {
+            prefersEventStream = try HTTPRequestValidator.postPreference(for: head.headers)
+        } catch HTTPRequestValidationFailure.notAcceptable {
             sendPlain(
                 on: context.channel,
                 status: .notAcceptable,
@@ -240,13 +237,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 requestLog: requestLog
             )
             return
-        }
-
-        guard contentTypeIsJSON(head.headers) else {
+        } catch HTTPRequestValidationFailure.unsupportedMediaType {
             sendPlain(
                 on: context.channel,
                 status: .unsupportedMediaType,
                 body: "content-type must be application/json",
+                keepAlive: head.isKeepAlive,
+                sessionId: nil,
+                requestLog: requestLog
+            )
+            return
+        } catch {
+            sendPlain(
+                on: context.channel,
+                status: .badRequest,
+                body: "invalid request headers",
                 keepAlive: head.isKeepAlive,
                 sessionId: nil,
                 requestLog: requestLog
@@ -269,14 +274,23 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        let headerSessionId = sessionIdFromHeaders(head.headers)
+        let headerSessionId = HTTPRequestValidator.sessionId(from: head.headers)
         let headerSessionExists = headerSessionId.map { sessionManager.hasSession(id: $0) } ?? false
 
         if let object = try? JSONSerialization.jsonObject(with: bodyData, options: []) as? [String: Any],
            let method = object["method"] as? String {
             if method == "initialize" {
                 guard let originalIdValue = object["id"], let originalId = RPCId(any: originalIdValue) else {
-                    sendPlain(on: context.channel, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: nil, requestLog: requestLog)
+                    sendMCPError(
+                        on: context.channel,
+                        id: nil,
+                        code: -32600,
+                        message: "missing id",
+                        prefersEventStream: prefersEventStream,
+                        keepAlive: head.isKeepAlive,
+                        sessionId: headerSessionId ?? UUID().uuidString,
+                        requestLog: requestLog
+                    )
                     return
                 }
                 let sessionId = headerSessionId ?? UUID().uuidString
@@ -291,6 +305,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 future.whenComplete { result in
                     switch result {
                     case .success(let buffer):
+                        self.sessionManager.onRequestSucceeded(
+                            sessionId: sessionId,
+                            requestIdKey: originalId.key,
+                            upstreamIndex: 0
+                        )
                         var buffer = buffer
                         guard let data = buffer.readData(length: buffer.readableBytes) else {
                             self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)
@@ -304,7 +323,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             self.sendJSON(on: channel, buffer: out, keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)
                         }
                     case .failure:
-                        self.sendPlain(on: channel, status: .gatewayTimeout, body: "upstream timeout", keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)
+                        self.sendMCPError(
+                            on: channel,
+                            id: originalId,
+                            code: -32000,
+                            message: "upstream timeout",
+                            prefersEventStream: prefersEventStream,
+                            keepAlive: keepAlive,
+                            sessionId: sessionId,
+                            requestLog: requestLog
+                        )
                     }
                 }
                 return
@@ -317,7 +345,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // empty list response locally so clients don't choke on unsupported-method errors.
             if (method == "resources/list" || method == "resources/templates/list") && sessionManager.isInitialized() == false {
                 guard let originalIdValue = object["id"], let originalId = RPCId(any: originalIdValue) else {
-                    sendPlain(on: context.channel, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: nil, requestLog: requestLog)
+                    sendMCPError(
+                        on: context.channel,
+                        id: nil,
+                        code: -32600,
+                        message: "missing id",
+                        prefersEventStream: prefersEventStream,
+                        keepAlive: head.isKeepAlive,
+                        sessionId: headerSessionId ?? UUID().uuidString,
+                        requestLog: requestLog
+                    )
                     return
                 }
 
@@ -378,7 +415,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     metadata: [
                         "session": .string(headerSessionId),
                         "has_params": .string(hasParams ? "true" : "false"),
-                        "pinned_upstream": .string("\(pinnedUpstreamIndex)"),
+                        "pinned_upstream": .string(pinnedUpstreamIndex.map(String.init) ?? "none"),
                     ]
                 )
                 // Intentionally do not refresh tools/list in the background.
@@ -408,42 +445,63 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         }
 
         let sessionId = headerSessionId ?? UUID().uuidString
+        let requestMetadata = MCPErrorResponder.requestMetadata(from: bodyData)
+        let requestIDs = requestMetadata.ids
+        let requestIsBatch = requestMetadata.isBatch
+        let parsedRequestJSON = try? JSONSerialization.jsonObject(with: bodyData, options: [])
 
         if sessionManager.isInitialized() == false {
-            sendPlain(
-                on: context.channel,
-                status: .unprocessableEntity,
-                body: "expected initialize request",
-                keepAlive: head.isKeepAlive,
-                sessionId: sessionId,
-                requestLog: requestLog
-            )
+            if requestIDs.isEmpty {
+                sendPlain(
+                    on: context.channel,
+                    status: .unprocessableEntity,
+                    body: "expected initialize request",
+                    keepAlive: head.isKeepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            } else {
+                sendMCPError(
+                    on: context.channel,
+                    ids: requestIDs,
+                    code: -32000,
+                    message: "expected initialize request",
+                    forceBatchArray: requestIsBatch,
+                    prefersEventStream: prefersEventStream,
+                    keepAlive: head.isKeepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            }
             return
         }
 
-        let shouldPinUpstream: Bool = {
-            guard let any = try? JSONSerialization.jsonObject(with: bodyData, options: []) else {
-                return false
+        let shouldPinUpstream = parsedRequestJSON.map(MCPMethodDispatcher.shouldPinUpstream(for:)) ?? false
+        guard let upstreamIndex = sessionManager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: shouldPinUpstream) else {
+            if requestIDs.isEmpty {
+                sendPlain(
+                    on: context.channel,
+                    status: .serviceUnavailable,
+                    body: "upstream unavailable",
+                    keepAlive: head.isKeepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            } else {
+                sendMCPError(
+                    on: context.channel,
+                    ids: requestIDs,
+                    code: -32001,
+                    message: "upstream unavailable",
+                    forceBatchArray: requestIsBatch,
+                    prefersEventStream: prefersEventStream,
+                    keepAlive: head.isKeepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
             }
-            if let object = any as? [String: Any] {
-                guard let method = object["method"] as? String, method != "initialize" else {
-                    return false
-                }
-                return object["id"] != nil && !(object["id"] is NSNull)
-            }
-            if let array = any as? [Any] {
-                for item in array {
-                    guard let object = item as? [String: Any] else { continue }
-                    guard let method = object["method"] as? String, method != "initialize" else { continue }
-                    if let id = object["id"], !(id is NSNull) {
-                        return true
-                    }
-                }
-            }
-            return false
-        }()
-
-        let upstreamIndex = sessionManager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: shouldPinUpstream)
+            return
+        }
 
         let transform: RequestTransform
         do {
@@ -459,7 +517,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 }
             )
         } catch {
-            sendPlain(on: context.channel, status: .badRequest, body: "invalid json", keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
+            sendMCPError(
+                on: context.channel,
+                id: nil,
+                code: -32700,
+                message: "invalid json",
+                prefersEventStream: prefersEventStream,
+                keepAlive: head.isKeepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
             return
         }
 
@@ -481,14 +548,28 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         if headerSessionId == nil {
             if transform.isBatch || transform.method != "initialize" || !transform.expectsResponse {
-                sendPlain(
-                    on: context.channel,
-                    status: .unprocessableEntity,
-                    body: "expected initialize request",
-                    keepAlive: head.isKeepAlive,
-                    sessionId: sessionId,
-                    requestLog: requestLog
-                )
+                if transform.responseIds.isEmpty {
+                    sendPlain(
+                        on: context.channel,
+                        status: .unprocessableEntity,
+                        body: "expected initialize request",
+                        keepAlive: head.isKeepAlive,
+                        sessionId: sessionId,
+                        requestLog: requestLog
+                    )
+                } else {
+                    sendMCPError(
+                        on: context.channel,
+                        ids: transform.responseIds,
+                        code: -32000,
+                        message: "expected initialize request",
+                        forceBatchArray: transform.isBatch,
+                        prefersEventStream: prefersEventStream,
+                        keepAlive: head.isKeepAlive,
+                        sessionId: sessionId,
+                        requestLog: requestLog
+                    )
+                }
                 return
             }
         }
@@ -497,12 +578,25 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         if transform.expectsResponse {
             let future: EventLoopFuture<ByteBuffer>
+            let requestTimeout = MCPMethodDispatcher.timeoutForMethod(
+                transform.method,
+                defaultSeconds: config.requestTimeout
+            )
             if transform.isBatch {
-                future = session.router.registerBatch(on: context.eventLoop)
+                future = session.router.registerBatch(on: context.eventLoop, timeout: requestTimeout)
             } else if let idKey = transform.idKey {
-                future = session.router.registerRequest(idKey: idKey, on: context.eventLoop)
+                future = session.router.registerRequest(idKey: idKey, on: context.eventLoop, timeout: requestTimeout)
             } else {
-                sendPlain(on: context.channel, status: .badRequest, body: "missing id", keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
+                sendMCPError(
+                    on: context.channel,
+                    id: nil,
+                    code: -32600,
+                    message: "missing id",
+                    prefersEventStream: prefersEventStream,
+                    keepAlive: head.isKeepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
                 return
             }
 
@@ -513,6 +607,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             future.whenComplete { result in
                 switch result {
                 case .success(let buffer):
+                    for responseId in transform.responseIds {
+                        self.sessionManager.onRequestSucceeded(
+                            sessionId: sessionIdCopy,
+                            requestIdKey: responseId.key,
+                            upstreamIndex: upstreamIndex
+                        )
+                    }
                     var buffer = buffer
                     guard let data = buffer.readData(length: buffer.readableBytes) else {
                         self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
@@ -537,7 +638,31 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         self.sendJSON(on: channel, buffer: out, keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
                     }
                 case .failure:
-                    self.sendPlain(on: channel, status: .gatewayTimeout, body: "upstream timeout", keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
+                    if let firstResponseId = transform.responseIds.first {
+                        self.sessionManager.onRequestTimeout(
+                            sessionId: sessionIdCopy,
+                            requestIdKey: firstResponseId.key,
+                            upstreamIndex: upstreamIndex
+                        )
+                        for responseId in transform.responseIds.dropFirst() {
+                            self.sessionManager.removeUpstreamIdMapping(
+                                sessionId: sessionIdCopy,
+                                requestIdKey: responseId.key,
+                                upstreamIndex: upstreamIndex
+                            )
+                        }
+                    }
+                    self.sendMCPError(
+                        on: channel,
+                        ids: transform.responseIds,
+                        code: -32000,
+                        message: "upstream timeout",
+                        forceBatchArray: transform.isBatch,
+                        prefersEventStream: prefersEventStream,
+                        keepAlive: keepAlive,
+                        sessionId: sessionIdCopy,
+                        requestLog: requestLog
+                    )
                 }
             }
         } else {
@@ -551,7 +676,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private func sendSingleSSE(on channel: Channel, data: Data, keepAlive: Bool, sessionId: String, requestLog: RequestLogContext) {
-        guard let payload = SSECodec.encodeDataEvent(data) else {
+        guard MCPResponseEmitter.sendSingleSSE(
+            on: channel,
+            data: data,
+            keepAlive: keepAlive,
+            sessionId: sessionId
+        ) else {
             sendPlain(
                 on: channel,
                 status: .badGateway,
@@ -562,24 +692,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             )
             return
         }
-
         logResponse(requestLog, status: .ok, sessionId: sessionId)
-        var headers = HTTPHeaders()
-        headers.add(name: "Content-Type", value: "text/event-stream")
-        headers.add(name: "Cache-Control", value: "no-cache")
-        headers.add(name: "Mcp-Session-Id", value: sessionId)
-
-        var head = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
-        head.headers.add(name: "Connection", value: keepAlive ? "keep-alive" : "close")
-        channel.write(HTTPServerResponsePart.head(head), promise: nil)
-
-        var buffer = channel.allocator.buffer(capacity: payload.utf8.count)
-        buffer.writeString(payload)
-        channel.write(HTTPServerResponsePart.body(.byteBuffer(buffer)), promise: nil)
-        channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
-        if !keepAlive {
-            channel.close(promise: nil)
-        }
     }
 
     private func rewriteUnsupportedResourcesListResponseIfNeeded(
@@ -676,10 +789,12 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     private func sendJSON(on channel: Channel, buffer: ByteBuffer, keepAlive: Bool, sessionId: String, requestLog: RequestLogContext) {
         logResponse(requestLog, status: .ok, sessionId: sessionId)
-        var headers = HTTPHeaders()
-        headers.add(name: "Content-Type", value: "application/json")
-        headers.add(name: "Mcp-Session-Id", value: sessionId)
-        Self.sendBuffer(on: channel, status: .ok, headers: headers, buffer: buffer, keepAlive: keepAlive)
+        MCPResponseEmitter.sendJSON(
+            on: channel,
+            buffer: buffer,
+            keepAlive: keepAlive,
+            sessionId: sessionId
+        )
     }
 
     private func sendPlain(
@@ -691,39 +806,92 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         requestLog: RequestLogContext
     ) {
         logResponse(requestLog, status: status, sessionId: sessionId)
-        var headers = HTTPHeaders()
-        headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
-        if let sessionId {
-            headers.add(name: "Mcp-Session-Id", value: sessionId)
-        }
-        var buffer = channel.allocator.buffer(capacity: body.utf8.count)
-        buffer.writeString(body)
-        Self.sendBuffer(on: channel, status: status, headers: headers, buffer: buffer, keepAlive: keepAlive)
+        MCPResponseEmitter.sendPlain(
+            on: channel,
+            status: status,
+            body: body,
+            keepAlive: keepAlive,
+            sessionId: sessionId
+        )
     }
 
     private func sendEmpty(on channel: Channel, status: HTTPResponseStatus, keepAlive: Bool, sessionId: String, requestLog: RequestLogContext) {
         logResponse(requestLog, status: status, sessionId: sessionId)
-        var headers = HTTPHeaders()
-        headers.add(name: "Mcp-Session-Id", value: sessionId)
-        Self.sendBuffer(on: channel, status: status, headers: headers, buffer: nil, keepAlive: keepAlive)
+        MCPResponseEmitter.sendEmpty(
+            on: channel,
+            status: status,
+            keepAlive: keepAlive,
+            sessionId: sessionId
+        )
     }
 
-    private static func sendBuffer(
+    private func sendMCPError(
         on channel: Channel,
-        status: HTTPResponseStatus,
-        headers: HTTPHeaders,
-        buffer: ByteBuffer?,
-        keepAlive: Bool
+        id: RPCId?,
+        code: Int,
+        message: String,
+        prefersEventStream: Bool,
+        keepAlive: Bool,
+        sessionId: String,
+        requestLog: RequestLogContext
     ) {
-        var head = HTTPResponseHead(version: .http1_1, status: status, headers: headers)
-        head.headers.add(name: "Connection", value: keepAlive ? "keep-alive" : "close")
-        channel.write(HTTPServerResponsePart.head(head), promise: nil)
-        if let buffer {
-            channel.write(HTTPServerResponsePart.body(.byteBuffer(buffer)), promise: nil)
+        guard let data = MCPErrorResponder.errorResponseData(
+            id: id,
+            code: code,
+            message: message
+        ) else {
+            sendPlain(
+                on: channel,
+                status: .badGateway,
+                body: "invalid error response",
+                keepAlive: keepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
+            return
         }
-        channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
-        if !keepAlive {
-            channel.close(promise: nil)
+        if prefersEventStream {
+            sendSingleSSE(on: channel, data: data, keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)
+        } else {
+            var buffer = channel.allocator.buffer(capacity: data.count)
+            buffer.writeBytes(data)
+            sendJSON(on: channel, buffer: buffer, keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)
+        }
+    }
+
+    private func sendMCPError(
+        on channel: Channel,
+        ids: [RPCId],
+        code: Int,
+        message: String,
+        forceBatchArray: Bool = false,
+        prefersEventStream: Bool,
+        keepAlive: Bool,
+        sessionId: String,
+        requestLog: RequestLogContext
+    ) {
+        guard let data = MCPErrorResponder.errorResponseData(
+            ids: ids,
+            code: code,
+            message: message,
+            forceBatchArray: forceBatchArray
+        ) else {
+            sendPlain(
+                on: channel,
+                status: .badGateway,
+                body: "invalid error response",
+                keepAlive: keepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
+            return
+        }
+        if prefersEventStream {
+            sendSingleSSE(on: channel, data: data, keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)
+        } else {
+            var buffer = channel.allocator.buffer(capacity: data.count)
+            buffer.writeBytes(data)
+            sendJSON(on: channel, buffer: buffer, keepAlive: keepAlive, sessionId: sessionId, requestLog: requestLog)
         }
     }
 
@@ -738,10 +906,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             buffer.writeString(payload)
             _ = channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buffer)))
         }
-    }
-
-    private func sessionIdFromHeaders(_ headers: HTTPHeaders) -> String? {
-        headers.first(name: "Mcp-Session-Id")
     }
 
     private func logRequest(_ request: RequestLogContext) {
@@ -782,20 +946,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         return String(describing: address)
     }
 
-    private func acceptsEventStream(_ headers: HTTPHeaders) -> Bool {
-        guard let accept = headers.first(name: "Accept")?.lowercased() else { return false }
-        return accept.contains("text/event-stream")
-    }
-
-    private func acceptsJSON(_ headers: HTTPHeaders) -> Bool {
-        guard let accept = headers.first(name: "Accept")?.lowercased() else { return true }
-        return accept.contains("application/json") || accept.contains("*/*")
-    }
-
-    private func contentTypeIsJSON(_ headers: HTTPHeaders) -> Bool {
-        guard let contentType = headers.first(name: "Content-Type")?.lowercased() else { return false }
-        return contentType.hasPrefix("application/json")
-    }
 }
 
 struct RequestInfo {
@@ -809,6 +959,7 @@ struct RequestTransform {
     let expectsResponse: Bool
     let isBatch: Bool
     let idKey: String?
+    let responseIds: [RPCId]
     let method: String?
     let originalId: RPCId?
     let isCacheableToolsListRequest: Bool
@@ -835,6 +986,7 @@ enum RequestInspector {
                     expectsResponse: true,
                     isBatch: false,
                     idKey: rpcId.key,
+                    responseIds: [rpcId],
                     method: method,
                     originalId: rpcId,
                     isCacheableToolsListRequest: isCacheableToolsListRequest
@@ -846,6 +998,7 @@ enum RequestInspector {
                 expectsResponse: false,
                 isBatch: false,
                 idKey: nil,
+                responseIds: [],
                 method: method,
                 originalId: nil,
                 isCacheableToolsListRequest: isCacheableToolsListRequest
@@ -854,13 +1007,14 @@ enum RequestInspector {
 
         if let array = json as? [Any] {
             var transformed: [Any] = []
-            var hasRequest = false
+            var responseIds: [RPCId] = []
+            responseIds.reserveCapacity(array.count)
             for item in array {
                 if var object = item as? [String: Any] {
                     if let id = object["id"], let rpcId = RPCId(any: id) {
                         let upstreamId = mapId(sessionId, rpcId)
                         object["id"] = upstreamId
-                        hasRequest = true
+                        responseIds.append(rpcId)
                     }
                     transformed.append(object)
                 } else {
@@ -870,9 +1024,10 @@ enum RequestInspector {
             let upstream = try JSONSerialization.data(withJSONObject: transformed, options: [])
             return RequestTransform(
                 upstreamData: upstream,
-                expectsResponse: hasRequest,
+                expectsResponse: !responseIds.isEmpty,
                 isBatch: true,
                 idKey: nil,
+                responseIds: responseIds,
                 method: nil,
                 originalId: nil,
                 isCacheableToolsListRequest: false
@@ -884,6 +1039,7 @@ enum RequestInspector {
             expectsResponse: false,
             isBatch: false,
             idKey: nil,
+            responseIds: [],
             method: nil,
             originalId: nil,
             isCacheableToolsListRequest: false

--- a/Sources/XcodeMCPProxy/HTTPRequestValidator.swift
+++ b/Sources/XcodeMCPProxy/HTTPRequestValidator.swift
@@ -1,0 +1,43 @@
+import Foundation
+import NIOHTTP1
+
+enum HTTPRequestValidationFailure: Error {
+    case notAcceptable
+    case unsupportedMediaType
+}
+
+enum HTTPRequestValidator {
+    static func sessionId(from headers: HTTPHeaders) -> String? {
+        headers.first(name: "Mcp-Session-Id")
+    }
+
+    static func acceptsEventStream(_ headers: HTTPHeaders) -> Bool {
+        guard let accept = headers.first(name: "Accept")?.lowercased() else { return false }
+        return accept.contains("text/event-stream")
+    }
+
+    static func acceptsJSON(_ headers: HTTPHeaders) -> Bool {
+        guard let accept = headers.first(name: "Accept")?.lowercased() else { return true }
+        return accept.contains("application/json") || accept.contains("*/*")
+    }
+
+    static func contentTypeIsJSON(_ headers: HTTPHeaders) -> Bool {
+        guard let contentType = headers.first(name: "Content-Type")?.lowercased() else { return false }
+        return contentType.hasPrefix("application/json")
+    }
+
+    static func postPreference(
+        for headers: HTTPHeaders
+    ) throws -> Bool {
+        let wantsEventStream = acceptsEventStream(headers)
+        let wantsJSON = acceptsJSON(headers)
+        guard wantsEventStream || wantsJSON else {
+            throw HTTPRequestValidationFailure.notAcceptable
+        }
+        guard contentTypeIsJSON(headers) else {
+            throw HTTPRequestValidationFailure.unsupportedMediaType
+        }
+        // Prefer JSON when both are acceptable.
+        return wantsEventStream && !wantsJSON
+    }
+}

--- a/Sources/XcodeMCPProxy/MCPErrorResponder.swift
+++ b/Sources/XcodeMCPProxy/MCPErrorResponder.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+enum MCPErrorResponder {
+    static func errorResponseData(
+        id: RPCId?,
+        code: Int,
+        message: String,
+        data: JSONValue? = nil
+    ) -> Data? {
+        let errorObject = makeErrorObject(code: code, message: message, data: data)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id?.value.foundationObject ?? NSNull(),
+            "error": errorObject,
+        ]
+        guard JSONSerialization.isValidJSONObject(response) else {
+            return nil
+        }
+        return try? JSONSerialization.data(withJSONObject: response, options: [])
+    }
+
+    static func errorResponseData(
+        ids: [RPCId],
+        code: Int,
+        message: String,
+        data: JSONValue? = nil,
+        forceBatchArray: Bool = false
+    ) -> Data? {
+        if ids.isEmpty {
+            return errorResponseData(id: nil, code: code, message: message, data: data)
+        }
+        if ids.count == 1, forceBatchArray == false {
+            return errorResponseData(id: ids[0], code: code, message: message, data: data)
+        }
+        let errorObject = makeErrorObject(code: code, message: message, data: data)
+        let responses: [[String: Any]] = ids.map { id in
+            [
+                "jsonrpc": "2.0",
+                "id": id.value.foundationObject,
+                "error": errorObject,
+            ]
+        }
+        guard JSONSerialization.isValidJSONObject(responses) else {
+            return nil
+        }
+        return try? JSONSerialization.data(withJSONObject: responses, options: [])
+    }
+
+    static func requestMetadata(from data: Data) -> (ids: [RPCId], isBatch: Bool) {
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            return ([], false)
+        }
+        if let object = json as? [String: Any] {
+            if let id = object["id"], let rpcId = RPCId(any: id) {
+                return ([rpcId], false)
+            }
+            return ([], false)
+        }
+        if let array = json as? [Any] {
+            let ids: [RPCId] = array.compactMap { item -> RPCId? in
+                guard let object = item as? [String: Any],
+                      let id = object["id"] else {
+                    return nil
+                }
+                return RPCId(any: id)
+            }
+            return (ids, true)
+        }
+        return ([], false)
+    }
+
+    static func requestIDs(from data: Data) -> [RPCId] {
+        requestMetadata(from: data).ids
+    }
+
+    private static func makeErrorObject(
+        code: Int,
+        message: String,
+        data: JSONValue?
+    ) -> [String: Any] {
+        var error: [String: Any] = [
+            "code": code,
+            "message": message,
+        ]
+        if let data {
+            error["data"] = data.foundationObject
+        }
+        return error
+    }
+}

--- a/Sources/XcodeMCPProxy/MCPMethodDispatcher.swift
+++ b/Sources/XcodeMCPProxy/MCPMethodDispatcher.swift
@@ -1,0 +1,57 @@
+import Foundation
+import NIO
+
+enum MCPMethodDispatcher {
+    private static let capped20sMethods: Set<String> = [
+        "tools/list",
+        "resources/list",
+        "resources/templates/list",
+    ]
+
+    static func timeoutForInitialize(defaultSeconds: TimeInterval) -> TimeAmount? {
+        timeout(defaultSeconds: defaultSeconds, capSeconds: 60)
+    }
+
+    static func timeoutForMethod(
+        _ method: String?,
+        defaultSeconds: TimeInterval
+    ) -> TimeAmount? {
+        guard let method else {
+            return makeRequestTimeout(defaultSeconds)
+        }
+        if method == "initialize" {
+            return timeout(defaultSeconds: defaultSeconds, capSeconds: 60)
+        }
+        if capped20sMethods.contains(method) {
+            return timeout(defaultSeconds: defaultSeconds, capSeconds: 20)
+        }
+        return makeRequestTimeout(defaultSeconds)
+    }
+
+    static func shouldPinUpstream(for requestJSON: Any) -> Bool {
+        if let object = requestJSON as? [String: Any] {
+            guard let method = object["method"] as? String, method != "initialize" else {
+                return false
+            }
+            return object["id"] != nil && !(object["id"] is NSNull)
+        }
+        if let array = requestJSON as? [Any] {
+            for item in array {
+                guard let object = item as? [String: Any] else { continue }
+                guard let method = object["method"] as? String, method != "initialize" else { continue }
+                if let id = object["id"], !(id is NSNull) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private static func timeout(
+        defaultSeconds: TimeInterval,
+        capSeconds: TimeInterval
+    ) -> TimeAmount? {
+        guard defaultSeconds > 0 else { return nil }
+        return makeRequestTimeout(min(defaultSeconds, capSeconds))
+    }
+}

--- a/Sources/XcodeMCPProxy/MCPResponseEmitter.swift
+++ b/Sources/XcodeMCPProxy/MCPResponseEmitter.swift
@@ -1,0 +1,93 @@
+import Foundation
+import NIO
+import NIOHTTP1
+
+enum MCPResponseEmitter {
+    static func sendJSON(
+        on channel: Channel,
+        buffer: ByteBuffer,
+        keepAlive: Bool,
+        sessionId: String
+    ) {
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "application/json")
+        headers.add(name: "Mcp-Session-Id", value: sessionId)
+        sendBuffer(on: channel, status: .ok, headers: headers, buffer: buffer, keepAlive: keepAlive)
+    }
+
+    static func sendSingleSSE(
+        on channel: Channel,
+        data: Data,
+        keepAlive: Bool,
+        sessionId: String
+    ) -> Bool {
+        guard let payload = SSECodec.encodeDataEvent(data) else {
+            return false
+        }
+
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "text/event-stream")
+        headers.add(name: "Cache-Control", value: "no-cache")
+        headers.add(name: "Mcp-Session-Id", value: sessionId)
+
+        var head = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
+        head.headers.add(name: "Connection", value: keepAlive ? "keep-alive" : "close")
+        channel.write(HTTPServerResponsePart.head(head), promise: nil)
+
+        var buffer = channel.allocator.buffer(capacity: payload.utf8.count)
+        buffer.writeString(payload)
+        channel.write(HTTPServerResponsePart.body(.byteBuffer(buffer)), promise: nil)
+        channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
+        if !keepAlive {
+            channel.close(promise: nil)
+        }
+        return true
+    }
+
+    static func sendPlain(
+        on channel: Channel,
+        status: HTTPResponseStatus,
+        body: String,
+        keepAlive: Bool,
+        sessionId: String?
+    ) {
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
+        if let sessionId {
+            headers.add(name: "Mcp-Session-Id", value: sessionId)
+        }
+        var buffer = channel.allocator.buffer(capacity: body.utf8.count)
+        buffer.writeString(body)
+        sendBuffer(on: channel, status: status, headers: headers, buffer: buffer, keepAlive: keepAlive)
+    }
+
+    static func sendEmpty(
+        on channel: Channel,
+        status: HTTPResponseStatus,
+        keepAlive: Bool,
+        sessionId: String
+    ) {
+        var headers = HTTPHeaders()
+        headers.add(name: "Mcp-Session-Id", value: sessionId)
+        sendBuffer(on: channel, status: status, headers: headers, buffer: nil, keepAlive: keepAlive)
+    }
+
+    private static func sendBuffer(
+        on channel: Channel,
+        status: HTTPResponseStatus,
+        headers: HTTPHeaders,
+        buffer: ByteBuffer?,
+        keepAlive: Bool
+    ) {
+        var head = HTTPResponseHead(version: .http1_1, status: status, headers: headers)
+        head.headers.add(name: "Connection", value: keepAlive ? "keep-alive" : "close")
+        channel.write(HTTPServerResponsePart.head(head), promise: nil)
+        if let buffer {
+            channel.write(HTTPServerResponsePart.body(.byteBuffer(buffer)), promise: nil)
+        }
+        channel.writeAndFlush(HTTPServerResponsePart.end(nil), promise: nil)
+        if !keepAlive {
+            channel.close(promise: nil)
+        }
+    }
+}

--- a/Sources/XcodeMCPProxy/ProxyRouter.swift
+++ b/Sources/XcodeMCPProxy/ProxyRouter.swift
@@ -51,9 +51,13 @@ final class ProxyRouter: Sendable {
         return promise.futureResult
     }
 
-    func registerBatch(on eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
+    func registerBatch(
+        on eventLoop: EventLoop,
+        timeout: TimeAmount? = nil
+    ) -> EventLoopFuture<ByteBuffer> {
         let promise = eventLoop.makePromise(of: ByteBuffer.self)
-        let timeout = requestTimeout.map { timeout in
+        let effectiveTimeout = timeout ?? requestTimeout
+        let timeout = effectiveTimeout.map { timeout in
             eventLoop.scheduleTask(in: timeout) { [weak self] in
                 guard let self else { return }
                 self.failBatchTimeout()

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -965,19 +965,22 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func completeInitPendingWithError(_ errorObject: [String: Any]) {
-        let result = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?, upstreamId: Int64?)? in
+        let result = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?, upstreamId: Int64?, shouldRetryEagerInit: Bool)? in
             if state.isShuttingDown {
                 return nil
             }
+            let shouldRetryEagerInit = state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure && state.initResult == nil
+            if shouldRetryEagerInit {
+                state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure = false
+            }
             state.initInFlight = false
-            state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure = false
             let timeout = state.initTimeout
             state.initTimeout = nil
             let pending = state.initPending
             state.initPending.removeAll()
             let upstreamId = state.primaryInitUpstreamId
             state.primaryInitUpstreamId = nil
-            return (pending, timeout, upstreamId)
+            return (pending, timeout, upstreamId, shouldRetryEagerInit)
         }
         guard let result else { return }
         result.timeout?.cancel()
@@ -995,6 +998,10 @@ final class SessionManager: Sendable, SessionManaging {
                     item.promise.fail(TimeoutError())
                 }
             }
+        }
+
+        if result.shouldRetryEagerInit, config.eagerInitialize {
+            startEagerInitializePrimary()
         }
     }
 

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -37,8 +37,11 @@ protocol SessionManaging: Sendable {
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer>
-    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int
+    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int?
     func assignUpstreamId(sessionId: String, originalId: RPCId, upstreamIndex: Int) -> Int64
+    func removeUpstreamIdMapping(sessionId: String, requestIdKey: String, upstreamIndex: Int)
+    func onRequestTimeout(sessionId: String, requestIdKey: String, upstreamIndex: Int)
+    func onRequestSucceeded(sessionId: String, requestIdKey: String, upstreamIndex: Int)
     func sendUpstream(_ data: Data, upstreamIndex: Int)
 }
 
@@ -94,7 +97,10 @@ final class SessionManager: Sendable, SessionManaging {
         var initTimeout: Scheduled<Void>?
         var didSendInitialized = false
         var initUpstreamId: Int64?
-        var unhealthyUntilUptimeNs: UInt64?
+        var healthState: UpstreamHealthState = .healthy
+        var consecutiveRequestTimeouts = 0
+        var healthProbeInFlight = false
+        var healthProbeGeneration: UInt64 = 0
         var consecutiveToolsListFailures: Int = 0
         var lastToolsListSuccessUptimeNs: UInt64?
     }
@@ -259,84 +265,122 @@ final class SessionManager: Sendable, SessionManaging {
         }
     }
 
-    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int {
-        // If we already pinned this session to an initialized upstream, always stick to it.
-        // This reduces cross-talk between multiple concurrent clients sharing the same proxy.
+    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int? {
         let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        var probesToStart: [(upstreamIndex: Int, probeGeneration: UInt64)] = []
+        probesToStart.reserveCapacity(2)
+
         var pinned = sessionsState.withLockedValue { state in
             state.sessions[sessionId]?.pinnedUpstreamIndex
         }
         if let pinnedIndex = pinned {
             let isUsable = upstreamState.withLockedValue { state in
                 guard pinnedIndex >= 0, pinnedIndex < state.upstreamStates.count else { return false }
-                if let until = state.upstreamStates[pinnedIndex].unhealthyUntilUptimeNs, until <= nowUptimeNs {
-                    state.upstreamStates[pinnedIndex].unhealthyUntilUptimeNs = nil
+                let health = classifyHealthAndCollectProbeIfNeeded(
+                    upstreamIndex: pinnedIndex,
+                    nowUptimeNs: nowUptimeNs,
+                    state: &state,
+                    probesToStart: &probesToStart
+                )
+                let isHealthyEnough: Bool
+                switch health {
+                case .healthy, .degraded:
+                    isHealthyEnough = true
+                case .quarantined:
+                    isHealthyEnough = false
                 }
-                let upstream = state.upstreamStates[pinnedIndex]
-                return upstream.isInitialized && upstream.unhealthyUntilUptimeNs == nil
+                return isHealthyEnough && state.upstreamStates[pinnedIndex].isInitialized
             }
             if isUsable {
                 return pinnedIndex
             }
 
-            // Upstream is no longer usable; clear the pin so we can re-pick.
             sessionsState.withLockedValue { state in
                 state.sessions[sessionId]?.pinnedUpstreamIndex = nil
             }
             pinned = nil
         }
 
-        let chosen = upstreamState.withLockedValue { state -> (index: Int, isHealthy: Bool) in
+        let chosen = upstreamState.withLockedValue { state -> Int? in
             let count = state.upstreamStates.count
-            guard count > 0 else { return (0, true) }
+            guard count > 0 else { return nil }
 
             let rawStart = state.nextPick % count
             let start = rawStart >= 0 ? rawStart : rawStart + count
             state.nextPick &+= 1
 
-            // Prefer initialized and healthy upstreams.
+            var degradedCandidate: Int?
             for offset in 0..<count {
                 let candidate = (start + offset) % count
-                if !state.upstreamStates[candidate].isInitialized {
+                guard state.upstreamStates[candidate].isInitialized else { continue }
+                let health = classifyHealthAndCollectProbeIfNeeded(
+                    upstreamIndex: candidate,
+                    nowUptimeNs: nowUptimeNs,
+                    state: &state,
+                    probesToStart: &probesToStart
+                )
+                switch health {
+                case .healthy:
+                    return candidate
+                case .degraded:
+                    if degradedCandidate == nil {
+                        degradedCandidate = candidate
+                    }
+                case .quarantined:
                     continue
                 }
-                if let until = state.upstreamStates[candidate].unhealthyUntilUptimeNs, until <= nowUptimeNs {
-                    state.upstreamStates[candidate].unhealthyUntilUptimeNs = nil
-                }
-                if state.upstreamStates[candidate].unhealthyUntilUptimeNs == nil {
-                    return (candidate, true)
-                }
             }
-
-            // Fall back to any initialized upstream, even if temporarily unhealthy.
-            for offset in 0..<count {
-                let candidate = (start + offset) % count
-                if !state.upstreamStates[candidate].isInitialized {
-                    continue
-                }
-                if let until = state.upstreamStates[candidate].unhealthyUntilUptimeNs, until <= nowUptimeNs {
-                    state.upstreamStates[candidate].unhealthyUntilUptimeNs = nil
-                }
-                let healthy = state.upstreamStates[candidate].unhealthyUntilUptimeNs == nil
-                return (candidate, healthy)
-            }
-
-            return (0, true)
+            return degradedCandidate
         }
 
-        // Only persist the pin when asked. We typically pin on the first non-initialize JSON-RPC request
-        // (method + id), not on notifications.
-        //
-        // Even if the chosen upstream is temporarily marked unhealthy (for example, after a best-effort
-        // tools/list warmup failure), pinning still improves session affinity for unmapped upstream
-        // messages and avoids broadcasting server-initiated traffic to unrelated unpinned sessions.
+        for probe in probesToStart {
+            probeUpstreamHealth(
+                upstreamIndex: probe.upstreamIndex,
+                probeGeneration: probe.probeGeneration
+            )
+        }
+
+        guard let chosen else {
+            return nil
+        }
+
         if pinned == nil, shouldPin {
             sessionsState.withLockedValue { state in
-                state.sessions[sessionId]?.pinnedUpstreamIndex = chosen.index
+                state.sessions[sessionId]?.pinnedUpstreamIndex = chosen
             }
         }
+        return chosen
+    }
 
-        return chosen.index
+    private func classifyHealthAndCollectProbeIfNeeded(
+        upstreamIndex: Int,
+        nowUptimeNs: UInt64,
+        state: inout UpstreamPoolState,
+        probesToStart: inout [(upstreamIndex: Int, probeGeneration: UInt64)]
+    ) -> UpstreamHealthState {
+        guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else {
+            return .quarantined(untilUptimeNs: nowUptimeNs)
+        }
+        let current = state.upstreamStates[upstreamIndex].healthState
+        switch current {
+        case .healthy:
+            return .healthy
+        case .degraded:
+            return .degraded
+        case .quarantined(let untilUptimeNs):
+            if nowUptimeNs < untilUptimeNs {
+                return .quarantined(untilUptimeNs: untilUptimeNs)
+            }
+            if state.upstreamStates[upstreamIndex].healthProbeInFlight == false {
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = true
+                state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
+                probesToStart.append((
+                    upstreamIndex: upstreamIndex,
+                    probeGeneration: state.upstreamStates[upstreamIndex].healthProbeGeneration
+                ))
+            }
+            return .quarantined(untilUptimeNs: untilUptimeNs)
+        }
     }
 
     func registerInitialize(
@@ -579,13 +623,91 @@ final class SessionManager: Sendable, SessionManaging {
         idMapper.assign(upstreamIndex: upstreamIndex, sessionId: sessionId, originalId: originalId, isInitialize: false)
     }
 
+    func removeUpstreamIdMapping(sessionId: String, requestIdKey: String, upstreamIndex: Int) {
+        _ = idMapper.remove(
+            upstreamIndex: upstreamIndex,
+            sessionId: sessionId,
+            requestIdKey: requestIdKey
+        )
+    }
+
+    func onRequestTimeout(sessionId: String, requestIdKey: String, upstreamIndex: Int) {
+        removeUpstreamIdMapping(sessionId: sessionId, requestIdKey: requestIdKey, upstreamIndex: upstreamIndex)
+        markRequestTimedOut(upstreamIndex: upstreamIndex)
+    }
+
+    func onRequestSucceeded(sessionId: String, requestIdKey: String, upstreamIndex: Int) {
+        _ = sessionId
+        _ = requestIdKey
+        markRequestSucceeded(upstreamIndex: upstreamIndex)
+    }
+
     func sendUpstream(_ data: Data, upstreamIndex: Int) {
         guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
             return
         }
         Task {
-            await upstreams[upstreamIndex].send(data)
+            let result = await upstreams[upstreamIndex].send(data)
+            if result == .accepted {
+                return
+            }
+            self.handleOverloadedUpstreamSend(
+                originalRequestData: data,
+                upstreamIndex: upstreamIndex
+            )
         }
+    }
+
+    private func handleOverloadedUpstreamSend(
+        originalRequestData: Data,
+        upstreamIndex: Int
+    ) {
+        guard let any = try? JSONSerialization.jsonObject(with: originalRequestData, options: []) else {
+            return
+        }
+
+        let overloadError: [String: Any] = [
+            "code": -32002,
+            "message": "upstream overloaded",
+        ]
+
+        let responseAny: Any? = {
+            if let object = any as? [String: Any] {
+                guard let id = object["id"], !(id is NSNull) else { return nil }
+                return [
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": overloadError,
+                ]
+            }
+            if let array = any as? [Any] {
+                let objects = array.compactMap { item -> [String: Any]? in
+                    guard let object = item as? [String: Any],
+                          let id = object["id"],
+                          !(id is NSNull) else {
+                        return nil
+                    }
+                    return [
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "error": overloadError,
+                    ]
+                }
+                if objects.isEmpty {
+                    return nil
+                }
+                return objects
+            }
+            return nil
+        }()
+
+        guard let responseAny,
+              JSONSerialization.isValidJSONObject(responseAny),
+              let data = try? JSONSerialization.data(withJSONObject: responseAny, options: []) else {
+            return
+        }
+
+        routeUpstreamMessage(data, upstreamIndex: upstreamIndex)
     }
 
     private func upstreamId(from value: Any?) -> Int64? {
@@ -750,7 +872,11 @@ final class SessionManager: Sendable, SessionManaging {
     private func handleInitializeResponse(_ object: [String: Any], upstreamIndex: Int) {
         guard let resultValue = object["result"], let result = JSONValue(any: resultValue) else {
             if upstreamIndex == 0 {
-                failInitPending(error: TimeoutError())
+                if let errorObject = object["error"] as? [String: Any], !errorObject.isEmpty {
+                    completeInitPendingWithError(errorObject)
+                } else {
+                    failInitPending(error: TimeoutError())
+                }
             } else {
                 clearUpstreamState(upstreamIndex: upstreamIndex)
             }
@@ -822,6 +948,55 @@ final class SessionManager: Sendable, SessionManaging {
         return buffer
     }
 
+    private func encodeInitializeErrorResponse(originalId: RPCId, errorObject: [String: Any]) -> ByteBuffer? {
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "error": errorObject,
+        ]
+        guard JSONSerialization.isValidJSONObject(response),
+              let data = try? JSONSerialization.data(withJSONObject: response, options: []) else {
+            return nil
+        }
+        var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+        buffer.writeBytes(data)
+        return buffer
+    }
+
+    private func completeInitPendingWithError(_ errorObject: [String: Any]) {
+        let result = initState.withLockedValue { state -> (pending: [InitPending], timeout: Scheduled<Void>?, upstreamId: Int64?)? in
+            if state.isShuttingDown {
+                return nil
+            }
+            state.initInFlight = false
+            state.shouldRetryEagerInitializePrimaryAfterWarmInitFailure = false
+            let timeout = state.initTimeout
+            state.initTimeout = nil
+            let pending = state.initPending
+            state.initPending.removeAll()
+            let upstreamId = state.primaryInitUpstreamId
+            state.primaryInitUpstreamId = nil
+            return (pending, timeout, upstreamId)
+        }
+        guard let result else { return }
+        result.timeout?.cancel()
+        if let upstreamId = result.upstreamId {
+            idMapper.remove(upstreamIndex: 0, upstreamId: upstreamId)
+        }
+        clearUpstreamInitInFlight(upstreamIndex: 0)
+        for item in result.pending {
+            if let buffer = encodeInitializeErrorResponse(originalId: item.originalId, errorObject: errorObject) {
+                item.eventLoop.execute {
+                    item.promise.succeed(buffer)
+                }
+            } else {
+                item.eventLoop.execute {
+                    item.promise.fail(TimeoutError())
+                }
+            }
+        }
+    }
+
     private func sendInitializedNotificationIfNeeded(upstreamIndex: Int) {
         let shouldSend = upstreamState.withLockedValue { state -> Bool in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return false }
@@ -843,7 +1018,7 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func scheduleInitTimeout() {
-        guard let timeoutAmount = makeRequestTimeout(config.requestTimeout) else {
+        guard let timeoutAmount = MCPMethodDispatcher.timeoutForInitialize(defaultSeconds: config.requestTimeout) else {
             return
         }
         let timeout = eventLoop.scheduleTask(in: timeoutAmount) { [weak self] in
@@ -920,7 +1095,10 @@ final class SessionManager: Sendable, SessionManaging {
             state.upstreamStates[upstreamIndex].initInFlight = false
             state.upstreamStates[upstreamIndex].didSendInitialized = false
             state.upstreamStates[upstreamIndex].initUpstreamId = nil
-            state.upstreamStates[upstreamIndex].unhealthyUntilUptimeNs = nil
+            state.upstreamStates[upstreamIndex].healthState = .healthy
+            state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
+            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
             state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
             state.upstreamStates[upstreamIndex].lastToolsListSuccessUptimeNs = nil
             return timeout
@@ -934,6 +1112,9 @@ final class SessionManager: Sendable, SessionManaging {
             state.upstreamStates[upstreamIndex].isInitialized = true
             state.upstreamStates[upstreamIndex].initInFlight = false
             state.upstreamStates[upstreamIndex].initUpstreamId = nil
+            state.upstreamStates[upstreamIndex].healthState = .healthy
+            state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
+            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
             let timeout = state.upstreamStates[upstreamIndex].initTimeout
             state.upstreamStates[upstreamIndex].initTimeout = nil
             return timeout
@@ -983,10 +1164,152 @@ final class SessionManager: Sendable, SessionManaging {
         }
     }
 
+    private func markRequestSucceeded(upstreamIndex: Int) {
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            state.upstreamStates[upstreamIndex].healthState = .healthy
+            state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
+            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+        }
+    }
+
+    private func markRequestTimedOut(upstreamIndex: Int) {
+        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        var shouldClearPins = false
+        var timeoutCount = 0
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts += 1
+            timeoutCount = state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts
+            if timeoutCount >= 3 {
+                let quarantineUntil = nowUptimeNs &+ 15_000_000_000
+                state.upstreamStates[upstreamIndex].healthState = .quarantined(untilUptimeNs: quarantineUntil)
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                shouldClearPins = true
+            } else {
+                state.upstreamStates[upstreamIndex].healthState = .degraded
+            }
+        }
+
+        if shouldClearPins {
+            let cleared = clearPinnedSessions(forUpstreamIndex: upstreamIndex)
+            logger.warning(
+                "Upstream quarantined after repeated request timeouts",
+                metadata: [
+                    "upstream": .string("\(upstreamIndex)"),
+                    "timeout_count": .string("\(timeoutCount)"),
+                    "cleared_pins": .string("\(cleared)"),
+                ]
+            )
+        }
+    }
+
+    private func probeUpstreamHealth(upstreamIndex: Int, probeGeneration: UInt64) {
+        let internalSessionId = toolsListInternalSessionId()
+        _ = session(id: internalSessionId)
+        let probeSession = session(id: internalSessionId)
+        let probeTimeout: TimeAmount = .seconds(2)
+        let originalId = RPCId(any: "__probe-\(upstreamIndex)-\(UUID().uuidString)")!
+        let future = probeSession.router.registerRequest(
+            idKey: originalId.key,
+            on: eventLoop,
+            timeout: probeTimeout
+        )
+        let upstreamId = assignUpstreamId(
+            sessionId: internalSessionId,
+            originalId: originalId,
+            upstreamIndex: upstreamIndex
+        )
+
+        let request: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": upstreamId,
+            "method": "tools/list",
+        ]
+        guard JSONSerialization.isValidJSONObject(request),
+              let requestData = try? JSONSerialization.data(withJSONObject: request, options: []) else {
+            finishHealthProbe(
+                upstreamIndex: upstreamIndex,
+                probeGeneration: probeGeneration,
+                success: false,
+                reason: "encode_request_failed"
+            )
+            return
+        }
+
+        sendUpstream(requestData, upstreamIndex: upstreamIndex)
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                var buffer = try await future.get()
+                guard let responseData = buffer.readData(length: buffer.readableBytes),
+                      let object = try JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any],
+                      object["error"] == nil,
+                      object["result"] != nil else {
+                    self.idMapper.remove(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
+                    self.finishHealthProbe(
+                        upstreamIndex: upstreamIndex,
+                        probeGeneration: probeGeneration,
+                        success: false,
+                        reason: "invalid_response"
+                    )
+                    return
+                }
+                self.finishHealthProbe(
+                    upstreamIndex: upstreamIndex,
+                    probeGeneration: probeGeneration,
+                    success: true,
+                    reason: "ok"
+                )
+            } catch {
+                self.idMapper.remove(upstreamIndex: upstreamIndex, upstreamId: upstreamId)
+                self.finishHealthProbe(
+                    upstreamIndex: upstreamIndex,
+                    probeGeneration: probeGeneration,
+                    success: false,
+                    reason: "timeout"
+                )
+            }
+        }
+    }
+
+    private func finishHealthProbe(
+        upstreamIndex: Int,
+        probeGeneration: UInt64,
+        success: Bool,
+        reason: String
+    ) {
+        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            guard state.upstreamStates[upstreamIndex].healthProbeGeneration == probeGeneration else { return }
+            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            if success {
+                state.upstreamStates[upstreamIndex].healthState = .healthy
+                state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
+            } else {
+                state.upstreamStates[upstreamIndex].healthState = .quarantined(
+                    untilUptimeNs: nowUptimeNs &+ 15_000_000_000
+                )
+            }
+        }
+        logger.debug(
+            "Upstream health probe completed",
+            metadata: [
+                "upstream": .string("\(upstreamIndex)"),
+                "success": .string(success ? "true" : "false"),
+                "reason": .string(reason),
+            ]
+        )
+    }
+
     private func markToolsListRefreshSucceeded(upstreamIndex: Int, nowUptimeNs: UInt64) {
         upstreamState.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
-            state.upstreamStates[upstreamIndex].unhealthyUntilUptimeNs = nil
+            state.upstreamStates[upstreamIndex].healthState = .healthy
+            state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
+            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
             state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
             state.upstreamStates[upstreamIndex].lastToolsListSuccessUptimeNs = nowUptimeNs
         }
@@ -999,7 +1322,8 @@ final class SessionManager: Sendable, SessionManaging {
         var failures = 0
         upstreamState.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
-            state.upstreamStates[upstreamIndex].unhealthyUntilUptimeNs = quarantineUntil
+            state.upstreamStates[upstreamIndex].healthState = .quarantined(untilUptimeNs: quarantineUntil)
+            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
             state.upstreamStates[upstreamIndex].consecutiveToolsListFailures += 1
             failures = state.upstreamStates[upstreamIndex].consecutiveToolsListFailures
         }
@@ -1031,9 +1355,10 @@ final class SessionManager: Sendable, SessionManaging {
         let internalSessionId = toolsListInternalSessionId()
         _ = session(id: internalSessionId)
 
-        let upstreamIndex = chooseUpstreamIndex(sessionId: internalSessionId, shouldPin: false)
-        guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
-            logger.debug("tools/list refresh: invalid upstream index", metadata: ["upstream": .string("\(upstreamIndex)")])
+        guard let upstreamIndex = chooseUpstreamIndex(sessionId: internalSessionId, shouldPin: false),
+              upstreamIndex >= 0,
+              upstreamIndex < upstreams.count else {
+            logger.debug("tools/list refresh: no available upstream")
             return
         }
 
@@ -1135,7 +1460,7 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func scheduleUpstreamInitTimeout(upstreamIndex: Int, upstreamId: Int64) {
-        guard let timeoutAmount = makeRequestTimeout(config.requestTimeout) else {
+        guard let timeoutAmount = MCPMethodDispatcher.timeoutForInitialize(defaultSeconds: config.requestTimeout) else {
             return
         }
         let timeout = eventLoop.scheduleTask(in: timeoutAmount) { [weak self] in
@@ -1194,7 +1519,7 @@ final class SessionManager: Sendable, SessionManaging {
     }
 }
 
-private func makeRequestTimeout(_ seconds: TimeInterval) -> TimeAmount? {
+func makeRequestTimeout(_ seconds: TimeInterval) -> TimeAmount? {
     guard seconds > 0 else { return nil }
     let nanos = max(1, Int64(seconds * 1_000_000_000))
     return .nanoseconds(nanos)
@@ -1216,7 +1541,16 @@ private extension SessionManager {
             args: config.upstreamArgs,
             environment: environment,
             restartInitialDelay: 1,
-            restartMaxDelay: 30
+            restartMaxDelay: 30,
+            maxQueuedWriteBytes: {
+                let minimum = 1_048_576
+                guard config.maxBodyBytes > 0 else { return minimum }
+                let multiplied = config.maxBodyBytes.multipliedReportingOverflow(by: 4)
+                if multiplied.overflow {
+                    return Int.max
+                }
+                return max(minimum, multiplied.partialValue)
+            }()
         )
         if count <= 1 {
             return [UpstreamProcess(config: upstreamConfig)]
@@ -1231,9 +1565,15 @@ private extension SessionManager {
 }
 
 private final class UpstreamIdMapper: Sendable {
+    private struct RequestLookupKey: Hashable, Sendable {
+        let sessionId: String
+        let requestIdKey: String
+    }
+
     private struct State: Sendable {
         var nextId: Int64 = 1
         var mappingsByUpstream: [[Int64: UpstreamMapping]] = []
+        var upstreamIdByRequestKeyByUpstream: [[RequestLookupKey: Int64]] = []
     }
 
     private let state = NIOLockedValueBox(State())
@@ -1241,6 +1581,7 @@ private final class UpstreamIdMapper: Sendable {
     init(upstreamCount: Int) {
         state.withLockedValue { state in
             state.mappingsByUpstream = Array(repeating: [:], count: upstreamCount)
+            state.upstreamIdByRequestKeyByUpstream = Array(repeating: [:], count: upstreamCount)
         }
     }
 
@@ -1254,6 +1595,10 @@ private final class UpstreamIdMapper: Sendable {
                 originalId: originalId,
                 isInitialize: isInitialize
             )
+            if isInitialize == false {
+                let requestKey = Self.requestLookupKey(sessionId: sessionId, requestIdKey: originalId.key)
+                state.upstreamIdByRequestKeyByUpstream[upstreamIndex][requestKey] = id
+            }
             return id
         }
     }
@@ -1275,14 +1620,43 @@ private final class UpstreamIdMapper: Sendable {
     func consume(upstreamIndex: Int, upstreamId: Int64) -> UpstreamMapping? {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return nil }
-            return state.mappingsByUpstream[upstreamIndex].removeValue(forKey: upstreamId)
+            let mapping = state.mappingsByUpstream[upstreamIndex].removeValue(forKey: upstreamId)
+            if let mapping,
+               let sessionId = mapping.sessionId,
+               let originalId = mapping.originalId {
+                let requestKey = Self.requestLookupKey(sessionId: sessionId, requestIdKey: originalId.key)
+                state.upstreamIdByRequestKeyByUpstream[upstreamIndex].removeValue(forKey: requestKey)
+            }
+            return mapping
         }
     }
 
     func remove(upstreamIndex: Int, upstreamId: Int64) {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return }
+            let mapping = state.mappingsByUpstream[upstreamIndex].removeValue(forKey: upstreamId)
+            if let mapping,
+               let sessionId = mapping.sessionId,
+               let originalId = mapping.originalId {
+                let requestKey = Self.requestLookupKey(sessionId: sessionId, requestIdKey: originalId.key)
+                state.upstreamIdByRequestKeyByUpstream[upstreamIndex].removeValue(forKey: requestKey)
+            }
+        }
+    }
+
+    func remove(
+        upstreamIndex: Int,
+        sessionId: String,
+        requestIdKey: String
+    ) -> Int64? {
+        state.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return nil }
+            let requestKey = Self.requestLookupKey(sessionId: sessionId, requestIdKey: requestIdKey)
+            guard let upstreamId = state.upstreamIdByRequestKeyByUpstream[upstreamIndex].removeValue(forKey: requestKey) else {
+                return nil
+            }
             state.mappingsByUpstream[upstreamIndex].removeValue(forKey: upstreamId)
+            return upstreamId
         }
     }
 
@@ -1290,7 +1664,12 @@ private final class UpstreamIdMapper: Sendable {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else { return }
             state.mappingsByUpstream[upstreamIndex].removeAll()
+            state.upstreamIdByRequestKeyByUpstream[upstreamIndex].removeAll()
         }
+    }
+
+    private static func requestLookupKey(sessionId: String, requestIdKey: String) -> RequestLookupKey {
+        RequestLookupKey(sessionId: sessionId, requestIdKey: requestIdKey)
     }
 }
 

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -651,6 +651,7 @@ final class SessionManager: Sendable, SessionManaging {
             if result == .accepted {
                 return
             }
+            self.markUpstreamOverloaded(upstreamIndex: upstreamIndex)
             self.handleOverloadedUpstreamSend(
                 originalRequestData: data,
                 upstreamIndex: upstreamIndex
@@ -1169,7 +1170,44 @@ final class SessionManager: Sendable, SessionManaging {
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
             state.upstreamStates[upstreamIndex].healthState = .healthy
             state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
-            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            if state.upstreamStates[upstreamIndex].healthProbeInFlight {
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                // Invalidate stale probe completions that started before this request-success transition.
+                state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
+            } else {
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            }
+        }
+    }
+
+    private func markUpstreamOverloaded(upstreamIndex: Int) {
+        var shouldClearPins = false
+        upstreamState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+
+            if case .healthy = state.upstreamStates[upstreamIndex].healthState {
+                state.upstreamStates[upstreamIndex].healthState = .degraded
+            }
+
+            if state.upstreamStates[upstreamIndex].healthProbeInFlight {
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
+            } else {
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            }
+            shouldClearPins = true
+        }
+
+        guard shouldClearPins else { return }
+        let cleared = clearPinnedSessions(forUpstreamIndex: upstreamIndex)
+        if cleared > 0 {
+            logger.warning(
+                "Upstream overloaded; cleared pinned sessions for failover",
+                metadata: [
+                    "upstream": .string("\(upstreamIndex)"),
+                    "cleared_pins": .string("\(cleared)"),
+                ]
+            )
         }
     }
 

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -1185,6 +1185,8 @@ final class SessionManager: Sendable, SessionManaging {
                 let quarantineUntil = nowUptimeNs &+ 15_000_000_000
                 state.upstreamStates[upstreamIndex].healthState = .quarantined(untilUptimeNs: quarantineUntil)
                 state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                // Invalidate any in-flight probe completion that started before this newer timeout-based quarantine.
+                state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
                 shouldClearPins = true
             } else {
                 state.upstreamStates[upstreamIndex].healthState = .degraded

--- a/Sources/XcodeMCPProxy/UpstreamClient.swift
+++ b/Sources/XcodeMCPProxy/UpstreamClient.swift
@@ -5,9 +5,14 @@ enum UpstreamEvent: Sendable {
     case exit(Int32)
 }
 
+enum UpstreamSendResult: Sendable {
+    case accepted
+    case overloaded
+}
+
 protocol UpstreamClient: Sendable {
     var events: AsyncStream<UpstreamEvent> { get }
     func start() async
     func stop() async
-    func send(_ data: Data) async
+    func send(_ data: Data) async -> UpstreamSendResult
 }

--- a/Sources/XcodeMCPProxy/UpstreamHealthState.swift
+++ b/Sources/XcodeMCPProxy/UpstreamHealthState.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum UpstreamHealthState: Sendable {
+    case healthy
+    case degraded
+    case quarantined(untilUptimeNs: UInt64)
+}

--- a/Sources/XcodeMCPProxy/UpstreamProcess.swift
+++ b/Sources/XcodeMCPProxy/UpstreamProcess.swift
@@ -8,6 +8,7 @@ actor UpstreamProcess: UpstreamClient {
         var environment: [String: String]
         var restartInitialDelay: TimeInterval
         var restartMaxDelay: TimeInterval
+        var maxQueuedWriteBytes: Int
     }
 
     typealias Event = UpstreamEvent
@@ -25,6 +26,9 @@ actor UpstreamProcess: UpstreamClient {
     private var framer = StdioFramer()
     private var isStopping = false
     private var restartTask: Task<Void, Never>?
+    private var queuedWriteBytes = 0
+    private var writeGeneration: UInt64 = 0
+    private let writeQueue = DispatchQueue(label: "XcodeMCPProxy.UpstreamProcess.write")
     private let logger: Logger = ProxyLogging.make("upstream")
 
     init(config: Config) {
@@ -68,7 +72,7 @@ actor UpstreamProcess: UpstreamClient {
         // The termination handler will emit an .exit event and schedule a restart.
     }
 
-    func send(_ data: Data) async {
+    func send(_ data: Data) async -> UpstreamSendResult {
         if process == nil {
             startLocked()
         }
@@ -76,7 +80,39 @@ actor UpstreamProcess: UpstreamClient {
         if payload.last != 0x0A {
             payload.append(0x0A)
         }
-        stdinPipe.fileHandleForWriting.write(payload)
+        if queuedWriteBytes + payload.count > config.maxQueuedWriteBytes {
+            logger.warning(
+                "Upstream write queue overloaded",
+                metadata: [
+                    "queued_bytes": "\(queuedWriteBytes)",
+                    "payload_bytes": "\(payload.count)",
+                    "limit_bytes": "\(config.maxQueuedWriteBytes)",
+                ]
+            )
+            return .overloaded
+        }
+
+        let queuedPayload = payload
+        let queuedPayloadBytes = queuedPayload.count
+        queuedWriteBytes += queuedPayloadBytes
+        let handle = stdinPipe.fileHandleForWriting
+        let generation = writeGeneration
+        writeQueue.async { [weak self] in
+            var writeError: Error?
+            do {
+                try handle.write(contentsOf: queuedPayload)
+            } catch {
+                writeError = error
+            }
+            Task { [weak self] in
+                await self?.completeQueuedWrite(
+                    bytes: queuedPayloadBytes,
+                    generation: generation,
+                    error: writeError
+                )
+            }
+        }
+        return .accepted
     }
 
     private func startLocked() {
@@ -86,6 +122,8 @@ actor UpstreamProcess: UpstreamClient {
         stdoutPipe = Pipe()
         stderrPipe = Pipe()
         framer = StdioFramer()
+        queuedWriteBytes = 0
+        writeGeneration &+= 1
 
         let (executableURL, args) = resolveCommand(command: config.command, args: config.args)
         let process = Process()
@@ -135,6 +173,8 @@ actor UpstreamProcess: UpstreamClient {
     private func stopLocked() {
         stdoutPipe.fileHandleForReading.readabilityHandler = nil
         stderrPipe.fileHandleForReading.readabilityHandler = nil
+        queuedWriteBytes = 0
+        writeGeneration &+= 1
         if let process = process {
             terminatingProcess = process
             process.terminate()
@@ -235,5 +275,17 @@ actor UpstreamProcess: UpstreamClient {
         }
         let env = "/usr/bin/env"
         return (URL(fileURLWithPath: env), [command] + args)
+    }
+
+    private func completeQueuedWrite(
+        bytes: Int,
+        generation: UInt64,
+        error: Error?
+    ) {
+        if generation == writeGeneration {
+            queuedWriteBytes = max(0, queuedWriteBytes - bytes)
+        }
+        guard let error else { return }
+        logger.warning("Upstream async write failed", metadata: ["error": "\(error)"])
     }
 }

--- a/Tests/XcodeMCPProxyTests/HTTPConcurrencyTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPConcurrencyTests.swift
@@ -201,9 +201,9 @@ private actor EchoUpstreamClient: UpstreamClient {
         continuation.finish()
     }
 
-    func send(_ data: Data) async {
+    func send(_ data: Data) async -> UpstreamSendResult {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
-            return
+            return .accepted
         }
         var responses: [Data] = []
         if let object = json as? [String: Any] {
@@ -222,6 +222,7 @@ private actor EchoUpstreamClient: UpstreamClient {
         for response in responses {
             continuation.yield(.message(response))
         }
+        return .accepted
     }
 
     private func makeResponse(from object: [String: Any]) -> Data? {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -479,6 +479,118 @@ import Testing
     #expect((error?["message"] as? String) == "upstream unavailable")
 }
 
+@Test func httpMalformedJSONReturnsParseErrorBeforeUpstreamUnavailable() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
+
+    sessionManager.setAvailableUpstreamIndex(nil)
+    let chooseCountBeforeMalformedRequest = sessionManager.chooseUpstreamIndexCallCount()
+
+    var malformedHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    malformedHead.headers.add(name: "Accept", value: "application/json")
+    malformedHead.headers.add(name: "Content-Type", value: "application/json")
+    malformedHead.headers.add(name: "Mcp-Session-Id", value: sessionId)
+    var malformedBody = channel.allocator.buffer(capacity: 20)
+    malformedBody.writeString("{\"jsonrpc\":\"2.0\",")
+    try channel.writeInbound(HTTPServerRequestPart.head(malformedHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(malformedBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let error = object?["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32700)
+    #expect((error?["message"] as? String) == "invalid json")
+    #expect(sessionManager.chooseUpstreamIndexCallCount() == chooseCountBeforeMalformedRequest)
+}
+
+@Test func httpOverloadedErrorResponseDoesNotMarkRequestSuccess() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config) { method, originalId in
+        #expect(method == "tools/list")
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": originalId.value.foundationObject,
+            "error": [
+                "code": -32002,
+                "message": "upstream overloaded",
+            ],
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [])
+    }
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 3101,
+        "method": "tools/list",
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let error = object?["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32002)
+    #expect((error?["message"] as? String) == "upstream overloaded")
+    #expect(sessionManager.requestSuccessNotificationCount() == 0)
+}
+
 @Test func httpSessionHeaderAutoCreatesSession() async throws {
     let config = makeConfig()
     let channel = EmbeddedChannel()

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -136,6 +136,7 @@ import Testing
     let responseObject = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
     let responseId = (responseObject?["id"] as? NSNumber)?.intValue
     #expect(responseId == 1)
+    #expect(sessionManager.requestSuccessNotificationCount() == 0)
 }
 
 @Test func httpInitializePrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {
@@ -1281,6 +1282,7 @@ private final class TestSessionManager: SessionManaging {
         var chooseUpstreamCalls: [ChooseUpstreamCall] = []
         var availableUpstreamIndex: Int? = 0
         var requestTimeoutNotifications = 0
+        var requestSuccessNotifications = 0
     }
 
     private let state = NIOLockedValueBox(State())
@@ -1401,7 +1403,11 @@ private final class TestSessionManager: SessionManaging {
         removeUpstreamIdMapping(sessionId: sessionId, requestIdKey: requestIdKey, upstreamIndex: upstreamIndex)
     }
 
-    func onRequestSucceeded(sessionId _: String, requestIdKey _: String, upstreamIndex _: Int) {}
+    func onRequestSucceeded(sessionId _: String, requestIdKey _: String, upstreamIndex _: Int) {
+        state.withLockedValue { state in
+            state.requestSuccessNotifications += 1
+        }
+    }
 
     func sendUpstream(_ data: Data, upstreamIndex _: Int) {
         state.withLockedValue { state in
@@ -1455,6 +1461,10 @@ private final class TestSessionManager: SessionManaging {
 
     func requestTimeoutNotificationCount() -> Int {
         state.withLockedValue { $0.requestTimeoutNotifications }
+    }
+
+    func requestSuccessNotificationCount() -> Int {
+        state.withLockedValue { $0.requestSuccessNotifications }
     }
 }
 

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -204,8 +204,278 @@ import Testing
     try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
     let response = try collectResponse(from: channel)
-    #expect(response.head.status == .badRequest)
-    #expect(response.body.contains("missing id"))
+    #expect(response.head.status == .ok)
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let error = object?["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32600)
+    #expect((error?["message"] as? String) == "missing id")
+}
+
+@Test func httpSingleElementBatchErrorReturnsArrayShape() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let payload: [[String: Any]] = [
+        [
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "tools/list",
+        ],
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    #expect(response.head.headers.first(name: "Content-Type") == "application/json")
+    let array = try #require(try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [[String: Any]])
+    #expect(array.count == 1)
+    #expect((array[0]["id"] as? NSNumber)?.intValue == 42)
+    let error = array[0]["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32000)
+    #expect((error?["message"] as? String) == "expected initialize request")
+}
+
+@Test func httpTimeoutReturnsMCPErrorAndCleansMapping() async throws {
+    let config = makeConfig(requestTimeout: 0.1)
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 2001,
+        "method": "tools/list",
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    #expect(sessionManager.mappedUpstreamRequestCount() == 1)
+    advanceEventLoopTime(on: channel, by: .milliseconds(300))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    #expect(response.head.headers.first(name: "Content-Type") == "application/json")
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let error = object?["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32000)
+    #expect((error?["message"] as? String) == "upstream timeout")
+    #expect(sessionManager.mappedUpstreamRequestCount() == 0)
+}
+
+@Test func httpTimeoutReturnsSSEErrorWhenEventStreamIsPreferred() async throws {
+    let config = makeConfig(requestTimeout: 0.1)
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 2002,
+        "method": "tools/list",
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "text/event-stream")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    advanceEventLoopTime(on: channel, by: .milliseconds(300))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    #expect(response.head.headers.first(name: "Content-Type") == "text/event-stream")
+    #expect(response.body.contains("data:"))
+    #expect(response.body.contains("\"code\":-32000"))
+}
+
+@Test func httpBatchTimeoutCountsHealthPenaltyOnceAndCleansAllMappings() async throws {
+    let config = makeConfig(requestTimeout: 0.1)
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
+
+    let payload: [[String: Any]] = [
+        [
+            "jsonrpc": "2.0",
+            "id": 2101,
+            "method": "tools/list",
+        ],
+        [
+            "jsonrpc": "2.0",
+            "id": 2102,
+            "method": "tools/list",
+        ],
+        [
+            "jsonrpc": "2.0",
+            "id": 2103,
+            "method": "tools/list",
+        ],
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    #expect(sessionManager.mappedUpstreamRequestCount() == 3)
+    advanceEventLoopTime(on: channel, by: .milliseconds(300))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    let array = try #require(try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [[String: Any]])
+    #expect(array.count == 3)
+    for object in array {
+        let error = object["error"] as? [String: Any]
+        #expect((error?["code"] as? NSNumber)?.intValue == -32000)
+        #expect((error?["message"] as? String) == "upstream timeout")
+    }
+    #expect(sessionManager.requestTimeoutNotificationCount() == 1)
+    #expect(sessionManager.mappedUpstreamRequestCount() == 0)
+}
+
+@Test func httpReturnsUpstreamUnavailableWhenNoHealthyUpstreamExists() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any](),
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+    let initResponse = try collectResponse(from: channel)
+    let sessionId = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
+
+    sessionManager.setAvailableUpstreamIndex(nil)
+
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 3001,
+        "method": "tools/list",
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    let object = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: []) as? [String: Any]
+    let error = object?["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32001)
+    #expect((error?["message"] as? String) == "upstream unavailable")
 }
 
 @Test func httpSessionHeaderAutoCreatesSession() async throws {
@@ -1009,6 +1279,8 @@ private final class TestSessionManager: SessionManaging {
         var upstreamSendCount = 0
         var upstreamIdMapping: [Int64: UpstreamMapping] = [:]
         var chooseUpstreamCalls: [ChooseUpstreamCall] = []
+        var availableUpstreamIndex: Int? = 0
+        var requestTimeoutNotifications = 0
     }
 
     private let state = NIOLockedValueBox(State())
@@ -1092,13 +1364,13 @@ private final class TestSessionManager: SessionManaging {
         return eventLoop.makeSucceededFuture(buffer)
     }
 
-    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int {
+    func chooseUpstreamIndex(sessionId: String, shouldPin: Bool) -> Int? {
         state.withLockedValue { state in
             state.chooseUpstreamCalls.append(
                 ChooseUpstreamCall(sessionId: sessionId, shouldPin: shouldPin)
             )
+            return state.availableUpstreamIndex
         }
-        return 0
     }
 
     func assignUpstreamId(sessionId: String, originalId: RPCId, upstreamIndex _: Int) -> Int64 {
@@ -1110,6 +1382,26 @@ private final class TestSessionManager: SessionManaging {
             return id
         }
     }
+
+    func removeUpstreamIdMapping(sessionId: String, requestIdKey: String, upstreamIndex _: Int) {
+        state.withLockedValue { state in
+            let removed = state.upstreamIdMapping.first { _, mapping in
+                mapping.sessionId == sessionId && mapping.originalId.key == requestIdKey
+            }?.key
+            if let removed {
+                state.upstreamIdMapping.removeValue(forKey: removed)
+            }
+        }
+    }
+
+    func onRequestTimeout(sessionId: String, requestIdKey: String, upstreamIndex: Int) {
+        state.withLockedValue { state in
+            state.requestTimeoutNotifications += 1
+        }
+        removeUpstreamIdMapping(sessionId: sessionId, requestIdKey: requestIdKey, upstreamIndex: upstreamIndex)
+    }
+
+    func onRequestSucceeded(sessionId _: String, requestIdKey _: String, upstreamIndex _: Int) {}
 
     func sendUpstream(_ data: Data, upstreamIndex _: Int) {
         state.withLockedValue { state in
@@ -1151,6 +1443,18 @@ private final class TestSessionManager: SessionManaging {
 
     func refreshToolsListCallCount() -> Int {
         state.withLockedValue { $0.refreshToolsListCalls }
+    }
+
+    func mappedUpstreamRequestCount() -> Int {
+        state.withLockedValue { $0.upstreamIdMapping.count }
+    }
+
+    func setAvailableUpstreamIndex(_ value: Int?) {
+        state.withLockedValue { $0.availableUpstreamIndex = value }
+    }
+
+    func requestTimeoutNotificationCount() -> Int {
+        state.withLockedValue { $0.requestTimeoutNotifications }
     }
 }
 
@@ -1202,4 +1506,8 @@ private func collectResponse(from channel: EmbeddedChannel) throws -> (head: HTT
     }
     let body = bodyBuffer.readString(length: bodyBuffer.readableBytes) ?? ""
     return (responseHead, body)
+}
+
+private func advanceEventLoopTime(on channel: EmbeddedChannel, by amount: TimeAmount) {
+    channel.embeddedEventLoop.advanceTime(by: amount)
 }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -277,6 +277,55 @@ import Testing
     try await waitForSentCount(upstream0, count: 4, timeoutSeconds: 2)
 }
 
+@Test func sessionManagerRetriesEagerInitializeAfterPrimaryWarmInitErrorWhenLastInitializedUpstreamExited() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
+    let _ = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Initialize both upstreams.
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    // Wait for per-upstream notifications/initialized.
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+    // Primary exit triggers warm init on primary.
+    await upstream0.yield(.exit(1))
+    try await waitForSentCount(upstream0, count: 3, timeoutSeconds: 2)
+    let retry = await upstream0.sent()
+    let retryId = try extractUpstreamId(from: retry[2])
+
+    // While primary warm init is in flight, last initialized upstream exits.
+    await upstream1.yield(.exit(1))
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    // Warm init fails with JSON-RPC error.
+    let errorResponse: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": retryId,
+        "error": [
+            "code": -1,
+            "message": "warm init failed",
+        ],
+    ]
+    await upstream0.yield(.message(try JSONSerialization.data(withJSONObject: errorResponse, options: [])))
+
+    // Proxy should restart eager/global init automatically.
+    try await waitForSentCount(upstream0, count: 4, timeoutSeconds: 2)
+}
+
 @Test func sessionManagerPinsSessionsRoundRobinAcrossUpstreams() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -721,6 +721,57 @@ import Testing
     #expect((error?["message"] as? String) == "upstream overloaded")
 }
 
+@Test func sessionManagerRepinsWhenPinnedUpstreamBecomesOverloaded() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = ToggleableOverloadUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    // Initialize both upstreams.
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+    let sessionId = "session-overload-repin"
+    let session = manager.session(id: sessionId)
+    let pinned = try #require(manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true))
+    #expect(pinned == 0)
+
+    await upstream0.setOverloaded(true)
+
+    let original = RPCId(any: NSNumber(value: 920))!
+    let future = session.router.registerRequest(idKey: original.key, on: eventLoop, timeout: .seconds(1))
+    let upstreamId = manager.assignUpstreamId(sessionId: sessionId, originalId: original, upstreamIndex: pinned)
+    manager.sendUpstream(try makeToolListRequest(id: upstreamId), upstreamIndex: pinned)
+
+    let response = try decodeJSON(from: try await future.get())
+    let error = response["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32002)
+    #expect((error?["message"] as? String) == "upstream overloaded")
+
+    let repinned = try #require(manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true))
+    #expect(repinned == 1)
+
+    let original2 = RPCId(any: NSNumber(value: 921))!
+    let future2 = session.router.registerRequest(idKey: original2.key, on: eventLoop, timeout: .seconds(1))
+    let upstreamId2 = manager.assignUpstreamId(sessionId: sessionId, originalId: original2, upstreamIndex: repinned)
+    manager.sendUpstream(try makeToolListRequest(id: upstreamId2), upstreamIndex: repinned)
+    await upstream1.yield(.message(try makeToolListResponse(id: upstreamId2)))
+    _ = try await future2.get()
+}
+
 private func makeConfig(eagerInitialize: Bool, requestTimeout: TimeInterval) -> ProxyConfig {
     ProxyConfig(
         listenHost: "127.0.0.1",
@@ -757,6 +808,44 @@ private actor AlwaysOverloadedUpstreamClient: UpstreamClient {
     func send(_ data: Data) async -> UpstreamSendResult {
         _ = data
         return .overloaded
+    }
+}
+
+private actor ToggleableOverloadUpstreamClient: UpstreamClient {
+    nonisolated let events: AsyncStream<UpstreamEvent>
+    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    private var sentMessages: [Data] = []
+    private var overloaded = false
+
+    init() {
+        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        self.events = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+    }
+
+    func start() async {}
+
+    func stop() async {
+        continuation.finish()
+    }
+
+    func setOverloaded(_ value: Bool) {
+        overloaded = value
+    }
+
+    func send(_ data: Data) async -> UpstreamSendResult {
+        sentMessages.append(data)
+        return overloaded ? .overloaded : .accepted
+    }
+
+    func yield(_ event: UpstreamEvent) async {
+        continuation.yield(event)
+    }
+
+    func sent() async -> [Data] {
+        sentMessages
     }
 }
 
@@ -810,6 +899,22 @@ private func shutdown(_ group: EventLoopGroup) async {
 
 private func waitForSentCount(
     _ upstream: TestUpstreamClient,
+    count: Int,
+    timeoutSeconds: UInt64
+) async throws {
+    let deadline = Date().addingTimeInterval(TimeInterval(timeoutSeconds))
+    while Date() < deadline {
+        if await upstream.sent().count >= count {
+            return
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+    }
+    let actual = await upstream.sent().count
+    throw WaitForSentCountError.timeout(expected: count, actual: actual)
+}
+
+private func waitForSentCount(
+    _ upstream: ToggleableOverloadUpstreamClient,
     count: Int,
     timeoutSeconds: UInt64
 ) async throws {

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -310,8 +310,8 @@ import Testing
     let originalA = RPCId(any: NSNumber(value: 100))!
     let originalB = RPCId(any: NSNumber(value: 101))!
 
-    let upstreamIndexA = manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true)
-    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true)
+    let upstreamIndexA = try #require(manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true))
+    let upstreamIndexB = try #require(manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true))
     #expect(upstreamIndexA != upstreamIndexB)
 
     let futureA = sessionA.router.registerRequest(idKey: originalA.key, on: eventLoop)
@@ -377,8 +377,8 @@ import Testing
     let sessionA = manager.session(id: sessionIdA)
     let sessionB = manager.session(id: sessionIdB)
 
-    let upstreamIndexA = manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true)
-    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true)
+    let upstreamIndexA = try #require(manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true))
+    let upstreamIndexB = try #require(manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true))
     #expect(upstreamIndexA != upstreamIndexB)
 
     // Ensure we're starting from a clean buffer state.
@@ -475,7 +475,7 @@ import Testing
     #expect(session.router.drainBufferedNotifications().isEmpty)
 }
 
-@Test func sessionManagerPinsFallbackUpstreamEvenWhenUnhealthy() async throws {
+@Test func sessionManagerReturnsNilWhenAllUpstreamsAreQuarantined() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }
     let eventLoop = group.next()
@@ -547,35 +547,8 @@ import Testing
     }
     try await Task.sleep(nanoseconds: 50_000_000)
 
-    let sessionIdA = "session-A"
-    let sessionIdB = "session-B"
-    let sessionA = manager.session(id: sessionIdA)
-    let sessionB = manager.session(id: sessionIdB)
-
-    _ = sessionA.router.drainBufferedNotifications()
-    _ = sessionB.router.drainBufferedNotifications()
-
-    // Pin session A even though the selected upstream is unhealthy, so unmapped messages don't broadcast
-    // to other unpinned sessions (session B).
-    let chosen = manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true)
-
-    let notification = try JSONSerialization.data(
-        withJSONObject: [
-            "jsonrpc": "2.0",
-            "method": "notifications/test",
-            "params": ["value": 1],
-        ],
-        options: []
-    )
-
-    await yieldMessage(notification, to: chosen == 0 ? upstream0 : upstream1)
-    try await Task.sleep(nanoseconds: 50_000_000)
-
-    let receivedA = sessionA.router.drainBufferedNotifications()
-    let receivedB = sessionB.router.drainBufferedNotifications()
-    #expect(receivedA.count == 1)
-    #expect(receivedA.first == notification)
-    #expect(receivedB.isEmpty)
+    let chosen = manager.chooseUpstreamIndex(sessionId: "session-A", shouldPin: true)
+    #expect(chosen == nil)
 }
 
 @Test func sessionManagerRepinsAfterUpstreamExit() async throws {
@@ -607,8 +580,8 @@ import Testing
     _ = manager.session(id: sessionIdA)
     _ = manager.session(id: sessionIdB)
 
-    let upstreamIndexA = manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true)
-    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true)
+    let upstreamIndexA = try #require(manager.chooseUpstreamIndex(sessionId: sessionIdA, shouldPin: true))
+    let upstreamIndexB = try #require(manager.chooseUpstreamIndex(sessionId: sessionIdB, shouldPin: true))
     #expect(upstreamIndexA != upstreamIndexB)
 
     let pinnedTo1SessionId = upstreamIndexA == 1 ? sessionIdA : sessionIdB
@@ -617,8 +590,42 @@ import Testing
     await upstream1.yield(.exit(1))
     try await Task.sleep(nanoseconds: 50_000_000)
 
-    let repinned = manager.chooseUpstreamIndex(sessionId: pinnedTo1SessionId, shouldPin: true)
+    let repinned = try #require(manager.chooseUpstreamIndex(sessionId: pinnedTo1SessionId, shouldPin: true))
     #expect(repinned == 0)
+}
+
+@Test func sessionManagerRepinsWhenPinnedUpstreamIsQuarantinedByTimeouts() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream0 = TestUpstreamClient()
+    let upstream1 = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+    try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+    let init0 = await upstream0.sent()
+    let init0Id = try extractUpstreamId(from: init0[0])
+    await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+    try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+    let init1 = await upstream1.sent()
+    let init1Id = try extractUpstreamId(from: init1[0])
+    await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+    try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+    try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+    let sessionId = "session-timeout-repin"
+    _ = manager.session(id: sessionId)
+    let pinned = try #require(manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true))
+
+    manager.onRequestTimeout(sessionId: sessionId, requestIdKey: "dummy-1", upstreamIndex: pinned)
+    manager.onRequestTimeout(sessionId: sessionId, requestIdKey: "dummy-2", upstreamIndex: pinned)
+    manager.onRequestTimeout(sessionId: sessionId, requestIdKey: "dummy-3", upstreamIndex: pinned)
+
+    let repinned = try #require(manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true))
+    #expect(repinned != pinned)
 }
 
 @Test func sessionManagerExitClearsMappingsAndKeepsServingOnOtherUpstreams() async throws {
@@ -656,7 +663,7 @@ import Testing
     // The proxy should continue serving on upstream0.
     let originalB = RPCId(any: NSNumber(value: 201))!
     let futureB = session.router.registerRequest(idKey: originalB.key, on: eventLoop)
-    let upstreamIndexB = manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true)
+    let upstreamIndexB = try #require(manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true))
     #expect(upstreamIndexB == 0)
     let upstreamIdB = manager.assignUpstreamId(sessionId: sessionId, originalId: originalB, upstreamIndex: upstreamIndexB)
     manager.sendUpstream(try makeToolListRequest(id: upstreamIdB), upstreamIndex: upstreamIndexB)
@@ -672,6 +679,48 @@ import Testing
     }
 }
 
+@Test func sessionManagerReturnsOverloadedErrorWhenUpstreamRejectsSend() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream = AlwaysOverloadedUpstreamClient()
+    let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+    let sessionId = "session-overloaded"
+    let session = manager.session(id: sessionId)
+    let original = RPCId(any: NSNumber(value: 910))!
+    let future = session.router.registerRequest(idKey: original.key, on: eventLoop, timeout: .seconds(1))
+    let upstreamId = manager.assignUpstreamId(sessionId: sessionId, originalId: original, upstreamIndex: 0)
+    manager.sendUpstream(try makeToolListRequest(id: upstreamId), upstreamIndex: 0)
+
+    let response = try decodeJSON(from: try await future.get())
+    let error = response["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32002)
+    #expect((error?["message"] as? String) == "upstream overloaded")
+}
+
+@Test func sessionManagerInitializeReturnsOverloadedErrorWhenUpstreamRejectsSend() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream = AlwaysOverloadedUpstreamClient()
+    let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+    let original = RPCId(any: NSNumber(value: 1001))!
+    let future = manager.registerInitialize(
+        originalId: original,
+        requestObject: makeInitializeRequest(id: 1001),
+        on: eventLoop
+    )
+
+    let response = try decodeJSON(from: try await future.get())
+    let error = response["error"] as? [String: Any]
+    #expect((error?["code"] as? NSNumber)?.intValue == -32002)
+    #expect((error?["message"] as? String) == "upstream overloaded")
+}
+
 private func makeConfig(eagerInitialize: Bool, requestTimeout: TimeInterval) -> ProxyConfig {
     ProxyConfig(
         listenHost: "127.0.0.1",
@@ -685,6 +734,30 @@ private func makeConfig(eagerInitialize: Bool, requestTimeout: TimeInterval) -> 
         eagerInitialize: eagerInitialize,
         prewarmToolsList: false
     )
+}
+
+private actor AlwaysOverloadedUpstreamClient: UpstreamClient {
+    nonisolated let events: AsyncStream<UpstreamEvent>
+    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+
+    init() {
+        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        self.events = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+    }
+
+    func start() async {}
+
+    func stop() async {
+        continuation.finish()
+    }
+
+    func send(_ data: Data) async -> UpstreamSendResult {
+        _ = data
+        return .overloaded
+    }
 }
 
 private func makeInitializeRequest(id: Int) -> [String: Any] {

--- a/Tests/XcodeMCPProxyTests/TestUpstreamClient.swift
+++ b/Tests/XcodeMCPProxyTests/TestUpstreamClient.swift
@@ -25,8 +25,9 @@ actor TestUpstreamClient: UpstreamClient {
         continuation.finish()
     }
 
-    func send(_ data: Data) async {
+    func send(_ data: Data) async -> UpstreamSendResult {
         sentMessages.append(data)
+        return .accepted
     }
 
     func yield(_ event: UpstreamEvent) async {

--- a/Tests/XcodeMCPProxyTests/UpstreamProcessTests.swift
+++ b/Tests/XcodeMCPProxyTests/UpstreamProcessTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import XcodeMCPProxy
+
+@Test func upstreamProcessSendRemainsResponsiveUnderStdinBackpressure() async throws {
+    let config = UpstreamProcess.Config(
+        command: "/bin/cat",
+        args: [],
+        environment: ProcessInfo.processInfo.environment,
+        restartInitialDelay: 1,
+        restartMaxDelay: 1,
+        maxQueuedWriteBytes: 550_000
+    )
+    let upstream = UpstreamProcess(config: config)
+    await upstream.start()
+    defer {
+        Task {
+            await upstream.stop()
+        }
+    }
+
+    let payload = Data(repeating: 0x41, count: 500_000)
+    let first = try await withTimeout(seconds: 2) {
+        await upstream.send(payload)
+    }
+    switch first {
+    case .accepted:
+        break
+    case .overloaded:
+        Issue.record("first send should be accepted before queue reaches limit")
+    }
+
+    let second = try await withTimeout(seconds: 2) {
+        await upstream.send(payload)
+    }
+    switch second {
+    case .accepted:
+        break
+    case .overloaded:
+        break
+    }
+
+    // Give the async writer a moment to drain before teardown.
+    try await Task.sleep(nanoseconds: 100_000_000)
+}
+
+private enum UpstreamProcessTestTimeoutError: Error {
+    case timedOut(seconds: UInt64)
+}
+
+private func withTimeout<T: Sendable>(
+    seconds: UInt64,
+    operation: @escaping @Sendable () async -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            await operation()
+        }
+        group.addTask {
+            try await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+            throw UpstreamProcessTestTimeoutError.timedOut(seconds: seconds)
+        }
+        guard let result = try await group.next() else {
+            throw UpstreamProcessTestTimeoutError.timedOut(seconds: seconds)
+        }
+        group.cancelAll()
+        return result
+    }
+}


### PR DESCRIPTION
Summary:
- Normalize timeout/error responses to MCP-compatible JSON-RPC errors (HTTP 200) for both JSON and SSE paths, avoiding text/plain transport breakage.
- Refactor HTTP handling into dedicated internal components (`HTTPRequestValidator`, `MCPMethodDispatcher`, `MCPResponseEmitter`, `MCPErrorResponder`) and keep `HTTPHandler` focused on orchestration.
- Add upstream health states (`healthy`/`degraded`/`quarantined`) with timeout-driven quarantine, pin clearing, and probe-based recovery; return `-32001 upstream unavailable` when no healthy upstream is available.
- Make upstream writes non-blocking via queued async writer path with queue limits and fail-fast `-32002 upstream overloaded` handling.
- Extend/adjust tests for timeout mapping cleanup, batch timeout accounting, quarantine behavior, overloaded initialize/request flows, and non-blocking write responsiveness.

Testing:
- swift test --filter XcodeMCPProxyTests --parallel