### PR TITLE
ci(release): publish draft GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,11 @@ jobs:
       - name: Package release archives
         run: scripts/package-universal.sh --dist-root dist --output-dir release
 
-      - name: Publish GitHub Release
+      - name: Publish Draft GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: |
             release/*.tar.gz
             release/SHA256SUMS.txt
+          draft: true
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- publish tag-triggered GitHub releases as drafts instead of immediately publishing them
- keep generated release notes enabled so the draft body can be edited before publishing
- preserve the existing packaged release assets and release workflow structure

## Testing
- `swift build`
- `swift test`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`
- `codex-review --uncommitted`