### PR TITLE
修正: discovery の STDIO 上流をループバックに制限

### DIFF
--- a/Sources/XcodeMCPProxy/Discovery.swift
+++ b/Sources/XcodeMCPProxy/Discovery.swift
@@ -36,6 +36,7 @@ public enum Discovery {
         guard let data = try? Data(contentsOf: url) else { return nil }
         guard let record = try? decoder.decode(DiscoveryRecord.self, from: data) else { return nil }
         guard isProcessAlive(record.pid) else { return nil }
+        guard isLoopbackURL(record.url) else { return nil }
         return record
     }
 
@@ -104,5 +105,26 @@ public enum Discovery {
         }
         let normalizedHost = host.contains(":") ? "[\(host)]" : host
         return "\(scheme)://\(normalizedHost):\(port)/mcp"
+    }
+
+    private static func isLoopbackURL(_ raw: String) -> Bool {
+        guard let components = URLComponents(string: raw),
+              let host = components.host?.lowercased() else {
+            return false
+        }
+        return isLoopbackHost(host)
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        if host == "localhost" || host == "::1" { return true }
+        if host == "127.0.0.1" { return true }
+        if host.hasPrefix("127.") {
+            let segments = host.split(separator: ".", omittingEmptySubsequences: false)
+            if segments.count == 4,
+               segments.allSatisfy({ Int($0).map { (0...255).contains($0) } == true }) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Tests/XcodeMCPProxyTests/CLIParserTests.swift
+++ b/Tests/XcodeMCPProxyTests/CLIParserTests.swift
@@ -142,6 +142,30 @@ private func makeTempDiscoveryURL() -> URL {
     #expect(config.stdioUpstreamSource == .discovery)
 }
 
+
+@Test func cliIgnoresNonLoopbackDiscoveryEndpoint() async throws {
+    let tempURL = makeTempDiscoveryURL()
+    let record = DiscoveryRecord(
+        url: "http://example.com:5555/mcp",
+        host: "example.com",
+        port: 5555,
+        pid: Int(ProcessInfo.processInfo.processIdentifier),
+        updatedAt: Date()
+    )
+    try Discovery.write(record: record, overrideURL: tempURL)
+    let config = try CLIParser.parse(
+        args: [
+            "xcode-mcp-proxy",
+            "--stdio",
+        ],
+        environment: [:],
+        discoveryOverrideURL: tempURL
+    )
+    #expect(config.transport == .stdio)
+    #expect(config.stdioUpstreamURL?.absoluteString == "http://localhost:8765/mcp")
+    #expect(config.stdioUpstreamSource == .fallback)
+}
+
 @Test func cliDefaultsStdioUpstreamFromEnvironment() async throws {
     let tempURL = makeTempDiscoveryURL()
     let config = try CLIParser.parse(

--- a/Tests/XcodeMCPProxyTests/DiscoveryTests.swift
+++ b/Tests/XcodeMCPProxyTests/DiscoveryTests.swift
@@ -54,6 +54,21 @@ private func cleanupTempDiscoveryURL(_ url: URL) {
     #expect(Discovery.read(overrideURL: url) == nil)
 }
 
+
+@Test func discoveryRejectsNonLoopbackURL() async throws {
+    let url = makeTempDiscoveryURL()
+    defer { cleanupTempDiscoveryURL(url) }
+    let record = DiscoveryRecord(
+        url: "http://example.com:8888/mcp",
+        host: "example.com",
+        port: 8888,
+        pid: Int(ProcessInfo.processInfo.processIdentifier),
+        updatedAt: Date()
+    )
+    try Discovery.write(record: record, overrideURL: url)
+    #expect(Discovery.read(overrideURL: url) == nil)
+}
+
 @Test func discoveryFormatsIPv6Host() async throws {
     let record = Discovery.makeRecord(host: "::1", port: 1234, pid: 1)
     #expect(record?.url == "http://[::1]:1234/mcp")


### PR DESCRIPTION
### Motivation
- `Discovery.read` が `endpoint.json` の `url` を PID 生存のみで受け入れており、ローカルキャッシュ書き換えにより外部 HTTP(s) へ STDIO トラフィックを流せてしまう脆弱性を防止するため。

### Description
- `Discovery.read` に `isLoopbackURL` チェックを追加して、記録された `url` がローカルループバック（`localhost` / `127.0.0.0/8` / `::1`）でない場合は拒否するようにした。 (`Sources/XcodeMCPProxy/Discovery.swift`)。
- ループバック判定用のヘルパー `isLoopbackURL` と `isLoopbackHost` を実装して IPv4 ループバックレンジおよび IPv6 の `::1` を扱えるようにした。 (`Sources/XcodeMCPProxy/Discovery.swift`)。
- 回帰防止のため、`Discovery.read` が非ループバック URL を拒否するユニットテスト `discoveryRejectsNonLoopbackURL` を追加した。 (`Tests/XcodeMCPProxyTests/DiscoveryTests.swift`)。
- CLI 経路の挙動を守るため、discovery が非ループバックのときにフォールバックが選ばれることを確認するテスト `cliIgnoresNonLoopbackDiscoveryEndpoint` を追加した。 (`Tests/XcodeMCPProxyTests/CLIParserTests.swift`)。

### Testing
- ローカルで `swift test` を実行しようとしたが、環境の Swift が要求するツールチェーンと異なり失敗したためテストは実行できなかった（`swift test` が失敗: パッケージは Swift tools 6.2.0 を要求するがインストール済みは 6.1.3）。
- 変更に対するユニットテストはリポジトリに追加済みで、適切な Swift ツールチェーン上で実行すればグリーンになることを想定している（追加テスト: `discoveryRejectsNonLoopbackURL`, `cliIgnoresNonLoopbackDiscoveryEndpoint`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab60ca26088325848e5e6d113f49c0)