### PR TITLE
ci: add v* tag release pipeline for universal binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,10 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Swift 6.2
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.2"
 
       - name: Run tests
         run: swift test
@@ -24,15 +19,10 @@ jobs:
   build-arm64:
     name: Build (arm64)
     needs: test
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Swift 6.2
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.2"
 
       - name: Build release binaries
         run: scripts/build-release.sh --arch arm64 --version "${GITHUB_REF_NAME}" --dist-root dist
@@ -47,15 +37,10 @@ jobs:
   build-x86_64:
     name: Build (x86_64)
     needs: test
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Swift 6.2
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.2"
 
       - name: Build release binaries
         run: scripts/build-release.sh --arch x86_64 --version "${GITHUB_REF_NAME}" --dist-root dist
@@ -72,17 +57,12 @@ jobs:
     needs:
       - build-arm64
       - build-x86_64
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup Swift 6.2
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.2"
 
       - name: Download arm64 artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
       - name: Run tests
         run: swift test
 
@@ -23,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
 
       - name: Build release binaries
         run: scripts/build-release.sh --arch arm64 --version "${GITHUB_REF_NAME}" --dist-root dist
@@ -41,6 +51,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
 
       - name: Build release binaries
         run: scripts/build-release.sh --arch x86_64 --version "${GITHUB_REF_NAME}" --dist-root dist
@@ -63,6 +78,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
 
       - name: Download arm64 artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  test:
