### PR TITLE
fix(proxy): stabilize refresh code issues diagnostics

### DIFF
--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -73,6 +73,13 @@ it usually means the MCP server process (`xcode-mcp-proxy`) was terminated while
   - `pkill -f xcode-mcp-proxy`
   - `pkill -f mcpbridge`
 
+## `XcodeRefreshCodeIssuesInFile` intermittently returns `error 5`
+Xcode's live diagnostics service is prone to transient failures when `XcodeRefreshCodeIssuesInFile` is fired in bursts for the same `tabIdentifier`.
+
+- `xcode-mcp-proxy-server` now serializes `XcodeRefreshCodeIssuesInFile` per `tabIdentifier` and retries the specific `SourceEditorCallableDiagnosticError error 5` response a small number of times.
+- This reduces cold-start contention, but it can increase latency when many refresh requests target the same tab at once.
+- For broad issue sweeps, prefer `XcodeListNavigatorIssues` first and only use `XcodeRefreshCodeIssuesInFile` for files that need per-file diagnostics output.
+
 ## Xcode dialog does not appear
 Make sure `--lazy-init` is not set (when enabled, the dialog appears on the first request instead of at startup).
 

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -24,14 +24,64 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         var bodyTooLarge = false
     }
 
+    private struct RefreshCodeIssuesRequest: Sendable {
+        static let toolName = "XcodeRefreshCodeIssuesInFile"
+        static let globalQueueKey = "__global__"
+
+        let tabIdentifier: String?
+
+        var queueKey: String {
+            guard let tabIdentifier, tabIdentifier.isEmpty == false else {
+                return Self.globalQueueKey
+            }
+            return tabIdentifier
+        }
+    }
+
+    private struct PreparedForwardRequest {
+        let transform: RequestTransform
+        let upstreamIndex: Int
+    }
+
+    private struct StartedForwardRequest {
+        let transform: RequestTransform
+        let upstreamIndex: Int
+        let future: EventLoopFuture<ByteBuffer>
+    }
+
+    private enum ForwardResponseResolution {
+        case success(Data)
+        case timeout
+        case invalidUpstreamResponse
+    }
+
+    private enum RefreshForwardAttemptResult {
+        case success(Data)
+        case timeout(responseIds: [RPCId], isBatch: Bool)
+        case upstreamUnavailable(responseIds: [RPCId], isBatch: Bool)
+        case invalidRequest
+        case invalidUpstreamResponse
+    }
+
+    private static let refreshRetryDelaysNanos: [UInt64] = [
+        200_000_000,
+        500_000_000,
+    ]
+
     private let state = NIOLockedValueBox(State())
     private let config: ProxyConfig
     private let sessionManager: any SessionManaging
+    private let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator
     private let logger: Logger = ProxyLogging.make("http")
 
