### PR TITLE
fix(proxy): restrict discovery stdio upstream to loopback

### DIFF
--- a/Sources/XcodeMCPProxy/Discovery.swift
+++ b/Sources/XcodeMCPProxy/Discovery.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Darwin
+import Network
 
 public struct DiscoveryRecord: Codable, Sendable {
     public var url: String
@@ -116,16 +117,9 @@ public enum Discovery {
     }
 
     private static func isLoopbackHost(_ host: String) -> Bool {
-        if host == "localhost" || host == "::1" { return true }
-        if host == "127.0.0.1" { return true }
-        if host.hasPrefix("127.") {
-            let segments = host.split(separator: ".", omittingEmptySubsequences: false)
-            if segments.count == 4,
-               segments.allSatisfy({ Int($0).map { (0...255).contains($0) } == true }) {
-                return true
-            }
-        }
-        return false
+        if host == "localhost" { return true }
+        if isIPv4Loopback(host) { return true }
+        return isIPv6Loopback(host)
     }
 
     private static func normalizeHost(_ host: String) -> String {
@@ -134,5 +128,16 @@ public enum Discovery {
             return String(value.dropFirst().dropLast())
         }
         return value
+    }
+
+    private static func isIPv4Loopback(_ host: String) -> Bool {
+        guard let address = IPv4Address(host) else { return false }
+        return address.rawValue.first == 127
+    }
+
+    private static func isIPv6Loopback(_ host: String) -> Bool {
+        guard let address = IPv6Address(host) else { return false }
+        let bytes = address.rawValue
+        return bytes.dropLast().allSatisfy { $0 == 0 } && bytes.last == 1
     }
 }

--- a/Sources/XcodeMCPProxy/Discovery.swift
+++ b/Sources/XcodeMCPProxy/Discovery.swift
@@ -36,6 +36,7 @@ public enum Discovery {
         guard let data = try? Data(contentsOf: url) else { return nil }
         guard let record = try? decoder.decode(DiscoveryRecord.self, from: data) else { return nil }
         guard isProcessAlive(record.pid) else { return nil }
+        guard isLoopbackURL(record.url) else { return nil }
         return record
     }
 
@@ -104,5 +105,34 @@ public enum Discovery {
         }
         let normalizedHost = host.contains(":") ? "[\(host)]" : host
         return "\(scheme)://\(normalizedHost):\(port)/mcp"
