### PR TITLE
fix(proxy): harden timeout recovery and debug diagnostics

### DIFF
--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -127,6 +127,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         switch (head.method, path) {
         case (.GET, "/health"):
             sendPlain(on: context.channel, status: .ok, body: "ok", keepAlive: head.isKeepAlive, sessionId: nil, requestLog: requestLog)
+        case (.GET, "/debug/upstreams"):
+            handleDebugSnapshot(context: context, head: head, requestLog: requestLog)
         case (.GET, "/mcp"), (.GET, "/"), (.GET, "/mcp/events"), (.GET, "/events"):
             handleSSE(context: context, head: head, requestLog: requestLog)
         case (.DELETE, "/mcp"), (.DELETE, "/"):
@@ -136,6 +138,44 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         default:
             sendPlain(on: context.channel, status: .notFound, body: "not found", keepAlive: head.isKeepAlive, sessionId: nil, requestLog: requestLog)
         }
+    }
+
+    private func handleDebugSnapshot(context: ChannelHandlerContext, head: HTTPRequestHead, requestLog: RequestLogContext) {
+        guard isLoopbackDebugEndpointEnabled else {
+            sendPlain(
+                on: context.channel,
+                status: .notFound,
+                body: "not found",
+                keepAlive: head.isKeepAlive,
+                sessionId: nil,
+                requestLog: requestLog
+            )
+            return
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        guard let data = try? encoder.encode(sessionManager.debugSnapshot()) else {
+            sendPlain(
+                on: context.channel,
+                status: .internalServerError,
+                body: "debug snapshot unavailable",
+                keepAlive: head.isKeepAlive,
+                sessionId: nil,
+                requestLog: requestLog
+            )
+            return
+        }
+
+        sendJSONData(
+            on: context.channel,
+            data: data,
+            keepAlive: head.isKeepAlive,
+            sessionId: nil,
+            requestLog: requestLog
+        )
     }
 
     private func handleSSE(context: ChannelHandlerContext, head: HTTPRequestHead, requestLog: RequestLogContext) {
@@ -808,6 +848,24 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         )
     }
 
+    private func sendJSONData(
+        on channel: Channel,
+        data: Data,
+        keepAlive: Bool,
+        sessionId: String?,
+        requestLog: RequestLogContext
+    ) {
+        logResponse(requestLog, status: .ok, sessionId: sessionId)
+        var buffer = channel.allocator.buffer(capacity: data.count)
+        buffer.writeBytes(data)
+        MCPResponseEmitter.sendJSON(
+            on: channel,
+            buffer: buffer,
+            keepAlive: keepAlive,
+            sessionId: sessionId
+        )
+    }
+
     private func sendPlain(
         on channel: Channel,
         status: HTTPResponseStatus,
@@ -993,6 +1051,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return "\(ip):\(port)"
         }
         return String(describing: address)
+    }
+
+    private var isLoopbackDebugEndpointEnabled: Bool {
+        switch config.listenHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "localhost", "127.0.0.1", "::1", "[::1]":
+            return true
+        default:
+            return false
+        }
     }
 
 }

--- a/Sources/XcodeMCPProxy/MCPResponseEmitter.swift
+++ b/Sources/XcodeMCPProxy/MCPResponseEmitter.swift
@@ -7,11 +7,13 @@ enum MCPResponseEmitter {
         on channel: Channel,
         buffer: ByteBuffer,
         keepAlive: Bool,
-        sessionId: String
+        sessionId: String?
     ) {
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "application/json")
-        headers.add(name: "Mcp-Session-Id", value: sessionId)
+        if let sessionId {
+            headers.add(name: "Mcp-Session-Id", value: sessionId)
+        }
         sendBuffer(on: channel, status: .ok, headers: headers, buffer: buffer, keepAlive: keepAlive)
     }
 

