### PR TITLE
未マップ上流通知のクロスセッション漏洩を防止

### DIFF
--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -736,10 +736,8 @@ final class SessionManager: Sendable, SessionManaging {
 
     private func routeUnmappedUpstreamMessage(_ data: Data, upstreamIndex: Int) {
         // We have no id-based mapping for this upstream message, so we can't unambiguously route it to a
-        // single session. To reduce cross-talk across multiple concurrent agents, only deliver it to
-        // sessions pinned to the same upstream. If no session is pinned to this upstream yet, still
-        // deliver server-initiated notifications/requests to unpinned sessions so they don't miss
-        // pre-pin messages.
+        // single session. To avoid cross-session data disclosure, only deliver server-initiated
+        // notifications/requests to sessions that are already pinned to the same upstream.
         //
         // Never forward unmapped JSON-RPC responses (no `method`) to sessions: if we dropped a mapping
         // due to timeouts (e.g. a best-effort tools/list warmup) then a late response must not leak
@@ -788,41 +786,20 @@ final class SessionManager: Sendable, SessionManaging {
             return
         }
 
-        let (pinnedTargets, unpinnedTargets) = sessionsState.withLockedValue { state -> ([SessionContext], [SessionContext]) in
+        let pinnedTargets = sessionsState.withLockedValue { state -> [SessionContext] in
             var pinned: [SessionContext] = []
-            var unpinned: [SessionContext] = []
             pinned.reserveCapacity(state.sessions.count)
-            unpinned.reserveCapacity(state.sessions.count)
             for record in state.sessions.values {
                 if record.pinnedUpstreamIndex == upstreamIndex {
                     pinned.append(record.context)
-                } else if record.pinnedUpstreamIndex == nil {
-                    unpinned.append(record.context)
                 }
             }
-            return (pinned, unpinned)
+            return pinned
         }
 
         if !pinnedTargets.isEmpty {
             for payload in serverInitiatedPayloads {
                 for session in pinnedTargets {
-                    session.router.handleIncoming(payload)
-                }
-            }
-            return
-        }
-
-        if !unpinnedTargets.isEmpty {
-            logger.debug(
-                "Routing unmapped upstream message to unpinned sessions",
-                metadata: [
-                    "upstream": .string("\(upstreamIndex)"),
-                    "bytes": .string("\(data.count)"),
-                    "targets": .string("\(unpinnedTargets.count)"),
-                ]
-            )
-            for payload in serverInitiatedPayloads {
-                for session in unpinnedTargets {
                     session.router.handleIncoming(payload)
                 }
             }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -456,7 +456,7 @@ import Testing
     #expect(receivedOther.isEmpty)
 }
 
-@Test func sessionManagerRoutesUnmappedNotificationsToUnpinnedSessionsWhenNoPinnedTargetsExist() async throws {
+@Test func sessionManagerDropsUnmappedNotificationsWhenNoPinnedTargetsExist() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }
     let eventLoop = group.next()
@@ -499,8 +499,7 @@ import Testing
     try await Task.sleep(nanoseconds: 50_000_000)
 
     let received = session.router.drainBufferedNotifications()
-    #expect(received.count == 1)
-    #expect(received.first == notification)
+    #expect(received.isEmpty)
 }
 
 @Test func sessionManagerDropsUnmappedResponsesEvenWhenPinnedTargetsExist() async throws {


### PR DESCRIPTION
### Motivation
- 共有された単一の上流プロセスが、IDでルーティングできない（通知や不正な/欠落IDのメッセージ）上流メッセージを全セッションへブロードキャストしており、クライアント間でプロジェクトデータ等が漏洩する可能性があったため、漏洩を防止する必要がある。

### Description
- `Sources/XcodeMCPProxy/SessionManager.swift` の `routeUnmappedUpstreamMessage` を変更し、IDでマッピングできないサーバー起点の通知/リクエストは「同じ upstream にピンされているセッション」にのみ配送するように限定した（未ピンのセッションへは配送しない）。
- 上記の変更により、未マップ応答（`method` を持たないレスポンス）は引き続き破棄される挙動を維持している。
- テスト `Tests/XcodeMCPProxyTests/SessionManagerTests.swift` を更新し、未ピン時に未マップ通知が配送されないことを検証するように期待値を `isEmpty` に変更し、該当テスト名を `sessionManagerDropsUnmappedNotificationsWhenNoPinnedTargetsExist` に改めた。

### Testing
- `swift test --filter SessionManagerTests` を実行しようとしたが、この実行環境の Swift は `6.1.3` でパッケージの tools version `6.2.0` と不一致のためテスト実行は失敗した（ビルドに至らず）。
- テストコードは変更済みでユニットテストの期待値を更新してあるが、上記理由で自動テストの成功はここでは確認できていない。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab6439cda4832586538562645c0f03)