+    }
+
+    private static func isLoopbackURL(_ raw: String) -> Bool {
+        guard let components = URLComponents(string: raw),
+              let host = components.host else {
+            return false
+        }
+        return isLoopbackHost(normalizeHost(host))
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
+        if host == "localhost" || host == "::1" { return true }
+        if host == "127.0.0.1" { return true }
+        if host.hasPrefix("127.") {
+            let segments = host.split(separator: ".", omittingEmptySubsequences: false)
+            if segments.count == 4,
+               segments.allSatisfy({ Int($0).map { (0...255).contains($0) } == true }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func normalizeHost(_ host: String) -> String {
+        let value = host.lowercased()
+        if value.hasPrefix("["), value.hasSuffix("]") {
+            return String(value.dropFirst().dropLast())
+        }
+        return value
     }
 }

--- a/Tests/XcodeMCPProxyTests/CLIParserTests.swift
+++ b/Tests/XcodeMCPProxyTests/CLIParserTests.swift
@@ -145,6 +145,29 @@ struct CLIParserTests {
         #expect(config.stdioUpstreamSource == .discovery)
     }
 
+    @Test func cliDefaultsStdioUpstreamFromExpandedIPv6Discovery() async throws {
+        let tempURL = makeTempDiscoveryURL()
+        let record = DiscoveryRecord(
+            url: "http://[0:0:0:0:0:0:0:1]:5555/mcp",
+            host: "0:0:0:0:0:0:0:1",
+            port: 5555,
+            pid: Int(ProcessInfo.processInfo.processIdentifier),
+            updatedAt: Date()
+        )
+        try Discovery.write(record: record, overrideURL: tempURL)
+        let config = try CLIParser.parse(
+            args: [
+                "xcode-mcp-proxy",
+                "--stdio",
+            ],
+            environment: [:],
+            discoveryOverrideURL: tempURL
+        )
+        #expect(config.transport == .stdio)
+        #expect(config.stdioUpstreamURL?.absoluteString == "http://[0:0:0:0:0:0:0:1]:5555/mcp")
+        #expect(config.stdioUpstreamSource == .discovery)
+    }
+
     @Test func cliIgnoresNonLoopbackDiscoveryEndpoint() async throws {
         let tempURL = makeTempDiscoveryURL()
         let record = DiscoveryRecord(

--- a/Tests/XcodeMCPProxyTests/CLIParserTests.swift
+++ b/Tests/XcodeMCPProxyTests/CLIParserTests.swift
@@ -145,6 +145,29 @@ struct CLIParserTests {
         #expect(config.stdioUpstreamSource == .discovery)
     }
 
+    @Test func cliIgnoresNonLoopbackDiscoveryEndpoint() async throws {
+        let tempURL = makeTempDiscoveryURL()
+        let record = DiscoveryRecord(
+            url: "http://example.com:5555/mcp",
+            host: "example.com",
+            port: 5555,
+            pid: Int(ProcessInfo.processInfo.processIdentifier),
+            updatedAt: Date()
+        )
+        try Discovery.write(record: record, overrideURL: tempURL)
+        let config = try CLIParser.parse(
+            args: [
+                "xcode-mcp-proxy",
+                "--stdio",
+            ],
+            environment: [:],
+            discoveryOverrideURL: tempURL
+        )
+        #expect(config.transport == .stdio)
+        #expect(config.stdioUpstreamURL?.absoluteString == "http://localhost:8765/mcp")
+        #expect(config.stdioUpstreamSource == .fallback)
+    }
+
     @Test func cliDefaultsStdioUpstreamFromEnvironment() async throws {
         let tempURL = makeTempDiscoveryURL()
         let config = try CLIParser.parse(

--- a/Tests/XcodeMCPProxyTests/DiscoveryTests.swift
+++ b/Tests/XcodeMCPProxyTests/DiscoveryTests.swift
@@ -85,6 +85,20 @@ struct DiscoveryTests {
         #expect(Discovery.read(overrideURL: url)?.url == record.url)
     }
 
+    @Test func discoveryAllowsExpandedIPv6LoopbackURL() async throws {
+        let url = makeTempDiscoveryURL()
+        defer { cleanupTempDiscoveryURL(url) }
+        let record = DiscoveryRecord(
+            url: "http://[0:0:0:0:0:0:0:1]:8888/mcp",
+            host: "0:0:0:0:0:0:0:1",
+            port: 8888,
+            pid: Int(ProcessInfo.processInfo.processIdentifier),
+            updatedAt: Date()
+        )
+        try Discovery.write(record: record, overrideURL: url)
+        #expect(Discovery.read(overrideURL: url)?.url == record.url)
+    }
+
     @Test func discoveryRejectsNonLoopbackURL() async throws {
         let url = makeTempDiscoveryURL()
         defer { cleanupTempDiscoveryURL(url) }

--- a/Tests/XcodeMCPProxyTests/DiscoveryTests.swift
+++ b/Tests/XcodeMCPProxyTests/DiscoveryTests.swift
@@ -57,6 +57,48 @@ struct DiscoveryTests {
         #expect(Discovery.read(overrideURL: url) == nil)
     }
 
+    @Test func discoveryAllowsIPv4LoopbackRange() async throws {
+        let url = makeTempDiscoveryURL()
+        defer { cleanupTempDiscoveryURL(url) }
+        let record = DiscoveryRecord(
+            url: "http://127.42.1.9:8888/mcp",
+            host: "127.42.1.9",
+            port: 8888,
+            pid: Int(ProcessInfo.processInfo.processIdentifier),
+            updatedAt: Date()
+        )
+        try Discovery.write(record: record, overrideURL: url)
+        #expect(Discovery.read(overrideURL: url)?.url == record.url)
+    }
+
+    @Test func discoveryAllowsIPv6LoopbackURL() async throws {
+        let url = makeTempDiscoveryURL()
+        defer { cleanupTempDiscoveryURL(url) }
+        let record = DiscoveryRecord(
+            url: "http://[::1]:8888/mcp",
+            host: "::1",
+            port: 8888,
+            pid: Int(ProcessInfo.processInfo.processIdentifier),
+            updatedAt: Date()
+        )
+        try Discovery.write(record: record, overrideURL: url)
+        #expect(Discovery.read(overrideURL: url)?.url == record.url)
+    }
+
+    @Test func discoveryRejectsNonLoopbackURL() async throws {
+        let url = makeTempDiscoveryURL()
+        defer { cleanupTempDiscoveryURL(url) }
+        let record = DiscoveryRecord(
+            url: "http://example.com:8888/mcp",
+            host: "example.com",
+            port: 8888,
+            pid: Int(ProcessInfo.processInfo.processIdentifier),
+            updatedAt: Date()
+        )
+        try Discovery.write(record: record, overrideURL: url)
+        #expect(Discovery.read(overrideURL: url) == nil)
+    }
+
     @Test func discoveryFormatsIPv6Host() async throws {
         let record = Discovery.makeRecord(host: "::1", port: 1234, pid: 1)
         #expect(record?.url == "http://[::1]:1234/mcp")


### PR DESCRIPTION
Summary:
- Reject discovery records whose upstream URL is not a loopback endpoint before STDIO default resolution can trust them
- Add coverage for allowed loopback discovery URLs, rejected non-loopback URLs, and STDIO fallback behavior when discovery is ignored

Testing:
- swift test