### PR TITLE
fix(proxy): harden refresh queue and test shutdown cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-/.build
+/.build*
 /Packages
 xcuserdata/
 DerivedData/

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -78,6 +78,7 @@ Xcode's live diagnostics service is prone to transient failures when `XcodeRefre
 
 - `xcode-mcp-proxy-server` now serializes `XcodeRefreshCodeIssuesInFile` per `tabIdentifier` and retries the specific `SourceEditorCallableDiagnosticError error 5` response a small number of times.
 - This reduces cold-start contention, but it can increase latency when many refresh requests target the same tab at once.
+- If a client bursts too many queued refreshes for the same tab, the proxy now applies backpressure and may return `refresh queue overloaded` instead of letting the queue grow without bound.
 - For broad issue sweeps, prefer `XcodeListNavigatorIssues` first and only use `XcodeRefreshCodeIssuesInFile` for files that need per-file diagnostics output.
 
 ## Xcode dialog does not appear

--- a/Sources/XcodeMCPProxy/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxy/HTTPHandler.swift
@@ -60,6 +60,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         case success(Data)
         case timeout(responseIds: [RPCId], isBatch: Bool)
         case upstreamUnavailable(responseIds: [RPCId], isBatch: Bool)
+        case overloaded(responseIds: [RPCId], isBatch: Bool)
         case invalidRequest
         case invalidUpstreamResponse
     }
@@ -79,12 +80,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     init(
         config: ProxyConfig,
         sessionManager: any SessionManaging,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator(),
+        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
         warmupDriver: XcodeEditorWarmupDriver = XcodeEditorWarmupDriver()
     ) {
         self.config = config
         self.sessionManager = sessionManager
-        self.refreshCodeIssuesCoordinator = refreshCodeIssuesCoordinator
+        self.refreshCodeIssuesCoordinator =
+            refreshCodeIssuesCoordinator
+            ?? RefreshCodeIssuesCoordinator.makeDefault(
+                requestTimeout: config.requestTimeout
+            )
         self.warmupDriver = warmupDriver
     }
 