--- a/Sources/XcodeMCPProxy/ProxyDebugSnapshot.swift
+++ b/Sources/XcodeMCPProxy/ProxyDebugSnapshot.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct ProxyDebugEvent: Codable, Sendable {
+    let timestamp: Date
+    let message: String
+}
+
+struct ProxyDebugTrafficEvent: Codable, Sendable {
+    let timestamp: Date
+    let upstreamIndex: Int
+    let direction: String
+    let bytes: Int
+    let preview: String
+}
+
+struct ProxyUpstreamDebugSnapshot: Codable, Sendable {
+    let upstreamIndex: Int
+    let isInitialized: Bool
+    let initInFlight: Bool
+    let didSendInitialized: Bool
+    let healthState: String
+    let consecutiveRequestTimeouts: Int
+    let consecutiveToolsListFailures: Int
+    let lastToolsListSuccessUptimeNs: UInt64?
+    let recentStderr: [ProxyDebugEvent]
+    let lastDecodeError: ProxyDebugEvent?
+    let lastBridgeError: ProxyDebugEvent?
+    let resyncCount: Int
+    let lastResyncAt: Date?
+    let lastResyncDroppedBytes: Int?
+    let lastResyncPreview: String?
+    let bufferedStdoutBytes: Int
+}
+
+struct ProxyDebugSnapshot: Codable, Sendable {
+    let generatedAt: Date
+    let proxyInitialized: Bool
+    let cachedToolsListAvailable: Bool
+    let warmupInFlight: Bool
+    let upstreams: [ProxyUpstreamDebugSnapshot]
+    let recentTraffic: [ProxyDebugTrafficEvent]
+}

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -43,9 +43,28 @@ protocol SessionManaging: Sendable {
     func onRequestTimeout(sessionId: String, requestIdKey: String, upstreamIndex: Int)
     func onRequestSucceeded(sessionId: String, requestIdKey: String, upstreamIndex: Int)
     func sendUpstream(_ data: Data, upstreamIndex: Int)
+    func debugSnapshot() -> ProxyDebugSnapshot
 }
 
 final class SessionManager: Sendable, SessionManaging {
+    private static let redactedDebugText = "<redacted>"
+
+    private struct DebugUpstreamState: Sendable {
+        var recentStderr: [ProxyDebugEvent] = []
+        var lastDecodeError: ProxyDebugEvent?
+        var lastBridgeError: ProxyDebugEvent?
+        var resyncCount = 0
+        var lastResyncAt: Date?
+        var lastResyncDroppedBytes: Int?
+        var lastResyncPreview: String?
+        var bufferedStdoutBytes = 0
+    }
+
+    private struct DebugState: Sendable {
+        var upstreams: [DebugUpstreamState] = []
+        var recentTraffic: [ProxyDebugTrafficEvent] = []
+    }
+
     private struct InitPending: Sendable {
         let eventLoop: EventLoop
         let promise: EventLoopPromise<ByteBuffer>
@@ -84,12 +103,15 @@ final class SessionManager: Sendable, SessionManaging {
     private let sessionsState = NIOLockedValueBox(SessionState())
     private let initState = NIOLockedValueBox(InitState())
     private let upstreamTaskBox = NIOLockedValueBox<[Task<Void, Never>]>([])
+    private let debugState = NIOLockedValueBox(DebugState())
     private let eventLoop: EventLoop
     private let idMapper: UpstreamIdMapper
     private let config: ProxyConfig
     private let logger: Logger = ProxyLogging.make("session")
     let upstreams: [any UpstreamClient]
     private let toolsListState = NIOLockedValueBox(ToolsListState())
+    private let debugTrafficLimit = 50
+    private let debugStderrLimit = 20
 
     private struct UpstreamState: Sendable {
         var isInitialized = false
@@ -129,6 +151,10 @@ final class SessionManager: Sendable, SessionManaging {
             state.upstreamStates = Array(repeating: UpstreamState(), count: upstreams.count)
             state.nextPick = 0
         }
+        debugState.withLockedValue { state in
+            state.upstreams = Array(repeating: DebugUpstreamState(), count: upstreams.count)
+            state.recentTraffic = []
+        }
 
         var tasks: [Task<Void, Never>] = []
         tasks.reserveCapacity(upstreams.count)
@@ -139,6 +165,12 @@ final class SessionManager: Sendable, SessionManaging {
                     switch event {
                     case .message(let data):
                         self.routeUpstreamMessage(data, upstreamIndex: upstreamIndex)
+                    case .stderr(let message):
+                        self.handleUpstreamStderr(message, upstreamIndex: upstreamIndex)
+                    case .stdoutRecovery(let recovery):
+                        self.handleUpstreamRecovery(recovery, upstreamIndex: upstreamIndex)
+                    case .stdoutBufferSize(let size):
+                        self.handleBufferedStdoutBytes(size, upstreamIndex: upstreamIndex)
                     case .exit(let status):
                         self.handleUpstreamExit(status, upstreamIndex: upstreamIndex)
                     }
@@ -472,6 +504,11 @@ final class SessionManager: Sendable, SessionManaging {
             if let sessionId = mapping.sessionId, let originalId = mapping.originalId {
                 object["id"] = originalId.value.foundationObject
                 if let rewritten = try? JSONSerialization.data(withJSONObject: object, options: []) {
+                    recordTraffic(
+                        upstreamIndex: upstreamIndex,
+                        direction: "inbound",
+                        data: rewritten
+                    )
                     let target = session(id: sessionId)
                     target.router.handleIncoming(rewritten)
                     return
@@ -504,6 +541,11 @@ final class SessionManager: Sendable, SessionManaging {
                 transformed.append(object)
             }
             if rewrittenAny, let sessionId, let rewritten = try? JSONSerialization.data(withJSONObject: transformed, options: []) {
+                recordTraffic(
+                    upstreamIndex: upstreamIndex,
+                    direction: "inbound",
+                    data: rewritten
+                )
                 let target = session(id: sessionId)
                 target.router.handleIncoming(rewritten)
                 return
@@ -649,6 +691,11 @@ final class SessionManager: Sendable, SessionManaging {
         Task {
             let result = await upstreams[upstreamIndex].send(data)
             if result == .accepted {
+                self.recordTraffic(
+                    upstreamIndex: upstreamIndex,
+                    direction: "outbound",
+                    data: data
+                )
                 return
             }
             self.markUpstreamOverloaded(upstreamIndex: upstreamIndex)
@@ -657,6 +704,102 @@ final class SessionManager: Sendable, SessionManaging {
                 upstreamIndex: upstreamIndex
             )
         }
+    }
+
+    func debugSnapshot() -> ProxyDebugSnapshot {
+        let initSnapshot = initState.withLockedValue { state in
+            (
+                proxyInitialized: state.initResult != nil,
+                isShuttingDown: state.isShuttingDown
+            )
+        }
+        let toolsSnapshot = toolsListState.withLockedValue { state in
+            (
+                cachedToolsListAvailable: state.cachedResult != nil,
+                warmupInFlight: state.warmupInFlight
+            )
+        }
+        let upstreamSnapshot = upstreamState.withLockedValue { state in
+            state.upstreamStates.enumerated().map { index, upstream in
+                ProxyUpstreamDebugSnapshot(
+                    upstreamIndex: index,
+                    isInitialized: upstream.isInitialized,
+                    initInFlight: upstream.initInFlight,
+                    didSendInitialized: upstream.didSendInitialized,
+                    healthState: debugHealthStateString(upstream.healthState),
+                    consecutiveRequestTimeouts: upstream.consecutiveRequestTimeouts,
+                    consecutiveToolsListFailures: upstream.consecutiveToolsListFailures,
+                    lastToolsListSuccessUptimeNs: upstream.lastToolsListSuccessUptimeNs,
+                    recentStderr: [],
+                    lastDecodeError: nil,
+                    lastBridgeError: nil,
+                    resyncCount: 0,
+                    lastResyncAt: nil,
+                    lastResyncDroppedBytes: nil,
+                    lastResyncPreview: nil,
+                    bufferedStdoutBytes: 0
+                )
+            }
+        }
+        let debugSnapshot = debugState.withLockedValue { state in
+            (
+                upstreams: state.upstreams,
+                recentTraffic: state.recentTraffic
+            )
+        }
+
+        let upstreams = upstreamSnapshot.map { base in
+            guard base.upstreamIndex < debugSnapshot.upstreams.count else { return base }
+            let debug = debugSnapshot.upstreams[base.upstreamIndex]
+            return ProxyUpstreamDebugSnapshot(
+                upstreamIndex: base.upstreamIndex,
+                isInitialized: base.isInitialized,
+                initInFlight: base.initInFlight,
+                didSendInitialized: base.didSendInitialized,
+                healthState: base.healthState,
+                consecutiveRequestTimeouts: base.consecutiveRequestTimeouts,
+                consecutiveToolsListFailures: base.consecutiveToolsListFailures,
+                lastToolsListSuccessUptimeNs: base.lastToolsListSuccessUptimeNs,
+                recentStderr: debug.recentStderr.map(redactedDebugEvent),
+                lastDecodeError: redactedDebugEvent(debug.lastDecodeError),
+                lastBridgeError: redactedDebugEvent(debug.lastBridgeError),
+                resyncCount: debug.resyncCount,
+                lastResyncAt: debug.lastResyncAt,
+                lastResyncDroppedBytes: debug.lastResyncDroppedBytes,
+                lastResyncPreview: debug.lastResyncPreview.map { _ in Self.redactedDebugText },
+                bufferedStdoutBytes: debug.bufferedStdoutBytes
+            )
+        }
+
+        return ProxyDebugSnapshot(
+            generatedAt: Date(),
+            proxyInitialized: initSnapshot.proxyInitialized && !initSnapshot.isShuttingDown,
+            cachedToolsListAvailable: toolsSnapshot.cachedToolsListAvailable,
+            warmupInFlight: toolsSnapshot.warmupInFlight,
+            upstreams: upstreams,
+            recentTraffic: debugSnapshot.recentTraffic.map(redactedTrafficEvent)
+        )
+    }
+
+    private func redactedDebugEvent(_ event: ProxyDebugEvent?) -> ProxyDebugEvent? {
+        event.map(redactedDebugEvent)
+    }
+
+    private func redactedDebugEvent(_ event: ProxyDebugEvent) -> ProxyDebugEvent {
+        ProxyDebugEvent(
+            timestamp: event.timestamp,
+            message: Self.redactedDebugText
+        )
+    }
+
+    private func redactedTrafficEvent(_ event: ProxyDebugTrafficEvent) -> ProxyDebugTrafficEvent {
+        ProxyDebugTrafficEvent(
+            timestamp: event.timestamp,
+            upstreamIndex: event.upstreamIndex,
+            direction: event.direction,
+            bytes: event.bytes,
+            preview: Self.redactedDebugText
+        )
     }
 
     private func handleOverloadedUpstreamSend(
@@ -735,6 +878,11 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     private func routeUnmappedUpstreamMessage(_ data: Data, upstreamIndex: Int) {
+        recordTraffic(
+            upstreamIndex: upstreamIndex,
+            direction: "inbound_unmapped",
+            data: data
+        )
         // We have no id-based mapping for this upstream message, so we can't unambiguously route it to a
         // single session. To reduce cross-talk across multiple concurrent agents, only deliver it to
         // sessions pinned to the same upstream. If no session is pinned to this upstream yet, still
@@ -836,6 +984,77 @@ final class SessionManager: Sendable, SessionManaging {
                 "bytes": .string("\(data.count)"),
             ]
         )
+    }
+
+    private func handleUpstreamStderr(_ message: String, upstreamIndex: Int) {
+        let event = ProxyDebugEvent(timestamp: Date(), message: message)
+        debugState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreams.count else { return }
+            state.upstreams[upstreamIndex].recentStderr.append(event)
+            if state.upstreams[upstreamIndex].recentStderr.count > debugStderrLimit {
+                state.upstreams[upstreamIndex].recentStderr.removeFirst(
+                    state.upstreams[upstreamIndex].recentStderr.count - debugStderrLimit
+                )
+            }
+            if message.contains("Could not decode agent message") {
+                state.upstreams[upstreamIndex].lastDecodeError = event
+            }
+            if message.contains("BridgeError") {
+                state.upstreams[upstreamIndex].lastBridgeError = event
+            }
+        }
+    }
+
+    private func handleUpstreamRecovery(_ recovery: StdioFramerRecovery, upstreamIndex: Int) {
+        debugState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreams.count else { return }
+            state.upstreams[upstreamIndex].resyncCount += 1
+            state.upstreams[upstreamIndex].lastResyncAt = Date()
+            state.upstreams[upstreamIndex].lastResyncDroppedBytes = recovery.droppedPrefixBytes
+            if let recovered = recovery.previewRecoveredMessage, !recovered.isEmpty {
+                state.upstreams[upstreamIndex].lastResyncPreview = recovered
+            } else {
+                state.upstreams[upstreamIndex].lastResyncPreview = recovery.previewBeforeDrop
+            }
+        }
+    }
+
+    private func handleBufferedStdoutBytes(_ size: Int, upstreamIndex: Int) {
+        debugState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreams.count else { return }
+            state.upstreams[upstreamIndex].bufferedStdoutBytes = size
+        }
+    }
+
+    private func recordTraffic(
+        upstreamIndex: Int,
+        direction: String,
+        data: Data
+    ) {
+        let event = ProxyDebugTrafficEvent(
+            timestamp: Date(),
+            upstreamIndex: upstreamIndex,
+            direction: direction,
+            bytes: data.count,
+            preview: Self.redactedDebugText
+        )
+        debugState.withLockedValue { state in
+            state.recentTraffic.append(event)
+            if state.recentTraffic.count > debugTrafficLimit {
+                state.recentTraffic.removeFirst(state.recentTraffic.count - debugTrafficLimit)
+            }
+        }
+    }
+
+    private func debugHealthStateString(_ state: UpstreamHealthState) -> String {
+        switch state {
+        case .healthy:
+            return "healthy"
+        case .degraded:
+            return "degraded"
+        case .quarantined(let untilUptimeNs):
+            return "quarantined(untilUptimeNs:\(untilUptimeNs))"
+        }
     }
 
     private func startEagerInitializePrimary() {
@@ -1112,6 +1331,10 @@ final class SessionManager: Sendable, SessionManaging {
             return timeout
         }
         timeout?.cancel()
+        debugState.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreams.count else { return }
+            state.upstreams[upstreamIndex] = DebugUpstreamState()
+        }
     }
 
     private func markUpstreamInitialized(upstreamIndex: Int) {

--- a/Sources/XcodeMCPProxy/StdioAdapter.swift
+++ b/Sources/XcodeMCPProxy/StdioAdapter.swift
@@ -90,8 +90,18 @@ public actor StdioAdapter {
     }
 
     private func handleInput(_ data: Data) {
-        let messages = framer.append(data)
-        for message in messages {
+        let result = framer.append(data)
+        for recovery in result.recoveries {
+            logger.warning(
+                "Recovered STDIO input stream corruption",
+                metadata: [
+                    "kind": "\(recovery.kind.rawValue)",
+                    "dropped_prefix_bytes": "\(recovery.droppedPrefixBytes)",
+                    "candidate_offset": "\(recovery.candidateOffset.map(String.init) ?? "none")",
+                ]
+            )
+        }
+        for message in result.messages {
             Task { [weak self] in
                 await self?.processMessage(message)
             }

--- a/Sources/XcodeMCPProxy/StdioFramer.swift
+++ b/Sources/XcodeMCPProxy/StdioFramer.swift
@@ -194,7 +194,6 @@ final class StdioFramer {
     }
 
     private func recoverCorruptJSONPrefixIfNeeded() -> StdioFramerRecovery? {
-        guard buffer.count > resyncScanThreshold else { return nil }
         guard let firstIndex = firstNonWhitespaceIndex(from: buffer.startIndex) else { return nil }
         let rootByte = buffer[firstIndex]
         guard rootByte == 0x7B || rootByte == 0x5B else { return nil }
@@ -206,10 +205,19 @@ final class StdioFramer {
             break
         }
 
+        // Invalid JSON at the buffer head is already a proven corruption signal, so recover as soon
+        // as we can find a later top-level root instead of waiting for the large-buffer threshold.
+        let allowsLooseLineBoundaries = buffer.count > resyncScanThreshold
+        let minimumCandidateIndex = allowsLooseLineBoundaries ? nil : jsonValueEndIndex(from: firstIndex)
+        if !allowsLooseLineBoundaries, minimumCandidateIndex == nil {
+            return nil
+        }
+
         let candidates = recoveryCandidateOffsets(
             startingAfter: buffer.index(after: firstIndex),
             allowsObjectRoots: true,
-            allowsArrayRoots: true
+            allowsArrayRoots: true,
+            minimumCandidateIndex: minimumCandidateIndex
         )
         for candidate in candidates {
             guard let messageEnd = jsonValueEndIndex(from: candidate) else { continue }
@@ -246,7 +254,8 @@ final class StdioFramer {
     private func recoveryCandidateOffsets(
         startingAfter lowerBound: Data.Index,
         allowsObjectRoots: Bool,
-        allowsArrayRoots: Bool
+        allowsArrayRoots: Bool,
+        minimumCandidateIndex: Data.Index?
     ) -> [Data.Index] {
         guard lowerBound < buffer.endIndex else { return [] }
         var offsets: [Data.Index] = []
@@ -256,7 +265,9 @@ final class StdioFramer {
             let byte = buffer[index]
             let isAllowedObjectRoot = byte == 0x7B && allowsObjectRoots
             let isAllowedArrayRoot = byte == 0x5B && allowsArrayRoots
+            let clearsMinimumBoundary = minimumCandidateIndex.map { index >= $0 } ?? true
             if (isAllowedObjectRoot || isAllowedArrayRoot),
+               clearsMinimumBoundary,
                isRecoveryBoundary(at: index),
                isPlausibleRecoveryRoot(at: index) {
                 offsets.append(index)
@@ -269,7 +280,10 @@ final class StdioFramer {
     private func isRecoveryBoundary(at index: Data.Index) -> Bool {
         guard index > buffer.startIndex else { return true }
         let previous = buffer[buffer.index(before: index)]
-        return previous == 0x0A || previous == 0x7D || previous == 0x5D
+        if previous == 0x7D || previous == 0x5D {
+            return true
+        }
+        return previous == 0x0A
     }
 
     private func isPlausibleRecoveryRoot(at index: Data.Index) -> Bool {

--- a/Sources/XcodeMCPProxy/StdioFramer.swift
+++ b/Sources/XcodeMCPProxy/StdioFramer.swift
@@ -1,12 +1,45 @@
 import Foundation
 
+struct StdioFramerRecovery: Sendable {
+    enum Kind: String, Codable, Sendable {
+        case resync
+        case fatalClear
+    }
+
+    let kind: Kind
+    let droppedPrefixBytes: Int
+    let candidateOffset: Int?
+    let previewBeforeDrop: String
+    let previewRecoveredMessage: String?
+}
+
+struct StdioFramerAppendResult: Sendable {
+    let messages: [Data]
+    let recoveries: [StdioFramerRecovery]
+    let bufferedByteCount: Int
+}
+
 final class StdioFramer {
+    private enum JSONPrefixParseResult {
+        case complete(Data.Index)
+        case incomplete
+        case invalid
+    }
+
+    private let resyncScanThreshold = 16 * 1024
+    private let bufferHardLimit = 4 * 1024 * 1024
+    private let previewLimit = 200
+
     private var buffer = Data()
 
-    func append(_ data: Data) -> [Data] {
-        guard !data.isEmpty else { return [] }
+    func append(_ data: Data) -> StdioFramerAppendResult {
+        guard !data.isEmpty else {
+            return StdioFramerAppendResult(messages: [], recoveries: [], bufferedByteCount: buffer.count)
+        }
+
         buffer.append(data)
         var messages: [Data] = []
+        var recoveries: [StdioFramerRecovery] = []
 
         while true {
             if let message = nextContentLengthMessage() {
@@ -23,10 +56,18 @@ final class StdioFramer {
             if dropLeadingNonJSONLine() {
                 continue
             }
+            if let recovery = recoverCorruptJSONPrefixIfNeeded() {
+                recoveries.append(recovery)
+                continue
+            }
             break
         }
 
-        return messages
+        return StdioFramerAppendResult(
+            messages: messages,
+            recoveries: recoveries,
+            bufferedByteCount: buffer.count
+        )
     }
 
     private func nextContentLengthMessage() -> Data? {
@@ -50,8 +91,6 @@ final class StdioFramer {
         let bodyEndIndex = headerEndIndex + length
         let bodyRange = headerEndIndex..<bodyEndIndex
 
-        // Validate that the framed body looks like a single JSON value. If it doesn't, treat the
-        // Content-Length header as junk (e.g. upstream log output) and resync by dropping the header.
         if let jsonStart = firstNonWhitespaceIndex(in: bodyRange),
            buffer[jsonStart] == 0x7B || buffer[jsonStart] == 0x5B,
            let jsonEndIndex = jsonValueEndIndex(from: jsonStart),
@@ -67,50 +106,15 @@ final class StdioFramer {
     }
 
     private func nextJSONValueMessage() -> Data? {
-        var index = buffer.startIndex
-        while index < buffer.endIndex, isWhitespace(buffer[index]) {
-            index = buffer.index(after: index)
+        guard let startIndex = firstNonWhitespaceIndex(from: buffer.startIndex) else {
+            return nil
         }
-        if index == buffer.endIndex { return nil }
-
-        let startIndex = index
-        let first = buffer[index]
+        let first = buffer[startIndex]
         guard first == 0x7B || first == 0x5B else { return nil }
+        guard let messageEnd = jsonValueEndIndex(from: startIndex) else { return nil }
 
-        var depth = 0
-        var inString = false
-        var isEscaped = false
-        var endIndex: Data.Index?
-
-        while index < buffer.endIndex {
-            let byte = buffer[index]
-            if inString {
-                if isEscaped {
-                    isEscaped = false
-                } else if byte == 0x5C {
-                    isEscaped = true
-                } else if byte == 0x22 {
-                    inString = false
-                }
-            } else {
-                if byte == 0x22 {
-                    inString = true
-                } else if byte == 0x7B || byte == 0x5B {
-                    depth += 1
-                } else if byte == 0x7D || byte == 0x5D {
-                    depth -= 1
-                    if depth == 0 {
-                        endIndex = index
-                        break
-                    }
-                }
-            }
-            index = buffer.index(after: index)
-        }
-
-        guard let endIndex, depth == 0, !inString else { return nil }
-        let messageEnd = buffer.index(after: endIndex)
         let message = buffer.subdata(in: startIndex..<messageEnd)
+        guard isValidJSONObjectOrArray(message) else { return nil }
         buffer.removeSubrange(0..<messageEnd)
         return message
     }
@@ -135,10 +139,6 @@ final class StdioFramer {
     private func dropLeadingNonJSONLine() -> Bool {
         guard !buffer.isEmpty else { return false }
 
-        // If we're at the start of a (possibly partial) Content-Length header, wait for more bytes.
-        // NOTE: Upstreams sometimes print newline-delimited log lines that begin with "Content-Length".
-        // We must avoid stalling forever on such junk, but also preserve correct framing when a real
-        // Content-Length header arrives split across multiple writes.
         if isPotentialContentLengthHeaderPrefix() {
             let delimiterCRLF = Data("\r\n\r\n".utf8)
             let delimiterLF = Data("\n\n".utf8)
@@ -150,15 +150,11 @@ final class StdioFramer {
                 if let headerText = String(data: headerData, encoding: .utf8),
                    let length = parseContentLength(from: headerText) {
                     if let bodyStart = firstNonWhitespaceIndex(from: headerEndIndex) {
-                        // If we have any bytes after the delimiter and it doesn't look like JSON,
-                        // treat the header as junk framing and resync.
                         if buffer[bodyStart] != 0x7B && buffer[bodyStart] != 0x5B {
                             buffer.removeSubrange(0..<headerEndIndex)
                             return true
                         }
 
-                        // If a full JSON value is already present after the delimiter, but it doesn't match
-                        // the declared Content-Length, treat this as junk framing and resync.
                         if let jsonEndIndex = jsonValueEndIndex(from: bodyStart) {
                             let observedLength = buffer.distance(from: headerEndIndex, to: jsonEndIndex)
                             if observedLength != length {
@@ -168,54 +164,158 @@ final class StdioFramer {
                         }
                     }
 
-                    // Otherwise, assume this is legitimate framing; wait for the body bytes.
                     return false
                 }
-
-                // Delimiter is present but the header isn't parseable: fall back to line dropping below.
             }
 
-            // No delimiter yet: if we haven't received even a newline, we're still in a partial line.
             guard let firstNewlineIndex = buffer.firstIndex(of: 0x0A) else {
                 return false
             }
 
-            // If we only have the first header line so far, keep waiting for the rest.
             let afterNewline = buffer.index(after: firstNewlineIndex)
             if afterNewline == buffer.endIndex {
                 return false
             }
 
-            // If JSON appears before any delimiter, treat the leading line as junk and drop it so parsing can continue.
             let hasJSONStartAfterNewline = buffer[afterNewline...].contains { $0 == 0x7B || $0 == 0x5B }
-            if !hasJSONStartAfterNewline {
-                // Otherwise, assume the header may still be arriving in pieces. This is bounded so we don't
-                // keep buffering unbounded junk forever.
-                if buffer.count < 8 * 1024 {
-                    return false
-                }
+            if !hasJSONStartAfterNewline, buffer.count < 8 * 1024 {
+                return false
             }
         }
 
-        // If the first non-whitespace token looks like JSON, don't drop anything; we might just be
-        // waiting for the rest of a multi-line JSON value.
         if let first = firstNonWhitespaceByte(), first == 0x7B || first == 0x5B {
             return false
         }
 
-        // Drop exactly one line of non-JSON stdout so we don't get stuck on accidental log output.
         guard let newlineIndex = buffer.firstIndex(of: 0x0A) else { return false }
         let dropEnd = buffer.index(after: newlineIndex)
         buffer.removeSubrange(0..<dropEnd)
         return true
     }
 
-    private func firstNonWhitespaceByte() -> UInt8? {
-        var index = buffer.startIndex
-        while index < buffer.endIndex, isWhitespace(buffer[index]) {
+    private func recoverCorruptJSONPrefixIfNeeded() -> StdioFramerRecovery? {
+        guard buffer.count > resyncScanThreshold else { return nil }
+        guard let firstIndex = firstNonWhitespaceIndex(from: buffer.startIndex) else { return nil }
+        let rootByte = buffer[firstIndex]
+        guard rootByte == 0x7B || rootByte == 0x5B else { return nil }
+
+        switch jsonPrefixParseResult(from: firstIndex) {
+        case .complete, .incomplete:
+            return nil
+        case .invalid:
+            break
+        }
+
+        let candidates = recoveryCandidateOffsets(
+            startingAfter: buffer.index(after: firstIndex),
+            allowsObjectRoots: true,
+            allowsArrayRoots: true
+        )
+        for candidate in candidates {
+            guard let messageEnd = jsonValueEndIndex(from: candidate) else { continue }
+            let recovered = buffer.subdata(in: candidate..<messageEnd)
+            guard isValidRecoveryRoot(recovered) else { continue }
+
+            let droppedPrefix = buffer.subdata(in: 0..<candidate)
+            buffer.removeSubrange(0..<candidate)
+            return StdioFramerRecovery(
+                kind: .resync,
+                droppedPrefixBytes: candidate,
+                candidateOffset: candidate,
+                previewBeforeDrop: preview(of: droppedPrefix, preferTail: true),
+                previewRecoveredMessage: preview(of: recovered, preferTail: false)
+            )
+        }
+
+        if buffer.count > bufferHardLimit {
+            let dropped = buffer
+            let droppedCount = buffer.count
+            buffer.removeAll(keepingCapacity: true)
+            return StdioFramerRecovery(
+                kind: .fatalClear,
+                droppedPrefixBytes: droppedCount,
+                candidateOffset: nil,
+                previewBeforeDrop: preview(of: dropped, preferTail: true),
+                previewRecoveredMessage: nil
+            )
+        }
+
+        return nil
+    }
+
+    private func recoveryCandidateOffsets(
+        startingAfter lowerBound: Data.Index,
+        allowsObjectRoots: Bool,
+        allowsArrayRoots: Bool
+    ) -> [Data.Index] {
+        guard lowerBound < buffer.endIndex else { return [] }
+        var offsets: [Data.Index] = []
+        offsets.reserveCapacity(8)
+        var index = lowerBound
+        while index < buffer.endIndex {
+            let byte = buffer[index]
+            let isAllowedObjectRoot = byte == 0x7B && allowsObjectRoots
+            let isAllowedArrayRoot = byte == 0x5B && allowsArrayRoots
+            if (isAllowedObjectRoot || isAllowedArrayRoot),
+               isRecoveryBoundary(at: index),
+               isPlausibleRecoveryRoot(at: index) {
+                offsets.append(index)
+            }
             index = buffer.index(after: index)
         }
-        guard index < buffer.endIndex else { return nil }
+        return offsets
+    }
+
+    private func isRecoveryBoundary(at index: Data.Index) -> Bool {
+        guard index > buffer.startIndex else { return true }
+        let previous = buffer[buffer.index(before: index)]
+        return previous == 0x0A || previous == 0x7D || previous == 0x5D
+    }
+
+    private func isPlausibleRecoveryRoot(at index: Data.Index) -> Bool {
+        guard index < buffer.endIndex else { return false }
+        let byte = buffer[index]
+        guard byte == 0x7B || byte == 0x5B else { return false }
+
+        let contentStart = buffer.index(after: index)
+        guard let nextIndex = firstNonWhitespaceIndex(from: contentStart) else { return false }
+
+        if byte == 0x7B {
+            return buffer[nextIndex] == 0x22
+        }
+
+        return buffer[nextIndex] == 0x7B
+    }
+
+    private func isValidRecoveryRoot(_ data: Data) -> Bool {
+        guard let any = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            return false
+        }
+
+        if let object = any as? [String: Any] {
+            guard object["jsonrpc"] as? String == "2.0" else { return false }
+            return object["id"] != nil || object["method"] is String
+        }
+
+        if let array = any as? [Any] {
+            guard let first = array.first as? [String: Any] else { return false }
+            return first["jsonrpc"] as? String == "2.0"
+        }
+
+        return false
+    }
+
+    private func isValidJSONObjectOrArray(_ data: Data) -> Bool {
+        guard let any = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            return false
+        }
+        return any is [String: Any] || any is [Any]
+    }
+
+    private func firstNonWhitespaceByte() -> UInt8? {
+        guard let index = firstNonWhitespaceIndex(from: buffer.startIndex) else {
+            return nil
+        }
         return buffer[index]
     }
 
@@ -278,6 +378,221 @@ final class StdioFramer {
         return buffer.index(after: endIndex)
     }
 
+    private func jsonPrefixParseResult(from startIndex: Data.Index) -> JSONPrefixParseResult {
+        parseJSONValuePrefix(from: startIndex)
+    }
+
+    private func parseJSONValuePrefix(from startIndex: Data.Index) -> JSONPrefixParseResult {
+        let index = skipWhitespace(from: startIndex)
+        guard index < buffer.endIndex else { return .incomplete }
+
+        switch buffer[index] {
+        case 0x7B:
+            return parseJSONObjectPrefix(from: index)
+        case 0x5B:
+            return parseJSONArrayPrefix(from: index)
+        case 0x22:
+            return parseJSONStringPrefix(from: index)
+        case 0x74:
+            return parseJSONLiteralPrefix("true", from: index)
+        case 0x66:
+            return parseJSONLiteralPrefix("false", from: index)
+        case 0x6E:
+            return parseJSONLiteralPrefix("null", from: index)
+        case 0x2D, 0x30 ... 0x39:
+            return parseJSONNumberPrefix(from: index)
+        default:
+            return .invalid
+        }
+    }
+
+    private func parseJSONObjectPrefix(from startIndex: Data.Index) -> JSONPrefixParseResult {
+        var index = skipWhitespace(from: buffer.index(after: startIndex))
+        guard index < buffer.endIndex else { return .incomplete }
+        if buffer[index] == 0x7D {
+            return .complete(buffer.index(after: index))
+        }
+
+        while true {
+            switch parseJSONStringPrefix(from: index) {
+            case .complete(let nextIndex):
+                index = skipWhitespace(from: nextIndex)
+            case .incomplete:
+                return .incomplete
+            case .invalid:
+                return .invalid
+            }
+
+            guard index < buffer.endIndex else { return .incomplete }
+            guard buffer[index] == 0x3A else { return .invalid }
+            index = skipWhitespace(from: buffer.index(after: index))
+
+            switch parseJSONValuePrefix(from: index) {
+            case .complete(let nextIndex):
+                index = skipWhitespace(from: nextIndex)
+            case .incomplete:
+                return .incomplete
+            case .invalid:
+                return .invalid
+            }
+
+            guard index < buffer.endIndex else { return .incomplete }
+            let byte = buffer[index]
+            if byte == 0x2C {
+                index = skipWhitespace(from: buffer.index(after: index))
+                guard index < buffer.endIndex else { return .incomplete }
+                continue
+            }
+            if byte == 0x7D {
+                return .complete(buffer.index(after: index))
+            }
+            return .invalid
+        }
+    }
+
+    private func parseJSONArrayPrefix(from startIndex: Data.Index) -> JSONPrefixParseResult {
+        var index = skipWhitespace(from: buffer.index(after: startIndex))
+        guard index < buffer.endIndex else { return .incomplete }
+        if buffer[index] == 0x5D {
+            return .complete(buffer.index(after: index))
+        }
+
+        while true {
+            switch parseJSONValuePrefix(from: index) {
+            case .complete(let nextIndex):
+                index = skipWhitespace(from: nextIndex)
+            case .incomplete:
+                return .incomplete
+            case .invalid:
+                return .invalid
+            }
+
+            guard index < buffer.endIndex else { return .incomplete }
+            let byte = buffer[index]
+            if byte == 0x2C {
+                index = skipWhitespace(from: buffer.index(after: index))
+                guard index < buffer.endIndex else { return .incomplete }
+                continue
+            }
+            if byte == 0x5D {
+                return .complete(buffer.index(after: index))
+            }
+            return .invalid
+        }
+    }
+
+    private func parseJSONStringPrefix(from startIndex: Data.Index) -> JSONPrefixParseResult {
+        guard startIndex < buffer.endIndex, buffer[startIndex] == 0x22 else { return .invalid }
+
+        var index = buffer.index(after: startIndex)
+        var isEscaped = false
+        var pendingUnicodeDigits = 0
+
+        while index < buffer.endIndex {
+            let byte = buffer[index]
+            if pendingUnicodeDigits > 0 {
+                guard isHexDigit(byte) else { return .invalid }
+                pendingUnicodeDigits -= 1
+            } else if isEscaped {
+                switch byte {
+                case 0x22, 0x5C, 0x2F, 0x62, 0x66, 0x6E, 0x72, 0x74:
+                    isEscaped = false
+                case 0x75:
+                    isEscaped = false
+                    pendingUnicodeDigits = 4
+                default:
+                    return .invalid
+                }
+            } else if byte == 0x5C {
+                isEscaped = true
+            } else if byte == 0x22 {
+                return .complete(buffer.index(after: index))
+            } else if byte < 0x20 {
+                return .invalid
+            }
+
+            index = buffer.index(after: index)
+        }
+
+        return .incomplete
+    }
+
+    private func parseJSONLiteralPrefix(_ literal: StaticString, from startIndex: Data.Index) -> JSONPrefixParseResult {
+        let bytes = Array(String(describing: literal).utf8)
+        var index = startIndex
+
+        for expected in bytes {
+            guard index < buffer.endIndex else { return .incomplete }
+            guard buffer[index] == expected else { return .invalid }
+            index = buffer.index(after: index)
+        }
+
+        if index < buffer.endIndex, !isJSONValueTerminator(buffer[index]) {
+            return .invalid
+        }
+        return .complete(index)
+    }
+
+    private func parseJSONNumberPrefix(from startIndex: Data.Index) -> JSONPrefixParseResult {
+        var index = startIndex
+        let start = index
+
+        if buffer[index] == 0x2D {
+            index = buffer.index(after: index)
+            guard index < buffer.endIndex else { return .incomplete }
+        }
+
+        guard index < buffer.endIndex else { return .incomplete }
+        switch buffer[index] {
+        case 0x30:
+            index = buffer.index(after: index)
+            if index < buffer.endIndex, isDigit(buffer[index]) {
+                return .invalid
+            }
+        case 0x31 ... 0x39:
+            repeat {
+                index = buffer.index(after: index)
+            } while index < buffer.endIndex && isDigit(buffer[index])
+        default:
+            return index == start ? .invalid : .incomplete
+        }
+
+        if index < buffer.endIndex, buffer[index] == 0x2E {
+            index = buffer.index(after: index)
+            guard index < buffer.endIndex else { return .incomplete }
+            guard isDigit(buffer[index]) else { return .invalid }
+            repeat {
+                index = buffer.index(after: index)
+            } while index < buffer.endIndex && isDigit(buffer[index])
+        }
+
+        if index < buffer.endIndex, buffer[index] == 0x45 || buffer[index] == 0x65 {
+            index = buffer.index(after: index)
+            guard index < buffer.endIndex else { return .incomplete }
+            if buffer[index] == 0x2B || buffer[index] == 0x2D {
+                index = buffer.index(after: index)
+                guard index < buffer.endIndex else { return .incomplete }
+            }
+            guard isDigit(buffer[index]) else { return .invalid }
+            repeat {
+                index = buffer.index(after: index)
+            } while index < buffer.endIndex && isDigit(buffer[index])
+        }
+
+        if index < buffer.endIndex, !isJSONValueTerminator(buffer[index]) {
+            return .invalid
+        }
+        return .complete(index)
+    }
+
+    private func skipWhitespace(from startIndex: Data.Index) -> Data.Index {
+        var index = startIndex
+        while index < buffer.endIndex, isWhitespace(buffer[index]) {
+            index = buffer.index(after: index)
+        }
+        return index
+    }
+
     private func parseContentLength(from headerText: String) -> Int? {
         for line in headerText.split(separator: "\n") {
             let parts = line.split(separator: ":", maxSplits: 1)
@@ -303,5 +618,32 @@ final class StdioFramer {
 
     private func isWhitespace(_ byte: UInt8) -> Bool {
         byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D
+    }
+
+    private func isDigit(_ byte: UInt8) -> Bool {
+        byte >= 0x30 && byte <= 0x39
+    }
+
+    private func isHexDigit(_ byte: UInt8) -> Bool {
+        isDigit(byte) || (byte >= 0x41 && byte <= 0x46) || (byte >= 0x61 && byte <= 0x66)
+    }
+
+    private func isJSONValueTerminator(_ byte: UInt8) -> Bool {
+        isWhitespace(byte) || byte == 0x2C || byte == 0x5D || byte == 0x7D
+    }
+
+    private func preview(of data: Data, preferTail: Bool) -> String {
+        guard !data.isEmpty else { return "" }
+        let slice: Data
+        if data.count <= previewLimit {
+            slice = data
+        } else if preferTail {
+            slice = data.suffix(previewLimit)
+        } else {
+            slice = data.prefix(previewLimit)
+        }
+
+        let text = String(decoding: slice, as: UTF8.self)
+        return data.count > previewLimit && preferTail ? "..." + text : text
     }
 }

--- a/Sources/XcodeMCPProxy/UpstreamClient.swift
+++ b/Sources/XcodeMCPProxy/UpstreamClient.swift
@@ -2,6 +2,9 @@ import Foundation
 
 enum UpstreamEvent: Sendable {
     case message(Data)
+    case stderr(String)
+    case stdoutRecovery(StdioFramerRecovery)
+    case stdoutBufferSize(Int)
     case exit(Int32)
 }
 

--- a/Sources/XcodeMCPProxy/UpstreamProcess.swift
+++ b/Sources/XcodeMCPProxy/UpstreamProcess.swift
@@ -28,8 +28,11 @@ actor UpstreamProcess: UpstreamClient {
     private var restartTask: Task<Void, Never>?
     private var queuedWriteBytes = 0
     private var writeGeneration: UInt64 = 0
+    private var stderrBuffer = ""
+    private var lastReportedBufferedStdoutBytes = 0
     private let writeQueue = DispatchQueue(label: "XcodeMCPProxy.UpstreamProcess.write")
     private let logger: Logger = ProxyLogging.make("upstream")
+    private let maxBufferedStderrBytes = 16 * 1024
 
     init(config: Config) {
         self.config = config
@@ -124,6 +127,8 @@ actor UpstreamProcess: UpstreamClient {
         framer = StdioFramer()
         queuedWriteBytes = 0
         writeGeneration &+= 1
+        stderrBuffer = ""
+        resetBufferedStdoutBytesIfNeeded()
 
         let (executableURL, args) = resolveCommand(command: config.command, args: config.args)
         let process = Process()
@@ -147,6 +152,9 @@ actor UpstreamProcess: UpstreamClient {
         stderrPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
             if data.isEmpty {
+                Task { [weak self] in
+                    await self?.handleStderrEOF()
+                }
                 return
             }
             Task { [weak self] in
@@ -171,10 +179,13 @@ actor UpstreamProcess: UpstreamClient {
     }
 
     private func stopLocked() {
+        flushBufferedStderrIfNeeded()
         stdoutPipe.fileHandleForReading.readabilityHandler = nil
         stderrPipe.fileHandleForReading.readabilityHandler = nil
         queuedWriteBytes = 0
         writeGeneration &+= 1
+        stderrBuffer = ""
+        resetBufferedStdoutBytesIfNeeded()
         if let process = process {
             terminatingProcess = process
             process.terminate()
@@ -183,8 +194,27 @@ actor UpstreamProcess: UpstreamClient {
     }
 
     private func handleStdoutData(_ data: Data) {
-        let messages = framer.append(data)
-        for message in messages {
+        let result = framer.append(data)
+        for recovery in result.recoveries {
+            logger.warning(
+                "Recovered upstream stdout stream corruption",
+                metadata: [
+                    "kind": .string(recovery.kind.rawValue),
+                    "dropped_prefix_bytes": .string("\(recovery.droppedPrefixBytes)"),
+                    "candidate_offset": .string(recovery.candidateOffset.map(String.init) ?? "none"),
+                    "preview_before_drop": .string(recovery.previewBeforeDrop),
+                    "preview_recovered": .string(recovery.previewRecoveredMessage ?? ""),
+                ]
+            )
+            continuation.yield(.stdoutRecovery(recovery))
+        }
+
+        if lastReportedBufferedStdoutBytes != result.bufferedByteCount {
+            lastReportedBufferedStdoutBytes = result.bufferedByteCount
+            continuation.yield(.stdoutBufferSize(result.bufferedByteCount))
+        }
+
+        for message in result.messages {
             guard isValidJSONPayload(message) else {
                 if let text = String(data: message, encoding: .utf8) {
                     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -206,6 +236,12 @@ actor UpstreamProcess: UpstreamClient {
             return false
         }
         return json is [String: Any] || json is [Any]
+    }
+
+    private func resetBufferedStdoutBytesIfNeeded() {
+        guard lastReportedBufferedStdoutBytes != 0 else { return }
+        lastReportedBufferedStdoutBytes = 0
+        continuation.yield(.stdoutBufferSize(0))
     }
 
     private func handleTermination(process terminated: Process, status: Int32) {
@@ -243,12 +279,43 @@ actor UpstreamProcess: UpstreamClient {
 
     private func handleStderrData(_ data: Data) {
         if let message = String(data: data, encoding: .utf8) {
-            let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return }
-            logger.error("Upstream stderr: \(trimmed)")
+            stderrBuffer.append(message)
+            let parts = stderrBuffer.split(separator: "\n", omittingEmptySubsequences: false)
+            let completeLines = parts.dropLast()
+            stderrBuffer = parts.last.map(String.init) ?? ""
+
+            for line in completeLines {
+                emitStderrLine(String(line))
+            }
+            flushBufferedStderrChunkIfNeeded()
         } else {
             logger.error("Upstream stderr (binary)", metadata: ["bytes": "\(data.count)"])
         }
+    }
+
+    private func handleStderrEOF() {
+        flushBufferedStderrIfNeeded()
+    }
+
+    private func flushBufferedStderrIfNeeded() {
+        emitStderrLine(stderrBuffer)
+        stderrBuffer = ""
+    }
+
+    private func flushBufferedStderrChunkIfNeeded() {
+        while stderrBuffer.utf8.count > maxBufferedStderrBytes {
+            let prefixData = Data(stderrBuffer.utf8.prefix(maxBufferedStderrBytes))
+            emitStderrLine(String(decoding: prefixData, as: UTF8.self), suffix: " [truncated]")
+            stderrBuffer = String(decoding: stderrBuffer.utf8.dropFirst(maxBufferedStderrBytes), as: UTF8.self)
+        }
+    }
+
+    private func emitStderrLine(_ line: String, suffix: String = "") {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let message = suffix.isEmpty ? trimmed : trimmed + suffix
+        logger.error("Upstream stderr: \(message)")
+        continuation.yield(.stderr(message))
     }
 
     private func scheduleRestart() {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -22,6 +22,47 @@ import Testing
     #expect(response.body == "ok")
 }
 
+@Test func httpDebugUpstreamsReturnsSnapshot() async throws {
+    let config = makeConfig()
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/debug/upstreams")
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .ok)
+    #expect(response.head.headers.first(name: "Content-Type") == "application/json")
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let snapshot = try decoder.decode(ProxyDebugSnapshot.self, from: Data(response.body.utf8))
+    #expect(snapshot.proxyInitialized == false)
+    #expect(snapshot.upstreams.count == 1)
+    #expect(snapshot.upstreams[0].upstreamIndex == 0)
+}
+
+@Test func httpDebugUpstreamsReturnsNotFoundWhenListenerIsNotLoopback() async throws {
+    var config = makeConfig()
+    config.listenHost = "0.0.0.0"
+
+    let channel = EmbeddedChannel()
+    defer { _ = try? channel.finish() }
+    let sessionManager = TestSessionManager(config: config)
+    try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+    let head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/debug/upstreams")
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let response = try collectResponse(from: channel)
+    #expect(response.head.status == .notFound)
+    #expect(response.body == "not found")
+}
+
 @Test func httpSSERequiresAcceptHeader() async throws {
     let config = makeConfig()
     let channel = EmbeddedChannel()
@@ -1543,6 +1584,36 @@ private final class TestSessionManager: SessionManaging {
         session.router.handleIncoming(responseData)
     }
 
+    func debugSnapshot() -> ProxyDebugSnapshot {
+        ProxyDebugSnapshot(
+            generatedAt: Date(timeIntervalSince1970: 0),
+            proxyInitialized: isInitialized(),
+            cachedToolsListAvailable: cachedToolsListResult() != nil,
+            warmupInFlight: false,
+            upstreams: [
+                ProxyUpstreamDebugSnapshot(
+                    upstreamIndex: 0,
+                    isInitialized: isInitialized(),
+                    initInFlight: false,
+                    didSendInitialized: false,
+                    healthState: "healthy",
+                    consecutiveRequestTimeouts: 0,
+                    consecutiveToolsListFailures: 0,
+                    lastToolsListSuccessUptimeNs: nil,
+                    recentStderr: [],
+                    lastDecodeError: nil,
+                    lastBridgeError: nil,
+                    resyncCount: 0,
+                    lastResyncAt: nil,
+                    lastResyncDroppedBytes: nil,
+                    lastResyncPreview: nil,
+                    bufferedStdoutBytes: 0
+                )
+            ],
+            recentTraffic: []
+        )
+    }
+
     func sentUpstreamCount() -> Int {
         state.withLockedValue { $0.upstreamSendCount }
     }
@@ -1580,7 +1651,10 @@ private final class TestSessionManager: SessionManaging {
     }
 }
 
-private func makeConfig(maxBodyBytes: Int = 1024, requestTimeout: TimeInterval = 1) -> ProxyConfig {
+private func makeConfig(
+    maxBodyBytes: Int = 1024,
+    requestTimeout: TimeInterval = 1
+) -> ProxyConfig {
     ProxyConfig(
         listenHost: "127.0.0.1",
         listenPort: 0,

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -524,6 +524,76 @@ import Testing
     #expect(session.router.drainBufferedNotifications().isEmpty)
 }
 
+@Test func sessionManagerDebugSnapshotCapturesTrafficAndStderr() async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    defer { Task { await shutdown(group) } }
+    let eventLoop = group.next()
+    let upstream = TestUpstreamClient()
+    let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+    let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+    try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+    let initMessages = await upstream.sent()
+    let initId = try extractUpstreamId(from: initMessages[0])
+    await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+    try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
+
+    let sessionId = "session-debug"
+    let session = manager.session(id: sessionId)
+    let upstreamIndex = try #require(manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true))
+    let original = RPCId(any: NSNumber(value: 301))!
+    let future = session.router.registerRequest(idKey: original.key, on: eventLoop, timeout: .seconds(1))
+    let upstreamId = manager.assignUpstreamId(
+        sessionId: sessionId,
+        originalId: original,
+        upstreamIndex: upstreamIndex
+    )
+    manager.sendUpstream(try makeToolListRequest(id: upstreamId), upstreamIndex: upstreamIndex)
+    await upstream.yield(.message(try makeToolListResponse(id: upstreamId)))
+    _ = try await future.get()
+
+    await upstream.yield(.message(try makeToolListResponse(id: 9_999_999)))
+    await upstream.yield(.stderr("Could not decode agent message: Error Domain=mcpbridge.DecodeError Code=1"))
+    await upstream.yield(.stderr("callTool request for 'DocumentationSearch' failed: Error Domain=IDEIntelligenceMessaging.BridgeError Code=1"))
+    await upstream.yield(
+        .stdoutRecovery(
+            StdioFramerRecovery(
+                kind: .resync,
+                droppedPrefixBytes: 1024,
+                candidateOffset: 1024,
+                previewBeforeDrop: "...broken",
+                previewRecoveredMessage: "{\"id\":301,\"jsonrpc\":\"2.0\"}"
+            )
+        )
+    )
+    await upstream.yield(.stdoutBufferSize(2048))
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let snapshot = manager.debugSnapshot()
+    #expect(snapshot.upstreams.count == 1)
+    #expect(snapshot.upstreams[0].lastDecodeError?.message == "<redacted>")
+    #expect(snapshot.upstreams[0].lastBridgeError?.message == "<redacted>")
+    #expect(snapshot.upstreams[0].resyncCount == 1)
+    #expect(snapshot.upstreams[0].lastResyncDroppedBytes == 1024)
+    #expect(snapshot.upstreams[0].lastResyncPreview == "<redacted>")
+    #expect(snapshot.upstreams[0].bufferedStdoutBytes == 2048)
+    #expect(snapshot.recentTraffic.contains { $0.direction == "outbound" && $0.bytes > 0 })
+    #expect(snapshot.recentTraffic.contains { $0.direction == "inbound" && $0.preview == "<redacted>" })
+    #expect(snapshot.recentTraffic.contains { $0.direction == "inbound_unmapped" && $0.preview == "<redacted>" })
+    #expect(snapshot.upstreams[0].recentStderr.allSatisfy { $0.message == "<redacted>" })
+
+    await upstream.yield(.exit(1))
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    let clearedSnapshot = manager.debugSnapshot()
+    #expect(clearedSnapshot.upstreams[0].recentStderr.isEmpty)
+    #expect(clearedSnapshot.upstreams[0].lastDecodeError == nil)
+    #expect(clearedSnapshot.upstreams[0].lastBridgeError == nil)
+    #expect(clearedSnapshot.upstreams[0].resyncCount == 0)
+    #expect(clearedSnapshot.upstreams[0].lastResyncPreview == nil)
+    #expect(clearedSnapshot.upstreams[0].bufferedStdoutBytes == 0)
+}
+
 @Test func sessionManagerReturnsNilWhenAllUpstreamsAreQuarantined() async throws {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     defer { Task { await shutdown(group) } }
@@ -747,6 +817,10 @@ import Testing
     let error = response["error"] as? [String: Any]
     #expect((error?["code"] as? NSNumber)?.intValue == -32002)
     #expect((error?["message"] as? String) == "upstream overloaded")
+
+    try await Task.sleep(nanoseconds: 50_000_000)
+    let snapshot = manager.debugSnapshot()
+    #expect(snapshot.recentTraffic.contains { $0.direction == "outbound" } == false)
 }
 
 @Test func sessionManagerInitializeReturnsOverloadedErrorWhenUpstreamRejectsSend() async throws {

--- a/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
+++ b/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
@@ -231,6 +231,79 @@ import Testing
     #expect(String(data: result.messages[0], encoding: .utf8) == json)
 }
 
+@Test func stdioFramerResyncsSmallInvalidObjectWithoutWaitingForThreshold() async throws {
+    let framer = StdioFramer()
+    let corrupt = "{\"result\":tru}"
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"ok\":true}}"
+
+    let result = framer.append(Data((corrupt + json).utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .resync)
+    #expect(recovery.droppedPrefixBytes == corrupt.utf8.count)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerResyncsSmallInvalidObjectAcrossNewlineDelimitedMessages() async throws {
+    let framer = StdioFramer()
+    let corrupt = "{\"result\":tru}\n"
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"ok\":true}}"
+
+    let result = framer.append(Data((corrupt + json).utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .resync)
+    #expect(recovery.droppedPrefixBytes == corrupt.utf8.count)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerDoesNotResyncNestedJSONInsideSmallMalformedObject() async throws {
+    let framer = StdioFramer()
+    let payload = """
+    {
+      "broken": tru,
+      "result": {
+        "jsonrpc": "2.0",
+        "id": 2
+      }
+    }
+    """
+
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.isEmpty)
+    #expect(result.recoveries.isEmpty)
+    #expect(result.bufferedByteCount == payload.utf8.count)
+}
+
+@Test func stdioFramerDoesNotResyncAdjacentNestedJSONObjectInsideSmallMalformedObject() async throws {
+    let framer = StdioFramer()
+    let payload = "{\"outer\":{\"broken\":true}{\"jsonrpc\":\"2.0\",\"id\":2}}"
+
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.isEmpty)
+    #expect(result.recoveries.isEmpty)
+    #expect(result.bufferedByteCount == payload.utf8.count)
+}
+
+@Test func stdioFramerDoesNotEarlyResyncWhenSmallMalformedObjectHasNoStructuralEnd() async throws {
+    let framer = StdioFramer()
+    let payload = """
+    {
+      "broken": tru,
+      "result":
+    {"jsonrpc":"2.0","id":2}
+    """
+
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.isEmpty)
+    #expect(result.recoveries.isEmpty)
+    #expect(result.bufferedByteCount == payload.utf8.count)
+}
+
 @Test func stdioFramerResyncsCorruptBatchToAdjacentRawJSONObject() async throws {
     let framer = StdioFramer()
     let corrupt = "[{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":tru}]"

--- a/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
+++ b/Tests/XcodeMCPProxyTests/StdioFramerTests.swift
@@ -6,10 +6,11 @@ import Testing
     let framer = StdioFramer()
     let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
     let payload = "Content-Length: \(json.utf8.count)\r\n\r\n\(json)"
-    let parts = framer.append(Data(payload.utf8))
-    #expect(parts.count == 1)
-    guard parts.count == 1 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json)
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
 }
 
 @Test func stdioFramerNDJSON() async throws {
@@ -17,49 +18,54 @@ import Testing
     let json1 = "{\"jsonrpc\":\"2.0\",\"id\":1}"
     let json2 = "{\"jsonrpc\":\"2.0\",\"id\":2}"
     let payload = "\(json1)\n\(json2)\n"
-    let parts = framer.append(Data(payload.utf8))
-    #expect(parts.count == 2)
-    guard parts.count == 2 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json1)
-    #expect(String(data: parts[1], encoding: .utf8) == json2)
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.count == 2)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 2 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json1)
+    #expect(String(data: result.messages[1], encoding: .utf8) == json2)
 }
 
 @Test func stdioFramerRawJSON() async throws {
     let framer = StdioFramer()
     let json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}"
-    let parts = framer.append(Data(json.utf8))
-    #expect(parts.count == 1)
-    guard parts.count == 1 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json)
+    let result = framer.append(Data(json.utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
 }
 
 @Test func stdioFramerMultilineJSON() async throws {
     let framer = StdioFramer()
     let json = "{\n\"jsonrpc\":\"2.0\",\n\"id\":1,\n\"result\":{\"ok\":true}\n}"
-    let parts = framer.append(Data(json.utf8))
-    #expect(parts.count == 1)
-    guard parts.count == 1 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json)
+    let result = framer.append(Data(json.utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
 }
 
 @Test func stdioFramerDropsLeadingNonJSONLineAndContinues() async throws {
     let framer = StdioFramer()
     let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
     let payload = "some log line\n\(json)"
-    let parts = framer.append(Data(payload.utf8))
-    #expect(parts.count == 1)
-    guard parts.count == 1 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json)
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
 }
 
 @Test func stdioFramerDoesNotStallOnContentLengthLookingLogLine() async throws {
     let framer = StdioFramer()
     let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
     let payload = "Content-Length: 123\n\(json)"
-    let parts = framer.append(Data(payload.utf8))
-    #expect(parts.count == 1)
-    guard parts.count == 1 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json)
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
 }
 
 @Test func stdioFramerKeepsWaitingForPartialContentLengthHeaderAcrossWrites() async throws {
@@ -68,41 +74,275 @@ import Testing
 
     let header = "Content-Length: \(json.utf8.count)\r\n"
     let partsA = framer.append(Data(header.utf8))
-    #expect(partsA.isEmpty)
+    #expect(partsA.messages.isEmpty)
+    #expect(partsA.recoveries.isEmpty)
 
     let rest = "\r\n\(json)"
     let partsB = framer.append(Data(rest.utf8))
-    #expect(partsB.count == 1)
-    guard partsB.count == 1 else { return }
-    #expect(String(data: partsB[0], encoding: .utf8) == json)
+    #expect(partsB.messages.count == 1)
+    #expect(partsB.recoveries.isEmpty)
+    guard partsB.messages.count == 1 else { return }
+    #expect(String(data: partsB.messages[0], encoding: .utf8) == json)
 }
 
 @Test func stdioFramerRecoversFromBogusContentLengthBlock() async throws {
     let framer = StdioFramer()
     let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
     let payload = "Content-Length: 123\n\nsome log line\n\(json)"
-    let parts = framer.append(Data(payload.utf8))
-    #expect(parts.count == 1)
-    guard parts.count == 1 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json)
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
 }
 
 @Test func stdioFramerRecoversFromBogusContentLengthShorterThanJSON() async throws {
     let framer = StdioFramer()
     let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
     let payload = "Content-Length: 5\r\n\r\n\(json)"
-    let parts = framer.append(Data(payload.utf8))
-    #expect(parts.count == 1)
-    guard parts.count == 1 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json)
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
 }
 
 @Test func stdioFramerRecoversFromBogusContentLengthLongerThanJSON() async throws {
     let framer = StdioFramer()
     let json = "{\"jsonrpc\":\"2.0\",\"id\":1}"
     let payload = "Content-Length: 123\n\n\(json)"
-    let parts = framer.append(Data(payload.utf8))
-    #expect(parts.count == 1)
-    guard parts.count == 1 else { return }
-    #expect(String(data: parts[0], encoding: .utf8) == json)
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.isEmpty)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerResyncsCorruptLeadingObjectToNextValidObject() async throws {
+    let framer = StdioFramer()
+    let corrupt = "{" + String(repeating: "x", count: 16 * 1024)
+    let json = "{\"id\":2,\"jsonrpc\":\"2.0\",\"result\":{\"ok\":true}}"
+
+    let result = framer.append(Data((corrupt + "\n" + json).utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .resync)
+    #expect(recovery.droppedPrefixBytes == corrupt.utf8.count + 1)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerResyncsCorruptLeadingObjectAndEmitsMultipleValidObjects() async throws {
+    let framer = StdioFramer()
+    let corrupt = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"broken\":\"" + String(repeating: "x", count: 16 * 1024)
+    let json1 = "{\"id\":2,\"jsonrpc\":\"2.0\",\"result\":{\"ok\":true}}"
+    let json2 = "{\"id\":3,\"jsonrpc\":\"2.0\",\"result\":{\"ok\":false}}"
+
+    let result = framer.append(Data((corrupt + "\n" + json1 + json2).utf8))
+    #expect(result.messages.count == 2)
+    #expect(result.recoveries.count == 1)
+    guard result.messages.count == 2 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json1)
+    #expect(String(data: result.messages[1], encoding: .utf8) == json2)
+}
+
+@Test func stdioFramerResyncsCorruptLeadingObjectToPrettyPrintedMethodFirstObject() async throws {
+    let framer = StdioFramer()
+    let corrupt = "{" + String(repeating: "x", count: 16 * 1024)
+    let json = """
+    {
+      "method": "notifications/progress",
+      "jsonrpc": "2.0",
+      "params": {
+        "value": true
+      }
+    }
+    """
+
+    let result = framer.append(Data((corrupt + "\n" + json).utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .resync)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerResyncsCorruptLeadingObjectToPrettyPrintedBatch() async throws {
+    let framer = StdioFramer()
+    let corrupt = "{" + String(repeating: "x", count: 16 * 1024)
+    let json = """
+    [
+      {
+        "method": "notifications/cancelled",
+        "jsonrpc": "2.0"
+      }
+    ]
+    """
+
+    let result = framer.append(Data((corrupt + "\n" + json).utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .resync)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerResyncsCorruptLeadingArrayToNextBatch() async throws {
+    let framer = StdioFramer()
+    let corrupt = "[" + String(repeating: "x", count: 16 * 1024)
+    let json = """
+    [
+      {
+        "jsonrpc": "2.0",
+        "id": 2
+      },
+      {
+        "jsonrpc": "2.0",
+        "method": "notifications/progress"
+      }
+    ]
+    """
+
+    let result = framer.append(Data((corrupt + "\n" + json).utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .resync)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerResyncsCorruptObjectToAdjacentRawJSONObject() async throws {
+    let framer = StdioFramer()
+    let corrupt = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":tru}"
+        + String(repeating: "x", count: 16 * 1024)
+        + "}"
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"ok\":true}}"
+
+    let result = framer.append(Data((corrupt + json).utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .resync)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerResyncsCorruptBatchToAdjacentRawJSONObject() async throws {
+    let framer = StdioFramer()
+    let corrupt = "[{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":tru}]"
+        + String(repeating: "x", count: 16 * 1024)
+        + "]"
+    let json = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"ok\":true}}"
+
+    let result = framer.append(Data((corrupt + json).utf8))
+    #expect(result.messages.count == 1)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .resync)
+    guard result.messages.count == 1 else { return }
+    #expect(String(data: result.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerWaitsForIncompleteLargeBatchInsteadOfResyncingInnerObject() async throws {
+    let framer = StdioFramer()
+    let largeText = String(repeating: "x", count: 20 * 1024)
+    let partial = """
+    [
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+          "text": "\(largeText)"
+        }
+      }
+    """
+
+    let resultA = framer.append(Data(partial.utf8))
+    #expect(resultA.messages.isEmpty)
+    #expect(resultA.recoveries.isEmpty)
+    #expect(resultA.bufferedByteCount == partial.utf8.count)
+
+    let completed = partial + "\n]"
+    let resultB = framer.append(Data("\n]".utf8))
+    #expect(resultB.messages.count == 1)
+    #expect(resultB.recoveries.isEmpty)
+    guard resultB.messages.count == 1 else { return }
+    #expect(String(data: resultB.messages[0], encoding: .utf8) == completed)
+}
+
+@Test func stdioFramerDoesNotResyncPartialValidMessageBelowThreshold() async throws {
+    let framer = StdioFramer()
+    let partial = "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":{\"value\":\"" + String(repeating: "x", count: 1024)
+
+    let result = framer.append(Data(partial.utf8))
+    #expect(result.messages.isEmpty)
+    #expect(result.recoveries.isEmpty)
+    #expect(result.bufferedByteCount == partial.utf8.count)
+}
+
+@Test func stdioFramerKeepsLargeValidJSONAcrossMultipleAppendsWithoutResync() async throws {
+    let framer = StdioFramer()
+    let largeText = String(repeating: "x", count: 20 * 1024)
+    let json = "{\"id\":1,\"jsonrpc\":\"2.0\",\"result\":{\"text\":\"\(largeText)\"}}"
+
+    let midpoint = json.index(json.startIndex, offsetBy: 12 * 1024)
+    let partA = String(json[..<midpoint])
+    let partB = String(json[midpoint...])
+
+    let resultA = framer.append(Data(partA.utf8))
+    #expect(resultA.messages.isEmpty)
+    #expect(resultA.recoveries.isEmpty)
+
+    let resultB = framer.append(Data(partB.utf8))
+    #expect(resultB.messages.count == 1)
+    #expect(resultB.recoveries.isEmpty)
+    guard resultB.messages.count == 1 else { return }
+    #expect(String(data: resultB.messages[0], encoding: .utf8) == json)
+}
+
+@Test func stdioFramerClearsBufferAtHardLimitWithoutCandidate() async throws {
+    let framer = StdioFramer()
+    let payload = "{" + String(repeating: "x", count: 4 * 1024 * 1024)
+
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.isEmpty)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .fatalClear)
+    #expect(recovery.candidateOffset == nil)
+    #expect(result.bufferedByteCount == 0)
+}
+
+@Test func stdioFramerClearsBufferAtHardLimitAfterRejectingFalseCandidates() async throws {
+    let framer = StdioFramer()
+    let payload = "{" + String(repeating: "x", count: 2 * 1024 * 1024) + "{\"id\":" + String(repeating: "y", count: 2 * 1024 * 1024)
+
+    let result = framer.append(Data(payload.utf8))
+    #expect(result.messages.isEmpty)
+    #expect(result.recoveries.count == 1)
+    guard let recovery = result.recoveries.first else { return }
+    #expect(recovery.kind == .fatalClear)
+    #expect(result.bufferedByteCount == 0)
+}
+
+@Test func stdioFramerKeepsIncompleteLargeRawJSONBeyondHardLimit() async throws {
+    let framer = StdioFramer()
+    let largeText = String(repeating: "x", count: 4 * 1024 * 1024)
+    let partial = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"text\":\"\(largeText)"
+
+    let resultA = framer.append(Data(partial.utf8))
+    #expect(resultA.messages.isEmpty)
+    #expect(resultA.recoveries.isEmpty)
+    #expect(resultA.bufferedByteCount == partial.utf8.count)
+
+    let completed = partial + "\"}}"
+    let resultB = framer.append(Data("\"}}".utf8))
+    #expect(resultB.messages.count == 1)
+    #expect(resultB.recoveries.isEmpty)
+    guard resultB.messages.count == 1 else { return }
+    #expect(String(data: resultB.messages[0], encoding: .utf8) == completed)
 }

--- a/Tests/XcodeMCPProxyTests/UpstreamProcessTests.swift
+++ b/Tests/XcodeMCPProxyTests/UpstreamProcessTests.swift
@@ -44,6 +44,122 @@ import Testing
     try await Task.sleep(nanoseconds: 100_000_000)
 }
 
+@Test func upstreamProcessFlushesTrailingStderrLineWithoutNewline() async throws {
+    let config = UpstreamProcess.Config(
+        command: "/bin/sh",
+        args: ["-c", "printf 'fatal stderr' >&2"],
+        environment: ProcessInfo.processInfo.environment,
+        restartInitialDelay: 1,
+        restartMaxDelay: 1,
+        maxQueuedWriteBytes: 1024
+    )
+    let upstream = UpstreamProcess(config: config)
+    await upstream.start()
+    defer {
+        Task {
+            await upstream.stop()
+        }
+    }
+
+    let stderr = try await withTimeout(seconds: 2) {
+        for await event in upstream.events {
+            switch event {
+            case .stderr(let message):
+                return message
+            case .message, .stdoutRecovery, .stdoutBufferSize, .exit:
+                continue
+            }
+        }
+        return ""
+    }
+
+    #expect(stderr == "fatal stderr")
+}
+
+@Test func upstreamProcessFlushesLargeStderrChunkWithoutWaitingForEOF() async throws {
+    let config = UpstreamProcess.Config(
+        command: "/bin/sh",
+        args: ["-c", "head -c 20000 /dev/zero | tr '\\0' 'x' >&2; sleep 1"],
+        environment: ProcessInfo.processInfo.environment,
+        restartInitialDelay: 1,
+        restartMaxDelay: 1,
+        maxQueuedWriteBytes: 1024
+    )
+    let upstream = UpstreamProcess(config: config)
+    await upstream.start()
+    defer {
+        Task {
+            await upstream.stop()
+        }
+    }
+
+    let stderr = try await withTimeout(seconds: 1) {
+        for await event in upstream.events {
+            switch event {
+            case .stderr(let message):
+                return message
+            case .message, .stdoutRecovery, .stdoutBufferSize, .exit:
+                continue
+            }
+        }
+        return ""
+    }
+
+    #expect(stderr.contains("[truncated]"))
+}
+
+@Test func upstreamProcessEmitsBufferedStdoutResetWhenRestarting() async throws {
+    let config = UpstreamProcess.Config(
+        command: "/bin/cat",
+        args: [],
+        environment: ProcessInfo.processInfo.environment,
+        restartInitialDelay: 1,
+        restartMaxDelay: 1,
+        maxQueuedWriteBytes: 1024
+    )
+    let upstream = UpstreamProcess(config: config)
+    await upstream.start()
+    defer {
+        Task {
+            await upstream.stop()
+        }
+    }
+
+    let observedSizes = Task { () -> [Int] in
+        var sizes: [Int] = []
+        for await event in upstream.events {
+            switch event {
+            case .stdoutBufferSize(let size):
+                sizes.append(size)
+                if sizes.contains(where: { $0 > 0 }), sizes.contains(0) {
+                    return sizes
+                }
+            case .message, .stderr, .stdoutRecovery, .exit:
+                continue
+            }
+        }
+        return sizes
+    }
+
+    let sendResult = await upstream.send(Data("{".utf8))
+    switch sendResult {
+    case .accepted:
+        break
+    case .overloaded:
+        Issue.record("send should not overload while checking buffered stdout reset")
+    }
+
+    try await Task.sleep(nanoseconds: 100_000_000)
+    await upstream.requestRestart()
+
+    let sizes = try await withTimeout(seconds: 2) {
+        await observedSizes.value
+    }
+
+    #expect(sizes.contains(where: { $0 > 0 }))
+    #expect(sizes.contains(0))
+}
+
 private enum UpstreamProcessTestTimeoutError: Error {
     case timedOut(seconds: UInt64)
 }


### PR DESCRIPTION
Summary:
- Harden stdout recovery so corrupted raw JSON and batch streams can recover without fabricating nested RPC messages or dropping adjacent valid payloads.
- Add `/debug/upstreams` diagnostics with redacted payload data and keep per-process traffic/error state accurate across overloads and restarts.
- Add regression coverage for timeout failover, stderr chunk flushing, stdout buffer resets, and debug snapshot behavior.

Testing:
- `swift build`
- `swift test`
- `$codex-review --uncommitted`

Fixes #24