### PR TITLE
fix(proxy): isolate initialize-time upstream routing

### DIFF
--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -390,6 +390,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 let sessionId = headerSessionId ?? UUID().uuidString
                 _ = sessionManager.session(id: sessionId)
                 let future = sessionManager.registerInitialize(
+                    sessionId: sessionId,
                     originalId: originalId,
                     requestObject: object,
                     on: context.eventLoop

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -84,6 +84,7 @@ final class SessionManager: Sendable, SessionManaging {
         let eventLoop: EventLoop
         let promise: EventLoopPromise<ByteBuffer>
         let sessionId: String
+        let sessionGeneration: UInt64
         let originalId: RPCId
     }
 
@@ -97,6 +98,7 @@ final class SessionManager: Sendable, SessionManaging {
     private struct SessionState: Sendable {
         struct SessionRecord: Sendable {
             let context: SessionContext
+            let generation: UInt64
             var pinnedUpstreamIndex: Int?
             var initializeUpstreamIndex: Int?
             var preferInitializeUpstreamOnNextPin: Bool
@@ -104,6 +106,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         var sessions: [String: SessionRecord] = [:]
+        var nextGeneration: UInt64 = 0
     }
 
     private struct InitState: Sendable {
@@ -216,8 +219,10 @@ final class SessionManager: Sendable, SessionManaging {
                 return existing.context
             }
             let context = SessionContext(id: id, config: config)
+            state.nextGeneration &+= 1
             state.sessions[id] = SessionState.SessionRecord(
                 context: context,
+                generation: state.nextGeneration,
                 pinnedUpstreamIndex: nil,
                 initializeUpstreamIndex: nil,
                 preferInitializeUpstreamOnNextPin: false,
@@ -557,6 +562,16 @@ final class SessionManager: Sendable, SessionManaging {
         }
     }
 
+    private func sessionStillMatchesPendingInitialize(
+        sessionId: String,
+        sessionGeneration: UInt64
+    ) -> Bool {
+        sessionsState.withLockedValue { state in
+            guard let record = state.sessions[sessionId] else { return false }
+            return record.generation == sessionGeneration
+        }
+    }
+
     private func classifyHealthAndCollectProbeIfNeeded(
         upstreamIndex: Int,
         nowUptimeNs: UInt64,
@@ -595,6 +610,10 @@ final class SessionManager: Sendable, SessionManaging {
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
+        _ = session(id: sessionId)
+        let sessionGeneration = sessionsState.withLockedValue { state in
+            state.sessions[sessionId]?.generation ?? 0
+        }
         var shouldSend = false
         var shouldScheduleTimeout = false
         var initRequest: [String: Any]?
@@ -618,6 +637,7 @@ final class SessionManager: Sendable, SessionManaging {
                     eventLoop: eventLoop,
                     promise: promise,
                     sessionId: sessionId,
+                    sessionGeneration: sessionGeneration,
                     originalId: originalId
                 )
             )
@@ -1398,12 +1418,16 @@ final class SessionManager: Sendable, SessionManaging {
         update.timeout?.cancel()
 
         for item in update.pending {
-            _ = session(id: item.sessionId)
-            setInitializeUpstreamIndexIfNeeded(
+            if sessionStillMatchesPendingInitialize(
                 sessionId: item.sessionId,
-                upstreamIndex: upstreamIndex,
-                preferOnNextPin: false
-            )
+                sessionGeneration: item.sessionGeneration
+            ) {
+                setInitializeUpstreamIndexIfNeeded(
+                    sessionId: item.sessionId,
+                    upstreamIndex: upstreamIndex,
+                    preferOnNextPin: false
+                )
+            }
             if let buffer = encodeInitializeResponse(originalId: item.originalId, result: result) {
                 item.eventLoop.execute {
                     item.promise.succeed(buffer)

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -33,6 +33,7 @@ protocol SessionManaging: Sendable {
     func setCachedToolsListResult(_ result: JSONValue)
     func refreshToolsListIfNeeded()
     func registerInitialize(
+        sessionId: String,
         originalId: RPCId,
         requestObject: [String: Any],
         on eventLoop: EventLoop
@@ -82,6 +83,7 @@ final class SessionManager: Sendable, SessionManaging {
     private struct InitPending: Sendable {
         let eventLoop: EventLoop
         let promise: EventLoopPromise<ByteBuffer>
+        let sessionId: String
         let originalId: RPCId
     }
 
@@ -96,6 +98,9 @@ final class SessionManager: Sendable, SessionManaging {
         struct SessionRecord: Sendable {
             let context: SessionContext
             var pinnedUpstreamIndex: Int?
+            var initializeUpstreamIndex: Int?
+            var preferInitializeUpstreamOnNextPin: Bool
+            var didReceiveInitializeUpstreamMessage: Bool
         }
 
         var sessions: [String: SessionRecord] = [:]
@@ -212,7 +217,12 @@ final class SessionManager: Sendable, SessionManaging {
             }
             let context = SessionContext(id: id, config: config)
             state.sessions[id] = SessionState.SessionRecord(
-                context: context, pinnedUpstreamIndex: nil)
+                context: context,
+                pinnedUpstreamIndex: nil,
+                initializeUpstreamIndex: nil,
+                preferInitializeUpstreamOnNextPin: false,
+                didReceiveInitializeUpstreamMessage: false
+            )
             return context
         }
     }
@@ -347,8 +357,68 @@ final class SessionManager: Sendable, SessionManaging {
 
             sessionsState.withLockedValue { state in
                 state.sessions[sessionId]?.pinnedUpstreamIndex = nil
+                state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
             }
             pinned = nil
+        }
+
+        let preferredInitializeUpstreamIndex = sessionsState.withLockedValue { state -> Int? in
+            guard let record = state.sessions[sessionId],
+                record.pinnedUpstreamIndex == nil,
+                (record.preferInitializeUpstreamOnNextPin || record.didReceiveInitializeUpstreamMessage),
+                let upstreamIndex = record.initializeUpstreamIndex
+            else {
+                return nil
+            }
+            return upstreamIndex
+        }
+
+        if shouldPin, let preferredInitializeUpstreamIndex {
+            let isUsable = upstreamState.withLockedValue { state in
+                guard preferredInitializeUpstreamIndex >= 0,
+                    preferredInitializeUpstreamIndex < state.upstreamStates.count
+                else {
+                    return false
+                }
+                let health = classifyHealthAndCollectProbeIfNeeded(
+                    upstreamIndex: preferredInitializeUpstreamIndex,
+                    nowUptimeNs: nowUptimeNs,
+                    state: &state,
+                    probesToStart: &probesToStart
+                )
+                let isHealthyEnough: Bool
+                switch health {
+                case .healthy, .degraded:
+                    isHealthyEnough = true
+                case .quarantined:
+                    isHealthyEnough = false
+                }
+                return isHealthyEnough
+                    && state.upstreamStates[preferredInitializeUpstreamIndex].isInitialized
+            }
+            if isUsable {
+                for probe in probesToStart {
+                    probeUpstreamHealth(
+                        upstreamIndex: probe.upstreamIndex,
+                        probeGeneration: probe.probeGeneration
+                    )
+                }
+                sessionsState.withLockedValue { state in
+                    state.sessions[sessionId]?.pinnedUpstreamIndex = preferredInitializeUpstreamIndex
+                    state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                    state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                    state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+                }
+                return preferredInitializeUpstreamIndex
+            }
+
+            sessionsState.withLockedValue { state in
+                state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+            }
         }
 
         let chosen = upstreamState.withLockedValue { state -> Int? in
@@ -397,9 +467,94 @@ final class SessionManager: Sendable, SessionManaging {
         if pinned == nil, shouldPin {
             sessionsState.withLockedValue { state in
                 state.sessions[sessionId]?.pinnedUpstreamIndex = chosen
+                state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
             }
         }
         return chosen
+    }
+
+    private func chooseInitializeUpstreamIndex(sessionId: String) -> Int? {
+        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        var probesToStart: [(upstreamIndex: Int, probeGeneration: UInt64)] = []
+        probesToStart.reserveCapacity(1)
+
+        let hintedUpstreamIndex = sessionsState.withLockedValue { state -> Int? in
+            if let pinned = state.sessions[sessionId]?.pinnedUpstreamIndex {
+                return pinned
+            }
+            return state.sessions[sessionId]?.initializeUpstreamIndex
+        }
+
+        if let hintedUpstreamIndex {
+            let isUsable = upstreamState.withLockedValue { state in
+                guard hintedUpstreamIndex >= 0, hintedUpstreamIndex < state.upstreamStates.count else {
+                    return false
+                }
+                let health = classifyHealthAndCollectProbeIfNeeded(
+                    upstreamIndex: hintedUpstreamIndex,
+                    nowUptimeNs: nowUptimeNs,
+                    state: &state,
+                    probesToStart: &probesToStart
+                )
+                let isHealthyEnough: Bool
+                switch health {
+                case .healthy, .degraded:
+                    isHealthyEnough = true
+                case .quarantined:
+                    isHealthyEnough = false
+                }
+                return isHealthyEnough && state.upstreamStates[hintedUpstreamIndex].isInitialized
+            }
+
+            for probe in probesToStart {
+                probeUpstreamHealth(
+                    upstreamIndex: probe.upstreamIndex,
+                    probeGeneration: probe.probeGeneration
+                )
+            }
+
+            if isUsable {
+                return hintedUpstreamIndex
+            }
+
+            sessionsState.withLockedValue { state in
+                if state.sessions[sessionId]?.pinnedUpstreamIndex == nil {
+                    state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                    state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                }
+            }
+        }
+
+        return chooseUpstreamIndex(sessionId: sessionId, shouldPin: false)
+    }
+
+    private func setInitializeUpstreamIndexIfNeeded(
+        sessionId: String,
+        upstreamIndex: Int,
+        preferOnNextPin: Bool
+    ) {
+        sessionsState.withLockedValue { state in
+            guard let record = state.sessions[sessionId] else { return }
+            if record.pinnedUpstreamIndex == nil {
+                state.sessions[sessionId]?.initializeUpstreamIndex = upstreamIndex
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = preferOnNextPin
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+            } else {
+                state.sessions[sessionId]?.initializeUpstreamIndex = nil
+                state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+                state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+            }
+        }
+    }
+
+    private func clearInitializeUpstreamIndex(sessionId: String) {
+        sessionsState.withLockedValue { state in
+            state.sessions[sessionId]?.initializeUpstreamIndex = nil
+            state.sessions[sessionId]?.preferInitializeUpstreamOnNextPin = false
+            state.sessions[sessionId]?.didReceiveInitializeUpstreamMessage = false
+        }
     }
 
     private func classifyHealthAndCollectProbeIfNeeded(
@@ -435,6 +590,7 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     func registerInitialize(
+        sessionId: String,
         originalId: RPCId,
         requestObject: [String: Any],
         on eventLoop: EventLoop
@@ -461,6 +617,7 @@ final class SessionManager: Sendable, SessionManaging {
                 InitPending(
                     eventLoop: eventLoop,
                     promise: promise,
+                    sessionId: sessionId,
                     originalId: originalId
                 )
             )
@@ -477,6 +634,25 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         if let cachedResult {
+            _ = session(id: sessionId)
+            if let upstreamIndex = chooseInitializeUpstreamIndex(sessionId: sessionId) {
+                let shouldPreferOnNextPin = upstreamState.withLockedValue { state in
+                    state.upstreamStates.reduce(into: 0) { count, upstream in
+                        guard upstream.isInitialized else { return }
+                        switch upstream.healthState {
+                        case .healthy, .degraded:
+                            count += 1
+                        case .quarantined:
+                            break
+                        }
+                    } > 1
+                }
+                setInitializeUpstreamIndexIfNeeded(
+                    sessionId: sessionId,
+                    upstreamIndex: upstreamIndex,
+                    preferOnNextPin: shouldPreferOnNextPin
+                )
+            }
             if let buffer = encodeInitializeResponse(originalId: originalId, result: cachedResult) {
                 return eventLoop.makeSucceededFuture(buffer)
             }
@@ -485,6 +661,15 @@ final class SessionManager: Sendable, SessionManaging {
 
         if shuttingDown {
             return eventLoop.makeFailedFuture(TimeoutError())
+        }
+
+        if pendingPromise != nil {
+            _ = session(id: sessionId)
+            setInitializeUpstreamIndexIfNeeded(
+                sessionId: sessionId,
+                upstreamIndex: 0,
+                preferOnNextPin: false
+            )
         }
 
         if shouldSend, var initRequest {
@@ -505,6 +690,19 @@ final class SessionManager: Sendable, SessionManaging {
             return eventLoop.makeFailedFuture(TimeoutError())
         }
         return promise.futureResult
+    }
+
+    func registerInitialize(
+        originalId: RPCId,
+        requestObject: [String: Any],
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<ByteBuffer> {
+        registerInitialize(
+            sessionId: "__initialize_pending__:\(originalId.key)",
+            originalId: originalId,
+            requestObject: requestObject,
+            on: eventLoop
+        )
     }
 
     private func routeUpstreamMessage(_ data: Data, upstreamIndex: Int) {
@@ -614,6 +812,7 @@ final class SessionManager: Sendable, SessionManaging {
                 idMapper.remove(upstreamIndex: 0, upstreamId: upstreamId)
             }
             for item in globalInit.pending {
+                clearInitializeUpstreamIndex(sessionId: item.sessionId)
                 item.eventLoop.execute {
                     item.promise.fail(TimeoutError())
                 }
@@ -631,7 +830,12 @@ final class SessionManager: Sendable, SessionManaging {
             for key in keys {
                 if state.sessions[key]?.pinnedUpstreamIndex == upstreamIndex {
                     state.sessions[key]?.pinnedUpstreamIndex = nil
+                    state.sessions[key]?.initializeUpstreamIndex = nil
+                    state.sessions[key]?.preferInitializeUpstreamOnNextPin = false
                     cleared += 1
+                } else if state.sessions[key]?.initializeUpstreamIndex == upstreamIndex {
+                    state.sessions[key]?.initializeUpstreamIndex = nil
+                    state.sessions[key]?.preferInitializeUpstreamOnNextPin = false
                 }
             }
             return cleared
@@ -954,10 +1158,9 @@ final class SessionManager: Sendable, SessionManaging {
             data: data
         )
         // We have no id-based mapping for this upstream message, so we can't unambiguously route it to a
-        // single session. To reduce cross-talk across multiple concurrent agents, only deliver it to
-        // sessions pinned to the same upstream. If no session is pinned to this upstream yet, still
-        // deliver server-initiated notifications/requests to unpinned sessions so they don't miss
-        // pre-pin messages.
+        // single session. To avoid cross-session disclosure, only deliver server-initiated
+        // notifications/requests to sessions already pinned to the same upstream or to sessions that
+        // have only been initialized against that upstream and have not chosen a permanent pin yet.
         //
         // Never forward unmapped JSON-RPC responses (no `method`) to sessions: if we dropped a mapping
         // due to timeouts (e.g. a best-effort tools/list warmup) then a late response must not leak
@@ -1008,42 +1211,28 @@ final class SessionManager: Sendable, SessionManaging {
             return
         }
 
-        let (pinnedTargets, unpinnedTargets) = sessionsState.withLockedValue {
-            state -> ([SessionContext], [SessionContext]) in
-            var pinned: [SessionContext] = []
-            var unpinned: [SessionContext] = []
-            pinned.reserveCapacity(state.sessions.count)
-            unpinned.reserveCapacity(state.sessions.count)
-            for record in state.sessions.values {
+        let routedTargets = sessionsState.withLockedValue {
+            state -> [SessionContext] in
+            var targets: [SessionContext] = []
+            targets.reserveCapacity(state.sessions.count)
+            let keys = Array(state.sessions.keys)
+            for key in keys {
+                guard let record = state.sessions[key] else { continue }
                 if record.pinnedUpstreamIndex == upstreamIndex {
-                    pinned.append(record.context)
-                } else if record.pinnedUpstreamIndex == nil {
-                    unpinned.append(record.context)
+                    targets.append(record.context)
+                } else if record.pinnedUpstreamIndex == nil
+                    && record.initializeUpstreamIndex == upstreamIndex
+                {
+                    state.sessions[key]?.didReceiveInitializeUpstreamMessage = true
+                    targets.append(record.context)
                 }
             }
-            return (pinned, unpinned)
+            return targets
         }
 
-        if !pinnedTargets.isEmpty {
+        if !routedTargets.isEmpty {
             for payload in serverInitiatedPayloads {
-                for session in pinnedTargets {
-                    session.router.handleIncoming(payload)
-                }
-            }
-            return
-        }
-
-        if !unpinnedTargets.isEmpty {
-            logger.debug(
-                "Routing unmapped upstream message to unpinned sessions",
-                metadata: [
-                    "upstream": .string("\(upstreamIndex)"),
-                    "bytes": .string("\(data.count)"),
-                    "targets": .string("\(unpinnedTargets.count)"),
-                ]
-            )
-            for payload in serverInitiatedPayloads {
-                for session in unpinnedTargets {
+                for session in routedTargets {
                     session.router.handleIncoming(payload)
                 }
             }
@@ -1051,7 +1240,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
 
         logger.debug(
-            "Dropping unmapped upstream message (no target sessions)",
+            "Dropping unmapped upstream message (no routed target sessions)",
             metadata: [
                 "upstream": .string("\(upstreamIndex)"),
                 "bytes": .string("\(data.count)"),
@@ -1209,6 +1398,12 @@ final class SessionManager: Sendable, SessionManaging {
         update.timeout?.cancel()
 
         for item in update.pending {
+            _ = session(id: item.sessionId)
+            setInitializeUpstreamIndexIfNeeded(
+                sessionId: item.sessionId,
+                upstreamIndex: upstreamIndex,
+                preferOnNextPin: false
+            )
             if let buffer = encodeInitializeResponse(originalId: item.originalId, result: result) {
                 item.eventLoop.execute {
                     item.promise.succeed(buffer)
@@ -1293,6 +1488,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
+            clearInitializeUpstreamIndex(sessionId: item.sessionId)
             if let buffer = encodeInitializeErrorResponse(
                 originalId: item.originalId, errorObject: errorObject)
             {
@@ -1383,6 +1579,7 @@ final class SessionManager: Sendable, SessionManaging {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
+            clearInitializeUpstreamIndex(sessionId: item.sessionId)
             item.eventLoop.execute {
                 item.promise.fail(error)
             }
@@ -1486,7 +1683,12 @@ final class SessionManager: Sendable, SessionManaging {
             for key in keys {
                 if state.sessions[key]?.pinnedUpstreamIndex == upstreamIndex {
                     state.sessions[key]?.pinnedUpstreamIndex = nil
+                    state.sessions[key]?.initializeUpstreamIndex = nil
+                    state.sessions[key]?.preferInitializeUpstreamOnNextPin = false
                     cleared += 1
+                } else if state.sessions[key]?.initializeUpstreamIndex == upstreamIndex {
+                    state.sessions[key]?.initializeUpstreamIndex = nil
+                    state.sessions[key]?.preferInitializeUpstreamOnNextPin = false
                 }
             }
             return cleared

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -182,6 +182,8 @@ struct HTTPHandlerTests {
             as? [String: Any]
         let responseId = (responseObject?["id"] as? NSNumber)?.intValue
         #expect(responseId == 1)
+        #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+        #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
         #expect(sessionManager.requestSuccessNotificationCount() == 0)
     }
 
@@ -770,7 +772,7 @@ struct HTTPHandlerTests {
 
         #expect(sessionManager.sentUpstreamCount() == 0)
         #expect(sessionManager.assignedUpstreamIdCount() == 0)
-        #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+        #expect(sessionManager.chooseUpstreamIndexCallCount() == 2)
         #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
         #expect(sessionManager.refreshToolsListCallCount() == 0)
     }
@@ -845,7 +847,7 @@ struct HTTPHandlerTests {
 
         #expect(sessionManager.sentUpstreamCount() == 0)
         #expect(sessionManager.assignedUpstreamIdCount() == 0)
-        #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+        #expect(sessionManager.chooseUpstreamIndexCallCount() == 2)
         #expect(sessionManager.lastChooseUpstreamShouldPin() == true)
         #expect(sessionManager.refreshToolsListCallCount() == 0)
     }
@@ -1934,6 +1936,7 @@ private final class TestSessionManager: SessionManaging {
     }
 
     func registerInitialize(
+        sessionId: String,
         originalId: RPCId,
         requestObject: [String: Any],
         on eventLoop: EventLoop
@@ -1941,6 +1944,7 @@ private final class TestSessionManager: SessionManaging {
         state.withLockedValue { state in
             state.initialized = true
         }
+        _ = chooseUpstreamIndex(sessionId: sessionId, shouldPin: true)
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": originalId.value.foundationObject,

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -171,6 +171,78 @@ struct SessionManagerTests {
         #expect(received.first == notification)
     }
 
+    @Test func sessionManagerDoesNotRecreateRemovedSessionWhenInitializeCompletes() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-removed"
+        _ = manager.session(id: sessionId)
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        manager.removeSession(id: sessionId)
+
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+        await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+
+        _ = try await future.get()
+        #expect(manager.hasSession(id: sessionId) == false)
+    }
+
+    @Test func sessionManagerDoesNotApplyRemovedInitializeStateToRecreatedSession() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-recreated"
+        _ = manager.session(id: sessionId)
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        manager.removeSession(id: sessionId)
+        let replacement = manager.session(id: sessionId)
+        _ = replacement.router.drainBufferedNotifications()
+
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+        await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+
+        let notification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 7],
+            ],
+            options: []
+        )
+        await upstream.yield(.message(notification))
+
+        _ = try await future.get()
+        #expect(
+            await staysTrue(for: .milliseconds(200)) {
+                replacement.router.drainBufferedNotifications().isEmpty
+            }
+        )
+    }
+
     @Test func sessionManagerPinsFirstRequestToCachedInitializeUpstreamAfterNotification() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -45,6 +45,193 @@ struct SessionManagerTests {
         #expect(id2 == 2)
     }
 
+    @Test func sessionManagerPinsInitializeSessionBeforeUnmappedNotificationsArrive() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-A"
+        let session = manager.session(id: sessionId)
+        _ = session.router.drainBufferedNotifications()
+
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+
+        await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+        let notification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 1],
+            ],
+            options: []
+        )
+        await upstream.yield(.message(notification))
+
+        _ = try await future.get()
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        #expect(received.first == notification)
+    }
+
+    @Test func sessionManagerRoutesUnmappedNotificationsDuringInitializeHandshake() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let sessionId = "session-handshake"
+        let session = manager.session(id: sessionId)
+        _ = session.router.drainBufferedNotifications()
+
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let notification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 99],
+            ],
+            options: []
+        )
+        await upstream.yield(.message(notification))
+
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        #expect(received.first == notification)
+
+        let sent = await upstream.sent()
+        let initId = try extractUpstreamId(from: sent[0])
+        await upstream.yield(.message(try makeInitializeResponse(id: initId)))
+        _ = try await future.get()
+    }
+
+    @Test func sessionManagerPinsCachedInitializeSessionBeforeUnmappedNotificationsArrive() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+
+        let firstFuture = manager.registerInitialize(
+            sessionId: "session-A",
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let firstSent = await upstream.sent()
+        let firstInitId = try extractUpstreamId(from: firstSent[0])
+        await upstream.yield(.message(try makeInitializeResponse(id: firstInitId)))
+        _ = try await firstFuture.get()
+
+        let sessionId = "session-B"
+        let session = manager.session(id: sessionId)
+        _ = session.router.drainBufferedNotifications()
+        let cachedFuture = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 2))!,
+            requestObject: makeInitializeRequest(id: 2),
+            on: eventLoop
+        )
+
+        let notification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 2],
+            ],
+            options: []
+        )
+        await upstream.yield(.message(notification))
+
+        _ = try await cachedFuture.get()
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        #expect(received.first == notification)
+    }
+
+    @Test func sessionManagerPinsFirstRequestToCachedInitializeUpstreamAfterNotification() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: true, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+
+        try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
+        let init0 = await upstream0.sent()
+        let init0Id = try extractUpstreamId(from: init0[0])
+        await upstream0.yield(.message(try makeInitializeResponse(id: init0Id)))
+
+        try await waitForSentCount(upstream1, count: 1, timeoutSeconds: 2)
+        let init1 = await upstream1.sent()
+        let init1Id = try extractUpstreamId(from: init1[0])
+        await upstream1.yield(.message(try makeInitializeResponse(id: init1Id)))
+
+        try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+        try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
+
+        let sessionId = "session-hinted-pin"
+        let session = manager.session(id: sessionId)
+        _ = session.router.drainBufferedNotifications()
+
+        let future = manager.registerInitialize(
+            sessionId: sessionId,
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        _ = try await future.get()
+
+        let notification0 = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 0],
+            ],
+            options: []
+        )
+        let notification1 = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/test",
+                "params": ["value": 1],
+            ],
+            options: []
+        )
+        await upstream0.yield(.message(notification0))
+        await upstream1.yield(.message(notification1))
+
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        let routedUpstream = try #require(received.first).elementsEqual(notification0) ? 0 : 1
+
+        let pinned = try #require(manager.chooseUpstreamIndex(sessionId: sessionId, shouldPin: true))
+        #expect(pinned == routedUpstream)
+    }
+
     @Test func sessionManagerTimeoutResetsInitState() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -488,7 +675,7 @@ struct SessionManagerTests {
         #expect(receivedOther.isEmpty)
     }
 
-    @Test func sessionManagerRoutesUnmappedNotificationsToUnpinnedSessionsWhenNoPinnedTargetsExist()
+    @Test func sessionManagerDropsUnmappedNotificationsWhenNoPinnedTargetsExist()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -532,9 +719,11 @@ struct SessionManagerTests {
 
         await yieldMessage(notification, to: upstream0)
 
-        let received = try await nextBufferedNotifications(from: session.router)
-        #expect(received.count == 1)
-        #expect(received.first == notification)
+        #expect(
+            await staysTrue(for: .milliseconds(200)) {
+                session.router.drainBufferedNotifications().isEmpty
+            }
+        )
     }
 
     @Test func sessionManagerDropsUnmappedResponsesEvenWhenPinnedTargetsExist() async throws {


### PR DESCRIPTION
Summary:
- Route unmapped upstream notifications only to sessions bound to the same initialize/pinned upstream instead of broadcasting to unrelated sessions
- Track initialize-time upstream affinity separately from permanent pinning so early server-initiated messages stay isolated without regressing multi-upstream load balancing
- Guard pending initialize completions against removed or recreated sessions so stale initialize responses cannot resurrect or retarget session state
- Add regression coverage for initialize handshake, cached initialize, first-request routing after initialize, and removed/recreated session races

Testing:
- swift test