-    init(config: ProxyConfig, sessionManager: any SessionManaging) {
+    init(
+        config: ProxyConfig,
+        sessionManager: any SessionManaging,
+        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+    ) {
         self.config = config
         self.sessionManager = sessionManager
+        self.refreshCodeIssuesCoordinator = refreshCodeIssuesCoordinator
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -525,46 +575,83 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        let shouldPinUpstream = MCPMethodDispatcher.shouldPinUpstream(for: parsedRequestJSON)
-        guard let upstreamIndex = sessionManager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: shouldPinUpstream) else {
-            if requestIDs.isEmpty {
-                sendPlain(
-                    on: context.channel,
-                    status: .serviceUnavailable,
-                    body: "upstream unavailable",
-                    keepAlive: head.isKeepAlive,
-                    sessionId: sessionId,
-                    requestLog: requestLog
-                )
-            } else {
+        let refreshRequest = requestIsBatch ? nil : refreshCodeIssuesRequest(from: parsedRequestJSON)
+        if let refreshRequest, requestIDs.isEmpty == false {
+            if headerSessionId == nil {
                 sendMCPError(
                     on: context.channel,
                     ids: requestIDs,
-                    code: -32001,
-                    message: "upstream unavailable",
+                    code: -32000,
+                    message: "expected initialize request",
                     forceBatchArray: requestIsBatch,
                     prefersEventStream: prefersEventStream,
                     keepAlive: head.isKeepAlive,
                     sessionId: sessionId,
                     requestLog: requestLog
                 )
+                return
+            }
+
+            let keepAlive = head.isKeepAlive
+            let channel = context.channel
+            let eventLoop = context.eventLoop
+            let promise = eventLoop.makePromise(of: RefreshForwardAttemptResult.self)
+            promise.futureResult.whenSuccess { attemptResult in
+                self.respondToRefreshForwardAttempt(
+                    attemptResult,
+                    on: channel,
+                    prefersEventStream: prefersEventStream,
+                    keepAlive: keepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            }
+            Task { [self] in
+                let attemptResult = await forwardRefreshCodeIssuesRequest(
+                    refreshRequest,
+                    bodyData: bodyData,
+                    sessionId: sessionId,
+                    requestIDs: requestIDs,
+                    requestIsBatch: requestIsBatch,
+                    eventLoop: eventLoop
+                )
+                promise.succeed(attemptResult)
             }
             return
         }
 
-        let transform: RequestTransform
+        let prepared: PreparedForwardRequest
         do {
-            transform = try RequestInspector.transform(
-                bodyData,
-                sessionId: sessionId,
-                mapId: { sessionId, originalId in
-                    sessionManager.assignUpstreamId(
+            guard let candidate = try prepareForwardRequest(
+                bodyData: bodyData,
+                parsedRequestJSON: parsedRequestJSON,
+                sessionId: sessionId
+            ) else {
+                if requestIDs.isEmpty {
+                    sendPlain(
+                        on: context.channel,
+                        status: .serviceUnavailable,
+                        body: "upstream unavailable",
+                        keepAlive: head.isKeepAlive,
                         sessionId: sessionId,
-                        originalId: originalId,
-                        upstreamIndex: upstreamIndex
+                        requestLog: requestLog
+                    )
+                } else {
+                    sendMCPError(
+                        on: context.channel,
+                        ids: requestIDs,
+                        code: -32001,
+                        message: "upstream unavailable",
+                        forceBatchArray: requestIsBatch,
+                        prefersEventStream: prefersEventStream,
+                        keepAlive: head.isKeepAlive,
+                        sessionId: sessionId,
+                        requestLog: requestLog
                     )
                 }
-            )
+                return
+            }
+            prepared = candidate
         } catch {
             sendMCPError(
                 on: context.channel,
@@ -579,7 +666,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        if transform.method == "tools/list" {
+        if prepared.transform.method == "tools/list" {
             let hasCache = sessionManager.cachedToolsListResult() != nil
             let params = (try? JSONSerialization.jsonObject(with: bodyData, options: []))
                 .flatMap { $0 as? [String: Any] }?["params"]
@@ -590,14 +677,14 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     "session": .string(sessionId),
                     "has_cache": .string(hasCache ? "true" : "false"),
                     "has_params": .string(hasParams ? "true" : "false"),
-                    "upstream": .string("\(upstreamIndex)"),
+                    "upstream": .string("\(prepared.upstreamIndex)"),
                 ]
             )
         }
 
         if headerSessionId == nil {
-            if transform.isBatch || transform.method != "initialize" || !transform.expectsResponse {
-                if transform.responseIds.isEmpty {
+            if prepared.transform.isBatch || prepared.transform.method != "initialize" || !prepared.transform.expectsResponse {
+                if prepared.transform.responseIds.isEmpty {
                     sendPlain(
                         on: context.channel,
                         status: .unprocessableEntity,
@@ -609,10 +696,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 } else {
                     sendMCPError(
                         on: context.channel,
-                        ids: transform.responseIds,
+                        ids: prepared.transform.responseIds,
                         code: -32000,
                         message: "expected initialize request",
-                        forceBatchArray: transform.isBatch,
+                        forceBatchArray: prepared.transform.isBatch,
                         prefersEventStream: prefersEventStream,
                         keepAlive: head.isKeepAlive,
                         sessionId: sessionId,
@@ -625,17 +712,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         let session = sessionManager.session(id: sessionId)
 
-        if transform.expectsResponse {
-            let future: EventLoopFuture<ByteBuffer>
-            let requestTimeout = MCPMethodDispatcher.timeoutForMethod(
-                transform.method,
-                defaultSeconds: config.requestTimeout
-            )
-            if transform.isBatch {
-                future = session.router.registerBatch(on: context.eventLoop, timeout: requestTimeout)
-            } else if let idKey = transform.idKey {
-                future = session.router.registerRequest(idKey: idKey, on: context.eventLoop, timeout: requestTimeout)
-            } else {
+        if prepared.transform.expectsResponse {
+            let started: StartedForwardRequest
+            do {
+                started = try startPreparedForwardRequest(
+                    prepared,
+                    session: session,
+                    on: context.eventLoop
+                )
+            } catch {
                 sendMCPError(
                     on: context.channel,
                     id: nil,
@@ -649,38 +734,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return
             }
 
-            sessionManager.sendUpstream(transform.upstreamData, upstreamIndex: upstreamIndex)
             let keepAlive = head.isKeepAlive
             let sessionIdCopy = sessionId
             let channel = context.channel
-            future.whenComplete { result in
-                switch result {
-                case .success(let buffer):
-                    var buffer = buffer
-                    guard let data = buffer.readData(length: buffer.readableBytes) else {
-                        self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
-                        return
-                    }
-                    let responseData = self.rewriteUnsupportedResourcesListResponseIfNeeded(
-                        method: transform.method,
-                        originalId: transform.originalId,
-                        upstreamData: data
-                    )
-                    if transform.isCacheableToolsListRequest,
-                       let object = try? JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any],
-                       let resultAny = object["result"],
-                       let result = JSONValue(any: resultAny) {
-                        self.sessionManager.setCachedToolsListResult(result)
-                    }
-                    if self.shouldNotifyUpstreamSuccess(for: responseData) {
-                        for responseId in transform.responseIds {
-                            self.sessionManager.onRequestSucceeded(
-                                sessionId: sessionIdCopy,
-                                requestIdKey: responseId.key,
-                                upstreamIndex: upstreamIndex
-                            )
-                        }
-                    }
+            started.future.whenComplete { result in
+                switch self.resolveForwardResponse(
+                    result,
+                    started: started,
+                    sessionId: sessionIdCopy
+                ) {
+                case .success(let responseData):
                     if prefersEventStream {
                         self.sendSingleSSE(on: channel, data: responseData, keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
                     } else {
@@ -688,27 +751,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         out.writeBytes(responseData)
                         self.sendJSON(on: channel, buffer: out, keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
                     }
-                case .failure:
-                    if let firstResponseId = transform.responseIds.first {
-                        self.sessionManager.onRequestTimeout(
-                            sessionId: sessionIdCopy,
-                            requestIdKey: firstResponseId.key,
-                            upstreamIndex: upstreamIndex
-                        )
-                        for responseId in transform.responseIds.dropFirst() {
-                            self.sessionManager.removeUpstreamIdMapping(
-                                sessionId: sessionIdCopy,
-                                requestIdKey: responseId.key,
-                                upstreamIndex: upstreamIndex
-                            )
-                        }
-                    }
+                case .invalidUpstreamResponse:
+                    self.sendPlain(on: channel, status: .badGateway, body: "invalid upstream response", keepAlive: keepAlive, sessionId: sessionIdCopy, requestLog: requestLog)
+                case .timeout:
                     self.sendMCPError(
                         on: channel,
-                        ids: transform.responseIds,
+                        ids: started.transform.responseIds,
                         code: -32000,
                         message: "upstream timeout",
-                        forceBatchArray: transform.isBatch,
+                        forceBatchArray: started.transform.isBatch,
                         prefersEventStream: prefersEventStream,
                         keepAlive: keepAlive,
                         sessionId: sessionIdCopy,
@@ -717,12 +768,382 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 }
             }
         } else {
-            if transform.method == "notifications/initialized" && sessionManager.isInitialized() {
+            if prepared.transform.method == "notifications/initialized" && sessionManager.isInitialized() {
                 sendEmpty(on: context.channel, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
             } else {
-                sessionManager.sendUpstream(transform.upstreamData, upstreamIndex: upstreamIndex)
+                sessionManager.sendUpstream(prepared.transform.upstreamData, upstreamIndex: prepared.upstreamIndex)
                 sendEmpty(on: context.channel, status: .accepted, keepAlive: head.isKeepAlive, sessionId: sessionId, requestLog: requestLog)
             }
+        }
+    }
+
+    private func refreshCodeIssuesRequest(from requestJSON: Any) -> RefreshCodeIssuesRequest? {
+        guard let object = requestJSON as? [String: Any],
+            let method = object["method"] as? String,
+            method == "tools/call",
+            let params = object["params"] as? [String: Any],
+            let toolName = params["name"] as? String,
+            toolName == RefreshCodeIssuesRequest.toolName
+        else {
+            return nil
+        }
+
+        let arguments = params["arguments"] as? [String: Any]
+        let tabIdentifier = arguments?["tabIdentifier"] as? String
+        return RefreshCodeIssuesRequest(tabIdentifier: tabIdentifier)
+    }
+
+    private func prepareForwardRequest(
+        bodyData: Data,
+        parsedRequestJSON: Any,
+        sessionId: String
+    ) throws -> PreparedForwardRequest? {
+        let shouldPinUpstream = MCPMethodDispatcher.shouldPinUpstream(for: parsedRequestJSON)
+        guard let upstreamIndex = sessionManager.chooseUpstreamIndex(
+            sessionId: sessionId,
+            shouldPin: shouldPinUpstream
+        ) else {
+            return nil
+        }
+
+        let transform = try RequestInspector.transform(
+            bodyData,
+            sessionId: sessionId,
+            mapId: { sessionId, originalId in
+                sessionManager.assignUpstreamId(
+                    sessionId: sessionId,
+                    originalId: originalId,
+                    upstreamIndex: upstreamIndex
+                )
+            }
+        )
+        return PreparedForwardRequest(
+            transform: transform,
+            upstreamIndex: upstreamIndex
+        )
+    }
+
+    private func startPreparedForwardRequest(
+        _ prepared: PreparedForwardRequest,
+        session: SessionContext,
+        on eventLoop: EventLoop
+    ) throws -> StartedForwardRequest {
+        let requestTimeout = MCPMethodDispatcher.timeoutForMethod(
+            prepared.transform.method,
+            defaultSeconds: config.requestTimeout
+        )
+        let future: EventLoopFuture<ByteBuffer>
+        if prepared.transform.isBatch {
+            future = session.router.registerBatch(
+                on: eventLoop,
+                timeout: requestTimeout
+            )
+        } else if let idKey = prepared.transform.idKey {
+            future = session.router.registerRequest(
+                idKey: idKey,
+                on: eventLoop,
+                timeout: requestTimeout
+            )
+        } else {
+            struct MissingRequestIDError: Error {}
+            throw MissingRequestIDError()
+        }
+
+        sessionManager.sendUpstream(
+            prepared.transform.upstreamData,
+            upstreamIndex: prepared.upstreamIndex
+        )
+        return StartedForwardRequest(
+            transform: prepared.transform,
+            upstreamIndex: prepared.upstreamIndex,
+            future: future
+        )
+    }
+
+    private func resolveForwardResponse(
+        _ result: Result<ByteBuffer, Error>,
+        started: StartedForwardRequest,
+        sessionId: String
+    ) -> ForwardResponseResolution {
+        switch result {
+        case .success(let buffer):
+            var buffer = buffer
+            guard let data = buffer.readData(length: buffer.readableBytes) else {
+                return .invalidUpstreamResponse
+            }
+            let responseData = rewriteUnsupportedResourcesListResponseIfNeeded(
+                method: started.transform.method,
+                originalId: started.transform.originalId,
+                upstreamData: data
+            )
+            if started.transform.isCacheableToolsListRequest,
+                let object = try? JSONSerialization.jsonObject(
+                    with: responseData,
+                    options: []
+                ) as? [String: Any],
+                let resultAny = object["result"],
+                let result = JSONValue(any: resultAny)
+            {
+                sessionManager.setCachedToolsListResult(result)
+            }
+            if shouldNotifyUpstreamSuccess(for: responseData) {
+                for responseId in started.transform.responseIds {
+                    sessionManager.onRequestSucceeded(
+                        sessionId: sessionId,
+                        requestIdKey: responseId.key,
+                        upstreamIndex: started.upstreamIndex
+                    )
+                }
+            }
+            return .success(responseData)
+        case .failure:
+            if let firstResponseId = started.transform.responseIds.first {
+                sessionManager.onRequestTimeout(
+                    sessionId: sessionId,
+                    requestIdKey: firstResponseId.key,
+                    upstreamIndex: started.upstreamIndex
+                )
+                for responseId in started.transform.responseIds.dropFirst() {
+                    sessionManager.removeUpstreamIdMapping(
+                        sessionId: sessionId,
+                        requestIdKey: responseId.key,
+                        upstreamIndex: started.upstreamIndex
+                    )
+                }
+            }
+            return .timeout
+        }
+    }
+
+    private func forwardOnce(
+        bodyData: Data,
+        sessionId: String,
+        requestIDs: [RPCId],
+        requestIsBatch: Bool,
+        eventLoop: EventLoop
+    ) async -> RefreshForwardAttemptResult {
+        let parsedRequestJSON: Any
+        do {
+            parsedRequestJSON = try JSONSerialization.jsonObject(with: bodyData, options: [])
+        } catch {
+            return .invalidRequest
+        }
+
+        let prepared: PreparedForwardRequest
+        do {
+            guard let candidate = try prepareForwardRequest(
+                bodyData: bodyData,
+                parsedRequestJSON: parsedRequestJSON,
+                sessionId: sessionId
+            ) else {
+                return .upstreamUnavailable(
+                    responseIds: requestIDs,
+                    isBatch: requestIsBatch
+                )
+            }
+            prepared = candidate
+        } catch {
+            return .invalidRequest
+        }
+
+        let session = sessionManager.session(id: sessionId)
+        let started: StartedForwardRequest
+        do {
+            started = try startPreparedForwardRequest(
+                prepared,
+                session: session,
+                on: eventLoop
+            )
+        } catch {
+            return .invalidRequest
+        }
+
+        let resolution: ForwardResponseResolution
+        do {
+            let buffer = try await started.future.get()
+            resolution = resolveForwardResponse(
+                .success(buffer),
+                started: started,
+                sessionId: sessionId
+            )
+        } catch {
+            resolution = resolveForwardResponse(
+                .failure(error),
+                started: started,
+                sessionId: sessionId
+            )
+        }
+
+        switch resolution {
+        case .success(let responseData):
+            return .success(responseData)
+        case .timeout:
+            return .timeout(
+                responseIds: started.transform.responseIds,
+                isBatch: started.transform.isBatch
+            )
+        case .invalidUpstreamResponse:
+            return .invalidUpstreamResponse
+        }
+    }
+
+    private func forwardRefreshCodeIssuesRequest(
+        _ refreshRequest: RefreshCodeIssuesRequest,
+        bodyData: Data,
+        sessionId: String,
+        requestIDs: [RPCId],
+        requestIsBatch: Bool,
+        eventLoop: EventLoop
+    ) async -> RefreshForwardAttemptResult {
+        await refreshCodeIssuesCoordinator.withPermit(key: refreshRequest.queueKey) { queuePosition in
+            let baseMetadata: Logger.Metadata = [
+                "session": .string(sessionId),
+                "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
+                "queue_key": .string(refreshRequest.queueKey),
+            ]
+            if queuePosition > 0 {
+                logger.debug(
+                    "Queued refresh code issues request",
+                    metadata: baseMetadata.merging(
+                        ["queued_ahead": .string("\(queuePosition)")],
+                        uniquingKeysWith: { _, new in new }
+                    )
+                )
+            }
+            logger.debug(
+                "Dequeued refresh code issues request",
+                metadata: baseMetadata
+            )
+
+            for attemptIndex in 0...Self.refreshRetryDelaysNanos.count {
+                let attempt = attemptIndex + 1
+                let attemptMetadata = baseMetadata.merging(
+                    ["attempt": .string("\(attempt)")],
+                    uniquingKeysWith: { _, new in new }
+                )
+                let result = await forwardOnce(
+                    bodyData: bodyData,
+                    sessionId: sessionId,
+                    requestIDs: requestIDs,
+                    requestIsBatch: requestIsBatch,
+                    eventLoop: eventLoop
+                )
+
+                switch result {
+                case .success(let responseData):
+                    let retryable = isRetryableRefreshCodeIssuesFailure(responseData)
+                    if retryable, attemptIndex < Self.refreshRetryDelaysNanos.count {
+                        let delayNanos = Self.refreshRetryDelaysNanos[attemptIndex]
+                        logger.debug(
+                            "Retrying refresh code issues request after error 5",
+                            metadata: attemptMetadata.merging(
+                                ["delay_ms": .string("\(delayNanos / 1_000_000)")],
+                                uniquingKeysWith: { _, new in new }
+                            )
+                        )
+                        try? await Task.sleep(nanoseconds: delayNanos)
+                        continue
+                    }
+                    if retryable {
+                        logger.debug(
+                            "Refresh code issues request still failing after retries",
+                            metadata: attemptMetadata
+                        )
+                    }
+                    return .success(responseData)
+                case .timeout, .upstreamUnavailable, .invalidRequest, .invalidUpstreamResponse:
+                    return result
+                }
+            }
+
+            return .invalidRequest
+        }
+    }
+
+    private func respondToRefreshForwardAttempt(
+        _ result: RefreshForwardAttemptResult,
+        on channel: Channel,
+        prefersEventStream: Bool,
+        keepAlive: Bool,
+        sessionId: String,
+        requestLog: RequestLogContext
+    ) {
+        switch result {
+        case .success(let responseData):
+            if prefersEventStream {
+                sendSingleSSE(
+                    on: channel,
+                    data: responseData,
+                    keepAlive: keepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            } else {
+                var out = channel.allocator.buffer(capacity: responseData.count)
+                out.writeBytes(responseData)
+                sendJSON(
+                    on: channel,
+                    buffer: out,
+                    keepAlive: keepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            }
+        case .timeout(let responseIds, let isBatch):
+            sendMCPError(
+                on: channel,
+                ids: responseIds,
+                code: -32000,
+                message: "upstream timeout",
+                forceBatchArray: isBatch,
+                prefersEventStream: prefersEventStream,
+                keepAlive: keepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
+        case .upstreamUnavailable(let responseIds, let isBatch):
+            if responseIds.isEmpty {
+                sendPlain(
+                    on: channel,
+                    status: .serviceUnavailable,
+                    body: "upstream unavailable",
+                    keepAlive: keepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            } else {
+                sendMCPError(
+                    on: channel,
+                    ids: responseIds,
+                    code: -32001,
+                    message: "upstream unavailable",
+                    forceBatchArray: isBatch,
+                    prefersEventStream: prefersEventStream,
+                    keepAlive: keepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            }
+        case .invalidRequest:
+            sendMCPError(
+                on: channel,
+                id: nil,
+                code: -32700,
+                message: "invalid json",
+                prefersEventStream: prefersEventStream,
+                keepAlive: keepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
+        case .invalidUpstreamResponse:
+            sendPlain(
+                on: channel,
+                status: .badGateway,
+                body: "invalid upstream response",
+                keepAlive: keepAlive,
+                sessionId: sessionId,
+                requestLog: requestLog
+            )
         }
     }
 
@@ -946,6 +1367,33 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         }
 
         return true
+    }
+
+    private func isRetryableRefreshCodeIssuesFailure(_ responseData: Data) -> Bool {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: responseData, options: [])
+                as? [String: Any],
+            let result = object["result"] as? [String: Any],
+            let isError = result["isError"] as? Bool,
+            isError,
+            let content = result["content"] as? [Any]
+        else {
+            return false
+        }
+
+        for item in content {
+            guard let contentObject = item as? [String: Any],
+                let text = contentObject["text"] as? String
+            else {
+                continue
+            }
+            if text.contains("Failed to retrieve diagnostics for"),
+                text.contains("SourceEditor.SourceEditorCallableDiagnosticError error 5")
+            {
+                return true
+            }
+        }
+        return false
     }
 
     private func isUpstreamOverloadedErrorResponse(_ object: [String: Any]) -> Bool {

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -1599,6 +1599,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private func isRetryableRefreshCodeIssuesFailure(_ responseData: Data) -> Bool {
+        let retryableErrorText = "SourceEditorCallableDiagnosticError error 5"
         guard
             let object = try? JSONSerialization.jsonObject(with: responseData, options: [])
                 as? [String: Any],
@@ -1617,7 +1618,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 continue
             }
             if text.contains("Failed to retrieve diagnostics for"),
-                text.contains("SourceEditor.SourceEditorCallableDiagnosticError error 5")
+                text.contains(retryableErrorText)
             {
                 return true
             }

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -29,6 +29,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         static let globalQueueKey = "__global__"
 
         let tabIdentifier: String?
+        let filePath: String?
 
         var queueKey: String {
             guard let tabIdentifier, tabIdentifier.isEmpty == false else {
@@ -72,16 +73,19 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     private let config: ProxyConfig
     private let sessionManager: any SessionManaging
     private let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator
+    private let warmupDriver: XcodeEditorWarmupDriver
     private let logger: Logger = ProxyLogging.make("http")
 
     init(
         config: ProxyConfig,
         sessionManager: any SessionManaging,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator(),
+        warmupDriver: XcodeEditorWarmupDriver = XcodeEditorWarmupDriver()
     ) {
         self.config = config
         self.sessionManager = sessionManager
         self.refreshCodeIssuesCoordinator = refreshCodeIssuesCoordinator
+        self.warmupDriver = warmupDriver
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -790,7 +794,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
         let arguments = params["arguments"] as? [String: Any]
         let tabIdentifier = arguments?["tabIdentifier"] as? String
-        return RefreshCodeIssuesRequest(tabIdentifier: tabIdentifier)
+        let filePath = arguments?["filePath"] as? String
+        return RefreshCodeIssuesRequest(tabIdentifier: tabIdentifier, filePath: filePath)
     }
 
     private func prepareForwardRequest(
@@ -863,7 +868,9 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     private func resolveForwardResponse(
         _ result: Result<ByteBuffer, Error>,
         started: StartedForwardRequest,
-        sessionId: String
+        sessionId: String,
+        accountSuccess: Bool = true,
+        accountTimeout: Bool = true
     ) -> ForwardResponseResolution {
         switch result {
         case .success(let buffer):
@@ -886,7 +893,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             {
                 sessionManager.setCachedToolsListResult(result)
             }
-            if shouldNotifyUpstreamSuccess(for: responseData) {
+            if accountSuccess, shouldNotifyUpstreamSuccess(for: responseData) {
                 for responseId in started.transform.responseIds {
                     sessionManager.onRequestSucceeded(
                         sessionId: sessionId,
@@ -898,11 +905,19 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return .success(responseData)
         case .failure:
             if let firstResponseId = started.transform.responseIds.first {
-                sessionManager.onRequestTimeout(
-                    sessionId: sessionId,
-                    requestIdKey: firstResponseId.key,
-                    upstreamIndex: started.upstreamIndex
-                )
+                if accountTimeout {
+                    sessionManager.onRequestTimeout(
+                        sessionId: sessionId,
+                        requestIdKey: firstResponseId.key,
+                        upstreamIndex: started.upstreamIndex
+                    )
+                } else {
+                    sessionManager.removeUpstreamIdMapping(
+                        sessionId: sessionId,
+                        requestIdKey: firstResponseId.key,
+                        upstreamIndex: started.upstreamIndex
+                    )
+                }
                 for responseId in started.transform.responseIds.dropFirst() {
                     sessionManager.removeUpstreamIdMapping(
                         sessionId: sessionId,
@@ -913,6 +928,146 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             }
             return .timeout
         }
+    }
+
+    private func callInternalTool(
+        name: String,
+        arguments: [String: Any],
+        sessionId: String,
+        eventLoop: EventLoop
+    ) async -> [String: Any]? {
+        let requestObject: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": "__internal-\(UUID().uuidString)",
+            "method": "tools/call",
+            "params": [
+                "name": name,
+                "arguments": arguments,
+            ],
+        ]
+
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: requestObject, options: [])
+        else {
+            return nil
+        }
+
+        let prepared: PreparedForwardRequest
+        do {
+            guard let candidate = try prepareForwardRequest(
+                bodyData: bodyData,
+                parsedRequestJSON: requestObject,
+                sessionId: sessionId
+            ) else {
+                return nil
+            }
+            prepared = candidate
+        } catch {
+            return nil
+        }
+
+        let session = sessionManager.session(id: sessionId)
+        let started: StartedForwardRequest
+        do {
+            started = try startPreparedForwardRequest(
+                prepared,
+                session: session,
+                on: eventLoop
+            )
+        } catch {
+            return nil
+        }
+
+        let resolution: ForwardResponseResolution
+        do {
+            let buffer = try await started.future.get()
+            resolution = resolveForwardResponse(
+                .success(buffer),
+                started: started,
+                sessionId: sessionId
+            )
+        } catch {
+            resolution = resolveForwardResponse(
+                .failure(error),
+                started: started,
+                sessionId: sessionId
+            )
+        }
+
+        guard case .success(let responseData) = resolution,
+            let object = try? JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any],
+            let result = object["result"] as? [String: Any]
+        else {
+            return nil
+        }
+        if let isError = result["isError"] as? Bool, isError {
+            return nil
+        }
+        return result
+    }
+
+    private func listXcodeWindows(
+        sessionId: String,
+        eventLoop: EventLoop
+    ) async -> [XcodeWindowInfo]? {
+        guard let result = await callInternalTool(
+            name: "XcodeListWindows",
+            arguments: [:],
+            sessionId: sessionId,
+            eventLoop: eventLoop
+        ),
+            let message = extractToolMessage(from: result)
+        else {
+            return nil
+        }
+        return parseXcodeListWindowsMessage(message)
+    }
+
+    private func extractToolMessage(from result: [String: Any]) -> String? {
+        if let structuredContent = result["structuredContent"] as? [String: Any],
+            let message = structuredContent["message"] as? String,
+            message.isEmpty == false
+        {
+            return message
+        }
+
+        guard let content = result["content"] as? [[String: Any]] else {
+            return nil
+        }
+        for item in content {
+            guard let text = item["text"] as? String, text.isEmpty == false else {
+                continue
+            }
+            if let textData = text.data(using: .utf8),
+                let object = try? JSONSerialization.jsonObject(with: textData, options: []) as? [String: Any],
+                let message = object["message"] as? String
+            {
+                return message
+            }
+            return text
+        }
+        return nil
+    }
+
+    private func parseXcodeListWindowsMessage(_ message: String) -> [XcodeWindowInfo] {
+        message
+            .split(separator: "\n")
+            .compactMap { line -> XcodeWindowInfo? in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard trimmed.hasPrefix("* tabIdentifier: ") else { return nil }
+                let parts = trimmed.components(separatedBy: ", workspacePath: ")
+                guard parts.count == 2 else { return nil }
+                let tabIdentifier = parts[0]
+                    .replacingOccurrences(of: "* tabIdentifier: ", with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let workspacePath = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                guard tabIdentifier.isEmpty == false, workspacePath.isEmpty == false else {
+                    return nil
+                }
+                return XcodeWindowInfo(
+                    tabIdentifier: tabIdentifier,
+                    workspacePath: workspacePath
+                )
+            }
     }
 
     private func forwardOnce(
@@ -1015,12 +1170,74 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 metadata: baseMetadata
             )
 
-            for attemptIndex in 0...Self.refreshRetryDelaysNanos.count {
+            let warmupResult = await warmupDriver.warmUp(
+                tabIdentifier: refreshRequest.tabIdentifier,
+                filePath: refreshRequest.filePath,
+                sessionId: sessionId,
+                eventLoop: eventLoop,
+                windowsProvider: { sessionId, eventLoop in
+                    await self.listXcodeWindows(
+                        sessionId: sessionId,
+                        eventLoop: eventLoop
+                    )
+                }
+            )
+            let warmupMetadata = baseMetadata
+                .merging(
+                    [
+                        "workspace_path": .string(warmupResult.workspacePath ?? "none"),
+                        "requested_file_path": .string(refreshRequest.filePath ?? "none"),
+                        "resolved_file_path": .string(warmupResult.resolvedFilePath ?? "none"),
+                    ],
+                    uniquingKeysWith: { _, new in new }
+                )
+
+            if let failureReason = warmupResult.failureReason,
+                failureReason != "disabled",
+                failureReason != "missing tabIdentifier",
+                failureReason != "missing filePath"
+            {
+                logger.debug(
+                    "Refresh code issues warm-up fell back to plain refresh",
+                    metadata: warmupMetadata.merging(
+                        [
+                            "warmup_stage": .string("fallback"),
+                            "failure_reason": .string(failureReason),
+                        ],
+                        uniquingKeysWith: { _, new in new }
+                    )
+                )
+            } else if warmupResult.context != nil {
+                logger.debug(
+                    "Refresh code issues warm-up completed",
+                    metadata: warmupMetadata.merging(
+                        ["warmup_stage": .string("ready")],
+                        uniquingKeysWith: { _, new in new }
+                    )
+                )
+            }
+            var finalResult: RefreshForwardAttemptResult = .invalidRequest
+
+            resultLoop: for attemptIndex in 0...Self.refreshRetryDelaysNanos.count {
                 let attempt = attemptIndex + 1
-                let attemptMetadata = baseMetadata.merging(
+                let attemptMetadata = warmupMetadata.merging(
                     ["attempt": .string("\(attempt)")],
                     uniquingKeysWith: { _, new in new }
                 )
+                if let context = warmupResult.context {
+                    let touched = await warmupDriver.touchResolvedTarget(context)
+                    logger.debug(
+                        "Refresh code issues warm-up touch",
+                        metadata: attemptMetadata.merging(
+                            [
+                                "warmup_stage": .string("touch"),
+                                "touch_result": .string(touched ? "ready" : "failed"),
+                            ],
+                            uniquingKeysWith: { _, new in new }
+                        )
+                    )
+                }
+
                 let result = await forwardOnce(
                     bodyData: bodyData,
                     sessionId: sessionId,
@@ -1050,13 +1267,25 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             metadata: attemptMetadata
                         )
                     }
-                    return .success(responseData)
+                    finalResult = .success(responseData)
+                    break resultLoop
                 case .timeout, .upstreamUnavailable, .invalidRequest, .invalidUpstreamResponse:
-                    return result
+                    finalResult = result
+                    break resultLoop
                 }
             }
 
-            return .invalidRequest
+            let restoreResult = await warmupDriver.restore(warmupResult.context)
+            if warmupResult.context?.snapshot != nil {
+                logger.debug(
+                    "Refresh code issues restore finished",
+                    metadata: warmupMetadata.merging(
+                        ["restore_result": .string(restoreResult)],
+                        uniquingKeysWith: { _, new in new }
+                    )
+                )
+            }
+            return finalResult
         }
     }
 

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -983,13 +983,17 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             resolution = resolveForwardResponse(
                 .success(buffer),
                 started: started,
-                sessionId: sessionId
+                sessionId: sessionId,
+                accountSuccess: false,
+                accountTimeout: false
             )
         } catch {
             resolution = resolveForwardResponse(
                 .failure(error),
                 started: started,
-                sessionId: sessionId
+                sessionId: sessionId,
+                accountSuccess: false,
+                accountTimeout: false
             )
         }
 

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -801,9 +801,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     private func prepareForwardRequest(
         bodyData: Data,
         parsedRequestJSON: Any,
-        sessionId: String
+        sessionId: String,
+        shouldPinUpstreamOverride: Bool? = nil
     ) throws -> PreparedForwardRequest? {
-        let shouldPinUpstream = MCPMethodDispatcher.shouldPinUpstream(for: parsedRequestJSON)
+        let shouldPinUpstream =
+            shouldPinUpstreamOverride ?? MCPMethodDispatcher.shouldPinUpstream(for: parsedRequestJSON)
         guard let upstreamIndex = sessionManager.chooseUpstreamIndex(
             sessionId: sessionId,
             shouldPin: shouldPinUpstream
@@ -956,7 +958,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             guard let candidate = try prepareForwardRequest(
                 bodyData: bodyData,
                 parsedRequestJSON: requestObject,
-                sessionId: sessionId
+                sessionId: sessionId,
+                shouldPinUpstreamOverride: false
             ) else {
                 return nil
             }

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -390,6 +390,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 let sessionId = headerSessionId ?? UUID().uuidString
                 _ = sessionManager.session(id: sessionId)
                 let future = sessionManager.registerInitialize(
+                    sessionId: sessionId,
                     originalId: originalId,
                     requestObject: object,
                     on: context.eventLoop

--- a/Sources/XcodeMCPProxy/ProcessRunner.swift
+++ b/Sources/XcodeMCPProxy/ProcessRunner.swift
@@ -1,24 +1,43 @@
 import Foundation
 import NIOConcurrencyHelpers
 
+final class DispatchGroupLeaveGuard: @unchecked Sendable {
+    private let group: DispatchGroup
+    private let didLeave = NIOLockedValueBox(false)
+
+    init(group: DispatchGroup) {
+        self.group = group
+        self.group.enter()
+    }
+
+    func leaveIfNeeded() {
+        let shouldLeave = didLeave.withLockedValue { didLeave in
+            guard didLeave == false else { return false }
+            didLeave = true
+            return true
+        }
+        guard shouldLeave else { return }
+        group.leave()
+    }
+}
+
 private final class PipeCollector: @unchecked Sendable {
     private let fileHandle: FileHandle
-    private let drainGroup: DispatchGroup
+    private let drainGuard: DispatchGroupLeaveGuard
     private let buffer = NIOLockedValueBox(Data())
 
     init(fileHandle: FileHandle, drainGroup: DispatchGroup) {
         self.fileHandle = fileHandle
-        self.drainGroup = drainGroup
-        self.drainGroup.enter()
+        self.drainGuard = DispatchGroupLeaveGuard(group: drainGroup)
     }
 
     func start() {
-        fileHandle.readabilityHandler = { [buffer, drainGroup] handle in
+        fileHandle.readabilityHandler = { [buffer, drainGuard] handle in
             let chunk = handle.availableData
             if chunk.isEmpty {
                 handle.readabilityHandler = nil
                 try? handle.close()
-                drainGroup.leave()
+                drainGuard.leaveIfNeeded()
                 return
             }
             buffer.withLockedValue { data in
@@ -34,7 +53,7 @@ private final class PipeCollector: @unchecked Sendable {
     func cancel() {
         fileHandle.readabilityHandler = nil
         try? fileHandle.close()
-        drainGroup.leave()
+        drainGuard.leaveIfNeeded()
     }
 }
 

--- a/Sources/XcodeMCPProxy/ProcessRunner.swift
+++ b/Sources/XcodeMCPProxy/ProcessRunner.swift
@@ -1,0 +1,131 @@
+import Foundation
+import NIOConcurrencyHelpers
+
+private final class PipeCollector: @unchecked Sendable {
+    private let fileHandle: FileHandle
+    private let drainGroup: DispatchGroup
+    private let buffer = NIOLockedValueBox(Data())
+
+    init(fileHandle: FileHandle, drainGroup: DispatchGroup) {
+        self.fileHandle = fileHandle
+        self.drainGroup = drainGroup
+        self.drainGroup.enter()
+    }
+
+    func start() {
+        fileHandle.readabilityHandler = { [buffer, drainGroup] handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                handle.readabilityHandler = nil
+                try? handle.close()
+                drainGroup.leave()
+                return
+            }
+            buffer.withLockedValue { data in
+                data.append(chunk)
+            }
+        }
+    }
+
+    func collectedData() -> Data {
+        buffer.withLockedValue { $0 }
+    }
+
+    func cancel() {
+        fileHandle.readabilityHandler = nil
+        try? fileHandle.close()
+        drainGroup.leave()
+    }
+}
+
+struct ProcessRequest: Sendable {
+    let label: String
+    let executablePath: String
+    let arguments: [String]
+    let input: String?
+}
+
+struct ProcessOutput: Sendable {
+    let terminationStatus: Int32
+    let stdout: String
+    let stderr: String
+}
+
+protocol ProcessRunning: Sendable {
+    func run(_ request: ProcessRequest) async throws -> ProcessOutput
+}
+
+struct ProcessRunner: ProcessRunning {
+    func run(_ request: ProcessRequest) async throws -> ProcessOutput {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            let stdinPipe = Pipe()
+            let drainGroup = DispatchGroup()
+            let stdoutCollector = PipeCollector(
+                fileHandle: stdoutPipe.fileHandleForReading,
+                drainGroup: drainGroup
+            )
+            let stderrCollector = PipeCollector(
+                fileHandle: stderrPipe.fileHandleForReading,
+                drainGroup: drainGroup
+            )
+            let didResume = NIOLockedValueBox(false)
+            let resumeOnce: @Sendable (Result<ProcessOutput, Error>) -> Void = { result in
+                let shouldResume = didResume.withLockedValue { didResume in
+                    guard didResume == false else { return false }
+                    didResume = true
+                    return true
+                }
+                guard shouldResume else { return }
+                continuation.resume(with: result)
+            }
+
+            process.executableURL = URL(fileURLWithPath: request.executablePath)
+            process.arguments = request.arguments
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+            if request.input != nil {
+                process.standardInput = stdinPipe
+            }
+            stdoutCollector.start()
+            stderrCollector.start()
+
+            process.terminationHandler = { process in
+                DispatchQueue.global().async {
+                    drainGroup.wait()
+                    let output = ProcessOutput(
+                        terminationStatus: process.terminationStatus,
+                        stdout: String(decoding: stdoutCollector.collectedData(), as: UTF8.self),
+                        stderr: String(decoding: stderrCollector.collectedData(), as: UTF8.self)
+                    )
+                    resumeOnce(.success(output))
+                }
+            }
+
+            do {
+                try process.run()
+                try? stdoutPipe.fileHandleForWriting.close()
+                try? stderrPipe.fileHandleForWriting.close()
+                if let input = request.input {
+                    if let inputData = input.data(using: .utf8) {
+                        try stdinPipe.fileHandleForWriting.write(contentsOf: inputData)
+                    }
+                    try stdinPipe.fileHandleForWriting.close()
+                }
+            } catch {
+                process.terminationHandler = nil
+                if process.isRunning {
+                    process.terminate()
+                }
+                stdoutCollector.cancel()
+                stderrCollector.cancel()
+                try? stdoutPipe.fileHandleForWriting.close()
+                try? stderrPipe.fileHandleForWriting.close()
+                try? stdinPipe.fileHandleForWriting.close()
+                resumeOnce(.failure(error))
+            }
+        }
+    }
+}

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -7,6 +7,7 @@ public final class ProxyServer {
     private let config: ProxyConfig
     private let group: EventLoopGroup
     private let sessionManager: SessionManager
+    private let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator
     private var channels: [Channel] = []
     private let logger: Logger = ProxyLogging.make("server")
 
@@ -15,6 +16,7 @@ public final class ProxyServer {
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = group.next()
         self.sessionManager = SessionManager(config: config, eventLoop: eventLoop)
+        self.refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
     }
 
     public func run() async throws {
@@ -39,12 +41,13 @@ public final class ProxyServer {
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-            .childChannelInitializer { [sessionManager, config] channel in
+            .childChannelInitializer { [sessionManager, config, refreshCodeIssuesCoordinator] channel in
                 channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
                     channel.pipeline.addHandler(
                         HTTPHandler(
                             config: config,
-                            sessionManager: sessionManager
+                            sessionManager: sessionManager,
+                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator
                         )
                     )
                 }

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -8,6 +8,7 @@ public final class ProxyServer {
     private let group: EventLoopGroup
     private let sessionManager: SessionManager
     private let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator
+    private let warmupDriver: XcodeEditorWarmupDriver
     private var channels: [Channel] = []
     private let logger: Logger = ProxyLogging.make("server")
 
@@ -17,6 +18,7 @@ public final class ProxyServer {
         let eventLoop = group.next()
         self.sessionManager = SessionManager(config: config, eventLoop: eventLoop)
         self.refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+        self.warmupDriver = XcodeEditorWarmupDriver()
     }
 
     public func run() async throws {
@@ -41,13 +43,14 @@ public final class ProxyServer {
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-            .childChannelInitializer { [sessionManager, config, refreshCodeIssuesCoordinator] channel in
+            .childChannelInitializer { [sessionManager, config, refreshCodeIssuesCoordinator, warmupDriver] channel in
                 channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
                     channel.pipeline.addHandler(
                         HTTPHandler(
                             config: config,
                             sessionManager: sessionManager,
-                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator
+                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
+                            warmupDriver: warmupDriver
                         )
                     )
                 }

--- a/Sources/XcodeMCPProxy/RefreshCodeIssuesCoordinator.swift
+++ b/Sources/XcodeMCPProxy/RefreshCodeIssuesCoordinator.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+actor RefreshCodeIssuesCoordinator {
+    private struct Waiter {
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private var busyKeys: Set<String> = []
+    private var waitersByKey: [String: [Waiter]] = [:]
+
+    func withPermit<T: Sendable>(
+        key: String,
+        body: @Sendable (_ queuePosition: Int) async throws -> T
+    ) async rethrows -> T {
+        let queuePosition = await acquire(key: key)
+        do {
+            let result = try await body(queuePosition)
+            release(key: key)
+            return result
+        } catch {
+            release(key: key)
+            throw error
+        }
+    }
+
+    private func acquire(key: String) async -> Int {
+        if busyKeys.contains(key) == false {
+            busyKeys.insert(key)
+            return 0
+        }
+
+        let queuePosition = (waitersByKey[key]?.count ?? 0) + 1
+        await withCheckedContinuation { continuation in
+            waitersByKey[key, default: []].append(Waiter(continuation: continuation))
+        }
+        return queuePosition
+    }
+
+    private func release(key: String) {
+        guard var waiters = waitersByKey[key], waiters.isEmpty == false else {
+            busyKeys.remove(key)
+            waitersByKey.removeValue(forKey: key)
+            return
+        }
+
+        let next = waiters.removeFirst()
+        if waiters.isEmpty {
+            waitersByKey.removeValue(forKey: key)
+        } else {
+            waitersByKey[key] = waiters
+        }
+        next.continuation.resume()
+    }
+}

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -84,6 +84,7 @@ final class SessionManager: Sendable, SessionManaging {
         let eventLoop: EventLoop
         let promise: EventLoopPromise<ByteBuffer>
         let sessionId: String
+        let sessionGeneration: UInt64
         let originalId: RPCId
     }
 
@@ -97,6 +98,7 @@ final class SessionManager: Sendable, SessionManaging {
     private struct SessionState: Sendable {
         struct SessionRecord: Sendable {
             let context: SessionContext
+            let generation: UInt64
             var pinnedUpstreamIndex: Int?
             var initializeUpstreamIndex: Int?
             var preferInitializeUpstreamOnNextPin: Bool
@@ -104,6 +106,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         var sessions: [String: SessionRecord] = [:]
+        var nextGeneration: UInt64 = 0
     }
 
     private struct InitState: Sendable {
@@ -216,8 +219,10 @@ final class SessionManager: Sendable, SessionManaging {
                 return existing.context
             }
             let context = SessionContext(id: id, config: config)
+            state.nextGeneration &+= 1
             state.sessions[id] = SessionState.SessionRecord(
                 context: context,
+                generation: state.nextGeneration,
                 pinnedUpstreamIndex: nil,
                 initializeUpstreamIndex: nil,
                 preferInitializeUpstreamOnNextPin: false,
@@ -557,6 +562,16 @@ final class SessionManager: Sendable, SessionManaging {
         }
     }
 
+    private func sessionStillMatchesPendingInitialize(
+        sessionId: String,
+        sessionGeneration: UInt64
+    ) -> Bool {
+        sessionsState.withLockedValue { state in
+            guard let record = state.sessions[sessionId] else { return false }
+            return record.generation == sessionGeneration
+        }
+    }
+
     private func classifyHealthAndCollectProbeIfNeeded(
         upstreamIndex: Int,
         nowUptimeNs: UInt64,
@@ -595,6 +610,10 @@ final class SessionManager: Sendable, SessionManaging {
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
+        _ = session(id: sessionId)
+        let sessionGeneration = sessionsState.withLockedValue { state in
+            state.sessions[sessionId]?.generation ?? 0
+        }
         var shouldSend = false
         var shouldScheduleTimeout = false
         var initRequest: [String: Any]?
@@ -618,6 +637,7 @@ final class SessionManager: Sendable, SessionManaging {
                     eventLoop: eventLoop,
                     promise: promise,
                     sessionId: sessionId,
+                    sessionGeneration: sessionGeneration,
                     originalId: originalId
                 )
             )
@@ -1398,12 +1418,16 @@ final class SessionManager: Sendable, SessionManaging {
         update.timeout?.cancel()
 
         for item in update.pending {
-            _ = session(id: item.sessionId)
-            setInitializeUpstreamIndexIfNeeded(
+            if sessionStillMatchesPendingInitialize(
                 sessionId: item.sessionId,
-                upstreamIndex: upstreamIndex,
-                preferOnNextPin: false
-            )
+                sessionGeneration: item.sessionGeneration
+            ) {
+                setInitializeUpstreamIndexIfNeeded(
+                    sessionId: item.sessionId,
+                    upstreamIndex: upstreamIndex,
+                    preferOnNextPin: false
+                )
+            }
             if let buffer = encodeInitializeResponse(originalId: item.originalId, result: result) {
                 item.eventLoop.execute {
                     item.promise.succeed(buffer)

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -33,6 +33,7 @@ protocol SessionManaging: Sendable {
     func setCachedToolsListResult(_ result: JSONValue)
     func refreshToolsListIfNeeded()
     func registerInitialize(
+        sessionId: String,
         originalId: RPCId,
         requestObject: [String: Any],
         on eventLoop: EventLoop
@@ -82,6 +83,7 @@ final class SessionManager: Sendable, SessionManaging {
     private struct InitPending: Sendable {
         let eventLoop: EventLoop
         let promise: EventLoopPromise<ByteBuffer>
+        let sessionId: String
         let originalId: RPCId
     }
 
@@ -96,6 +98,9 @@ final class SessionManager: Sendable, SessionManaging {
         struct SessionRecord: Sendable {
             let context: SessionContext
             var pinnedUpstreamIndex: Int?
+            var initializeUpstreamIndex: Int?
+            var preferInitializeUpstreamOnNextPin: Bool
+            var didReceiveInitializeUpstreamMessage: Bool
         }
 
         var sessions: [String: SessionRecord] = [:]
@@ -212,7 +217,12 @@ final class SessionManager: Sendable, SessionManaging {
             }
             let context = SessionContext(id: id, config: config)
             state.sessions[id] = SessionState.SessionRecord(
-                context: context, pinnedUpstreamIndex: nil)
+                context: context,
+                pinnedUpstreamIndex: nil,
+                initializeUpstreamIndex: nil,
+                preferInitializeUpstreamOnNextPin: false,
+                didReceiveInitializeUpstreamMessage: false
+            )
             return context
         }
     }
@@ -347,8 +357,68 @@ final class SessionManager: Sendable, SessionManaging {
 
             sessionsState.withLockedValue { state in
                 state.sessions[sessionId]?.pinnedUpstreamIndex = nil
+                state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
             }
             pinned = nil
+        }
+
+        let preferredInitializeUpstreamIndex = sessionsState.withLockedValue { state -> Int? in
+            guard let record = state.sessions[sessionId],
+                record.pinnedUpstreamIndex == nil,
+                (record.preferInitializeUpstreamOnNextPin || record.didReceiveInitializeUpstreamMessage),
+                let upstreamIndex = record.initializeUpstreamIndex
+            else {
+                return nil
+            }
+            return upstreamIndex
+        }
+
+        if shouldPin, let preferredInitializeUpstreamIndex {
+            let isUsable = upstreamState.withLockedValue { state in
+                guard preferredInitializeUpstreamIndex >= 0,
+                    preferredInitializeUpstreamIndex < state.upstreamStates.count
+                else {
+                    return false
+                }
+                let health = classifyHealthAndCollectProbeIfNeeded(
+                    upstreamIndex: preferredInitializeUpstreamIndex,
+                    nowUptimeNs: nowUptimeNs,
+                    state: &state,
+                    probesToStart: &probesToStart
+                )
+                let isHealthyEnough: Bool
+                switch health {
+                case .healthy, .degraded:
+                    isHealthyEnough = true
+                case .quarantined:
+                    isHealthyEnough = false
+                }
+                return isHealthyEnough
+                    && state.upstreamStates[preferredInitializeUpstreamIndex].isInitialized
+            }
+            if isUsable {
+                for probe in probesToStart {
+                    probeUpstreamHealth(
+                        upstreamIndex: probe.upstreamIndex,
+                        probeGeneration: probe.probeGeneration
+                    )
+                }
+                sessionsState.withLockedValue { state in
+                    state.sessions[sessionId]?.pinnedUpstreamIndex = preferredInitializeUpstreamIndex
+                    state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                    state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                    state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+                }
+                return preferredInitializeUpstreamIndex
+            }
+
+            sessionsState.withLockedValue { state in
+                state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+            }
         }
 
         let chosen = upstreamState.withLockedValue { state -> Int? in
@@ -397,9 +467,94 @@ final class SessionManager: Sendable, SessionManaging {
         if pinned == nil, shouldPin {
             sessionsState.withLockedValue { state in
                 state.sessions[sessionId]?.pinnedUpstreamIndex = chosen
+                state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
             }
         }
         return chosen
+    }
+
+    private func chooseInitializeUpstreamIndex(sessionId: String) -> Int? {
+        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        var probesToStart: [(upstreamIndex: Int, probeGeneration: UInt64)] = []
+        probesToStart.reserveCapacity(1)
+
+        let hintedUpstreamIndex = sessionsState.withLockedValue { state -> Int? in
+            if let pinned = state.sessions[sessionId]?.pinnedUpstreamIndex {
+                return pinned
+            }
+            return state.sessions[sessionId]?.initializeUpstreamIndex
+        }
+
+        if let hintedUpstreamIndex {
+            let isUsable = upstreamState.withLockedValue { state in
+                guard hintedUpstreamIndex >= 0, hintedUpstreamIndex < state.upstreamStates.count else {
+                    return false
+                }
+                let health = classifyHealthAndCollectProbeIfNeeded(
+                    upstreamIndex: hintedUpstreamIndex,
+                    nowUptimeNs: nowUptimeNs,
+                    state: &state,
+                    probesToStart: &probesToStart
+                )
+                let isHealthyEnough: Bool
+                switch health {
+                case .healthy, .degraded:
+                    isHealthyEnough = true
+                case .quarantined:
+                    isHealthyEnough = false
+                }
+                return isHealthyEnough && state.upstreamStates[hintedUpstreamIndex].isInitialized
+            }
+
+            for probe in probesToStart {
+                probeUpstreamHealth(
+                    upstreamIndex: probe.upstreamIndex,
+                    probeGeneration: probe.probeGeneration
+                )
+            }
+
+            if isUsable {
+                return hintedUpstreamIndex
+            }
+
+            sessionsState.withLockedValue { state in
+                if state.sessions[sessionId]?.pinnedUpstreamIndex == nil {
+                    state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                    state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                }
+            }
+        }
+
+        return chooseUpstreamIndex(sessionId: sessionId, shouldPin: false)
+    }
+
+    private func setInitializeUpstreamIndexIfNeeded(
+        sessionId: String,
+        upstreamIndex: Int,
+        preferOnNextPin: Bool
+    ) {
+        sessionsState.withLockedValue { state in
+            guard let record = state.sessions[sessionId] else { return }
+            if record.pinnedUpstreamIndex == nil {
+                state.sessions[sessionId]?.initializeUpstreamIndex = upstreamIndex
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = preferOnNextPin
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+            } else {
+                state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+            }
+        }
+    }
+
+    private func clearInitializeUpstreamIndex(sessionId: String) {
+        sessionsState.withLockedValue { state in
+            state.sessions[sessionId]?.initializeUpstreamIndex = nil
+            state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+            state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+        }
     }
 
     private func classifyHealthAndCollectProbeIfNeeded(
@@ -435,6 +590,7 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     func registerInitialize(
+        sessionId: String,
         originalId: RPCId,
         requestObject: [String: Any],
         on eventLoop: EventLoop
@@ -461,6 +617,7 @@ final class SessionManager: Sendable, SessionManaging {
                 InitPending(
                     eventLoop: eventLoop,
                     promise: promise,
+                    sessionId: sessionId,
                     originalId: originalId
                 )
             )
@@ -477,6 +634,25 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         if let cachedResult {
+            _ = session(id: sessionId)
+            if let upstreamIndex = chooseInitializeUpstreamIndex(sessionId: sessionId) {
+                let shouldPreferOnNextPin = upstreamState.withLockedValue { state in
+                    state.upstreamStates.reduce(into: 0) { count, upstream in
+                        guard upstream.isInitialized else { return }
+                        switch upstream.healthState {
+                        case .healthy, .degraded:
+                            count += 1
+                        case .quarantined:
+                            break
+                        }
+                    } > 1
+                }
+                setInitializeUpstreamIndexIfNeeded(
+                    sessionId: sessionId,
+                    upstreamIndex: upstreamIndex,
+                    preferOnNextPin: shouldPreferOnNextPin
+                )
+            }
             if let buffer = encodeInitializeResponse(originalId: originalId, result: cachedResult) {
                 return eventLoop.makeSucceededFuture(buffer)
             }
@@ -485,6 +661,15 @@ final class SessionManager: Sendable, SessionManaging {
 
         if shuttingDown {
             return eventLoop.makeFailedFuture(TimeoutError())
+        }
+
+        if pendingPromise != nil {
+            _ = session(id: sessionId)
+            setInitializeUpstreamIndexIfNeeded(
+                sessionId: sessionId,
+                upstreamIndex: 0,
+                preferOnNextPin: false
+            )
         }
 
         if shouldSend, var initRequest {
@@ -505,6 +690,19 @@ final class SessionManager: Sendable, SessionManaging {
             return eventLoop.makeFailedFuture(TimeoutError())
         }
         return promise.futureResult
+    }
+
+    func registerInitialize(
+        originalId: RPCId,
+        requestObject: [String: Any],
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<ByteBuffer> {
+        registerInitialize(
+            sessionId: "__initialize_pending__:\(originalId.key)",
+            originalId: originalId,
+            requestObject: requestObject,
+            on: eventLoop
+        )
     }
 
     private func routeUpstreamMessage(_ data: Data, upstreamIndex: Int) {
@@ -614,6 +812,7 @@ final class SessionManager: Sendable, SessionManaging {
                 idMapper.remove(upstreamIndex: 0, upstreamId: upstreamId)
             }
             for item in globalInit.pending {
+                clearInitializeUpstreamIndex(sessionId: item.sessionId)
                 item.eventLoop.execute {
                     item.promise.fail(TimeoutError())
                 }
@@ -631,7 +830,12 @@ final class SessionManager: Sendable, SessionManaging {
             for key in keys {
                 if state.sessions[key]?.pinnedUpstreamIndex == upstreamIndex {
                     state.sessions[key]?.pinnedUpstreamIndex = nil
+                    state.sessions[key]?.initializeUpstreamIndex = nil
+                    state.sessions[key]?.preferInitializeUpstreamOnNextPin = false
                     cleared += 1
+                } else if state.sessions[key]?.initializeUpstreamIndex == upstreamIndex {
+                    state.sessions[key]?.initializeUpstreamIndex = nil
+                    state.sessions[key]?.preferInitializeUpstreamOnNextPin = false
                 }
             }
             return cleared
@@ -954,10 +1158,9 @@ final class SessionManager: Sendable, SessionManaging {
             data: data
         )
         // We have no id-based mapping for this upstream message, so we can't unambiguously route it to a
-        // single session. To reduce cross-talk across multiple concurrent agents, only deliver it to
-        // sessions pinned to the same upstream. If no session is pinned to this upstream yet, still
-        // deliver server-initiated notifications/requests to unpinned sessions so they don't miss
-        // pre-pin messages.
+        // single session. To avoid cross-session disclosure, only deliver server-initiated
+        // notifications/requests to sessions already pinned to the same upstream or to sessions that
+        // have only been initialized against that upstream and have not chosen a permanent pin yet.
         //
         // Never forward unmapped JSON-RPC responses (no `method`) to sessions: if we dropped a mapping
         // due to timeouts (e.g. a best-effort tools/list warmup) then a late response must not leak
@@ -1008,42 +1211,28 @@ final class SessionManager: Sendable, SessionManaging {
             return
         }
 
-        let (pinnedTargets, unpinnedTargets) = sessionsState.withLockedValue {
-            state -> ([SessionContext], [SessionContext]) in
-            var pinned: [SessionContext] = []
-            var unpinned: [SessionContext] = []
-            pinned.reserveCapacity(state.sessions.count)
-            unpinned.reserveCapacity(state.sessions.count)
-            for record in state.sessions.values {
+        let routedTargets = sessionsState.withLockedValue {
+            state -> [SessionContext] in
+            var targets: [SessionContext] = []
+            targets.reserveCapacity(state.sessions.count)
+            let keys = Array(state.sessions.keys)
+            for key in keys {
+                guard let record = state.sessions[key] else { continue }
                 if record.pinnedUpstreamIndex == upstreamIndex {
-                    pinned.append(record.context)
-                } else if record.pinnedUpstreamIndex == nil {
-                    unpinned.append(record.context)
+                    targets.append(record.context)
+                } else if record.pinnedUpstreamIndex == nil
+                    && record.initializeUpstreamIndex == upstreamIndex
+                {
+                    state.sessions[key]?.didReceiveInitializeUpstreamMessage = true
+                    targets.append(record.context)
                 }
             }
-            return (pinned, unpinned)
+            return targets
         }
 
-        if !pinnedTargets.isEmpty {
+        if !routedTargets.isEmpty {
             for payload in serverInitiatedPayloads {
-                for session in pinnedTargets {
-                    session.router.handleIncoming(payload)
-                }
-            }
-            return
-        }
-
-        if !unpinnedTargets.isEmpty {
-            logger.debug(
-                "Routing unmapped upstream message to unpinned sessions",
-                metadata: [
-                    "upstream": .string("\(upstreamIndex)"),
-                    "bytes": .string("\(data.count)"),
-                    "targets": .string("\(unpinnedTargets.count)"),
-                ]
-            )
-            for payload in serverInitiatedPayloads {
-                for session in unpinnedTargets {
+                for session in routedTargets {
                     session.router.handleIncoming(payload)
                 }
             }
@@ -1051,7 +1240,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         logger.debug(
-            "Dropping unmapped upstream message (no target sessions)",
+            "Dropping unmapped upstream message (no routed target sessions)",
             metadata: [
                 "upstream": .string("\(upstreamIndex)"),
                 "bytes": .string("\(data.count)"),
@@ -1209,6 +1398,12 @@ final class SessionManager: Sendable, SessionManaging {
         update.timeout?.cancel()
 
         for item in update.pending {
+            _ = session(id: item.sessionId)
+            setInitializeUpstreamIndexIfNeeded(
+                sessionId: item.sessionId,
+                upstreamIndex: upstreamIndex,
+                preferOnNextPin: false
+            )
             if let buffer = encodeInitializeResponse(originalId: item.originalId, result: result) {
                 item.eventLoop.execute {
                     item.promise.succeed(buffer)
@@ -1293,6 +1488,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
+            clearInitializeUpstreamIndex(sessionId: item.sessionId)
             if let buffer = encodeInitializeErrorResponse(
                 originalId: item.originalId, errorObject: errorObject)
             {
@@ -1383,6 +1579,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
+            clearInitializeUpstreamIndex(sessionId: item.sessionId)
             item.eventLoop.execute {
                 item.promise.fail(error)
             }
@@ -1486,7 +1683,12 @@ final class SessionManager: Sendable, SessionManaging {
             for key in keys {
                 if state.sessions[key]?.pinnedUpstreamIndex == upstreamIndex {
                     state.sessions[key]?.pinnedUpstreamIndex = nil
+                    state.sessions[key]?.initializeUpstreamIndex = nil
+                    state.sessions[key]?.preferInitializeUpstreamOnNextPin = false
                     cleared += 1
+                } else if state.sessions[key]?.initializeUpstreamIndex == upstreamIndex {
+                    state.sessions[key]?.initializeUpstreamIndex = nil
+                    state.sessions[key]?.preferInitializeUpstreamOnNextPin = false
                 }
             }
             return cleared

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -57,6 +57,14 @@ final class SessionManager: Sendable, SessionManaging {
             let healthState: UpstreamHealthState
         }
 
+        struct Session: Sendable {
+            let generation: UInt64
+            let pinnedUpstreamIndex: Int?
+            let initializeUpstreamIndex: Int?
+            let preferInitializeUpstreamOnNextPin: Bool
+            let didReceiveInitializeUpstreamMessage: Bool
+        }
+
         let hasInitResult: Bool
         let initInFlight: Bool
         let didWarmSecondary: Bool
@@ -554,8 +562,15 @@ final class SessionManager: Sendable, SessionManaging {
         }
     }
 
-    private func clearInitializeUpstreamIndex(sessionId: String) {
+    private func clearInitializeUpstreamIndex(
+        sessionId: String,
+        onlyIfGeneration sessionGeneration: UInt64? = nil
+    ) {
         sessionsState.withLockedValue { state in
+            guard let record = state.sessions[sessionId] else { return }
+            if let sessionGeneration, record.generation != sessionGeneration {
+                return
+            }
             state.sessions[sessionId]?.initializeUpstreamIndex = nil
             state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
             state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
@@ -832,7 +847,10 @@ final class SessionManager: Sendable, SessionManaging {
                 idMapper.remove(upstreamIndex: 0, upstreamId: upstreamId)
             }
             for item in globalInit.pending {
-                clearInitializeUpstreamIndex(sessionId: item.sessionId)
+                clearInitializeUpstreamIndex(
+                    sessionId: item.sessionId,
+                    onlyIfGeneration: item.sessionGeneration
+                )
                 item.eventLoop.execute {
                     item.promise.fail(TimeoutError())
                 }
@@ -1070,6 +1088,36 @@ final class SessionManager: Sendable, SessionManaging {
                 .shouldRetryEagerInitializePrimaryAfterWarmInitFailure,
             upstreams: upstreams
         )
+    }
+
+    func testSessionSnapshot(id: String) -> TestSnapshot.Session? {
+        sessionsState.withLockedValue { state in
+            guard let record = state.sessions[id] else { return nil }
+            return TestSnapshot.Session(
+                generation: record.generation,
+                pinnedUpstreamIndex: record.pinnedUpstreamIndex,
+                initializeUpstreamIndex: record.initializeUpstreamIndex,
+                preferInitializeUpstreamOnNextPin: record.preferInitializeUpstreamOnNextPin,
+                didReceiveInitializeUpstreamMessage: record.didReceiveInitializeUpstreamMessage
+            )
+        }
+    }
+
+    func testSetInitializeRoutingState(
+        sessionId: String,
+        upstreamIndex: Int,
+        preferOnNextPin: Bool,
+        didReceiveInitializeUpstreamMessage: Bool = false
+    ) {
+        setInitializeUpstreamIndexIfNeeded(
+            sessionId: sessionId,
+            upstreamIndex: upstreamIndex,
+            preferOnNextPin: preferOnNextPin
+        )
+        guard didReceiveInitializeUpstreamMessage else { return }
+        sessionsState.withLockedValue { state in
+            state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = true
+        }
     }
 
     private func redactedDebugEvent(_ event: ProxyDebugEvent?) -> ProxyDebugEvent? {
@@ -1512,7 +1560,10 @@ final class SessionManager: Sendable, SessionManaging {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
-            clearInitializeUpstreamIndex(sessionId: item.sessionId)
+            clearInitializeUpstreamIndex(
+                sessionId: item.sessionId,
+                onlyIfGeneration: item.sessionGeneration
+            )
             if let buffer = encodeInitializeErrorResponse(
                 originalId: item.originalId, errorObject: errorObject)
             {
@@ -1603,7 +1654,10 @@ final class SessionManager: Sendable, SessionManaging {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
-            clearInitializeUpstreamIndex(sessionId: item.sessionId)
+            clearInitializeUpstreamIndex(
+                sessionId: item.sessionId,
+                onlyIfGeneration: item.sessionGeneration
+            )
             item.eventLoop.execute {
                 item.promise.fail(error)
             }

--- a/Sources/XcodeMCPProxy/XcodeEditorWarmupDriver.swift
+++ b/Sources/XcodeMCPProxy/XcodeEditorWarmupDriver.swift
@@ -1,0 +1,525 @@
+import Foundation
+import Logging
+import NIO
+
+struct XcodeWindowInfo: Sendable, Equatable {
+    let tabIdentifier: String
+    let workspacePath: String
+}
+
+struct EditorSnapshot: Sendable, Equatable {
+    let workspacePath: String
+    let workspaceRoot: String
+    let windowTitle: String
+    let candidateSourceDocumentPaths: [String]
+    let visibleSourceBasename: String?
+}
+
+struct WarmupContext: Sendable, Equatable {
+    let workspacePath: String
+    let workspaceRoot: String
+    let resolvedFilePath: String
+    let snapshot: EditorSnapshot?
+}
+
+struct WarmupResult: Sendable, Equatable {
+    let context: WarmupContext?
+    let snapshot: EditorSnapshot?
+    let workspacePath: String?
+    let resolvedFilePath: String?
+    let failureReason: String?
+}
+
+actor XcodeEditorWarmupDriver {
+    typealias WindowsProvider = @Sendable (_ sessionId: String, _ eventLoop: EventLoop) async -> [XcodeWindowInfo]?
+
+    private struct FileResolutionKey: Hashable {
+        let workspacePath: String
+        let filePath: String
+    }
+
+    private let processRunner: any ProcessRunning
+    private let fileManager = FileManager.default
+    private let logger: Logger
+    private let isEnabled: Bool
+
+    private var workspacePathCache: [String: String] = [:]
+    private var resolvedFilePathCache: [FileResolutionKey: String] = [:]
+
+    init(
+        processRunner: any ProcessRunning = ProcessRunner(),
+        logger: Logger = ProxyLogging.make("warmup"),
+        isEnabled: Bool = true
+    ) {
+        self.processRunner = processRunner
+        self.logger = logger
+        self.isEnabled = isEnabled
+    }
+
+    static func disabled() -> XcodeEditorWarmupDriver {
+        XcodeEditorWarmupDriver(isEnabled: false)
+    }
+
+    func warmUp(
+        tabIdentifier: String?,
+        filePath: String?,
+        sessionId: String,
+        eventLoop: EventLoop,
+        windowsProvider: WindowsProvider
+    ) async -> WarmupResult {
+        guard isEnabled else {
+            return WarmupResult(
+                context: nil,
+                snapshot: nil,
+                workspacePath: nil,
+                resolvedFilePath: nil,
+                failureReason: "disabled"
+            )
+        }
+        guard let tabIdentifier, tabIdentifier.isEmpty == false else {
+            return WarmupResult(
+                context: nil,
+                snapshot: nil,
+                workspacePath: nil,
+                resolvedFilePath: nil,
+                failureReason: "missing tabIdentifier"
+            )
+        }
+        guard let filePath, filePath.isEmpty == false else {
+            return WarmupResult(
+                context: nil,
+                snapshot: nil,
+                workspacePath: nil,
+                resolvedFilePath: nil,
+                failureReason: "missing filePath"
+            )
+        }
+
+        let workspacePath = await resolveWorkspacePath(
+            tabIdentifier: tabIdentifier,
+            sessionId: sessionId,
+            eventLoop: eventLoop,
+            windowsProvider: windowsProvider
+        )
+        guard let workspacePath else {
+            return WarmupResult(
+                context: nil,
+                snapshot: nil,
+                workspacePath: nil,
+                resolvedFilePath: nil,
+                failureReason: "workspacePath not found"
+            )
+        }
+
+        let workspaceRoot = workspaceRoot(for: workspacePath)
+        let resolvedFilePath = resolveAbsoluteFilePath(
+            workspacePath: workspacePath,
+            workspaceRoot: workspaceRoot,
+            requestedFilePath: filePath
+        )
+
+        let snapshot = await editorSnapshot(
+            workspacePath: workspacePath,
+            workspaceRoot: workspaceRoot
+        )
+
+        guard let resolvedFilePath else {
+            return WarmupResult(
+                context: nil,
+                snapshot: snapshot,
+                workspacePath: workspacePath,
+                resolvedFilePath: nil,
+                failureReason: "could not resolve target path"
+            )
+        }
+
+        let opened = await openSourceDocument(
+            at: resolvedFilePath,
+            workspacePath: workspacePath
+        )
+        guard opened else {
+            return WarmupResult(
+                context: nil,
+                snapshot: snapshot,
+                workspacePath: workspacePath,
+                resolvedFilePath: resolvedFilePath,
+                failureReason: "could not open source document"
+            )
+        }
+
+        let touched = await ensureSourceDocumentVisible(
+            at: resolvedFilePath,
+            workspacePath: workspacePath
+        )
+        guard touched else {
+            return WarmupResult(
+                context: nil,
+                snapshot: snapshot,
+                workspacePath: workspacePath,
+                resolvedFilePath: resolvedFilePath,
+                failureReason: "could not activate source document"
+            )
+        }
+
+        return WarmupResult(
+            context: WarmupContext(
+                workspacePath: workspacePath,
+                workspaceRoot: workspaceRoot,
+                resolvedFilePath: resolvedFilePath,
+                snapshot: snapshot
+            ),
+            snapshot: snapshot,
+            workspacePath: workspacePath,
+            resolvedFilePath: resolvedFilePath,
+            failureReason: nil
+        )
+    }
+
+    func touchResolvedTarget(_ context: WarmupContext) async -> Bool {
+        guard isEnabled else { return false }
+        return await ensureSourceDocumentVisible(
+            at: context.resolvedFilePath,
+            workspacePath: context.workspacePath
+        )
+    }
+
+    @discardableResult
+    func restore(_ context: WarmupContext?) async -> String {
+        guard isEnabled else { return "disabled" }
+        guard let context else { return "no_context" }
+        let snapshot = context.snapshot
+        guard let snapshot else { return "no_snapshot" }
+        let currentVisibleBasename = await windowTitle(for: snapshot.workspacePath)
+            .flatMap { visibleSourceBasename(from: $0) }
+        let targetBasename = URL(fileURLWithPath: context.resolvedFilePath).lastPathComponent
+        if let currentVisibleBasename, currentVisibleBasename != targetBasename {
+            return "restore_skipped_user_navigation"
+        }
+        guard let basename = snapshot.visibleSourceBasename, basename.isEmpty == false else {
+            return "no_visible_source_basename"
+        }
+
+        let candidates = snapshot.candidateSourceDocumentPaths.filter {
+            URL(fileURLWithPath: $0).lastPathComponent == basename
+        }
+        guard candidates.count == 1, let path = candidates.first else {
+            return candidates.isEmpty ? "restore_candidate_missing" : "restore_candidate_ambiguous"
+        }
+
+        let opened = await openSourceDocument(
+            at: path,
+            workspacePath: snapshot.workspacePath
+        )
+        guard opened else {
+            return "restore_open_failed"
+        }
+        let touched = await ensureSourceDocumentVisible(
+            at: path,
+            workspacePath: snapshot.workspacePath
+        )
+        return touched ? "restored" : "restore_touch_failed"
+    }
+
+    func resolveAbsoluteFilePath(
+        workspacePath: String,
+        workspaceRoot: String,
+        requestedFilePath: String
+    ) -> String? {
+        guard let requestedRelativeComponents = sanitizedRelativePathComponents(requestedFilePath),
+              requestedRelativeComponents.isEmpty == false
+        else {
+            return nil
+        }
+        let key = FileResolutionKey(
+            workspacePath: workspacePath,
+            filePath: requestedFilePath
+        )
+        if let cached = resolvedFilePathCache[key] {
+            return cached
+        }
+
+        let directURL = requestedRelativeComponents.reduce(
+            URL(fileURLWithPath: workspaceRoot)
+        ) { partialURL, component in
+            partialURL.appendingPathComponent(component)
+        }
+        let directPath = directURL.standardizedFileURL.path
+        if isPath(directPath, containedIn: workspaceRoot),
+           fileManager.fileExists(atPath: directPath)
+        {
+            resolvedFilePathCache[key] = directPath
+            return directPath
+        }
+
+        guard let requestedBasename = requestedRelativeComponents.last?.lowercased() else {
+            return nil
+        }
+        let requestedComponents = requestedRelativeComponents.map { $0.lowercased() }
+        let enumerator = fileManager.enumerator(
+            at: URL(fileURLWithPath: workspaceRoot),
+            includingPropertiesForKeys: nil
+        )
+
+        var bestPath: String?
+        var bestScore = 0
+        var ambiguous = false
+
+        while let fileURL = enumerator?.nextObject() as? URL {
+            guard fileURL.hasDirectoryPath == false else { continue }
+            guard fileURL.lastPathComponent.lowercased() == requestedBasename else { continue }
+
+            let score = suffixMatchScore(
+                requestedComponents: requestedComponents,
+                candidateComponents: normalizedPathComponents(fileURL.path)
+            )
+            guard score > 0 else { continue }
+
+            if score > bestScore {
+                bestScore = score
+                bestPath = fileURL.path
+                ambiguous = false
+            } else if score == bestScore {
+                ambiguous = true
+            }
+        }
+
+        guard ambiguous == false, let bestPath else {
+            return nil
+        }
+        resolvedFilePathCache[key] = bestPath
+        return bestPath
+    }
+
+    func workspaceRoot(for workspacePath: String) -> String {
+        let url = URL(fileURLWithPath: workspacePath)
+        if ["xcworkspace", "xcodeproj"].contains(url.pathExtension.lowercased()) {
+            return url.deletingLastPathComponent().path
+        }
+        return workspacePath
+    }
+
+    func visibleSourceBasename(from windowTitle: String) -> String? {
+        let separators = [" — ", " - "]
+        for separator in separators {
+            let parts = windowTitle.components(separatedBy: separator)
+            if parts.count > 1, let candidate = parts.last, candidate.isEmpty == false {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private func resolveWorkspacePath(
+        tabIdentifier: String,
+        sessionId: String,
+        eventLoop: EventLoop,
+        windowsProvider: WindowsProvider
+    ) async -> String? {
+        let cached = workspacePathCache[tabIdentifier]
+        guard let windows = await windowsProvider(sessionId, eventLoop) else {
+            return cached
+        }
+        guard let workspacePath = windows.first(where: { $0.tabIdentifier == tabIdentifier })?.workspacePath else {
+            workspacePathCache.removeValue(forKey: tabIdentifier)
+            return nil
+        }
+        workspacePathCache[tabIdentifier] = workspacePath
+        return workspacePath
+    }
+
+    private func editorSnapshot(
+        workspacePath: String,
+        workspaceRoot: String
+    ) async -> EditorSnapshot? {
+        let windowTitle = await windowTitle(for: workspacePath) ?? ""
+        let sourceDocumentPaths = await sourceDocumentPaths()
+        let candidates = sourceDocumentPaths.filter { isPath($0, containedIn: workspaceRoot) }
+        return EditorSnapshot(
+            workspacePath: workspacePath,
+            workspaceRoot: workspaceRoot,
+            windowTitle: windowTitle,
+            candidateSourceDocumentPaths: candidates,
+            visibleSourceBasename: visibleSourceBasename(from: windowTitle)
+        )
+    }
+
+    private func openSourceDocument(
+        at absolutePath: String,
+        workspacePath: String
+    ) async -> Bool {
+        let script = """
+        tell application "Xcode"
+            repeat with w in windows
+                try
+                    if (path of document of w) is \(appleScriptString(workspacePath)) then
+                        set index of w to 1
+                        exit repeat
+                    end if
+                end try
+            end repeat
+            open POSIX file \(appleScriptString(absolutePath))
+        end tell
+        return "ok"
+        """
+        let output = await runAppleScript(label: "open-source-document", script: script)
+        return output?.terminationStatus == 0
+    }
+
+    private func ensureSourceDocumentVisible(
+        at absolutePath: String,
+        workspacePath: String
+    ) async -> Bool {
+        let script = """
+        tell application "Xcode"
+            repeat with w in windows
+                try
+                    if (path of document of w) is \(appleScriptString(workspacePath)) then
+                        set index of w to 1
+                        exit repeat
+                    end if
+                end try
+            end repeat
+            try
+                set openedDocuments to open POSIX file \(appleScriptString(absolutePath))
+                set d to item 1 of openedDocuments
+                hack document d start 1 stop 1
+                return "ready"
+            on error
+                return "missing"
+            end try
+        end tell
+        """
+        let output = await runAppleScript(label: "touch-source-document", script: script)
+        guard output?.terminationStatus == 0 else { return false }
+        return output?.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "ready"
+    }
+
+    private func windowTitle(for workspacePath: String) async -> String? {
+        let script = """
+        tell application "Xcode"
+            repeat with w in windows
+                try
+                    if (path of document of w) is \(appleScriptString(workspacePath)) then
+                        return name of w
+                    end if
+                end try
+            end repeat
+        end tell
+        return ""
+        """
+        let output = await runAppleScript(label: "window-title", script: script)
+        guard output?.terminationStatus == 0 else { return nil }
+        let text = output?.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return text?.isEmpty == false ? text : nil
+    }
+
+    private func sourceDocumentPaths() async -> [String] {
+        let script = """
+        tell application "Xcode"
+            set oldDelimiters to AppleScript's text item delimiters
+            set AppleScript's text item delimiters to linefeed
+            try
+                set docPaths to (path of source documents) as text
+            on error
+                set docPaths to ""
+            end try
+            set AppleScript's text item delimiters to oldDelimiters
+            return docPaths
+        end tell
+        """
+        let output = await runAppleScript(label: "source-document-paths", script: script)
+        guard output?.terminationStatus == 0 else { return [] }
+        return output?.stdout
+            .split(separator: "\n")
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false } ?? []
+    }
+
+    private func runAppleScript(label: String, script: String) async -> ProcessOutput? {
+        do {
+            let output = try await processRunner.run(
+                ProcessRequest(
+                    label: label,
+                    executablePath: "/usr/bin/osascript",
+                    arguments: ["-"],
+                    input: script
+                )
+            )
+            if output.terminationStatus != 0 {
+                logger.debug(
+                    "AppleScript failed",
+                    metadata: [
+                        "label": .string(label),
+                        "status": .string("\(output.terminationStatus)"),
+                        "stderr": .string(output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)),
+                    ]
+                )
+            }
+            return output
+        } catch {
+            logger.debug(
+                "AppleScript execution failed",
+                metadata: [
+                    "label": .string(label),
+                    "error": .string(String(describing: error)),
+                ]
+            )
+            return nil
+        }
+    }
+
+    private func appleScriptString(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+
+    private func normalizedPathComponents(_ path: String) -> [String] {
+        URL(fileURLWithPath: path).pathComponents
+            .filter { $0 != "/" && $0 != "." }
+            .map { $0.lowercased() }
+    }
+
+    private func sanitizedRelativePathComponents(_ path: String) -> [String]? {
+        guard path.isEmpty == false, path.hasPrefix("/") == false else { return nil }
+
+        var components: [String] = []
+        for component in path.split(separator: "/", omittingEmptySubsequences: true) {
+            switch component {
+            case ".":
+                continue
+            case "..":
+                return nil
+            default:
+                components.append(String(component))
+            }
+        }
+        return components.isEmpty ? nil : components
+    }
+
+    private func isPath(_ path: String, containedIn workspaceRoot: String) -> Bool {
+        let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        let standardizedRoot = URL(fileURLWithPath: workspaceRoot).standardizedFileURL.path
+        guard standardizedRoot.isEmpty == false else { return false }
+        if standardizedPath == standardizedRoot {
+            return true
+        }
+        let rootPrefix = standardizedRoot.hasSuffix("/") ? standardizedRoot : standardizedRoot + "/"
+        return standardizedPath.hasPrefix(rootPrefix)
+    }
+
+    private func suffixMatchScore(
+        requestedComponents: [String],
+        candidateComponents: [String]
+    ) -> Int {
+        let requested = Array(requestedComponents.reversed())
+        let candidate = Array(candidateComponents.reversed())
+        var score = 0
+        for (lhs, rhs) in zip(requested, candidate) {
+            guard lhs == rhs else { break }
+            score += 1
+        }
+        return score
+    }
+}

--- a/Sources/XcodeMCPProxy/XcodeEditorWarmupDriver.swift
+++ b/Sources/XcodeMCPProxy/XcodeEditorWarmupDriver.swift
@@ -499,14 +499,19 @@ actor XcodeEditorWarmupDriver {
     }
 
     private func isPath(_ path: String, containedIn workspaceRoot: String) -> Bool {
-        let standardizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
-        let standardizedRoot = URL(fileURLWithPath: workspaceRoot).standardizedFileURL.path
-        guard standardizedRoot.isEmpty == false else { return false }
-        if standardizedPath == standardizedRoot {
+        let resolvedPath = resolvedPathForContainment(path)
+        let resolvedRoot = resolvedPathForContainment(workspaceRoot)
+        guard resolvedRoot.isEmpty == false else { return false }
+        if resolvedPath == resolvedRoot {
             return true
         }
-        let rootPrefix = standardizedRoot.hasSuffix("/") ? standardizedRoot : standardizedRoot + "/"
-        return standardizedPath.hasPrefix(rootPrefix)
+        let rootPrefix = resolvedRoot.hasSuffix("/") ? resolvedRoot : resolvedRoot + "/"
+        return resolvedPath.hasPrefix(rootPrefix)
+    }
+
+    private func resolvedPathForContainment(_ path: String) -> String {
+        let symlinkResolvedPath = (path as NSString).resolvingSymlinksInPath
+        return URL(fileURLWithPath: symlinkResolvedPath).standardizedFileURL.path
     }
 
     private func suffixMatchScore(

--- a/Sources/XcodeMCPProxy/XcodeEditorWarmupDriver.swift
+++ b/Sources/XcodeMCPProxy/XcodeEditorWarmupDriver.swift
@@ -267,6 +267,7 @@ actor XcodeEditorWarmupDriver {
         while let fileURL = enumerator?.nextObject() as? URL {
             guard fileURL.hasDirectoryPath == false else { continue }
             guard fileURL.lastPathComponent.lowercased() == requestedBasename else { continue }
+            guard isPath(fileURL.path, containedIn: workspaceRoot) else { continue }
 
             let score = suffixMatchScore(
                 requestedComponents: requestedComponents,

--- a/Sources/XcodeMCPProxy/XcodeEditorWarmupDriver.swift
+++ b/Sources/XcodeMCPProxy/XcodeEditorWarmupDriver.swift
@@ -38,12 +38,17 @@ actor XcodeEditorWarmupDriver {
         let filePath: String
     }
 
+    private struct WorkspaceCacheKey: Hashable {
+        let sessionId: String
+        let tabIdentifier: String
+    }
+
     private let processRunner: any ProcessRunning
     private let fileManager = FileManager.default
     private let logger: Logger
     private let isEnabled: Bool
 
-    private var workspacePathCache: [String: String] = [:]
+    private var workspacePathCache: [WorkspaceCacheKey: String] = [:]
     private var resolvedFilePathCache: [FileResolutionKey: String] = [:]
 
     init(
@@ -316,15 +321,19 @@ actor XcodeEditorWarmupDriver {
         eventLoop: EventLoop,
         windowsProvider: WindowsProvider
     ) async -> String? {
-        let cached = workspacePathCache[tabIdentifier]
+        let cacheKey = WorkspaceCacheKey(
+            sessionId: sessionId,
+            tabIdentifier: tabIdentifier
+        )
+        let cached = workspacePathCache[cacheKey]
         guard let windows = await windowsProvider(sessionId, eventLoop) else {
             return cached
         }
         guard let workspacePath = windows.first(where: { $0.tabIdentifier == tabIdentifier })?.workspacePath else {
-            workspacePathCache.removeValue(forKey: tabIdentifier)
+            workspacePathCache.removeValue(forKey: cacheKey)
             return nil
         }
-        workspacePathCache[tabIdentifier] = workspacePath
+        workspacePathCache[cacheKey] = workspacePath
         return workspacePath
     }
 

--- a/Tests/XcodeMCPKitTests/HTTPConcurrencyTests.swift
+++ b/Tests/XcodeMCPKitTests/HTTPConcurrencyTests.swift
@@ -211,6 +211,7 @@ private struct TestHTTPServer {
         let sessionManager = SessionManager(
             config: config, eventLoop: group.next(), upstreams: [upstream])
         let refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+        let warmupDriver = XcodeEditorWarmupDriver.disabled()
 
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
@@ -221,7 +222,8 @@ private struct TestHTTPServer {
                         HTTPHandler(
                             config: config,
                             sessionManager: sessionManager,
-                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator
+                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
+                            warmupDriver: warmupDriver
                         )
                     )
                 }

--- a/Tests/XcodeMCPKitTests/HTTPConcurrencyTests.swift
+++ b/Tests/XcodeMCPKitTests/HTTPConcurrencyTests.swift
@@ -93,6 +93,62 @@ struct HTTPConcurrencyTests {
         }
         await server.shutdown()
     }
+
+    @Test func httpConcurrentRefreshCodeIssuesRequestsDoNotSurfaceErrorFive() async throws {
+        let server = try TestHTTPServer.start(upstream: RefreshSensitiveUpstreamClient())
+        let url = server.url
+
+        do {
+            let (initializeResponse, _) = try await postJSON(
+                url: url,
+                sessionId: nil,
+                payload: initializePayload(id: 1)
+            )
+            guard let sessionId = initializeResponse.value(forHTTPHeaderField: "Mcp-Session-Id")
+            else {
+                throw ConcurrencyTestError.missingSessionId
+            }
+
+            let responses = try await withThrowingTaskGroup(
+                of: (Int, Bool).self
+            ) { group in
+                for index in 0..<3 {
+                    group.addTask {
+                        let (response, body) = try await postJSON(
+                            url: url,
+                            sessionId: sessionId,
+                            payload: toolCallPayload(
+                                id: index + 200,
+                                name: "XcodeRefreshCodeIssuesInFile",
+                                arguments: [
+                                    "tabIdentifier": "windowtab-refresh",
+                                    "filePath": "App\(index).swift",
+                                ]
+                            )
+                        )
+                        let result = body["result"] as? [String: Any]
+                        return (response.statusCode, (result?["isError"] as? Bool) == true)
+                    }
+                }
+
+                var responses: [(Int, Bool)] = []
+                for try await response in group {
+                    responses.append(response)
+                }
+                return responses
+            }
+
+            #expect(responses.count == 3)
+            for (statusCode, isError) in responses {
+                #expect(statusCode == 200)
+                #expect(isError == false)
+            }
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
 }
 
 private enum ConcurrencyTestError: Error {
@@ -133,9 +189,11 @@ private struct TestHTTPServer {
     let channel: Channel
     let url: URL
     let sessionManager: SessionManager
-    let upstream: EchoUpstreamClient
+    let upstream: any UpstreamClient
 
-    static func start() throws -> TestHTTPServer {
+    static func start(
+        upstream providedUpstream: (any UpstreamClient)? = nil
+    ) throws -> TestHTTPServer {
         ProxyLogging.bootstrap(environment: ["MCP_LOG_LEVEL": "critical"])
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
         let config = ProxyConfig(
@@ -149,9 +207,10 @@ private struct TestHTTPServer {
             requestTimeout: 5,
             eagerInitialize: false
         )
-        let upstream = EchoUpstreamClient()
+        let upstream = providedUpstream ?? EchoUpstreamClient()
         let sessionManager = SessionManager(
             config: config, eventLoop: group.next(), upstreams: [upstream])
+        let refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
 
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
@@ -161,7 +220,8 @@ private struct TestHTTPServer {
                     channel.pipeline.addHandler(
                         HTTPHandler(
                             config: config,
-                            sessionManager: sessionManager
+                            sessionManager: sessionManager,
+                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator
                         )
                     )
                 }
@@ -253,6 +313,133 @@ private actor EchoUpstreamClient: UpstreamClient {
     }
 }
 
+private actor RefreshSensitiveUpstreamClient: UpstreamClient {
+    nonisolated let events: AsyncStream<UpstreamEvent>
+    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    private var activeTabs: Set<String> = []
+
+    init() {
+        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        self.events = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+    }
+
+    func start() async {}
+
+    func stop() async {
+        continuation.finish()
+    }
+
+    func send(_ data: Data) async -> UpstreamSendResult {
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            return .accepted
+        }
+
+        if let object = json as? [String: Any] {
+            await handle(object)
+            return .accepted
+        }
+
+        if let array = json as? [Any] {
+            for item in array {
+                guard let object = item as? [String: Any] else { continue }
+                await handle(object)
+            }
+        }
+        return .accepted
+    }
+
+    private func handle(_ object: [String: Any]) async {
+        guard let id = object["id"] else { return }
+        let method = object["method"] as? String
+
+        if method == "initialize" {
+            continuation.yield(.message(makeInitializeResponse(id: id)))
+            return
+        }
+
+        guard
+            method == "tools/call",
+            let params = object["params"] as? [String: Any],
+            let name = params["name"] as? String,
+            name == "XcodeRefreshCodeIssuesInFile"
+        else {
+            continuation.yield(.message(makeSuccessResponse(id: id)))
+            return
+        }
+
+        let arguments = params["arguments"] as? [String: Any]
+        let tabIdentifier =
+            (arguments?["tabIdentifier"] as? String) ?? "__global__"
+        if activeTabs.contains(tabIdentifier) {
+            continuation.yield(.message(makeErrorFiveResponse(id: id)))
+            return
+        }
+
+        activeTabs.insert(tabIdentifier)
+        let responseData = makeSuccessResponse(id: id)
+        Task { [tabIdentifier, responseData] in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            completeRefresh(
+                tabIdentifier: tabIdentifier,
+                responseData: responseData
+            )
+        }
+    }
+
+    private func completeRefresh(tabIdentifier: String, responseData: Data) {
+        activeTabs.remove(tabIdentifier)
+        continuation.yield(.message(responseData))
+    }
+
+    private func makeInitializeResponse(id: Any) -> Data {
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "capabilities": [String: Any]()
+            ],
+        ]
+        return try! JSONSerialization.data(withJSONObject: response, options: [])
+    }
+
+    private func makeSuccessResponse(id: Any) -> Data {
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "ok",
+                    ]
+                ]
+            ],
+        ]
+        return try! JSONSerialization.data(withJSONObject: response, options: [])
+    }
+
+    private func makeErrorFiveResponse(id: Any) -> Data {
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "content": [
+                    [
+                        "type": "text",
+                        "text":
+                            "Failed to retrieve diagnostics for 'App.swift': The operation couldn’t be completed. (SourceEditor.SourceEditorCallableDiagnosticError error 5.)",
+                    ]
+                ],
+                "isError": true,
+            ],
+        ]
+        return try! JSONSerialization.data(withJSONObject: response, options: [])
+    }
+}
+
 private func initializePayload(id: Int) -> [String: Any] {
     [
         "jsonrpc": "2.0",
@@ -265,6 +452,22 @@ private func initializePayload(id: Int) -> [String: Any] {
                 "name": "xcode-mcp-proxy-concurrency-tests",
                 "version": "0.0",
             ],
+        ],
+    ]
+}
+
+private func toolCallPayload(
+    id: Int,
+    name: String,
+    arguments: [String: Any]
+) -> [String: Any] {
+    [
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": [
+            "name": name,
+            "arguments": arguments,
         ],
     ]
 }

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -1562,6 +1562,60 @@ struct HTTPHandlerTests {
         await server.shutdown()
     }
 
+    @Test func httpRefreshCodeIssuesRetriesShortSourceEditorErrorFiveText() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let attempts = NIOLockedValueBox(0)
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                let attempt = attempts.withLockedValue { value in
+                    value += 1
+                    return value
+                }
+                if attempt == 1 {
+                    return .immediate(
+                        try makeToolErrorResponse(
+                            id: originalId,
+                            text:
+                                "Failed to retrieve diagnostics for 'App.swift': The operation couldn’t be completed. (SourceEditorCallableDiagnosticError error 5.)"
+                        )
+                    )
+                }
+                return .immediate(try makeToolSuccessResponse(id: originalId, text: "ok"))
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionId: "session-retry-short",
+                payload: toolsCallPayload(
+                    id: 13,
+                    name: "XcodeRefreshCodeIssuesInFile",
+                    arguments: [
+                        "tabIdentifier": "windowtab-retry-short",
+                        "filePath": "App.swift",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            #expect((result?["isError"] as? Bool) != true)
+            #expect(sessionManager.sentUpstreamCount() == 2)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
     @Test func httpRefreshCodeIssuesDoesNotRetryNonRetryableToolError() async throws {
         let config = makeConfig(requestTimeout: 2)
         let sessionManager = TestSessionManager(

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -182,6 +182,8 @@ struct HTTPHandlerTests {
             as? [String: Any]
         let responseId = (responseObject?["id"] as? NSNumber)?.intValue
         #expect(responseId == 1)
+        #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+        #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
         #expect(sessionManager.requestSuccessNotificationCount() == 0)
     }
 
@@ -770,7 +772,7 @@ struct HTTPHandlerTests {
 
         #expect(sessionManager.sentUpstreamCount() == 0)
         #expect(sessionManager.assignedUpstreamIdCount() == 0)
-        #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+        #expect(sessionManager.chooseUpstreamIndexCallCount() == 2)
         #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
         #expect(sessionManager.refreshToolsListCallCount() == 0)
     }
@@ -845,7 +847,7 @@ struct HTTPHandlerTests {
 
         #expect(sessionManager.sentUpstreamCount() == 0)
         #expect(sessionManager.assignedUpstreamIdCount() == 0)
-        #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+        #expect(sessionManager.chooseUpstreamIndexCallCount() == 2)
         #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
         #expect(sessionManager.refreshToolsListCallCount() == 0)
     }
@@ -1934,6 +1936,7 @@ private final class TestSessionManager: SessionManaging {
     }
 
     func registerInitialize(
+        sessionId: String,
         originalId: RPCId,
         requestObject: [String: Any],
         on eventLoop: EventLoop
@@ -1941,6 +1944,7 @@ private final class TestSessionManager: SessionManaging {
         state.withLockedValue { state in
             state.initialized = true
         }
+        _ = chooseUpstreamIndex(sessionId: sessionId, shouldPin: true)
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": originalId.value.foundationObject,

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -1703,6 +1703,74 @@ struct HTTPHandlerTests {
         }
         await server.shutdown()
     }
+
+    @Test func httpRefreshWarmupInternalWindowLookupDoesNotResetUpstreamSuccessState() async throws {
+        let config = makeConfig(requestTimeout: 0.05)
+        let attempts = NIOLockedValueBox(0)
+        let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: temporaryRoot) }
+
+        let runner = HTTPHandlerFakeProcessRunner()
+        await runner.enqueue(label: "window-title", stdout: "tweetpd — Foo.swift\n")
+        await runner.enqueue(label: "source-document-paths", stdout: "")
+
+        let warmupDriver = XcodeEditorWarmupDriver(processRunner: runner)
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                let attempt = attempts.withLockedValue { value in
+                    value += 1
+                    return value
+                }
+                if attempt == 1 {
+                    return .immediate(
+                        try makeToolSuccessResponse(
+                            id: originalId,
+                            text:
+                                "{\"message\":\"* tabIdentifier: windowtab-timeout, workspacePath: \(temporaryRoot)\"}"
+                        )
+                    )
+                }
+                return .delayed(
+                    try makeToolSuccessResponse(id: originalId, text: "late"),
+                    delayNanos: 500_000_000
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager,
+            warmupDriver: warmupDriver
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionId: "session-internal-window-lookup",
+                payload: toolsCallPayload(
+                    id: 14,
+                    name: "XcodeRefreshCodeIssuesInFile",
+                    arguments: [
+                        "tabIdentifier": "windowtab-timeout",
+                        "filePath": "Missing.swift",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let error = body["error"] as? [String: Any]
+            #expect(error != nil)
+            #expect(sessionManager.sentUpstreamCount() == 2)
+            #expect(sessionManager.requestSuccessNotificationCount() == 0)
+            #expect(sessionManager.requestTimeoutNotificationCount() == 1)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
 }
 
 private enum HTTPTestError: Error {
@@ -1722,6 +1790,46 @@ private struct UpstreamResponsePlan {
         delayNanos: UInt64
     ) -> UpstreamResponsePlan {
         UpstreamResponsePlan(data: data, delayNanos: delayNanos)
+    }
+}
+
+private actor HTTPHandlerFakeProcessRunner: ProcessRunning {
+    private struct PlannedOutput {
+        let label: String
+        let stdout: String
+        let stderr: String
+        let terminationStatus: Int32
+    }
+
+    private var plannedOutputs: [PlannedOutput] = []
+
+    func enqueue(
+        label: String,
+        stdout: String = "",
+        stderr: String = "",
+        terminationStatus: Int32 = 0
+    ) {
+        plannedOutputs.append(
+            PlannedOutput(
+                label: label,
+                stdout: stdout,
+                stderr: stderr,
+                terminationStatus: terminationStatus
+            )
+        )
+    }
+
+    func run(_ request: ProcessRequest) async throws -> ProcessOutput {
+        guard plannedOutputs.isEmpty == false else {
+            return ProcessOutput(terminationStatus: 1, stdout: "", stderr: "no output")
+        }
+        let next = plannedOutputs.removeFirst()
+        #expect(next.label == request.label)
+        return ProcessOutput(
+            terminationStatus: next.terminationStatus,
+            stdout: next.stdout,
+            stderr: next.stderr
+        )
     }
 }
 
@@ -2023,6 +2131,13 @@ private func makeConfig(
         requestTimeout: requestTimeout,
         eagerInitialize: false
     )
+}
+
+private func makeHTTPTemporaryWorkspaceRoot() -> String {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url.path
 }
 
 private func addHTTPHandler(

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -1711,7 +1711,7 @@ struct HTTPHandlerTests {
         defer { try? FileManager.default.removeItem(atPath: temporaryRoot) }
 
         let runner = HTTPHandlerFakeProcessRunner()
-        await runner.enqueue(label: "window-title", stdout: "tweetpd — Foo.swift\n")
+        await runner.enqueue(label: "window-title", stdout: "SampleProject — Foo.swift\n")
         await runner.enqueue(label: "source-document-paths", stdout: "")
 
         let warmupDriver = XcodeEditorWarmupDriver(processRunner: runner)
@@ -1765,6 +1765,7 @@ struct HTTPHandlerTests {
             #expect(sessionManager.sentUpstreamCount() == 2)
             #expect(sessionManager.requestSuccessNotificationCount() == 0)
             #expect(sessionManager.requestTimeoutNotificationCount() == 1)
+            #expect(sessionManager.chooseUpstreamShouldPinValues() == [false, true])
         } catch {
             await server.shutdown()
             throw error
@@ -2089,6 +2090,10 @@ private final class TestSessionManager: SessionManaging {
 
     func lastChooseUpstreamShouldPin() -> Bool {
         state.withLockedValue { $0.chooseUpstreamCalls.last?.shouldPin ?? false }
+    }
+
+    func chooseUpstreamShouldPinValues() -> [Bool] {
+        state.withLockedValue { $0.chooseUpstreamCalls.map(\.shouldPin) }
     }
 
     func refreshToolsListCallCount() -> Int {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -1450,154 +1450,62 @@ struct HTTPHandlerTests {
     }
 
     @Test func httpRefreshCodeIssuesSerializesRequestsForSameTabIdentifier() async throws {
-        let config = makeConfig(requestTimeout: 2)
         let coordinator = RefreshCodeIssuesCoordinator()
-        let sessionManager = TestSessionManager(
-            config: config,
-            upstreamPlanResponder: { method, originalId in
-                #expect(method == "tools/call")
-                return .delayed(
-                    try makeToolSuccessResponse(id: originalId, text: "ok"),
-                    delayNanos: 150_000_000
-                )
+        let firstEntered = AsyncSignal()
+        let releaseFirst = AsyncSignal()
+        let secondEntered = NIOLockedValueBox(false)
+
+        let firstTask = Task<Void, Never> {
+            _ = await coordinator.withPermit(key: "windowtab-same") { _ in
+                await firstEntered.signal()
+                await releaseFirst.wait()
             }
-        )
-        sessionManager.setInitialized(true)
-        let server = try TestHTTPHandlerServer.start(
-            config: config,
-            sessionManager: sessionManager,
-            refreshCodeIssuesCoordinator: coordinator
-        )
-
-        do {
-            let firstTask = Task<Int, Error> {
-                let (response, _) = try await postHTTPJSON(
-                    url: server.url,
-                    sessionId: "session-1",
-                    payload: toolsCallPayload(
-                        id: 1,
-                        name: "XcodeRefreshCodeIssuesInFile",
-                        arguments: [
-                            "tabIdentifier": "windowtab-same",
-                            "filePath": "App.swift",
-                        ]
-                    )
-                )
-                return response.statusCode
-            }
-
-            #expect(
-                await waitUntil(timeoutNanoseconds: 100_000_000) {
-                    sessionManager.sentUpstreamCount() == 1
-                }
-            )
-
-            let secondTask = Task<Int, Error> {
-                let (response, _) = try await postHTTPJSON(
-                    url: server.url,
-                    sessionId: "session-2",
-                    payload: toolsCallPayload(
-                        id: 2,
-                        name: "XcodeRefreshCodeIssuesInFile",
-                        arguments: [
-                            "tabIdentifier": "windowtab-same",
-                            "filePath": "Other.swift",
-                        ]
-                    )
-                )
-                return response.statusCode
-            }
-
-            #expect(sessionManager.sentUpstreamCount() == 1)
-            #expect(
-                await waitUntil(timeoutNanoseconds: 75_000_000) {
-                    sessionManager.sentUpstreamCount() == 2
-                } == false
-            )
-            #expect(
-                await waitUntil(timeoutNanoseconds: 350_000_000) {
-                    sessionManager.sentUpstreamCount() == 2
-                }
-            )
-
-            let response1 = try await firstTask.value
-            let response2 = try await secondTask.value
-            #expect(response1 == 200)
-            #expect(response2 == 200)
-        } catch {
-            await server.shutdown()
-            throw error
         }
-        await server.shutdown()
+        await firstEntered.wait()
+
+        let secondTask = Task<Void, Never> {
+            _ = await coordinator.withPermit(key: "windowtab-same") { _ in
+                secondEntered.withLockedValue { value in
+                    value = true
+                }
+            }
+        }
+
+        await Task.yield()
+        await Task.yield()
+        #expect(secondEntered.withLockedValue { $0 } == false)
+
+        await releaseFirst.signal()
+        _ = await firstTask.value
+        _ = await secondTask.value
+        #expect(secondEntered.withLockedValue { $0 } == true)
     }
 
     @Test func httpRefreshCodeIssuesKeepsDifferentTabIdentifiersConcurrent() async throws {
-        let config = makeConfig(requestTimeout: 2)
         let coordinator = RefreshCodeIssuesCoordinator()
-        let sessionManager = TestSessionManager(
-            config: config,
-            upstreamPlanResponder: { method, originalId in
-                #expect(method == "tools/call")
-                return .delayed(
-                    try makeToolSuccessResponse(id: originalId, text: "ok"),
-                    delayNanos: 150_000_000
-                )
-            }
-        )
-        sessionManager.setInitialized(true)
-        let server = try TestHTTPHandlerServer.start(
-            config: config,
-            sessionManager: sessionManager,
-            refreshCodeIssuesCoordinator: coordinator
-        )
+        let firstEntered = AsyncSignal()
+        let secondEntered = AsyncSignal()
+        let releaseFirst = AsyncSignal()
 
-        do {
-            let firstTask = Task<Int, Error> {
-                let (response, _) = try await postHTTPJSON(
-                    url: server.url,
-                    sessionId: "session-a",
-                    payload: toolsCallPayload(
-                        id: 3,
-                        name: "XcodeRefreshCodeIssuesInFile",
-                        arguments: [
-                            "tabIdentifier": "windowtab-a",
-                            "filePath": "A.swift",
-                        ]
-                    )
-                )
-                return response.statusCode
+        let firstTask = Task<Void, Never> {
+            _ = await coordinator.withPermit(key: "windowtab-a") { _ in
+                await firstEntered.signal()
+                await releaseFirst.wait()
             }
-            let secondTask = Task<Int, Error> {
-                let (response, _) = try await postHTTPJSON(
-                    url: server.url,
-                    sessionId: "session-b",
-                    payload: toolsCallPayload(
-                        id: 4,
-                        name: "XcodeRefreshCodeIssuesInFile",
-                        arguments: [
-                            "tabIdentifier": "windowtab-b",
-                            "filePath": "B.swift",
-                        ]
-                    )
-                )
-                return response.statusCode
-            }
-
-            #expect(
-                await waitUntil(timeoutNanoseconds: 100_000_000) {
-                    sessionManager.sentUpstreamCount() == 2
-                }
-            )
-
-            let response1 = try await firstTask.value
-            let response2 = try await secondTask.value
-            #expect(response1 == 200)
-            #expect(response2 == 200)
-        } catch {
-            await server.shutdown()
-            throw error
         }
-        await server.shutdown()
+        await firstEntered.wait()
+
+        let secondTask = Task<Void, Never> {
+            _ = await coordinator.withPermit(key: "windowtab-b") { _ in
+                await secondEntered.signal()
+            }
+        }
+
+        await secondEntered.wait()
+        await releaseFirst.signal()
+        _ = await firstTask.value
+        _ = await secondTask.value
+        #expect(Bool(true))
     }
 
     @Test func httpRefreshCodeIssuesRetriesSourceEditorErrorFive() async throws {
@@ -1750,21 +1658,16 @@ private enum HTTPTestError: Error {
 private struct UpstreamResponsePlan {
     let data: Data
     let delayNanos: UInt64?
-    let deliverManually: Bool
 
     static func immediate(_ data: Data) -> UpstreamResponsePlan {
-        UpstreamResponsePlan(data: data, delayNanos: nil, deliverManually: false)
+        UpstreamResponsePlan(data: data, delayNanos: nil)
     }
 
     static func delayed(
         _ data: Data,
         delayNanos: UInt64
     ) -> UpstreamResponsePlan {
-        UpstreamResponsePlan(data: data, delayNanos: delayNanos, deliverManually: false)
-    }
-
-    static func manual(_ data: Data) -> UpstreamResponsePlan {
-        UpstreamResponsePlan(data: data, delayNanos: nil, deliverManually: true)
+        UpstreamResponsePlan(data: data, delayNanos: delayNanos)
     }
 }
 
@@ -1780,11 +1683,6 @@ private final class TestSessionManager: SessionManaging {
     }
 
     private struct State: Sendable {
-        struct PendingResponse: Sendable {
-            let sessionId: String
-            let data: Data
-        }
-
         var sessions: [String: SessionContext] = [:]
         var nextUpstreamId: Int64 = 1
         var assignUpstreamIdCount = 0
@@ -1797,7 +1695,6 @@ private final class TestSessionManager: SessionManaging {
         var availableUpstreamIndex: Int? = 0
         var requestTimeoutNotifications = 0
         var requestSuccessNotifications = 0
-        var pendingResponses: [PendingResponse] = []
     }
 
     private let state = NIOLockedValueBox(State())
@@ -1976,16 +1873,7 @@ private final class TestSessionManager: SessionManaging {
             let session = self.session(id: mapping.sessionId)
             session.router.handleIncoming(responsePlan.data)
         }
-        if responsePlan.deliverManually {
-            state.withLockedValue { state in
-                state.pendingResponses.append(
-                    State.PendingResponse(
-                        sessionId: mapping.sessionId,
-                        data: responsePlan.data
-                    )
-                )
-            }
-        } else if let delayNanos = responsePlan.delayNanos {
+        if let delayNanos = responsePlan.delayNanos {
             Task {
                 try? await Task.sleep(nanoseconds: delayNanos)
                 deliverResponse()
@@ -2063,16 +1951,6 @@ private final class TestSessionManager: SessionManaging {
 
     func setInitialized(_ value: Bool) {
         state.withLockedValue { $0.initialized = value }
-    }
-
-    func deliverNextPendingResponse() {
-        let pending = state.withLockedValue { state -> State.PendingResponse? in
-            guard state.pendingResponses.isEmpty == false else { return nil }
-            return state.pendingResponses.removeFirst()
-        }
-        guard let pending else { return }
-        let session = session(id: pending.sessionId)
-        session.router.handleIncoming(pending.data)
     }
 }
 
@@ -2173,21 +2051,6 @@ private func postJSON(
     try channel.writeInbound(HTTPServerRequestPart.end(nil))
 }
 
-private func waitUntil(
-    timeoutNanoseconds: UInt64 = 1_000_000_000,
-    intervalNanoseconds: UInt64 = 20_000_000,
-    condition: @escaping @Sendable () -> Bool
-) async -> Bool {
-    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
-    while DispatchTime.now().uptimeNanoseconds < deadline {
-        if condition() {
-            return true
-        }
-        try? await Task.sleep(nanoseconds: intervalNanoseconds)
-    }
-    return condition()
-}
-
 private struct TestHTTPHandlerServer {
     let group: MultiThreadedEventLoopGroup
     let channel: Channel
@@ -2259,6 +2122,30 @@ private func postHTTPJSON(
         (try? JSONSerialization.jsonObject(with: responseData, options: [])) as? [String: Any]
         ?? [:]
     return (httpResponse, object)
+}
+
+private actor AsyncSignal {
+    private var signaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if signaled {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func signal() {
+        guard signaled == false else { return }
+        signaled = true
+        let continuations = waiters
+        waiters.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
 }
 
 private func makeToolSuccessResponse(id: RPCId, text: String) throws -> Data {

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -1975,12 +1975,14 @@ private func addHTTPHandler(
     to channel: EmbeddedChannel,
     config: ProxyConfig,
     sessionManager: any SessionManaging,
-    refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+    refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator(),
+    warmupDriver: XcodeEditorWarmupDriver = .disabled()
 ) throws {
     let handler = HTTPHandler(
         config: config,
         sessionManager: sessionManager,
-        refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator
+        refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
+        warmupDriver: warmupDriver
     )
     try channel.pipeline.addHandler(handler).wait()
 }
@@ -2060,7 +2062,8 @@ private struct TestHTTPHandlerServer {
     static func start(
         config: ProxyConfig,
         sessionManager: any SessionManaging,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator(),
+        warmupDriver: XcodeEditorWarmupDriver = .disabled()
     ) throws -> TestHTTPHandlerServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let bootstrap = ServerBootstrap(group: group)
@@ -2072,7 +2075,8 @@ private struct TestHTTPHandlerServer {
                         HTTPHandler(
                             config: config,
                             sessionManager: sessionManager,
-                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator
+                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
+                            warmupDriver: warmupDriver
                         )
                     )
                 }

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -1448,10 +1448,324 @@ struct HTTPHandlerTests {
         #expect((result?["isError"] as? Bool) == true)
         #expect(result?["resources"] == nil)
     }
+
+    @Test func httpRefreshCodeIssuesSerializesRequestsForSameTabIdentifier() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let coordinator = RefreshCodeIssuesCoordinator()
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                return .delayed(
+                    try makeToolSuccessResponse(id: originalId, text: "ok"),
+                    delayNanos: 150_000_000
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager,
+            refreshCodeIssuesCoordinator: coordinator
+        )
+
+        do {
+            let firstTask = Task<Int, Error> {
+                let (response, _) = try await postHTTPJSON(
+                    url: server.url,
+                    sessionId: "session-1",
+                    payload: toolsCallPayload(
+                        id: 1,
+                        name: "XcodeRefreshCodeIssuesInFile",
+                        arguments: [
+                            "tabIdentifier": "windowtab-same",
+                            "filePath": "App.swift",
+                        ]
+                    )
+                )
+                return response.statusCode
+            }
+
+            #expect(
+                await waitUntil(timeoutNanoseconds: 100_000_000) {
+                    sessionManager.sentUpstreamCount() == 1
+                }
+            )
+
+            let secondTask = Task<Int, Error> {
+                let (response, _) = try await postHTTPJSON(
+                    url: server.url,
+                    sessionId: "session-2",
+                    payload: toolsCallPayload(
+                        id: 2,
+                        name: "XcodeRefreshCodeIssuesInFile",
+                        arguments: [
+                            "tabIdentifier": "windowtab-same",
+                            "filePath": "Other.swift",
+                        ]
+                    )
+                )
+                return response.statusCode
+            }
+
+            #expect(sessionManager.sentUpstreamCount() == 1)
+            #expect(
+                await waitUntil(timeoutNanoseconds: 75_000_000) {
+                    sessionManager.sentUpstreamCount() == 2
+                } == false
+            )
+            #expect(
+                await waitUntil(timeoutNanoseconds: 350_000_000) {
+                    sessionManager.sentUpstreamCount() == 2
+                }
+            )
+
+            let response1 = try await firstTask.value
+            let response2 = try await secondTask.value
+            #expect(response1 == 200)
+            #expect(response2 == 200)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpRefreshCodeIssuesKeepsDifferentTabIdentifiersConcurrent() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let coordinator = RefreshCodeIssuesCoordinator()
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                return .delayed(
+                    try makeToolSuccessResponse(id: originalId, text: "ok"),
+                    delayNanos: 150_000_000
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager,
+            refreshCodeIssuesCoordinator: coordinator
+        )
+
+        do {
+            let firstTask = Task<Int, Error> {
+                let (response, _) = try await postHTTPJSON(
+                    url: server.url,
+                    sessionId: "session-a",
+                    payload: toolsCallPayload(
+                        id: 3,
+                        name: "XcodeRefreshCodeIssuesInFile",
+                        arguments: [
+                            "tabIdentifier": "windowtab-a",
+                            "filePath": "A.swift",
+                        ]
+                    )
+                )
+                return response.statusCode
+            }
+            let secondTask = Task<Int, Error> {
+                let (response, _) = try await postHTTPJSON(
+                    url: server.url,
+                    sessionId: "session-b",
+                    payload: toolsCallPayload(
+                        id: 4,
+                        name: "XcodeRefreshCodeIssuesInFile",
+                        arguments: [
+                            "tabIdentifier": "windowtab-b",
+                            "filePath": "B.swift",
+                        ]
+                    )
+                )
+                return response.statusCode
+            }
+
+            #expect(
+                await waitUntil(timeoutNanoseconds: 100_000_000) {
+                    sessionManager.sentUpstreamCount() == 2
+                }
+            )
+
+            let response1 = try await firstTask.value
+            let response2 = try await secondTask.value
+            #expect(response1 == 200)
+            #expect(response2 == 200)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpRefreshCodeIssuesRetriesSourceEditorErrorFive() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let attempts = NIOLockedValueBox(0)
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                let attempt = attempts.withLockedValue { value in
+                    value += 1
+                    return value
+                }
+                if attempt == 1 {
+                    return .immediate(
+                        try makeToolErrorResponse(
+                            id: originalId,
+                            text:
+                                "Failed to retrieve diagnostics for 'App.swift': The operation couldn’t be completed. (SourceEditor.SourceEditorCallableDiagnosticError error 5.)"
+                        )
+                    )
+                }
+                return .immediate(try makeToolSuccessResponse(id: originalId, text: "ok"))
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionId: "session-retry",
+                payload: toolsCallPayload(
+                    id: 10,
+                    name: "XcodeRefreshCodeIssuesInFile",
+                    arguments: [
+                        "tabIdentifier": "windowtab-retry",
+                        "filePath": "App.swift",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            #expect((result?["isError"] as? Bool) != true)
+            #expect(sessionManager.sentUpstreamCount() == 2)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpRefreshCodeIssuesDoesNotRetryNonRetryableToolError() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                return .immediate(
+                    try makeToolErrorResponse(
+                        id: originalId,
+                        text: "permission denied"
+                    )
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionId: "session-no-retry",
+                payload: toolsCallPayload(
+                    id: 11,
+                    name: "XcodeRefreshCodeIssuesInFile",
+                    arguments: [
+                        "tabIdentifier": "windowtab-no-retry",
+                        "filePath": "App.swift",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            #expect((result?["isError"] as? Bool) == true)
+            #expect(sessionManager.sentUpstreamCount() == 1)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpNonTargetToolsCallDoesNotUseRefreshRetryPath() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                return .immediate(
+                    try makeToolErrorResponse(
+                        id: originalId,
+                        text:
+                            "Failed to retrieve diagnostics for 'App.swift': The operation couldn’t be completed. (SourceEditor.SourceEditorCallableDiagnosticError error 5.)"
+                    )
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionId: "session-other-tool",
+                payload: toolsCallPayload(
+                    id: 12,
+                    name: "XcodeListWindows",
+                    arguments: [:]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            #expect((result?["isError"] as? Bool) == true)
+            #expect(sessionManager.sentUpstreamCount() == 1)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
 }
 
 private enum HTTPTestError: Error {
     case missingResponseHead
+}
+
+private struct UpstreamResponsePlan {
+    let data: Data
+    let delayNanos: UInt64?
+    let deliverManually: Bool
+
+    static func immediate(_ data: Data) -> UpstreamResponsePlan {
+        UpstreamResponsePlan(data: data, delayNanos: nil, deliverManually: false)
+    }
+
+    static func delayed(
+        _ data: Data,
+        delayNanos: UInt64
+    ) -> UpstreamResponsePlan {
+        UpstreamResponsePlan(data: data, delayNanos: delayNanos, deliverManually: false)
+    }
+
+    static func manual(_ data: Data) -> UpstreamResponsePlan {
+        UpstreamResponsePlan(data: data, delayNanos: nil, deliverManually: true)
+    }
 }
 
 private final class TestSessionManager: SessionManaging {
@@ -1466,6 +1780,11 @@ private final class TestSessionManager: SessionManaging {
     }
 
     private struct State: Sendable {
+        struct PendingResponse: Sendable {
+            let sessionId: String
+            let data: Data
+        }
+
         var sessions: [String: SessionContext] = [:]
         var nextUpstreamId: Int64 = 1
         var assignUpstreamIdCount = 0
@@ -1478,11 +1797,14 @@ private final class TestSessionManager: SessionManaging {
         var availableUpstreamIndex: Int? = 0
         var requestTimeoutNotifications = 0
         var requestSuccessNotifications = 0
+        var pendingResponses: [PendingResponse] = []
     }
 
     private let state = NIOLockedValueBox(State())
     private let config: ProxyConfig
     private let upstreamResponder:
+        (@Sendable (_ method: String, _ originalId: RPCId) throws -> UpstreamResponsePlan)?
+    private let legacyUpstreamResponder:
         (@Sendable (_ method: String, _ originalId: RPCId) throws -> Data)?
 
     init(
@@ -1490,7 +1812,17 @@ private final class TestSessionManager: SessionManaging {
         upstreamResponder: (@Sendable (_ method: String, _ originalId: RPCId) throws -> Data)? = nil
     ) {
         self.config = config
-        self.upstreamResponder = upstreamResponder
+        self.upstreamResponder = nil
+        self.legacyUpstreamResponder = upstreamResponder
+    }
+
+    init(
+        config: ProxyConfig,
+        upstreamPlanResponder: (@Sendable (_ method: String, _ originalId: RPCId) throws -> UpstreamResponsePlan)?
+    ) {
+        self.config = config
+        self.upstreamResponder = upstreamPlanResponder
+        self.legacyUpstreamResponder = nil
     }
 
     func session(id: String) -> SessionContext {
@@ -1612,7 +1944,6 @@ private final class TestSessionManager: SessionManaging {
             state.upstreamSendCount += 1
         }
 
-        guard let upstreamResponder else { return }
         guard
             let object = try? JSONSerialization.jsonObject(with: data, options: [])
                 as? [String: Any],
@@ -1623,14 +1954,45 @@ private final class TestSessionManager: SessionManaging {
         }
         let upstreamId = (upstreamIdValue as? NSNumber)?.int64Value ?? (upstreamIdValue as? Int64)
         guard let upstreamId,
-            let mapping = state.withLockedValue({ $0.upstreamIdMapping[upstreamId] }),
-            let responseData = try? upstreamResponder(method, mapping.originalId)
+            let mapping = state.withLockedValue({ $0.upstreamIdMapping[upstreamId] })
         else {
             return
         }
 
-        let session = self.session(id: mapping.sessionId)
-        session.router.handleIncoming(responseData)
+        let responsePlan: UpstreamResponsePlan
+        if let upstreamResponder,
+            let planned = try? upstreamResponder(method, mapping.originalId)
+        {
+            responsePlan = planned
+        } else if let legacyUpstreamResponder,
+            let responseData = try? legacyUpstreamResponder(method, mapping.originalId)
+        {
+            responsePlan = .immediate(responseData)
+        } else {
+            return
+        }
+
+        let deliverResponse = { [self] in
+            let session = self.session(id: mapping.sessionId)
+            session.router.handleIncoming(responsePlan.data)
+        }
+        if responsePlan.deliverManually {
+            state.withLockedValue { state in
+                state.pendingResponses.append(
+                    State.PendingResponse(
+                        sessionId: mapping.sessionId,
+                        data: responsePlan.data
+                    )
+                )
+            }
+        } else if let delayNanos = responsePlan.delayNanos {
+            Task {
+                try? await Task.sleep(nanoseconds: delayNanos)
+                deliverResponse()
+            }
+        } else {
+            deliverResponse()
+        }
     }
 
     func debugSnapshot() -> ProxyDebugSnapshot {
@@ -1698,6 +2060,20 @@ private final class TestSessionManager: SessionManaging {
     func requestSuccessNotificationCount() -> Int {
         state.withLockedValue { $0.requestSuccessNotifications }
     }
+
+    func setInitialized(_ value: Bool) {
+        state.withLockedValue { $0.initialized = value }
+    }
+
+    func deliverNextPendingResponse() {
+        let pending = state.withLockedValue { state -> State.PendingResponse? in
+            guard state.pendingResponses.isEmpty == false else { return nil }
+            return state.pendingResponses.removeFirst()
+        }
+        guard let pending else { return }
+        let session = session(id: pending.sessionId)
+        session.router.handleIncoming(pending.data)
+    }
 }
 
 private func makeConfig(
@@ -1720,9 +2096,14 @@ private func makeConfig(
 private func addHTTPHandler(
     to channel: EmbeddedChannel,
     config: ProxyConfig,
-    sessionManager: any SessionManaging
+    sessionManager: any SessionManaging,
+    refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
 ) throws {
-    let handler = HTTPHandler(config: config, sessionManager: sessionManager)
+    let handler = HTTPHandler(
+        config: config,
+        sessionManager: sessionManager,
+        refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator
+    )
     try channel.pipeline.addHandler(handler).wait()
 }
 
@@ -1757,4 +2138,158 @@ private func collectResponse(from channel: EmbeddedChannel) throws -> (
 
 private func advanceEventLoopTime(on channel: EmbeddedChannel, by amount: TimeAmount) {
     channel.embeddedEventLoop.advanceTime(by: amount)
+}
+
+private func toolsCallPayload(
+    id: Int,
+    name: String,
+    arguments: [String: Any]
+) -> [String: Any] {
+    [
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": [
+            "name": name,
+            "arguments": arguments,
+        ],
+    ]
+}
+
+private func postJSON(
+    _ payload: [String: Any],
+    sessionId: String,
+    to channel: EmbeddedChannel
+) throws {
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    head.headers.add(name: "Mcp-Session-Id", value: sessionId)
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+}
+
+private func waitUntil(
+    timeoutNanoseconds: UInt64 = 1_000_000_000,
+    intervalNanoseconds: UInt64 = 20_000_000,
+    condition: @escaping @Sendable () -> Bool
+) async -> Bool {
+    let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+    while DispatchTime.now().uptimeNanoseconds < deadline {
+        if condition() {
+            return true
+        }
+        try? await Task.sleep(nanoseconds: intervalNanoseconds)
+    }
+    return condition()
+}
+
+private struct TestHTTPHandlerServer {
+    let group: MultiThreadedEventLoopGroup
+    let channel: Channel
+    let url: URL
+    let sessionManager: any SessionManaging
+
+    static func start(
+        config: ProxyConfig,
+        sessionManager: any SessionManaging,
+        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+    ) throws -> TestHTTPHandlerServer {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let bootstrap = ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
+                    channel.pipeline.addHandler(
+                        HTTPHandler(
+                            config: config,
+                            sessionManager: sessionManager,
+                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator
+                        )
+                    )
+                }
+            }
+            .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+
+        let channel = try bootstrap.bind(host: config.listenHost, port: 0).wait()
+        let port = channel.localAddress?.port ?? 0
+        let url = URL(string: "http://\(config.listenHost):\(port)/mcp")!
+        return TestHTTPHandlerServer(
+            group: group,
+            channel: channel,
+            url: url,
+            sessionManager: sessionManager
+        )
+    }
+
+    func shutdown() async {
+        sessionManager.shutdown()
+        channel.close(promise: nil)
+        await withCheckedContinuation { continuation in
+            group.shutdownGracefully { _ in
+                continuation.resume()
+            }
+        }
+    }
+}
+
+private func postHTTPJSON(
+    url: URL,
+    sessionId: String,
+    payload: [String: Any]
+) async throws -> (HTTPURLResponse, [String: Any]) {
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = data
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue(sessionId, forHTTPHeaderField: "Mcp-Session-Id")
+
+    let (responseData, response) = try await URLSession.shared.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+        throw HTTPTestError.missingResponseHead
+    }
+    let object =
+        (try? JSONSerialization.jsonObject(with: responseData, options: [])) as? [String: Any]
+        ?? [:]
+    return (httpResponse, object)
+}
+
+private func makeToolSuccessResponse(id: RPCId, text: String) throws -> Data {
+    let response: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": id.value.foundationObject,
+        "result": [
+            "content": [
+                [
+                    "type": "text",
+                    "text": text,
+                ]
+            ]
+        ],
+    ]
+    return try JSONSerialization.data(withJSONObject: response, options: [])
+}
+
+private func makeToolErrorResponse(id: RPCId, text: String) throws -> Data {
+    let response: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": id.value.foundationObject,
+        "result": [
+            "content": [
+                [
+                    "type": "text",
+                    "text": text,
+                ]
+            ],
+            "isError": true,
+        ],
+    ]
+    return try JSONSerialization.data(withJSONObject: response, options: [])
 }

--- a/Tests/XcodeMCPProxyTests/ProcessRunnerTests.swift
+++ b/Tests/XcodeMCPProxyTests/ProcessRunnerTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+@testable import XcodeMCPProxy
+
+@Suite
+struct ProcessRunnerTests {
+    @Test func processRunnerDrainsLargeStdoutWithoutHanging() async throws {
+        let runner = ProcessRunner()
+        let output = try await runner.run(
+            ProcessRequest(
+                label: "large-stdout",
+                executablePath: "/bin/sh",
+                arguments: ["-c", "yes x | head -c 200000"],
+                input: nil
+            )
+        )
+
+        #expect(output.terminationStatus == 0)
+        #expect(output.stdout.utf8.count == 200000)
+    }
+}

--- a/Tests/XcodeMCPProxyTests/ProcessRunnerTests.swift
+++ b/Tests/XcodeMCPProxyTests/ProcessRunnerTests.swift
@@ -1,9 +1,20 @@
+import Foundation
 import Testing
 
 @testable import XcodeMCPProxy
 
 @Suite
 struct ProcessRunnerTests {
+    @Test func dispatchGroupLeaveGuardLeavesOnlyOnce() {
+        let group = DispatchGroup()
+        let guarder = DispatchGroupLeaveGuard(group: group)
+
+        guarder.leaveIfNeeded()
+        guarder.leaveIfNeeded()
+
+        #expect(group.wait(timeout: .now()) == .success)
+    }
+
     @Test func processRunnerDrainsLargeStdoutWithoutHanging() async throws {
         let runner = ProcessRunner()
         let output = try await runner.run(

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -171,6 +171,78 @@ struct SessionManagerTests {
         #expect(received.first == notification)
     }
 
+    @Test func sessionManagerDoesNotRecreateRemovedSessionWhenInitializeCompletes() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-removed"
+        _ = manager.session(id: sessionId)
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        manager.removeSession(id: sessionId)
+
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+        await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+
+        _ = try await future.get()
+        #expect(manager.hasSession(id: sessionId) == false)
+    }
+
+    @Test func sessionManagerDoesNotApplyRemovedInitializeStateToRecreatedSession() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-recreated"
+        _ = manager.session(id: sessionId)
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        manager.removeSession(id: sessionId)
+        let replacement = manager.session(id: sessionId)
+        _ = replacement.router.drainBufferedNotifications()
+
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+        await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+
+        let notification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 7],
+            ],
+            options: []
+        )
+        await upstream.yield(.message(notification))
+
+        _ = try await future.get()
+        #expect(
+            await staysTrue(for: .milliseconds(200)) {
+                replacement.router.drainBufferedNotifications().isEmpty
+            }
+        )
+    }
+
     @Test func sessionManagerPinsFirstRequestToCachedInitializeUpstreamAfterNotification() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -342,6 +342,108 @@ struct SessionManagerTests {
         #expect((await upstream.sent()).count == 2)
     }
 
+    @Test func sessionManagerTimeoutDoesNotClearRecreatedSessionInitializeRoutingState()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 0.1)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-timeout-recreated"
+        _ = manager.session(id: sessionId)
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+
+        manager.removeSession(id: sessionId)
+        _ = manager.session(id: sessionId)
+        manager.testSetInitializeRoutingState(
+            sessionId: sessionId,
+            upstreamIndex: 0,
+            preferOnNextPin: true,
+            didReceiveInitializeUpstreamMessage: true
+        )
+        let replacementSnapshotBeforeTimeout = try #require(manager.testSessionSnapshot(id: sessionId))
+
+        await #expect(throws: TimeoutError.self) {
+            try await future.get()
+        }
+
+        let replacementSnapshotAfterTimeout = try #require(manager.testSessionSnapshot(id: sessionId))
+        #expect(replacementSnapshotAfterTimeout.generation == replacementSnapshotBeforeTimeout.generation)
+        #expect(replacementSnapshotAfterTimeout.initializeUpstreamIndex == 0)
+        #expect(replacementSnapshotAfterTimeout.preferInitializeUpstreamOnNextPin)
+        #expect(replacementSnapshotAfterTimeout.didReceiveInitializeUpstreamMessage)
+    }
+
+    @Test func sessionManagerInitializeErrorDoesNotClearRecreatedSessionInitializeRoutingState()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-error-recreated"
+        _ = manager.session(id: sessionId)
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+
+        manager.removeSession(id: sessionId)
+        _ = manager.session(id: sessionId)
+        manager.testSetInitializeRoutingState(
+            sessionId: sessionId,
+            upstreamIndex: 0,
+            preferOnNextPin: true,
+            didReceiveInitializeUpstreamMessage: true
+        )
+        let replacementSnapshotBeforeError = try #require(manager.testSessionSnapshot(id: sessionId))
+
+        await upstream.yield(
+            .message(
+                try JSONSerialization.data(
+                    withJSONObject: [
+                        "jsonrpc": "2.0",
+                        "id": initId,
+                        "error": [
+                            "code": -32000,
+                            "message": "boom",
+                        ],
+                    ],
+                    options: []
+                )
+            )
+        )
+
+        let response = try decodeJSON(from: try await future.get())
+        let errorObject = try #require(response["error"] as? [String: Any])
+        #expect(errorObject["message"] as? String == "boom")
+
+        let replacementSnapshotAfterError = try #require(manager.testSessionSnapshot(id: sessionId))
+        #expect(replacementSnapshotAfterError.generation == replacementSnapshotBeforeError.generation)
+        #expect(replacementSnapshotAfterError.initializeUpstreamIndex == 0)
+        #expect(replacementSnapshotAfterError.preferInitializeUpstreamOnNextPin)
+        #expect(replacementSnapshotAfterError.didReceiveInitializeUpstreamMessage)
+    }
+
     @Test func sessionManagerEagerInitializeRestartsAfterExit() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -45,6 +45,193 @@ struct SessionManagerTests {
         #expect(id2 == 2)
     }
 
+    @Test func sessionManagerPinsInitializeSessionBeforeUnmappedNotificationsArrive() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-A"
+        let session = manager.session(id: sessionId)
+        _ = session.router.drainBufferedNotifications()
+
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+
+        await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+        let notification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 1],
+            ],
+            options: []
+        )
+        await upstream.yield(.message(notification))
+
+        _ = try await future.get()
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        #expect(received.first == notification)
+    }
+
+    @Test func sessionManagerRoutesUnmappedNotificationsDuringInitializeHandshake() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-handshake"
+        let session = manager.session(id: sessionId)
+        _ = session.router.drainBufferedNotifications()
+
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let notification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 99],
+            ],
+            options: []
+        )
+        await upstream.yield(.message(notification))
+
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        #expect(received.first == notification)
+
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+        await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+        _ = try await future.get()
+    }
+
+    @Test func sessionManagerPinsCachedInitializeSessionBeforeUnmappedNotificationsArrive() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let firstFuture = manager.registerInitialize(
+            sessionId: "session-A",
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let firstSent = await upstream.sent()
+        let firstInitId = try extractUpstreamId(from: firstSent[0])
+        await upstream.yield(.message(try makeInitializeResponse(id: firstInitId)))
+        _ = try await firstFuture.get()
+
+        let sessionId = "session-B"
+        let session = manager.session(id: sessionId)
+        _ = session.router.drainBufferedNotifications()
+        let cachedFuture = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 2))!,
+            requestObject: makeInitializeRequest(id: 2),
+            on: eventLoop
+        )
+
+        let notification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 2],
+            ],
+            options: []
+        )
+        await upstream.yield(.message(notification))
+
+        _ = try await cachedFuture.get()
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        #expect(received.first == notification)
+    }
+
+    @Test func sessionManagerPinsFirstRequestToCachedInitializeUpstreamAfterNotification() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: true, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+        try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+        let init0 = await upstream0.sent()
+        let init0Id = try extractUpstreamId(from: init0[0])
+        await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+        try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+        let init1 = await upstream1.sent()
+        let init1Id = try extractUpstreamId(from: init1[0])
+        await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+        try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+        try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+        let sessionId = "session-hinted-pin"
+        let session = manager.session(id: sessionId)
+        _ = session.router.drainBufferedNotifications()
+
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        _ = try await future.get()
+
+        let notification0 = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 0],
+            ],
+            options: []
+        )
+        let notification1 = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 1],
+            ],
+            options: []
+        )
+        await upstream0.yield(.message(notification0))
+        await upstream1.yield(.message(notification1))
+
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        let routedUpstream = try #require(received.first).elementsEqual(notification0) ? 0 : 1
+
+        let pinned = try #require(manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true))
+        #expect(pinned == routedUpstream)
+    }
+
     @Test func sessionManagerTimeoutResetsInitState() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -488,7 +675,7 @@ struct SessionManagerTests {
         #expect(receivedOther.isEmpty)
     }
 
-    @Test func sessionManagerRoutesUnmappedNotificationsToUnpinnedSessionsWhenNoPinnedTargetsExist()
+    @Test func sessionManagerDropsUnmappedNotificationsWhenNoPinnedTargetsExist()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -532,9 +719,11 @@ struct SessionManagerTests {
 
         await yieldMessage(notification, to: upstream0)
 
-        let received = try await nextBufferedNotifications(from: session.router)
-        #expect(received.count == 1)
-        #expect(received.first == notification)
+        #expect(
+            await staysTrue(for: .milliseconds(200)) {
+                session.router.drainBufferedNotifications().isEmpty
+            }
+        )
     }
 
     @Test func sessionManagerDropsUnmappedResponsesEvenWhenPinnedTargetsExist() async throws {

--- a/Tests/XcodeMCPProxyTests/XcodeEditorWarmupDriverTests.swift
+++ b/Tests/XcodeMCPProxyTests/XcodeEditorWarmupDriverTests.swift
@@ -33,7 +33,7 @@ struct XcodeEditorWarmupDriverTests {
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let target = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd/TimeLine/View/Regular/RegularTimelineView.swift")
+            .appendingPathComponent("SampleProject/Feature/Scene/PrimaryView.swift")
         try FileManager.default.createDirectory(
             at: target.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -44,7 +44,7 @@ struct XcodeEditorWarmupDriverTests {
         let resolved = await driver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
-            requestedFilePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift"
+            requestedFilePath: "SampleProject/Feature/Scene/PrimaryView.swift"
         )
 
         #expect(resolved?.lowercased() == target.path.lowercased())
@@ -55,8 +55,8 @@ struct XcodeEditorWarmupDriverTests {
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let candidates = [
-            "A/Timeline/View/Foo.swift",
-            "B/Timeline/View/Foo.swift",
+            "A/Feature/Screen/Foo.swift",
+            "B/Feature/Screen/Foo.swift",
         ]
         for relativePath in candidates {
             let url = URL(fileURLWithPath: root).appendingPathComponent(relativePath)
@@ -71,7 +71,7 @@ struct XcodeEditorWarmupDriverTests {
         let resolved = await driver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
-            requestedFilePath: "Timeline/View/Foo.swift"
+            requestedFilePath: "Feature/Screen/Foo.swift"
         )
 
         #expect(resolved == nil)
@@ -177,15 +177,15 @@ struct XcodeEditorWarmupDriverTests {
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let workspacePath = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd.xcworkspace").path
+            .appendingPathComponent("SampleProject.xcworkspace").path
         try FileManager.default.createDirectory(
             atPath: workspacePath,
             withIntermediateDirectories: true
         )
         let target = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd/TimeLine/View/Regular/RegularTimelineView.swift")
+            .appendingPathComponent("SampleProject/Feature/Scene/PrimaryView.swift")
         let restorePath = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd/Store/AccountStore.swift")
+            .appendingPathComponent("SampleProject/Data/StateStore.swift")
         try FileManager.default.createDirectory(
             at: target.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -200,7 +200,7 @@ struct XcodeEditorWarmupDriverTests {
         let runner = FakeProcessRunner()
         await runner.enqueue(
             label: "window-title",
-            stdout: "tweetpd — AccountStore.swift\n"
+            stdout: "SampleProject — StateStore.swift\n"
         )
         await runner.enqueue(
             label: "source-document-paths",
@@ -208,7 +208,7 @@ struct XcodeEditorWarmupDriverTests {
         )
         await runner.enqueue(label: "open-source-document", stdout: "ok\n")
         await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
-        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "window-title", stdout: "SampleProject — PrimaryView.swift\n")
         await runner.enqueue(label: "open-source-document", stdout: "ok\n")
         await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
 
@@ -216,7 +216,7 @@ struct XcodeEditorWarmupDriverTests {
         let eventLoop = EmbeddedEventLoop()
         let result = await driver.warmUp(
             tabIdentifier: "windowtab2",
-            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            filePath: "SampleProject/Feature/Scene/PrimaryView.swift",
             sessionId: "session-1",
             eventLoop: eventLoop,
             windowsProvider: { _, _ in
@@ -225,7 +225,7 @@ struct XcodeEditorWarmupDriverTests {
         )
 
         #expect(result.context?.resolvedFilePath.lowercased() == target.path.lowercased())
-        #expect(result.snapshot?.visibleSourceBasename == "AccountStore.swift")
+        #expect(result.snapshot?.visibleSourceBasename == "StateStore.swift")
 
         let restoreResult = await driver.restore(result.context)
         #expect(restoreResult == "restored")
@@ -251,17 +251,17 @@ struct XcodeEditorWarmupDriverTests {
         }
 
         let workspacePath = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd.xcworkspace").path
+            .appendingPathComponent("SampleProject.xcworkspace").path
         try FileManager.default.createDirectory(
             atPath: workspacePath,
             withIntermediateDirectories: true
         )
         let target = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd/Timeline/View/Regular/RegularTimelineView.swift")
+            .appendingPathComponent("SampleProject/Feature/Scene/PrimaryView.swift")
         let insideRestorePath = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd/Store/AccountStore.swift")
+            .appendingPathComponent("SampleProject/Data/StateStore.swift")
         let outsideRestorePath = URL(fileURLWithPath: outsideRoot)
-            .appendingPathComponent("tweetpd/Store/AccountStore.swift")
+            .appendingPathComponent("SampleProject/Data/StateStore.swift")
 
         try FileManager.default.createDirectory(
             at: target.deletingLastPathComponent(),
@@ -282,7 +282,7 @@ struct XcodeEditorWarmupDriverTests {
         let runner = FakeProcessRunner()
         await runner.enqueue(
             label: "window-title",
-            stdout: "tweetpd — AccountStore.swift\n"
+            stdout: "SampleProject — StateStore.swift\n"
         )
         await runner.enqueue(
             label: "source-document-paths",
@@ -290,7 +290,7 @@ struct XcodeEditorWarmupDriverTests {
         )
         await runner.enqueue(label: "open-source-document", stdout: "ok\n")
         await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
-        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "window-title", stdout: "SampleProject — PrimaryView.swift\n")
         await runner.enqueue(label: "open-source-document", stdout: "ok\n")
         await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
 
@@ -298,7 +298,7 @@ struct XcodeEditorWarmupDriverTests {
         let eventLoop = EmbeddedEventLoop()
         let result = await driver.warmUp(
             tabIdentifier: "windowtab2",
-            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            filePath: "SampleProject/Feature/Scene/PrimaryView.swift",
             sessionId: "session-1",
             eventLoop: eventLoop,
             windowsProvider: { _, _ in
@@ -321,19 +321,19 @@ struct XcodeEditorWarmupDriverTests {
         }
 
         let workspacePath = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd.xcworkspace").path
+            .appendingPathComponent("SampleProject.xcworkspace").path
         try FileManager.default.createDirectory(
             atPath: workspacePath,
             withIntermediateDirectories: true
         )
 
         let target = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd/Timeline/View/Regular/RegularTimelineView.swift")
+            .appendingPathComponent("SampleProject/Feature/Scene/PrimaryView.swift")
         let insideRestorePath = URL(fileURLWithPath: root)
-            .appendingPathComponent("tweetpd/Store/AccountStore.swift")
+            .appendingPathComponent("SampleProject/Data/StateStore.swift")
         let symlinkPath = URL(fileURLWithPath: root).appendingPathComponent("linked").path
         let outsideRestorePath = URL(fileURLWithPath: outsideRoot)
-            .appendingPathComponent("AccountStore.swift")
+            .appendingPathComponent("StateStore.swift")
 
         try FileManager.default.createDirectory(
             at: target.deletingLastPathComponent(),
@@ -354,15 +354,15 @@ struct XcodeEditorWarmupDriverTests {
         let runner = FakeProcessRunner()
         await runner.enqueue(
             label: "window-title",
-            stdout: "tweetpd — AccountStore.swift\n"
+            stdout: "SampleProject — StateStore.swift\n"
         )
         await runner.enqueue(
             label: "source-document-paths",
-            stdout: "\(insideRestorePath.path)\n\(symlinkPath)/AccountStore.swift\n"
+            stdout: "\(insideRestorePath.path)\n\(symlinkPath)/StateStore.swift\n"
         )
         await runner.enqueue(label: "open-source-document", stdout: "ok\n")
         await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
-        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "window-title", stdout: "SampleProject — PrimaryView.swift\n")
         await runner.enqueue(label: "open-source-document", stdout: "ok\n")
         await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
 
@@ -370,7 +370,7 @@ struct XcodeEditorWarmupDriverTests {
         let eventLoop = EmbeddedEventLoop()
         let result = await driver.warmUp(
             tabIdentifier: "windowtab2",
-            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            filePath: "SampleProject/Feature/Scene/PrimaryView.swift",
             sessionId: "session-1",
             eventLoop: eventLoop,
             windowsProvider: { _, _ in
@@ -390,16 +390,16 @@ struct XcodeEditorWarmupDriverTests {
         }
 
         let workspaceA = URL(fileURLWithPath: rootA)
-            .appendingPathComponent("tweetpd.xcworkspace").path
+            .appendingPathComponent("SampleProject.xcworkspace").path
         let workspaceB = URL(fileURLWithPath: rootB)
-            .appendingPathComponent("tweetpd.xcworkspace").path
+            .appendingPathComponent("SampleProject.xcworkspace").path
         try FileManager.default.createDirectory(atPath: workspaceA, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(atPath: workspaceB, withIntermediateDirectories: true)
 
         let targetA = URL(fileURLWithPath: rootA)
-            .appendingPathComponent("tweetpd/Timeline/View/Regular/RegularTimelineView.swift")
+            .appendingPathComponent("SampleProject/Feature/Scene/PrimaryView.swift")
         let targetB = URL(fileURLWithPath: rootB)
-            .appendingPathComponent("tweetpd/Timeline/View/Regular/RegularTimelineView.swift")
+            .appendingPathComponent("SampleProject/Feature/Scene/PrimaryView.swift")
         try FileManager.default.createDirectory(
             at: targetA.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -412,11 +412,11 @@ struct XcodeEditorWarmupDriverTests {
         try "".write(to: targetB, atomically: true, encoding: .utf8)
 
         let runner = FakeProcessRunner()
-        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "window-title", stdout: "SampleProject — PrimaryView.swift\n")
         await runner.enqueue(label: "source-document-paths", stdout: "\(targetA.path)\n")
         await runner.enqueue(label: "open-source-document", stdout: "ok\n")
         await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
-        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "window-title", stdout: "SampleProject — PrimaryView.swift\n")
         await runner.enqueue(label: "source-document-paths", stdout: "\(targetB.path)\n")
         await runner.enqueue(label: "open-source-document", stdout: "ok\n")
         await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
@@ -426,7 +426,7 @@ struct XcodeEditorWarmupDriverTests {
 
         let first = await driver.warmUp(
             tabIdentifier: "windowtab2",
-            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            filePath: "SampleProject/Feature/Scene/PrimaryView.swift",
             sessionId: "session-1",
             eventLoop: eventLoop,
             windowsProvider: { _, _ in
@@ -435,7 +435,7 @@ struct XcodeEditorWarmupDriverTests {
         )
         let second = await driver.warmUp(
             tabIdentifier: "windowtab2",
-            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            filePath: "SampleProject/Feature/Scene/PrimaryView.swift",
             sessionId: "session-1",
             eventLoop: eventLoop,
             windowsProvider: { _, _ in
@@ -448,6 +448,55 @@ struct XcodeEditorWarmupDriverTests {
         #expect(second.context?.resolvedFilePath == targetB.path)
     }
 
+    @Test func warmupDriverDoesNotReuseWorkspaceCacheAcrossSessions() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let workspacePath = URL(fileURLWithPath: root)
+            .appendingPathComponent("SampleProject.xcworkspace").path
+        try FileManager.default.createDirectory(atPath: workspacePath, withIntermediateDirectories: true)
+
+        let target = URL(fileURLWithPath: root)
+            .appendingPathComponent("SampleProject/Feature/Scene/PrimaryView.swift")
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: target, atomically: true, encoding: .utf8)
+
+        let runner = FakeProcessRunner()
+        await runner.enqueue(label: "window-title", stdout: "SampleProject — PrimaryView.swift\n")
+        await runner.enqueue(label: "source-document-paths", stdout: "")
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+
+        let driver = XcodeEditorWarmupDriver(processRunner: runner)
+        let eventLoop = EmbeddedEventLoop()
+
+        let first = await driver.warmUp(
+            tabIdentifier: "windowtab2",
+            filePath: "SampleProject/Feature/Scene/PrimaryView.swift",
+            sessionId: "session-A",
+            eventLoop: eventLoop,
+            windowsProvider: { _, _ in
+                [XcodeWindowInfo(tabIdentifier: "windowtab2", workspacePath: workspacePath)]
+            }
+        )
+        let second = await driver.warmUp(
+            tabIdentifier: "windowtab2",
+            filePath: "SampleProject/Feature/Scene/PrimaryView.swift",
+            sessionId: "session-B",
+            eventLoop: eventLoop,
+            windowsProvider: { _, _ in
+                nil
+            }
+        )
+
+        #expect(first.failureReason == nil)
+        #expect(second.workspacePath == nil)
+        #expect(second.failureReason == "workspacePath not found")
+    }
+
     @Test func warmupDriverRestoreSkipsAmbiguousCandidate() async throws {
         let runner = FakeProcessRunner()
         let driver = XcodeEditorWarmupDriver(processRunner: runner)
@@ -458,7 +507,7 @@ struct XcodeEditorWarmupDriverTests {
             snapshot: EditorSnapshot(
                 workspacePath: "/tmp/workspace",
                 workspaceRoot: "/tmp/workspace",
-                windowTitle: "tweetpd — Foo.swift",
+                windowTitle: "SampleProject — Foo.swift",
                 candidateSourceDocumentPaths: [
                     "/tmp/workspace/A/Foo.swift",
                     "/tmp/workspace/B/Foo.swift",
@@ -467,7 +516,7 @@ struct XcodeEditorWarmupDriverTests {
             )
         )
 
-        await runner.enqueue(label: "window-title", stdout: "tweetpd — Foo.swift\n")
+        await runner.enqueue(label: "window-title", stdout: "SampleProject — Foo.swift\n")
         let restoreResult = await driver.restore(context)
         #expect(restoreResult == "restore_candidate_ambiguous")
         #expect(await runner.requests().map(\.label) == ["window-title"])

--- a/Tests/XcodeMCPProxyTests/XcodeEditorWarmupDriverTests.swift
+++ b/Tests/XcodeMCPProxyTests/XcodeEditorWarmupDriverTests.swift
@@ -141,6 +141,37 @@ struct XcodeEditorWarmupDriverTests {
         #expect(resolved == nil)
     }
 
+    @Test func warmupDriverRejectsSuffixMatchedSymlinkEscapeOutsideWorkspaceRoot() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        let outsideRoot = makeTemporaryWorkspaceRoot()
+        defer {
+            try? FileManager.default.removeItem(atPath: root)
+            try? FileManager.default.removeItem(atPath: outsideRoot)
+        }
+
+        let outsideFile = URL(fileURLWithPath: outsideRoot)
+            .appendingPathComponent("Outside.swift")
+        try "".write(to: outsideFile, atomically: true, encoding: .utf8)
+
+        let symlinkDirectory = URL(fileURLWithPath: root)
+            .appendingPathComponent("Some")
+            .path
+        try FileManager.default.createDirectory(atPath: symlinkDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: URL(fileURLWithPath: symlinkDirectory).appendingPathComponent("Outside.swift").path,
+            withDestinationPath: outsideFile.path
+        )
+
+        let driver = XcodeEditorWarmupDriver(isEnabled: false)
+        let resolved = await driver.resolveAbsoluteFilePath(
+            workspacePath: root,
+            workspaceRoot: root,
+            requestedFilePath: "Nested/Outside.swift"
+        )
+
+        #expect(resolved == nil)
+    }
+
     @Test func warmupDriverWarmsAndRestoresUsingProcessRunner() async throws {
         let root = makeTemporaryWorkspaceRoot()
         defer { try? FileManager.default.removeItem(atPath: root) }

--- a/Tests/XcodeMCPProxyTests/XcodeEditorWarmupDriverTests.swift
+++ b/Tests/XcodeMCPProxyTests/XcodeEditorWarmupDriverTests.swift
@@ -113,6 +113,34 @@ struct XcodeEditorWarmupDriverTests {
         #expect(resolved == nil)
     }
 
+    @Test func warmupDriverRejectsSymlinkEscapeOutsideWorkspaceRoot() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        let outsideRoot = makeTemporaryWorkspaceRoot()
+        defer {
+            try? FileManager.default.removeItem(atPath: root)
+            try? FileManager.default.removeItem(atPath: outsideRoot)
+        }
+
+        let outsideFile = URL(fileURLWithPath: outsideRoot)
+            .appendingPathComponent("Outside.swift")
+        try "".write(to: outsideFile, atomically: true, encoding: .utf8)
+
+        let symlinkPath = URL(fileURLWithPath: root).appendingPathComponent("linked").path
+        try FileManager.default.createSymbolicLink(
+            atPath: symlinkPath,
+            withDestinationPath: outsideRoot
+        )
+
+        let driver = XcodeEditorWarmupDriver(isEnabled: false)
+        let resolved = await driver.resolveAbsoluteFilePath(
+            workspacePath: root,
+            workspaceRoot: root,
+            requestedFilePath: "linked/Outside.swift"
+        )
+
+        #expect(resolved == nil)
+    }
+
     @Test func warmupDriverWarmsAndRestoresUsingProcessRunner() async throws {
         let root = makeTemporaryWorkspaceRoot()
         defer { try? FileManager.default.removeItem(atPath: root) }
@@ -251,6 +279,75 @@ struct XcodeEditorWarmupDriverTests {
 
         let restoreResult = await driver.restore(result.context)
         #expect(restoreResult == "restored")
+    }
+
+    @Test func warmupDriverSnapshotExcludesSymlinkEscapesOutsideWorkspaceRoot() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        let outsideRoot = makeTemporaryWorkspaceRoot()
+        defer {
+            try? FileManager.default.removeItem(atPath: root)
+            try? FileManager.default.removeItem(atPath: outsideRoot)
+        }
+
+        let workspacePath = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd.xcworkspace").path
+        try FileManager.default.createDirectory(
+            atPath: workspacePath,
+            withIntermediateDirectories: true
+        )
+
+        let target = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd/Timeline/View/Regular/RegularTimelineView.swift")
+        let insideRestorePath = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd/Store/AccountStore.swift")
+        let symlinkPath = URL(fileURLWithPath: root).appendingPathComponent("linked").path
+        let outsideRestorePath = URL(fileURLWithPath: outsideRoot)
+            .appendingPathComponent("AccountStore.swift")
+
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: insideRestorePath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: target, atomically: true, encoding: .utf8)
+        try "".write(to: insideRestorePath, atomically: true, encoding: .utf8)
+        try "".write(to: outsideRestorePath, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            atPath: symlinkPath,
+            withDestinationPath: outsideRoot
+        )
+
+        let runner = FakeProcessRunner()
+        await runner.enqueue(
+            label: "window-title",
+            stdout: "tweetpd — AccountStore.swift\n"
+        )
+        await runner.enqueue(
+            label: "source-document-paths",
+            stdout: "\(insideRestorePath.path)\n\(symlinkPath)/AccountStore.swift\n"
+        )
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+
+        let driver = XcodeEditorWarmupDriver(processRunner: runner)
+        let eventLoop = EmbeddedEventLoop()
+        let result = await driver.warmUp(
+            tabIdentifier: "windowtab2",
+            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            sessionId: "session-1",
+            eventLoop: eventLoop,
+            windowsProvider: { _, _ in
+                [XcodeWindowInfo(tabIdentifier: "windowtab2", workspacePath: workspacePath)]
+            }
+        )
+
+        #expect(result.snapshot?.candidateSourceDocumentPaths == [insideRestorePath.path])
     }
 
     @Test func warmupDriverRevalidatesCachedWorkspacePath() async throws {

--- a/Tests/XcodeMCPProxyTests/XcodeEditorWarmupDriverTests.swift
+++ b/Tests/XcodeMCPProxyTests/XcodeEditorWarmupDriverTests.swift
@@ -1,0 +1,400 @@
+import Foundation
+import NIOEmbedded
+import Testing
+
+@testable import XcodeMCPProxy
+
+@Suite
+struct XcodeEditorWarmupDriverTests {
+    @Test func warmupDriverResolvesDirectPath() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let target = URL(fileURLWithPath: root)
+            .appendingPathComponent("App/Sources/Foo.swift")
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: target, atomically: true, encoding: .utf8)
+
+        let driver = XcodeEditorWarmupDriver(isEnabled: false)
+        let resolved = await driver.resolveAbsoluteFilePath(
+            workspacePath: root,
+            workspaceRoot: root,
+            requestedFilePath: "App/Sources/Foo.swift"
+        )
+
+        #expect(resolved == target.path)
+    }
+
+    @Test func warmupDriverResolvesSuffixMatchedPath() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let target = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd/TimeLine/View/Regular/RegularTimelineView.swift")
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: target, atomically: true, encoding: .utf8)
+
+        let driver = XcodeEditorWarmupDriver(isEnabled: false)
+        let resolved = await driver.resolveAbsoluteFilePath(
+            workspacePath: root,
+            workspaceRoot: root,
+            requestedFilePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift"
+        )
+
+        #expect(resolved?.lowercased() == target.path.lowercased())
+    }
+
+    @Test func warmupDriverReturnsNilForAmbiguousSuffixMatchedPath() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let candidates = [
+            "A/Timeline/View/Foo.swift",
+            "B/Timeline/View/Foo.swift",
+        ]
+        for relativePath in candidates {
+            let url = URL(fileURLWithPath: root).appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try "".write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        let driver = XcodeEditorWarmupDriver(isEnabled: false)
+        let resolved = await driver.resolveAbsoluteFilePath(
+            workspacePath: root,
+            workspaceRoot: root,
+            requestedFilePath: "Timeline/View/Foo.swift"
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test func warmupDriverRejectsAbsolutePathOutsideWorkspaceRoot() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        let outsideRoot = makeTemporaryWorkspaceRoot()
+        defer {
+            try? FileManager.default.removeItem(atPath: root)
+            try? FileManager.default.removeItem(atPath: outsideRoot)
+        }
+
+        let outsideFile = URL(fileURLWithPath: outsideRoot)
+            .appendingPathComponent("Outside.swift")
+        try "".write(to: outsideFile, atomically: true, encoding: .utf8)
+
+        let driver = XcodeEditorWarmupDriver(isEnabled: false)
+        let resolved = await driver.resolveAbsoluteFilePath(
+            workspacePath: root,
+            workspaceRoot: root,
+            requestedFilePath: outsideFile.path
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test func warmupDriverRejectsTraversalOutsideWorkspaceRoot() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let driver = XcodeEditorWarmupDriver(isEnabled: false)
+        let resolved = await driver.resolveAbsoluteFilePath(
+            workspacePath: root,
+            workspaceRoot: root,
+            requestedFilePath: "../Outside.swift"
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test func warmupDriverWarmsAndRestoresUsingProcessRunner() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let workspacePath = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd.xcworkspace").path
+        try FileManager.default.createDirectory(
+            atPath: workspacePath,
+            withIntermediateDirectories: true
+        )
+        let target = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd/TimeLine/View/Regular/RegularTimelineView.swift")
+        let restorePath = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd/Store/AccountStore.swift")
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: restorePath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: target, atomically: true, encoding: .utf8)
+        try "".write(to: restorePath, atomically: true, encoding: .utf8)
+
+        let runner = FakeProcessRunner()
+        await runner.enqueue(
+            label: "window-title",
+            stdout: "tweetpd — AccountStore.swift\n"
+        )
+        await runner.enqueue(
+            label: "source-document-paths",
+            stdout: "\(restorePath.path)\n"
+        )
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+
+        let driver = XcodeEditorWarmupDriver(processRunner: runner)
+        let eventLoop = EmbeddedEventLoop()
+        let result = await driver.warmUp(
+            tabIdentifier: "windowtab2",
+            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            sessionId: "session-1",
+            eventLoop: eventLoop,
+            windowsProvider: { _, _ in
+                [XcodeWindowInfo(tabIdentifier: "windowtab2", workspacePath: workspacePath)]
+            }
+        )
+
+        #expect(result.context?.resolvedFilePath.lowercased() == target.path.lowercased())
+        #expect(result.snapshot?.visibleSourceBasename == "AccountStore.swift")
+
+        let restoreResult = await driver.restore(result.context)
+        #expect(restoreResult == "restored")
+
+        let requests = await runner.requests()
+        #expect(requests.map(\.label) == [
+            "window-title",
+            "source-document-paths",
+            "open-source-document",
+            "touch-source-document",
+            "window-title",
+            "open-source-document",
+            "touch-source-document",
+        ])
+    }
+
+    @Test func warmupDriverSnapshotExcludesPathsOutsideWorkspaceRoot() async throws {
+        let root = makeTemporaryWorkspaceRoot()
+        let outsideRoot = root + "-backup"
+        defer {
+            try? FileManager.default.removeItem(atPath: root)
+            try? FileManager.default.removeItem(atPath: outsideRoot)
+        }
+
+        let workspacePath = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd.xcworkspace").path
+        try FileManager.default.createDirectory(
+            atPath: workspacePath,
+            withIntermediateDirectories: true
+        )
+        let target = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd/Timeline/View/Regular/RegularTimelineView.swift")
+        let insideRestorePath = URL(fileURLWithPath: root)
+            .appendingPathComponent("tweetpd/Store/AccountStore.swift")
+        let outsideRestorePath = URL(fileURLWithPath: outsideRoot)
+            .appendingPathComponent("tweetpd/Store/AccountStore.swift")
+
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: insideRestorePath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: outsideRestorePath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: target, atomically: true, encoding: .utf8)
+        try "".write(to: insideRestorePath, atomically: true, encoding: .utf8)
+        try "".write(to: outsideRestorePath, atomically: true, encoding: .utf8)
+
+        let runner = FakeProcessRunner()
+        await runner.enqueue(
+            label: "window-title",
+            stdout: "tweetpd — AccountStore.swift\n"
+        )
+        await runner.enqueue(
+            label: "source-document-paths",
+            stdout: "\(insideRestorePath.path)\n\(outsideRestorePath.path)\n"
+        )
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+
+        let driver = XcodeEditorWarmupDriver(processRunner: runner)
+        let eventLoop = EmbeddedEventLoop()
+        let result = await driver.warmUp(
+            tabIdentifier: "windowtab2",
+            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            sessionId: "session-1",
+            eventLoop: eventLoop,
+            windowsProvider: { _, _ in
+                [XcodeWindowInfo(tabIdentifier: "windowtab2", workspacePath: workspacePath)]
+            }
+        )
+
+        #expect(result.snapshot?.candidateSourceDocumentPaths == [insideRestorePath.path])
+
+        let restoreResult = await driver.restore(result.context)
+        #expect(restoreResult == "restored")
+    }
+
+    @Test func warmupDriverRevalidatesCachedWorkspacePath() async throws {
+        let rootA = makeTemporaryWorkspaceRoot()
+        let rootB = makeTemporaryWorkspaceRoot()
+        defer {
+            try? FileManager.default.removeItem(atPath: rootA)
+            try? FileManager.default.removeItem(atPath: rootB)
+        }
+
+        let workspaceA = URL(fileURLWithPath: rootA)
+            .appendingPathComponent("tweetpd.xcworkspace").path
+        let workspaceB = URL(fileURLWithPath: rootB)
+            .appendingPathComponent("tweetpd.xcworkspace").path
+        try FileManager.default.createDirectory(atPath: workspaceA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: workspaceB, withIntermediateDirectories: true)
+
+        let targetA = URL(fileURLWithPath: rootA)
+            .appendingPathComponent("tweetpd/Timeline/View/Regular/RegularTimelineView.swift")
+        let targetB = URL(fileURLWithPath: rootB)
+            .appendingPathComponent("tweetpd/Timeline/View/Regular/RegularTimelineView.swift")
+        try FileManager.default.createDirectory(
+            at: targetA.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: targetB.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: targetA, atomically: true, encoding: .utf8)
+        try "".write(to: targetB, atomically: true, encoding: .utf8)
+
+        let runner = FakeProcessRunner()
+        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "source-document-paths", stdout: "\(targetA.path)\n")
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+        await runner.enqueue(label: "window-title", stdout: "tweetpd — RegularTimelineView.swift\n")
+        await runner.enqueue(label: "source-document-paths", stdout: "\(targetB.path)\n")
+        await runner.enqueue(label: "open-source-document", stdout: "ok\n")
+        await runner.enqueue(label: "touch-source-document", stdout: "ready\n")
+
+        let driver = XcodeEditorWarmupDriver(processRunner: runner)
+        let eventLoop = EmbeddedEventLoop()
+
+        let first = await driver.warmUp(
+            tabIdentifier: "windowtab2",
+            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            sessionId: "session-1",
+            eventLoop: eventLoop,
+            windowsProvider: { _, _ in
+                [XcodeWindowInfo(tabIdentifier: "windowtab2", workspacePath: workspaceA)]
+            }
+        )
+        let second = await driver.warmUp(
+            tabIdentifier: "windowtab2",
+            filePath: "tweetpd/Timeline/View/Regular/RegularTimelineView.swift",
+            sessionId: "session-1",
+            eventLoop: eventLoop,
+            windowsProvider: { _, _ in
+                [XcodeWindowInfo(tabIdentifier: "windowtab2", workspacePath: workspaceB)]
+            }
+        )
+
+        #expect(first.workspacePath == workspaceA)
+        #expect(second.workspacePath == workspaceB)
+        #expect(second.context?.resolvedFilePath == targetB.path)
+    }
+
+    @Test func warmupDriverRestoreSkipsAmbiguousCandidate() async throws {
+        let runner = FakeProcessRunner()
+        let driver = XcodeEditorWarmupDriver(processRunner: runner)
+        let context = WarmupContext(
+            workspacePath: "/tmp/workspace",
+            workspaceRoot: "/tmp/workspace",
+            resolvedFilePath: "/tmp/workspace/Target/Foo.swift",
+            snapshot: EditorSnapshot(
+                workspacePath: "/tmp/workspace",
+                workspaceRoot: "/tmp/workspace",
+                windowTitle: "tweetpd — Foo.swift",
+                candidateSourceDocumentPaths: [
+                    "/tmp/workspace/A/Foo.swift",
+                    "/tmp/workspace/B/Foo.swift",
+                ],
+                visibleSourceBasename: "Foo.swift"
+            )
+        )
+
+        await runner.enqueue(label: "window-title", stdout: "tweetpd — Foo.swift\n")
+        let restoreResult = await driver.restore(context)
+        #expect(restoreResult == "restore_candidate_ambiguous")
+        #expect(await runner.requests().map(\.label) == ["window-title"])
+    }
+}
+
+private actor FakeProcessRunner: ProcessRunning {
+    private struct PlannedOutput {
+        let label: String
+        let stdout: String
+        let stderr: String
+        let terminationStatus: Int32
+    }
+
+    private var plannedOutputs: [PlannedOutput] = []
+    private var capturedRequests: [ProcessRequest] = []
+
+    func enqueue(
+        label: String,
+        stdout: String = "",
+        stderr: String = "",
+        terminationStatus: Int32 = 0
+    ) {
+        plannedOutputs.append(
+            PlannedOutput(
+                label: label,
+                stdout: stdout,
+                stderr: stderr,
+                terminationStatus: terminationStatus
+            )
+        )
+    }
+
+    func run(_ request: ProcessRequest) async throws -> ProcessOutput {
+        capturedRequests.append(request)
+        guard plannedOutputs.isEmpty == false else {
+            return ProcessOutput(terminationStatus: 1, stdout: "", stderr: "no output")
+        }
+        let next = plannedOutputs.removeFirst()
+        #expect(next.label == request.label)
+        return ProcessOutput(
+            terminationStatus: next.terminationStatus,
+            stdout: next.stdout,
+            stderr: next.stderr
+        )
+    }
+
+    func requests() -> [ProcessRequest] {
+        capturedRequests
+    }
+}
+
+private func makeTemporaryWorkspaceRoot() -> String {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url.path
+}


### PR DESCRIPTION
Summary:
- Add an editor-backed warmup flow for `XcodeRefreshCodeIssuesInFile`, including workspace-aware file resolution, best-effort restore, and AppleScript-based document activation.
- Keep same-tab serialization and bounded retries around refresh requests while preserving upstream health accounting, disabling internal warmup pinning, revalidating cached tab-to-workspace mappings per session, and matching both `error 5` message variants.
- Harden proxy robustness with symlink-aware workspace containment, initialize-session generation guards in failure cleanup, and drain-group leave protection in `ProcessRunner`, plus regression coverage for warmup path safety, process pipe draining, concurrent refresh behavior, and recreated-session initialize routing.

Testing:
- `swift test`
- Manual smoke: 10 concurrent refresh burst rounds against `localhost:8765` (`totalFailures=0`, `totalError5=0`)