@@ -1158,142 +1163,189 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         requestIsBatch: Bool,
         eventLoop: EventLoop
     ) async -> RefreshForwardAttemptResult {
-        await refreshCodeIssuesCoordinator.withPermit(key: refreshRequest.queueKey) { queuePosition in
-            let baseMetadata: Logger.Metadata = [
-                "session": .string(sessionId),
-                "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
-                "queue_key": .string(refreshRequest.queueKey),
-            ]
-            if queuePosition > 0 {
-                logger.debug(
-                    "Queued refresh code issues request",
-                    metadata: baseMetadata.merging(
-                        ["queued_ahead": .string("\(queuePosition)")],
-                        uniquingKeysWith: { _, new in new }
-                    )
-                )
-            }
-            logger.debug(
-                "Dequeued refresh code issues request",
-                metadata: baseMetadata
-            )
-
-            let warmupResult = await warmupDriver.warmUp(
-                tabIdentifier: refreshRequest.tabIdentifier,
-                filePath: refreshRequest.filePath,
-                sessionId: sessionId,
-                eventLoop: eventLoop,
-                windowsProvider: { sessionId, eventLoop in
-                    await self.listXcodeWindows(
-                        sessionId: sessionId,
-                        eventLoop: eventLoop
-                    )
-                }
-            )
-            let warmupMetadata = baseMetadata
-                .merging(
-                    [
-                        "workspace_path": .string(warmupResult.workspacePath ?? "none"),
-                        "requested_file_path": .string(refreshRequest.filePath ?? "none"),
-                        "resolved_file_path": .string(warmupResult.resolvedFilePath ?? "none"),
-                    ],
-                    uniquingKeysWith: { _, new in new }
-                )
-
-            if let failureReason = warmupResult.failureReason,
-                failureReason != "disabled",
-                failureReason != "missing tabIdentifier",
-                failureReason != "missing filePath"
-            {
-                logger.debug(
-                    "Refresh code issues warm-up fell back to plain refresh",
-                    metadata: warmupMetadata.merging(
-                        [
-                            "warmup_stage": .string("fallback"),
-                            "failure_reason": .string(failureReason),
-                        ],
-                        uniquingKeysWith: { _, new in new }
-                    )
-                )
-            } else if warmupResult.context != nil {
-                logger.debug(
-                    "Refresh code issues warm-up completed",
-                    metadata: warmupMetadata.merging(
-                        ["warmup_stage": .string("ready")],
-                        uniquingKeysWith: { _, new in new }
-                    )
-                )
-            }
-            var finalResult: RefreshForwardAttemptResult = .invalidRequest
-
-            resultLoop: for attemptIndex in 0...Self.refreshRetryDelaysNanos.count {
-                let attempt = attemptIndex + 1
-                let attemptMetadata = warmupMetadata.merging(
-                    ["attempt": .string("\(attempt)")],
-                    uniquingKeysWith: { _, new in new }
-                )
-                if let context = warmupResult.context {
-                    let touched = await warmupDriver.touchResolvedTarget(context)
+        do {
+            return try await refreshCodeIssuesCoordinator.withPermit(
+                key: refreshRequest.queueKey
+            ) { permit in
+                let baseMetadata: Logger.Metadata = [
+                    "session": .string(sessionId),
+                    "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
+                    "queue_key": .string(refreshRequest.queueKey),
+                ]
+                let queueMetadata: Logger.Metadata = [
+                    "pending_for_key": .string("\(permit.pendingForKey)"),
+                    "pending_total": .string("\(permit.pendingTotal)"),
+                ]
+                if permit.queuePosition > 0 {
                     logger.debug(
-                        "Refresh code issues warm-up touch",
-                        metadata: attemptMetadata.merging(
-                            [
-                                "warmup_stage": .string("touch"),
-                                "touch_result": .string(touched ? "ready" : "failed"),
-                            ],
+                        "Queued refresh code issues request",
+                        metadata: baseMetadata.merging(
+                            queueMetadata.merging(
+                                ["queued_ahead": .string("\(permit.queuePosition)")],
+                                uniquingKeysWith: { _, new in new }
+                            ),
                             uniquingKeysWith: { _, new in new }
                         )
                     )
                 }
-
-                let result = await forwardOnce(
-                    bodyData: bodyData,
-                    sessionId: sessionId,
-                    requestIDs: requestIDs,
-                    requestIsBatch: requestIsBatch,
-                    eventLoop: eventLoop
-                )
-
-                switch result {
-                case .success(let responseData):
-                    let retryable = isRetryableRefreshCodeIssuesFailure(responseData)
-                    if retryable, attemptIndex < Self.refreshRetryDelaysNanos.count {
-                        let delayNanos = Self.refreshRetryDelaysNanos[attemptIndex]
-                        logger.debug(
-                            "Retrying refresh code issues request after error 5",
-                            metadata: attemptMetadata.merging(
-                                ["delay_ms": .string("\(delayNanos / 1_000_000)")],
-                                uniquingKeysWith: { _, new in new }
-                            )
-                        )
-                        try? await Task.sleep(nanoseconds: delayNanos)
-                        continue
-                    }
-                    if retryable {
-                        logger.debug(
-                            "Refresh code issues request still failing after retries",
-                            metadata: attemptMetadata
-                        )
-                    }
-                    finalResult = .success(responseData)
-                    break resultLoop
-                case .timeout, .upstreamUnavailable, .invalidRequest, .invalidUpstreamResponse:
-                    finalResult = result
-                    break resultLoop
-                }
-            }
-
-            let restoreResult = await warmupDriver.restore(warmupResult.context)
-            if warmupResult.context?.snapshot != nil {
                 logger.debug(
-                    "Refresh code issues restore finished",
-                    metadata: warmupMetadata.merging(
-                        ["restore_result": .string(restoreResult)],
+                    "Dequeued refresh code issues request",
+                    metadata: baseMetadata.merging(
+                        queueMetadata,
                         uniquingKeysWith: { _, new in new }
                     )
                 )
+
+                let warmupResult = await warmupDriver.warmUp(
+                    tabIdentifier: refreshRequest.tabIdentifier,
+                    filePath: refreshRequest.filePath,
+                    sessionId: sessionId,
+                    eventLoop: eventLoop,
+                    windowsProvider: { sessionId, eventLoop in
+                        await self.listXcodeWindows(
+                            sessionId: sessionId,
+                            eventLoop: eventLoop
+                        )
+                    }
+                )
+                let warmupMetadata = baseMetadata
+                    .merging(
+                        [
+                            "workspace_path": .string(warmupResult.workspacePath ?? "none"),
+                            "requested_file_path": .string(refreshRequest.filePath ?? "none"),
+                            "resolved_file_path": .string(warmupResult.resolvedFilePath ?? "none"),
+                        ],
+                        uniquingKeysWith: { _, new in new }
+                    )
+
+                if let failureReason = warmupResult.failureReason,
+                    failureReason != "disabled",
+                    failureReason != "missing tabIdentifier",
+                    failureReason != "missing filePath"
+                {
+                    logger.debug(
+                        "Refresh code issues warm-up fell back to plain refresh",
+                        metadata: warmupMetadata.merging(
+                            [
+                                "warmup_stage": .string("fallback"),
+                                "failure_reason": .string(failureReason),
+                            ],
+                            uniquingKeysWith: { _, new in new }
+                        )
+                    )
+                } else if warmupResult.context != nil {
+                    logger.debug(
+                        "Refresh code issues warm-up completed",
+                        metadata: warmupMetadata.merging(
+                            ["warmup_stage": .string("ready")],
+                            uniquingKeysWith: { _, new in new }
+                        )
+                    )
+                }
+                var finalResult: RefreshForwardAttemptResult = .invalidRequest
+
+                resultLoop: for attemptIndex in 0...Self.refreshRetryDelaysNanos.count {
+                    let attempt = attemptIndex + 1
+                    let attemptMetadata = warmupMetadata.merging(
+                        ["attempt": .string("\(attempt)")],
+                        uniquingKeysWith: { _, new in new }
+                    )
+                    if let context = warmupResult.context {
+                        let touched = await warmupDriver.touchResolvedTarget(context)
+                        logger.debug(
+                            "Refresh code issues warm-up touch",
+                            metadata: attemptMetadata.merging(
+                                [
+                                    "warmup_stage": .string("touch"),
+                                    "touch_result": .string(touched ? "ready" : "failed"),
+                                ],
+                                uniquingKeysWith: { _, new in new }
+                            )
+                        )
+                    }
+
+                    let result = await forwardOnce(
+                        bodyData: bodyData,
+                        sessionId: sessionId,
+                        requestIDs: requestIDs,
+                        requestIsBatch: requestIsBatch,
+                        eventLoop: eventLoop
+                    )
+
+                    switch result {
+                    case .success(let responseData):
+                        let retryable = isRetryableRefreshCodeIssuesFailure(responseData)
+                        if retryable, attemptIndex < Self.refreshRetryDelaysNanos.count {
+                            let delayNanos = Self.refreshRetryDelaysNanos[attemptIndex]
+                            logger.debug(
+                                "Retrying refresh code issues request after error 5",
+                                metadata: attemptMetadata.merging(
+                                    ["delay_ms": .string("\(delayNanos / 1_000_000)")],
+                                    uniquingKeysWith: { _, new in new }
+                                )
+                            )
+                            try? await Task.sleep(nanoseconds: delayNanos)
+                            continue
+                        }
+                        if retryable {
+                            logger.debug(
+                                "Refresh code issues request still failing after retries",
+                                metadata: attemptMetadata
+                            )
+                        }
+                        finalResult = .success(responseData)
+                        break resultLoop
+                    case .timeout, .upstreamUnavailable, .overloaded, .invalidRequest,
+                        .invalidUpstreamResponse:
+                        finalResult = result
+                        break resultLoop
+                    }
+                }
+
+                let restoreResult = await warmupDriver.restore(warmupResult.context)
+                if warmupResult.context?.snapshot != nil {
+                    logger.debug(
+                        "Refresh code issues restore finished",
+                        metadata: warmupMetadata.merging(
+                            ["restore_result": .string(restoreResult)],
+                            uniquingKeysWith: { _, new in new }
+                        )
+                    )
+                }
+                return finalResult
             }
-            return finalResult
+        } catch RefreshCodeIssuesCoordinator.AcquireError.queueLimitExceeded {
+            logger.warning(
+                "Rejected refresh code issues request because queue is full",
+                metadata: [
+                    "session": .string(sessionId),
+                    "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
+                    "queue_key": .string(refreshRequest.queueKey),
+                ]
+            )
+            return .overloaded(responseIds: requestIDs, isBatch: requestIsBatch)
+        } catch RefreshCodeIssuesCoordinator.AcquireError.queueWaitTimedOut {
+            logger.warning(
+                "Rejected refresh code issues request after queue wait timeout",
+                metadata: [
+                    "session": .string(sessionId),
+                    "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
+                    "queue_key": .string(refreshRequest.queueKey),
+                ]
+            )
+            return .overloaded(responseIds: requestIDs, isBatch: requestIsBatch)
+        } catch is CancellationError {
+            logger.debug(
+                "Cancelled queued refresh code issues request",
+                metadata: [
+                    "session": .string(sessionId),
+                    "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
+                    "queue_key": .string(refreshRequest.queueKey),
+                ]
+            )
+            return .overloaded(responseIds: requestIDs, isBatch: requestIsBatch)
+        } catch {
+            return .invalidRequest
         }
     }
 
@@ -1354,6 +1406,29 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     ids: responseIds,
                     code: -32001,
                     message: "upstream unavailable",
+                    forceBatchArray: isBatch,
+                    prefersEventStream: prefersEventStream,
+                    keepAlive: keepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            }
+        case .overloaded(let responseIds, let isBatch):
+            if responseIds.isEmpty {
+                sendPlain(
+                    on: channel,
+                    status: .tooManyRequests,
+                    body: "refresh queue overloaded",
+                    keepAlive: keepAlive,
+                    sessionId: sessionId,
+                    requestLog: requestLog
+                )
+            } else {
+                sendMCPError(
+                    on: channel,
+                    ids: responseIds,
+                    code: -32003,
+                    message: "refresh queue overloaded",
                     forceBatchArray: isBatch,
                     prefersEventStream: prefersEventStream,
                     keepAlive: keepAlive,

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -17,7 +17,9 @@ public final class ProxyServer {
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = group.next()
         self.sessionManager = SessionManager(config: config, eventLoop: eventLoop)
-        self.refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+        self.refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator.makeDefault(
+            requestTimeout: config.requestTimeout
+        )
         self.warmupDriver = XcodeEditorWarmupDriver()
     }
 

--- a/Sources/XcodeMCPProxy/RefreshCodeIssuesCoordinator.swift
+++ b/Sources/XcodeMCPProxy/RefreshCodeIssuesCoordinator.swift
@@ -87,7 +87,7 @@ actor RefreshCodeIssuesCoordinator {
         let timeoutTask = Task { [queueWaitTimeoutNanoseconds] in
             do {
                 try await Task.sleep(nanoseconds: queueWaitTimeoutNanoseconds)
-                await self.timeoutWaiter(key: key, waiterID: waiterID)
+                self.timeoutWaiter(key: key, waiterID: waiterID)
             } catch {
                 return
             }

--- a/Sources/XcodeMCPProxy/RefreshCodeIssuesCoordinator.swift
+++ b/Sources/XcodeMCPProxy/RefreshCodeIssuesCoordinator.swift
@@ -1,20 +1,58 @@
 import Foundation
 
 actor RefreshCodeIssuesCoordinator {
-    private struct Waiter {
-        let continuation: CheckedContinuation<Void, Never>
+    struct Permit: Sendable {
+        let queuePosition: Int
+        let pendingForKey: Int
+        let pendingTotal: Int
     }
 
+    enum AcquireError: Error {
+        case queueLimitExceeded
+        case queueWaitTimedOut
+    }
+
+    private struct Waiter {
+        let id: UInt64
+        let permit: Permit
+        let continuation: CheckedContinuation<Permit, Error>
+    }
+
+    private let maxPendingPerKey: Int
+    private let maxPendingTotal: Int
+    private let queueWaitTimeoutNanoseconds: UInt64
+    private var nextWaiterID: UInt64 = 0
     private var busyKeys: Set<String> = []
+    private var pendingWaiterCount = 0
     private var waitersByKey: [String: [Waiter]] = [:]
+
+    static func defaultQueueWaitTimeout(for requestTimeout: TimeInterval) -> TimeInterval {
+        requestTimeout > 0 ? min(requestTimeout, 30) : 30
+    }
+
+    static func makeDefault(requestTimeout: TimeInterval) -> RefreshCodeIssuesCoordinator {
+        RefreshCodeIssuesCoordinator(
+            queueWaitTimeout: defaultQueueWaitTimeout(for: requestTimeout)
+        )
+    }
+
+    init(
+        maxPendingPerKey: Int = 4,
+        maxPendingTotal: Int = 32,
+        queueWaitTimeout: TimeInterval = 30
+    ) {
+        self.maxPendingPerKey = max(0, maxPendingPerKey)
+        self.maxPendingTotal = max(0, maxPendingTotal)
+        self.queueWaitTimeoutNanoseconds = Self.nanoseconds(from: queueWaitTimeout)
+    }
 
     func withPermit<T: Sendable>(
         key: String,
-        body: @Sendable (_ queuePosition: Int) async throws -> T
-    ) async rethrows -> T {
-        let queuePosition = await acquire(key: key)
+        body: @Sendable (_ permit: Permit) async throws -> T
+    ) async throws -> T {
+        let permit = try await acquire(key: key)
         do {
-            let result = try await body(queuePosition)
+            let result = try await body(permit)
             release(key: key)
             return result
         } catch {
@@ -23,17 +61,97 @@ actor RefreshCodeIssuesCoordinator {
         }
     }
 
-    private func acquire(key: String) async -> Int {
+    private func acquire(key: String) async throws -> Permit {
         if busyKeys.contains(key) == false {
             busyKeys.insert(key)
-            return 0
+            return Permit(
+                queuePosition: 0,
+                pendingForKey: 0,
+                pendingTotal: pendingWaiterCount
+            )
         }
 
-        let queuePosition = (waitersByKey[key]?.count ?? 0) + 1
-        await withCheckedContinuation { continuation in
-            waitersByKey[key, default: []].append(Waiter(continuation: continuation))
+        let waiterCountForKey = waitersByKey[key]?.count ?? 0
+        guard waiterCountForKey < maxPendingPerKey, pendingWaiterCount < maxPendingTotal else {
+            throw AcquireError.queueLimitExceeded
         }
-        return queuePosition
+
+        let waiterID = nextWaiterID
+        nextWaiterID &+= 1
+        let permit = Permit(
+            queuePosition: waiterCountForKey + 1,
+            pendingForKey: waiterCountForKey + 1,
+            pendingTotal: pendingWaiterCount + 1
+        )
+
+        let timeoutTask = Task { [queueWaitTimeoutNanoseconds] in
+            do {
+                try await Task.sleep(nanoseconds: queueWaitTimeoutNanoseconds)
+                await self.timeoutWaiter(key: key, waiterID: waiterID)
+            } catch {
+                return
+            }
+        }
+
+        return try await withTaskCancellationHandler(
+            operation: {
+                defer { timeoutTask.cancel() }
+
+                return try await withCheckedThrowingContinuation { continuation in
+                    waitersByKey[key, default: []].append(
+                        Waiter(
+                            id: waiterID,
+                            permit: permit,
+                            continuation: continuation
+                        )
+                    )
+                    pendingWaiterCount += 1
+
+                    if Task.isCancelled {
+                        failWaiter(
+                            key: key,
+                            waiterID: waiterID,
+                            error: CancellationError()
+                        )
+                    }
+                }
+            },
+            onCancel: {
+                timeoutTask.cancel()
+                Task {
+                    await self.cancelWaiter(key: key, waiterID: waiterID)
+                }
+            }
+        )
+    }
+
+    private func cancelWaiter(key: String, waiterID: UInt64) {
+        failWaiter(key: key, waiterID: waiterID, error: CancellationError())
+    }
+
+    private func timeoutWaiter(key: String, waiterID: UInt64) {
+        failWaiter(
+            key: key,
+            waiterID: waiterID,
+            error: AcquireError.queueWaitTimedOut
+        )
+    }
+
+    private func failWaiter(key: String, waiterID: UInt64, error: Error) {
+        guard var waiters = waitersByKey[key],
+            let index = waiters.firstIndex(where: { $0.id == waiterID })
+        else {
+            return
+        }
+
+        let waiter = waiters.remove(at: index)
+        pendingWaiterCount -= 1
+        if waiters.isEmpty {
+            waitersByKey.removeValue(forKey: key)
+        } else {
+            waitersByKey[key] = waiters
+        }
+        waiter.continuation.resume(throwing: error)
     }
 
     private func release(key: String) {
@@ -44,11 +162,21 @@ actor RefreshCodeIssuesCoordinator {
         }
 
         let next = waiters.removeFirst()
+        pendingWaiterCount -= 1
         if waiters.isEmpty {
             waitersByKey.removeValue(forKey: key)
         } else {
             waitersByKey[key] = waiters
         }
-        next.continuation.resume()
+        next.continuation.resume(returning: next.permit)
+    }
+
+    private static func nanoseconds(from interval: TimeInterval) -> UInt64 {
+        let clamped = max(0, interval)
+        let nanoseconds = clamped * 1_000_000_000
+        if nanoseconds >= Double(UInt64.max) {
+            return UInt64.max
+        }
+        return UInt64(nanoseconds.rounded(.up))
     }
 }

--- a/Sources/XcodeMCPProxy/SessionManager.swift
+++ b/Sources/XcodeMCPProxy/SessionManager.swift
@@ -254,12 +254,22 @@ final class SessionManager: Sendable, SessionManaging {
     }
 
     func shutdown() {
-        let globalTimeout = initState.withLockedValue { state -> Scheduled<Void>? in
+        let pendingInitializes = initState.withLockedValue { state -> [InitPending] in
             state.isShuttingDown = true
             state.initInFlight = false
+            let pending = state.initPending
+            state.initPending.removeAll()
+            return pending
+        }
+        for pending in pendingInitializes {
+            pending.eventLoop.execute {
+                pending.promise.fail(CancellationError())
+            }
+        }
+
+        let globalTimeout = initState.withLockedValue { state -> Scheduled<Void>? in
             let existing = state.initTimeout
             state.initTimeout = nil
-            state.initPending.removeAll()
             return existing
         }
         globalTimeout?.cancel()

--- a/Tests/XcodeMCPKitTests/HTTPConcurrencyTests.swift
+++ b/Tests/XcodeMCPKitTests/HTTPConcurrencyTests.swift
@@ -210,7 +210,9 @@ private struct TestHTTPServer {
         let upstream = providedUpstream ?? EchoUpstreamClient()
         let sessionManager = SessionManager(
             config: config, eventLoop: group.next(), upstreams: [upstream])
-        let refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator()
+        let refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator.makeDefault(
+            requestTimeout: config.requestTimeout
+        )
         let warmupDriver = XcodeEditorWarmupDriver.disabled()
 
         let bootstrap = ServerBootstrap(group: group)

--- a/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyTests/HTTPHandlerTests.swift
@@ -1458,7 +1458,7 @@ struct HTTPHandlerTests {
         let secondEntered = NIOLockedValueBox(false)
 
         let firstTask = Task<Void, Never> {
-            _ = await coordinator.withPermit(key: "windowtab-same") { _ in
+            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
                 await firstEntered.signal()
                 await releaseFirst.wait()
             }
@@ -1466,7 +1466,7 @@ struct HTTPHandlerTests {
         await firstEntered.wait()
 
         let secondTask = Task<Void, Never> {
-            _ = await coordinator.withPermit(key: "windowtab-same") { _ in
+            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
                 secondEntered.withLockedValue { value in
                     value = true
                 }
@@ -1490,7 +1490,7 @@ struct HTTPHandlerTests {
         let releaseFirst = AsyncSignal()
 
         let firstTask = Task<Void, Never> {
-            _ = await coordinator.withPermit(key: "windowtab-a") { _ in
+            _ = try? await coordinator.withPermit(key: "windowtab-a") { _ in
                 await firstEntered.signal()
                 await releaseFirst.wait()
             }
@@ -1498,7 +1498,7 @@ struct HTTPHandlerTests {
         await firstEntered.wait()
 
         let secondTask = Task<Void, Never> {
-            _ = await coordinator.withPermit(key: "windowtab-b") { _ in
+            _ = try? await coordinator.withPermit(key: "windowtab-b") { _ in
                 await secondEntered.signal()
             }
         }
@@ -1508,6 +1508,164 @@ struct HTTPHandlerTests {
         _ = await firstTask.value
         _ = await secondTask.value
         #expect(Bool(true))
+    }
+
+    @Test func httpRefreshCodeIssuesRejectsWhenPerKeyQueueLimitIsExceeded() async throws {
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 1,
+            maxPendingTotal: 8,
+            queueWaitTimeout: 5
+        )
+        let firstEntered = AsyncSignal()
+        let releaseFirst = AsyncSignal()
+        let secondEntered = AsyncSignal()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
+                await firstEntered.signal()
+                await releaseFirst.wait()
+            }
+        }
+        await firstEntered.wait()
+
+        let secondTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
+                await secondEntered.signal()
+            }
+        }
+
+        await Task.yield()
+        await Task.yield()
+
+        do {
+            _ = try await coordinator.withPermit(key: "windowtab-same") { _ in
+                ()
+            }
+            #expect(Bool(false))
+        } catch RefreshCodeIssuesCoordinator.AcquireError.queueLimitExceeded {
+            #expect(Bool(true))
+        }
+
+        await releaseFirst.signal()
+        await secondEntered.wait()
+        _ = await firstTask.value
+        _ = await secondTask.value
+    }
+
+    @Test func httpRefreshCodeIssuesRejectsWhenGlobalQueueLimitIsExceeded() async throws {
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 4,
+            maxPendingTotal: 0,
+            queueWaitTimeout: 5
+        )
+        let firstEntered = AsyncSignal()
+        let releaseFirst = AsyncSignal()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-a") { _ in
+                await firstEntered.signal()
+                await releaseFirst.wait()
+            }
+        }
+        await firstEntered.wait()
+
+        do {
+            _ = try await coordinator.withPermit(key: "windowtab-a") { _ in
+                ()
+            }
+            #expect(Bool(false))
+        } catch RefreshCodeIssuesCoordinator.AcquireError.queueLimitExceeded {
+            #expect(Bool(true))
+        }
+
+        await releaseFirst.signal()
+        _ = await firstTask.value
+    }
+
+    @Test func httpRefreshCodeIssuesTimeoutRemovesQueuedWaiter() async throws {
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 1,
+            maxPendingTotal: 4,
+            queueWaitTimeout: 0.05
+        )
+        let firstEntered = AsyncSignal()
+        let releaseFirst = AsyncSignal()
+        let thirdEntered = AsyncSignal()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-timeout") { _ in
+                await firstEntered.signal()
+                await releaseFirst.wait()
+            }
+        }
+        await firstEntered.wait()
+
+        do {
+            _ = try await coordinator.withPermit(key: "windowtab-timeout") { _ in
+                ()
+            }
+            #expect(Bool(false))
+        } catch RefreshCodeIssuesCoordinator.AcquireError.queueWaitTimedOut {
+            #expect(Bool(true))
+        }
+
+        let thirdTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-timeout") { _ in
+                await thirdEntered.signal()
+            }
+        }
+
+        await Task.yield()
+        await releaseFirst.signal()
+        await thirdEntered.wait()
+        _ = await firstTask.value
+        _ = await thirdTask.value
+    }
+
+    @Test func httpRefreshCodeIssuesCancellationRemovesQueuedWaiter() async throws {
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 1,
+            maxPendingTotal: 4,
+            queueWaitTimeout: 5
+        )
+        let firstEntered = AsyncSignal()
+        let releaseFirst = AsyncSignal()
+        let thirdEntered = AsyncSignal()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-cancel") { _ in
+                await firstEntered.signal()
+                await releaseFirst.wait()
+            }
+        }
+        await firstEntered.wait()
+
+        let cancelledTask = Task<Void, Error> {
+            _ = try await coordinator.withPermit(key: "windowtab-cancel") { _ in
+                ()
+            }
+        }
+        await Task.yield()
+        cancelledTask.cancel()
+        let cancelledResult = await cancelledTask.result
+        switch cancelledResult {
+        case .failure(let error):
+            #expect(error is CancellationError)
+        case .success:
+            #expect(Bool(false))
+        }
+
+        let thirdTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-cancel") { _ in
+                await thirdEntered.signal()
+            }
+        }
+
+        await Task.yield()
+        await releaseFirst.signal()
+        await thirdEntered.wait()
+        _ = await firstTask.value
+        _ = await thirdTask.value
     }
 
     @Test func httpRefreshCodeIssuesRetriesSourceEditorErrorFive() async throws {
@@ -1706,6 +1864,148 @@ struct HTTPHandlerTests {
         await server.shutdown()
     }
 
+    @Test func httpRefreshCodeIssuesReturnsBackpressureErrorWhenQueueIsFull() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 0,
+            maxPendingTotal: 8,
+            queueWaitTimeout: 5
+        )
+        let firstSent = SyncSignal()
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                firstSent.signal()
+                return .manual(try makeToolSuccessResponse(id: originalId, text: "ok"))
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager,
+            refreshCodeIssuesCoordinator: coordinator
+        )
+
+        do {
+            let firstTask = Task<Int, Error> {
+                let (response, _) = try await postHTTPJSON(
+                    url: server.url,
+                    sessionId: "session-overload-1",
+                    payload: toolsCallPayload(
+                        id: 21,
+                        name: "XcodeRefreshCodeIssuesInFile",
+                        arguments: [
+                            "tabIdentifier": "windowtab-overload",
+                            "filePath": "A.swift",
+                        ]
+                    )
+                )
+                return response.statusCode
+            }
+
+            await firstSent.wait()
+
+            let (secondResponse, secondBody) = try await postHTTPJSON(
+                url: server.url,
+                sessionId: "session-overload-2",
+                payload: toolsCallPayload(
+                    id: 22,
+                    name: "XcodeRefreshCodeIssuesInFile",
+                    arguments: [
+                        "tabIdentifier": "windowtab-overload",
+                        "filePath": "B.swift",
+                    ]
+                )
+            )
+
+            #expect(secondResponse.statusCode == 200)
+            let error = secondBody["error"] as? [String: Any]
+            #expect((error?["code"] as? NSNumber)?.intValue == -32003)
+            #expect((error?["message"] as? String) == "refresh queue overloaded")
+
+            sessionManager.deliverNextPendingResponse()
+            let firstStatusCode = try await firstTask.value
+            #expect(firstStatusCode == 200)
+            #expect(sessionManager.sentUpstreamCount() == 1)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpRefreshCodeIssuesReturnsBackpressureErrorAfterQueueWaitTimeout() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 4,
+            maxPendingTotal: 8,
+            queueWaitTimeout: 0.05
+        )
+        let firstSent = SyncSignal()
+        let sessionManager = TestSessionManager(
+            config: config,
+            upstreamPlanResponder: { method, originalId in
+                #expect(method == "tools/call")
+                firstSent.signal()
+                return .manual(try makeToolSuccessResponse(id: originalId, text: "ok"))
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager,
+            refreshCodeIssuesCoordinator: coordinator
+        )
+
+        do {
+            let firstTask = Task<Int, Error> {
+                let (response, _) = try await postHTTPJSON(
+                    url: server.url,
+                    sessionId: "session-timeout-1",
+                    payload: toolsCallPayload(
+                        id: 24,
+                        name: "XcodeRefreshCodeIssuesInFile",
+                        arguments: [
+                            "tabIdentifier": "windowtab-timeout",
+                            "filePath": "A.swift",
+                        ]
+                    )
+                )
+                return response.statusCode
+            }
+
+            await firstSent.wait()
+
+            let (secondResponse, secondBody) = try await postHTTPJSON(
+                url: server.url,
+                sessionId: "session-timeout-2",
+                payload: toolsCallPayload(
+                    id: 25,
+                    name: "XcodeRefreshCodeIssuesInFile",
+                    arguments: [
+                        "tabIdentifier": "windowtab-timeout",
+                        "filePath": "B.swift",
+                    ]
+                )
+            )
+
+            #expect(secondResponse.statusCode == 200)
+            let error = secondBody["error"] as? [String: Any]
+            #expect((error?["code"] as? NSNumber)?.intValue == -32003)
+            #expect((error?["message"] as? String) == "refresh queue overloaded")
+
+            sessionManager.deliverNextPendingResponse()
+            let firstStatusCode = try await firstTask.value
+            #expect(firstStatusCode == 200)
+            #expect(sessionManager.sentUpstreamCount() == 1)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
     @Test func httpRefreshWarmupInternalWindowLookupDoesNotResetUpstreamSuccessState() async throws {
         let config = makeConfig(requestTimeout: 0.05)
         let attempts = NIOLockedValueBox(0)
@@ -1783,16 +2083,21 @@ private enum HTTPTestError: Error {
 private struct UpstreamResponsePlan {
     let data: Data
     let delayNanos: UInt64?
+    let deliverManually: Bool
 
     static func immediate(_ data: Data) -> UpstreamResponsePlan {
-        UpstreamResponsePlan(data: data, delayNanos: nil)
+        UpstreamResponsePlan(data: data, delayNanos: nil, deliverManually: false)
     }
 
     static func delayed(
         _ data: Data,
         delayNanos: UInt64
     ) -> UpstreamResponsePlan {
-        UpstreamResponsePlan(data: data, delayNanos: delayNanos)
+        UpstreamResponsePlan(data: data, delayNanos: delayNanos, deliverManually: false)
+    }
+
+    static func manual(_ data: Data) -> UpstreamResponsePlan {
+        UpstreamResponsePlan(data: data, delayNanos: nil, deliverManually: true)
     }
 }
 
@@ -1848,6 +2153,11 @@ private final class TestSessionManager: SessionManaging {
     }
 
     private struct State: Sendable {
+        struct PendingResponse: Sendable {
+            let sessionId: String
+            let data: Data
+        }
+
         var sessions: [String: SessionContext] = [:]
         var nextUpstreamId: Int64 = 1
         var assignUpstreamIdCount = 0
@@ -1860,6 +2170,7 @@ private final class TestSessionManager: SessionManaging {
         var availableUpstreamIndex: Int? = 0
         var requestTimeoutNotifications = 0
         var requestSuccessNotifications = 0
+        var pendingResponses: [PendingResponse] = []
     }
 
     private let state = NIOLockedValueBox(State())
@@ -2040,7 +2351,16 @@ private final class TestSessionManager: SessionManaging {
             let session = self.session(id: mapping.sessionId)
             session.router.handleIncoming(responsePlan.data)
         }
-        if let delayNanos = responsePlan.delayNanos {
+        if responsePlan.deliverManually {
+            state.withLockedValue { state in
+                state.pendingResponses.append(
+                    State.PendingResponse(
+                        sessionId: mapping.sessionId,
+                        data: responsePlan.data
+                    )
+                )
+            }
+        } else if let delayNanos = responsePlan.delayNanos {
             Task {
                 try? await Task.sleep(nanoseconds: delayNanos)
                 deliverResponse()
@@ -2123,6 +2443,16 @@ private final class TestSessionManager: SessionManaging {
     func setInitialized(_ value: Bool) {
         state.withLockedValue { $0.initialized = value }
     }
+
+    func deliverNextPendingResponse() {
+        let pending = state.withLockedValue { state -> State.PendingResponse? in
+            guard state.pendingResponses.isEmpty == false else { return nil }
+            return state.pendingResponses.removeFirst()
+        }
+        guard let pending else { return }
+        let session = session(id: pending.sessionId)
+        session.router.handleIncoming(pending.data)
+    }
 }
 
 private func makeConfig(
@@ -2153,7 +2483,7 @@ private func addHTTPHandler(
     to channel: EmbeddedChannel,
     config: ProxyConfig,
     sessionManager: any SessionManaging,
-    refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator(),
+    refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
     warmupDriver: XcodeEditorWarmupDriver = .disabled()
 ) throws {
     let handler = HTTPHandler(
@@ -2240,7 +2570,7 @@ private struct TestHTTPHandlerServer {
     static func start(
         config: ProxyConfig,
         sessionManager: any SessionManaging,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator(),
+        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
         warmupDriver: XcodeEditorWarmupDriver = .disabled()
     ) throws -> TestHTTPHandlerServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -2324,6 +2654,48 @@ private actor AsyncSignal {
         signaled = true
         let continuations = waiters
         waiters.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}
+
+private final class SyncSignal: @unchecked Sendable {
+    private struct State {
+        var signaled = false
+        var waiters: [CheckedContinuation<Void, Never>] = []
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    func wait() async {
+        if state.withLockedValue({ $0.signaled }) {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            let shouldResume = state.withLockedValue { state in
+                if state.signaled {
+                    return true
+                }
+                state.waiters.append(continuation)
+                return false
+            }
+            if shouldResume {
+                continuation.resume()
+            }
+        }
+    }
+
+    func signal() {
+        let continuations = state.withLockedValue { state -> [CheckedContinuation<Void, Never>] in
+            guard state.signaled == false else { return [] }
+            state.signaled = true
+            let waiters = state.waiters
+            state.waiters.removeAll()
+            return waiters
+        }
+
         for continuation in continuations {
             continuation.resume()
         }

--- a/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
+++ b/Tests/XcodeMCPProxyTests/SessionManagerTests.swift
@@ -14,6 +14,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let request1 = makeInitializeRequest(id: 1)
         let request2 = makeInitializeRequest(id: 2)
@@ -52,6 +53,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let sessionId = "session-A"
         let session = manager.session(id: sessionId)
@@ -92,6 +94,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let sessionId = "session-handshake"
         let session = manager.session(id: sessionId)
@@ -132,6 +135,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let firstFuture = manager.registerInitialize(
             sessionId: "session-A",
@@ -178,6 +182,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let sessionId = "session-removed"
         _ = manager.session(id: sessionId)
@@ -206,6 +211,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let sessionId = "session-recreated"
         _ = manager.session(id: sessionId)
@@ -251,6 +257,7 @@ struct SessionManagerTests {
         let upstream1 = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: true, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
         let init0 = await upstream0.sent()
@@ -311,6 +318,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 1)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let request = makeInitializeRequest(id: 1)
         let future = manager.registerInitialize(
@@ -342,6 +350,29 @@ struct SessionManagerTests {
         #expect((await upstream.sent()).count == 2)
     }
 
+    @Test func sessionManagerShutdownFailsPendingInitializeRequests() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        let future = manager.registerInitialize(
+            originalId: RPCId(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+
+        manager.shutdown()
+
+        await #expect(throws: CancellationError.self) {
+            try await future.get()
+        }
+    }
+
     @Test func sessionManagerTimeoutDoesNotClearRecreatedSessionInitializeRoutingState()
         async throws
     {
@@ -351,6 +382,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 0.1)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let sessionId = "session-timeout-recreated"
         _ = manager.session(id: sessionId)
@@ -393,6 +425,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let sessionId = "session-error-recreated"
         _ = manager.session(id: sessionId)
@@ -451,6 +484,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: true, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
         #expect(manager.isInitialized() == false)
 
         _ = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
@@ -467,6 +501,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let request = makeInitializeRequest(id: 1)
         let future = manager.registerInitialize(
@@ -501,6 +536,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         // First init establishes the cached init result.
         let init1 = manager.registerInitialize(
@@ -545,6 +581,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // First init establishes the cached init result (primary only).
         let init1 = manager.registerInitialize(
@@ -613,6 +650,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Initialize both upstreams.
         let init0 = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
@@ -668,6 +706,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Initialize both upstreams.
         let init0 = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
@@ -721,6 +760,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Eager init -> upstream0
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
@@ -797,6 +837,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Initialize both upstreams.
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
@@ -860,6 +901,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Initialize both upstreams.
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
@@ -907,6 +949,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let sessionId = "session-A"
         let session = manager.session(id: sessionId)
@@ -931,6 +974,7 @@ struct SessionManagerTests {
         let upstream = TestUpstreamClient()
         let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
         let initMessages = await upstream.sent()
@@ -1033,6 +1077,7 @@ struct SessionManagerTests {
         config.prewarmToolsList = true
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Initialize primary upstream0.
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
@@ -1110,6 +1155,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Initialize both upstreams.
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
@@ -1161,6 +1207,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
         let init0 = await upstream0.sent()
@@ -1201,6 +1248,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Initialize both upstreams.
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
@@ -1267,6 +1315,7 @@ struct SessionManagerTests {
         let upstream = AlwaysOverloadedUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let sessionId = "session-overloaded"
         let session = manager.session(id: sessionId)
@@ -1307,6 +1356,7 @@ struct SessionManagerTests {
         let upstream = AlwaysOverloadedUpstreamClient()
         let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
         let manager = SessionManager(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
 
         let original = RPCId(any: NSNumber(value: 1001))!
         let future = manager.registerInitialize(
@@ -1337,6 +1387,7 @@ struct SessionManagerTests {
         let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
         let manager = SessionManager(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        defer { manager.shutdown() }
 
         // Initialize both upstreams.
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)


### PR DESCRIPTION
Summary:
- Bound `XcodeRefreshCodeIssuesInFile` queueing with per-key/global limits, queue wait timeout, cancellation cleanup, and explicit backpressure responses
- Added coordinator/HTTP coverage for queue overload, queue wait timeout, and waiter cleanup, and switched the new handler tests to signal/manual-response coordination instead of timing-only ordering
- Fail pending initialize promises during `SessionManager.shutdown()` and call `manager.shutdown()` across `SessionManagerTests` to avoid lingering test helpers on shutdown paths
- Update troubleshooting docs for refresh queue backpressure and include the `.gitignore` build directory pattern change in this branch

Testing:
- `swift test --scratch-path .build-codex-r2 --filter SessionManagerTests`
- `swift test --scratch-path .build-codex-r2 --filter HTTPConcurrencyTests`
- `swift test --scratch-path .build-codex-r2`
- `codex-review-quiet.sh -C /Users/kn/Dev/XcodeMCPKit --uncommitted`