+    name: Test
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: swift test
+
+  build-arm64:
+    name: Build (arm64)
+    needs: test
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build release binaries
+        run: scripts/build-release.sh --arch arm64 --version "${GITHUB_REF_NAME}" --dist-root dist
+
+      - name: Upload arm64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-arm64
+          path: dist/arm64
+          if-no-files-found: error
+
+  build-x86_64:
+    name: Build (x86_64)
+    needs: test
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build release binaries
+        run: scripts/build-release.sh --arch x86_64 --version "${GITHUB_REF_NAME}" --dist-root dist
+
+      - name: Upload x86_64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-x86_64
+          path: dist/x86_64
+          if-no-files-found: error
+
+  release:
+    name: Package and Publish
+    needs:
+      - build-arm64
+      - build-x86_64
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download arm64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-arm64
+          path: dist/arm64
+
+      - name: Download x86_64 artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-x86_64
+          path: dist/x86_64
+
+      - name: Package universal binaries
+        run: scripts/package-universal.sh --version "${GITHUB_REF_NAME}" --dist-root dist --output-dir release
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/*.tar.gz
+            release/SHA256SUMS.txt
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           name: dist-x86_64
           path: dist/x86_64
 
-      - name: Package universal binaries
+      - name: Package release archives
         run: scripts/package-universal.sh --dist-root dist --output-dir release
 
       - name: Publish GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
+
       - name: Run tests
-        run: swift test
+        run: swift test -Xswiftc -strict-concurrency=minimal
 
   build-arm64:
     name: Build (arm64)
@@ -23,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
 
       - name: Build release binaries
         run: scripts/build-release.sh --arch arm64 --version "${GITHUB_REF_NAME}" --dist-root dist
@@ -41,6 +51,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
 
       - name: Build release binaries
         run: scripts/build-release.sh --arch x86_64 --version "${GITHUB_REF_NAME}" --dist-root dist
@@ -63,6 +78,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Swift 6.2
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.2"
 
       - name: Download arm64 artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           path: dist/x86_64
 
       - name: Package universal binaries
-        run: scripts/package-universal.sh --version "${GITHUB_REF_NAME}" --dist-root dist --output-dir release
+        run: scripts/package-universal.sh --dist-root dist --output-dir release
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .codex/tmp/
+/dist
+/release

--- a/README.md
+++ b/README.md
@@ -27,21 +27,22 @@ swift run -c release xcode-mcp-proxy-install
 
 Each release tag (`v*`) publishes:
 
-- `xcode-mcp-proxy_<tag>_darwin_universal.tar.gz`
+- `xcode-mcp-proxy-darwin-arm64.tar.gz`
+- `xcode-mcp-proxy-darwin-x86_64.tar.gz`
 - `SHA256SUMS.txt`
 
 Example:
 
 ```bash
 VERSION=v0.1.0
-ASSET="xcode-mcp-proxy_${VERSION}_darwin_universal.tar.gz"
 BASE_URL="https://github.com/<owner>/XcodeMCPKit/releases/download/${VERSION}"
 
-curl -fL -O "${BASE_URL}/${ASSET}"
+ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"   # or xcode-mcp-proxy-darwin-x86_64.tar.gz
+curl -fL -O "${BASE_URL}/${ARCHIVE}"
 curl -fL -O "${BASE_URL}/SHA256SUMS.txt"
 shasum -a 256 -c SHA256SUMS.txt
 
-tar -xzf "${ASSET}"
+tar -xzf "${ARCHIVE}"
 mkdir -p "${HOME}/.local/bin"
 cp bin/* "${HOME}/.local/bin/"
 chmod +x "${HOME}/.local/bin/xcode-mcp-proxy" \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ swift run -c release xcode-mcp-proxy-install
 
 Each release tag (`v*`) publishes:
 
+- `xcode-mcp-proxy.tar.gz` (universal binary)
 - `xcode-mcp-proxy-darwin-arm64.tar.gz`
 - `xcode-mcp-proxy-darwin-x86_64.tar.gz`
 - `SHA256SUMS.txt`
@@ -37,7 +38,7 @@ Example:
 VERSION=v0.1.0
 BASE_URL="https://github.com/<owner>/XcodeMCPKit/releases/download/${VERSION}"
 
-ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"   # or xcode-mcp-proxy-darwin-x86_64.tar.gz
+ARCHIVE="xcode-mcp-proxy.tar.gz"   # or: xcode-mcp-proxy-darwin-arm64.tar.gz / xcode-mcp-proxy-darwin-x86_64.tar.gz
 curl -fL -O "${BASE_URL}/${ARCHIVE}"
 curl -fL -O "${BASE_URL}/SHA256SUMS.txt"
 shasum -a 256 -c SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ See [Architecture](Docs/architecture.md) for the process overview.
 swift run -c release xcode-mcp-proxy-install
 ```
 
+### Install from GitHub Releases
+
+Each release tag (`v*`) publishes:
+
+- `xcode-mcp-proxy_<tag>_darwin_universal.tar.gz`
+- `SHA256SUMS.txt`
+
+Example:
+
+```bash
+VERSION=v0.1.0
+ASSET="xcode-mcp-proxy_${VERSION}_darwin_universal.tar.gz"
+BASE_URL="https://github.com/<owner>/XcodeMCPKit/releases/download/${VERSION}"
+
+curl -fL -O "${BASE_URL}/${ASSET}"
+curl -fL -O "${BASE_URL}/SHA256SUMS.txt"
+shasum -a 256 -c SHA256SUMS.txt
+
+tar -xzf "${ASSET}"
+mkdir -p "${HOME}/.local/bin"
+cp bin/* "${HOME}/.local/bin/"
+chmod +x "${HOME}/.local/bin/xcode-mcp-proxy" \
+         "${HOME}/.local/bin/xcode-mcp-proxy-server" \
+         "${HOME}/.local/bin/xcode-mcp-proxy-install"
+```
+
 Replace `xcrun mcpbridge` with one of the following:
 
 ### Codex

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -78,7 +78,10 @@ products=(
 pushd "$repo_root" >/dev/null
 
 for product in "${products[@]}"; do
-  swift build -c release --arch "$arch" --product "$product"
+  swift build -c release \
+    -Xswiftc -strict-concurrency=minimal \
+    --arch "$arch" \
+    --product "$product"
 done
 
 bin_path="$(swift build -c release --arch "$arch" --show-bin-path)"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-release.sh --arch <arm64|x86_64> --version <tag> [--dist-root <dir>]
+
+Builds release binaries and stages them under:
+  <dist-root>/<arch>/bin/
+EOF
+}
+
+arch=""
+version=""
+dist_root="dist"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch)
+      arch="${2:-}"
+      shift 2
+      ;;
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --dist-root)
+      dist_root="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$arch" ]]; then
+  echo "--arch is required." >&2
+  usage
+  exit 1
+fi
+
+if [[ -z "$version" ]]; then
+  echo "--version is required." >&2
+  usage
+  exit 1
+fi
+
+case "$arch" in
+  arm64|x86_64) ;;
+  *)
+    echo "Unsupported arch: $arch (expected arm64 or x86_64)" >&2
+    exit 1
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "$dist_root" = /* ]]; then
+  dist_base="$dist_root"
+else
+  dist_base="$repo_root/$dist_root"
+fi
+
+out_dir="$dist_base/$arch"
+bin_out="$out_dir/bin"
+products=(
+  "xcode-mcp-proxy"
+  "xcode-mcp-proxy-server"
+  "xcode-mcp-proxy-install"
+)
+
+pushd "$repo_root" >/dev/null
+
+for product in "${products[@]}"; do
+  swift build -c release --product "$product"
+done
+
+bin_path="$(swift build -c release --show-bin-path)"
+rm -rf "$out_dir"
+mkdir -p "$bin_out"
+
+for product in "${products[@]}"; do
+  source_path="$bin_path/$product"
+  if [[ ! -f "$source_path" ]]; then
+    source_path="$(find "$repo_root/.build" -type f -path "*/release/$product" | head -n 1 || true)"
+  fi
+  if [[ -z "$source_path" || ! -f "$source_path" ]]; then
+    echo "Failed to locate built binary: $product" >&2
+    exit 1
+  fi
+
+  target_path="$bin_out/$product"
+  cp "$source_path" "$target_path"
+  chmod +x "$target_path"
+  if command -v codesign >/dev/null 2>&1; then
+    codesign --remove-signature "$target_path" >/dev/null 2>&1 || true
+  fi
+done
+
+cat > "$out_dir/manifest.txt" <<EOF
+version=$version
+arch=$arch
+built_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+EOF
+
+popd >/dev/null
+
+echo "Staged release binaries at: $out_dir"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -78,10 +78,10 @@ products=(
 pushd "$repo_root" >/dev/null
 
 for product in "${products[@]}"; do
-  swift build -c release --product "$product"
+  swift build -c release --arch "$arch" --product "$product"
 done
 
-bin_path="$(swift build -c release --show-bin-path)"
+bin_path="$(swift build -c release --arch "$arch" --show-bin-path)"
 rm -rf "$out_dir"
 mkdir -p "$bin_out"
 

--- a/scripts/package-universal.sh
+++ b/scripts/package-universal.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/package-universal.sh --version <tag> [--dist-root <dir>] [--output-dir <dir>]
+
+Requires staged binaries from:
+  <dist-root>/arm64/bin/
+  <dist-root>/x86_64/bin/
+
+Outputs:
+  <output-dir>/xcode-mcp-proxy_<tag>_darwin_universal.tar.gz
+  <output-dir>/SHA256SUMS.txt
+EOF
+}
+
+version=""
+dist_root="dist"
+output_dir="release"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --dist-root)
+      dist_root="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$version" ]]; then
+  echo "--version is required." >&2
+  usage
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "$dist_root" = /* ]]; then
+  dist_base="$dist_root"
+else
+  dist_base="$repo_root/$dist_root"
+fi
+if [[ "$output_dir" = /* ]]; then
+  output_base="$output_dir"
+else
+  output_base="$repo_root/$output_dir"
+fi
+
+arm_bin="$dist_base/arm64/bin"
+x86_bin="$dist_base/x86_64/bin"
+binaries=(
+  "xcode-mcp-proxy"
+  "xcode-mcp-proxy-server"
+  "xcode-mcp-proxy-install"
+)
+
+for path in "$arm_bin" "$x86_bin"; do
+  if [[ ! -d "$path" ]]; then
+    echo "Missing staged directory: $path" >&2
+    exit 1
+  fi
+done
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin" "$output_base"
+
+for bin in "${binaries[@]}"; do
+  arm_src="$arm_bin/$bin"
+  x86_src="$x86_bin/$bin"
+  if [[ ! -f "$arm_src" || ! -f "$x86_src" ]]; then
+    echo "Missing binary for lipo merge: $bin" >&2
+    exit 1
+  fi
+  lipo -create "$arm_src" "$x86_src" -output "$tmp_dir/bin/$bin"
+  chmod +x "$tmp_dir/bin/$bin"
+done
+
+archive_name="xcode-mcp-proxy_${version}_darwin_universal.tar.gz"
+archive_path="$output_base/$archive_name"
+tar -C "$tmp_dir" -czf "$archive_path" bin
+
+(
+  cd "$output_base"
+  shasum -a 256 "$archive_name" > SHA256SUMS.txt
+)
+
+echo "Created release package: $archive_path"
+echo "Created checksum file: $output_base/SHA256SUMS.txt"

--- a/scripts/package-universal.sh
+++ b/scripts/package-universal.sh
@@ -10,6 +10,7 @@ Requires staged binaries from:
   <dist-root>/x86_64/bin/
 
 Outputs:
+  <output-dir>/xcode-mcp-proxy.tar.gz
   <output-dir>/xcode-mcp-proxy-darwin-arm64.tar.gz
   <output-dir>/xcode-mcp-proxy-darwin-x86_64.tar.gz
   <output-dir>/SHA256SUMS.txt
@@ -67,9 +68,44 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 mkdir -p "$output_base"
 
+universal_archive="$output_base/xcode-mcp-proxy.tar.gz"
 arm_archive="$output_base/xcode-mcp-proxy-darwin-arm64.tar.gz"
 x86_archive="$output_base/xcode-mcp-proxy-darwin-x86_64.tar.gz"
-rm -f "$arm_archive" "$x86_archive" "$output_base/SHA256SUMS.txt"
+find "$output_base" -maxdepth 1 -type f -name 'xcode-mcp-proxy*.tar.gz' -delete
+rm -f "$output_base/SHA256SUMS.txt"
+
+products=(
+  "xcode-mcp-proxy"
+  "xcode-mcp-proxy-server"
+  "xcode-mcp-proxy-install"
+)
+
+for product in "${products[@]}"; do
+  arm_product="$arm_bin/$product"
+  x86_product="$x86_bin/$product"
+  if [[ ! -f "$arm_product" ]]; then
+    echo "Missing staged binary: $arm_product" >&2
+    exit 1
+  fi
+  if [[ ! -f "$x86_product" ]]; then
+    echo "Missing staged binary: $x86_product" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$tmp_dir/universal/bin"
+for product in "${products[@]}"; do
+  target="$tmp_dir/universal/bin/$product"
+  lipo -create -output "$target" "$arm_bin/$product" "$x86_bin/$product"
+  chmod +x "$target"
+  if command -v codesign >/dev/null 2>&1; then
+    codesign --remove-signature "$target" >/dev/null 2>&1 || true
+  fi
+done
+
+cp -R "$tmp_dir/universal/bin" "$tmp_dir/bin"
+tar -C "$tmp_dir" -czf "$universal_archive" bin
+rm -rf "$tmp_dir/bin"
 
 cp -R "$arm_bin" "$tmp_dir/bin"
 tar -C "$tmp_dir" -czf "$arm_archive" bin
@@ -77,14 +113,17 @@ rm -rf "$tmp_dir/bin"
 
 cp -R "$x86_bin" "$tmp_dir/bin"
 tar -C "$tmp_dir" -czf "$x86_archive" bin
+rm -rf "$tmp_dir/bin"
 
 (
   cd "$output_base"
   shasum -a 256 \
+    xcode-mcp-proxy.tar.gz \
     xcode-mcp-proxy-darwin-arm64.tar.gz \
     xcode-mcp-proxy-darwin-x86_64.tar.gz > SHA256SUMS.txt
 )
 
+echo "Created release package: $universal_archive"
 echo "Created release package: $arm_archive"
 echo "Created release package: $x86_archive"
 echo "Created checksum file: $output_base/SHA256SUMS.txt"

--- a/scripts/package-universal.sh
+++ b/scripts/package-universal.sh
@@ -3,28 +3,24 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/package-universal.sh --version <tag> [--dist-root <dir>] [--output-dir <dir>]
+Usage: scripts/package-universal.sh [--dist-root <dir>] [--output-dir <dir>]
 
 Requires staged binaries from:
   <dist-root>/arm64/bin/
   <dist-root>/x86_64/bin/
 
 Outputs:
-  <output-dir>/xcode-mcp-proxy_<tag>_darwin_universal.tar.gz
+  <output-dir>/xcode-mcp-proxy-darwin-arm64.tar.gz
+  <output-dir>/xcode-mcp-proxy-darwin-x86_64.tar.gz
   <output-dir>/SHA256SUMS.txt
 EOF
 }
 
-version=""
 dist_root="dist"
 output_dir="release"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --version)
-      version="${2:-}"
-      shift 2
-      ;;
     --dist-root)
       dist_root="${2:-}"
       shift 2
@@ -45,12 +41,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$version" ]]; then
-  echo "--version is required." >&2
-  usage
-  exit 1
-fi
-
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if [[ "$dist_root" = /* ]]; then
   dist_base="$dist_root"
@@ -65,12 +55,6 @@ fi
 
 arm_bin="$dist_base/arm64/bin"
 x86_bin="$dist_base/x86_64/bin"
-binaries=(
-  "xcode-mcp-proxy"
-  "xcode-mcp-proxy-server"
-  "xcode-mcp-proxy-install"
-)
-
 for path in "$arm_bin" "$x86_bin"; do
   if [[ ! -d "$path" ]]; then
     echo "Missing staged directory: $path" >&2
@@ -81,27 +65,26 @@ done
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-mkdir -p "$tmp_dir/bin" "$output_base"
+mkdir -p "$output_base"
 
-for bin in "${binaries[@]}"; do
-  arm_src="$arm_bin/$bin"
-  x86_src="$x86_bin/$bin"
-  if [[ ! -f "$arm_src" || ! -f "$x86_src" ]]; then
-    echo "Missing binary for lipo merge: $bin" >&2
-    exit 1
-  fi
-  lipo -create "$arm_src" "$x86_src" -output "$tmp_dir/bin/$bin"
-  chmod +x "$tmp_dir/bin/$bin"
-done
+arm_archive="$output_base/xcode-mcp-proxy-darwin-arm64.tar.gz"
+x86_archive="$output_base/xcode-mcp-proxy-darwin-x86_64.tar.gz"
+rm -f "$arm_archive" "$x86_archive" "$output_base/SHA256SUMS.txt"
 
-archive_name="xcode-mcp-proxy_${version}_darwin_universal.tar.gz"
-archive_path="$output_base/$archive_name"
-tar -C "$tmp_dir" -czf "$archive_path" bin
+cp -R "$arm_bin" "$tmp_dir/bin"
+tar -C "$tmp_dir" -czf "$arm_archive" bin
+rm -rf "$tmp_dir/bin"
+
+cp -R "$x86_bin" "$tmp_dir/bin"
+tar -C "$tmp_dir" -czf "$x86_archive" bin
 
 (
   cd "$output_base"
-  shasum -a 256 "$archive_name" > SHA256SUMS.txt
+  shasum -a 256 \
+    xcode-mcp-proxy-darwin-arm64.tar.gz \
+    xcode-mcp-proxy-darwin-x86_64.tar.gz > SHA256SUMS.txt
 )
 
-echo "Created release package: $archive_path"
+echo "Created release package: $arm_archive"
+echo "Created release package: $x86_archive"
 echo "Created checksum file: $output_base/SHA256SUMS.txt"


### PR DESCRIPTION
## Summary
- add GitHub Actions release workflow triggered by `v*` tags
- build arm64 (macos-14) and x86_64 (macos-13) artifacts, then merge with `lipo`
- publish `xcode-mcp-proxy_<tag>_darwin_universal.tar.gz` and `SHA256SUMS.txt`
- add helper scripts for staging binaries and packaging universal release assets
- document release-based installation in README

## Why
Downstream apps need stable, machine-consumable release artifacts for auto-install/update flows.

## Validation
- `swift test`
- `swift build -c release --product xcode-mcp-proxy`
- `swift build -c release --product xcode-mcp-proxy-server`
- `swift build -c release --product xcode-mcp-proxy-install`
- `scripts/build-release.sh --arch arm64 --version v0.0.0-local --dist-root dist`
- `bash -n scripts/build-release.sh`
- `bash -n scripts/package-universal.sh`

## Notes
- Local machine cannot produce a real x86_64 build artifact, so universal packaging is verified in CI via split runners.
