### PR TITLE
refactor(proxy-cli): normalize PID naming

### DIFF
--- a/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
+++ b/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
@@ -14,7 +14,7 @@ package struct ProxyCLIServerScan {
     package var hasListenFlag = false
     package var hasHostFlag = false
     package var hasPortFlag = false
-    package var hasXcodePidFlag = false
+    package var hasXcodePIDFlag = false
     package var hasLazyInitFlag = false
     package var forceRestart = false
     package var dryRun = false
@@ -146,7 +146,7 @@ package enum ProxyCLIInvocationScanner {
             case "--port":
                 scan.hasPortFlag = true
             case "--xcode-pid":
-                scan.hasXcodePidFlag = true
+                scan.hasXcodePIDFlag = true
             default:
                 break
             }

--- a/Sources/ProxyCLI/ProxyServerCommandRuntime.swift
+++ b/Sources/ProxyCLI/ProxyServerCommandRuntime.swift
@@ -15,12 +15,12 @@ package struct ProxyServerCommandRuntime {
                 dependencies.stdout(XcodeMCPProxyServerCommand.serverUsage())
                 return 0
             }
-            XcodeMCPProxyServerCommand.applyDefaults(
-                from: environment,
-                to: &options,
-                resolveXcodePid: dependencies.resolveXcodePid,
-                stderr: dependencies.stderr
-            )
+        XcodeMCPProxyServerCommand.applyDefaults(
+            from: environment,
+            to: &options,
+            resolveXcodePID: dependencies.resolveXcodePID,
+            stderr: dependencies.stderr
+        )
 
             let isDryRun = options.dryRun || XcodeMCPProxyServerCommand.isTruthy(environment["DRY_RUN"])
             if isDryRun {

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
@@ -10,7 +10,7 @@ extension XcodeMCPProxyServerCommand {
             hasListenFlag: scan.hasListenFlag,
             hasHostFlag: scan.hasHostFlag,
             hasPortFlag: scan.hasPortFlag,
-            hasXcodePidFlag: scan.hasXcodePidFlag,
+            hasXcodePIDFlag: scan.hasXcodePIDFlag,
             hasLazyInitFlag: scan.hasLazyInitFlag,
             forceRestart: scan.forceRestart,
             dryRun: scan.dryRun
@@ -20,7 +20,7 @@ extension XcodeMCPProxyServerCommand {
     package static func applyDefaults(
         from environment: [String: String],
         to options: inout ProxyServerOptions,
-        resolveXcodePid: () -> String?,
+        resolveXcodePID: () -> String?,
         stderr: (String) -> Void
     ) {
         if !options.hasListenFlag && !options.hasHostFlag && !options.hasPortFlag {
@@ -43,10 +43,10 @@ extension XcodeMCPProxyServerCommand {
             options.forwardedArgs += ["--port", "8765"]
         }
 
-        if !options.hasXcodePidFlag {
+        if !options.hasXcodePIDFlag {
             if let explicit = nonEmpty(environment["XCODE_PID"]) ?? nonEmpty(environment["MCP_XCODE_PID"]) {
                 options.forwardedArgs += ["--xcode-pid", explicit]
-            } else if let resolved = resolveXcodePid() {
+            } else if let resolved = resolveXcodePID() {
                 options.forwardedArgs += ["--xcode-pid", resolved]
             } else {
                 stderr("warning: Xcode PID not found; running without --xcode-pid.")

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+ProcessControl.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+ProcessControl.swift
@@ -20,7 +20,7 @@ extension XcodeMCPProxyServerCommand {
         return requested == actual
     }
 
-    static func resolveXcodePid() -> String? {
+    static func resolveXcodePID() -> String? {
         if let pid = firstLine(runCommand("/usr/bin/pgrep", ["-x", "Xcode"])) {
             return pid
         }

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
@@ -10,7 +10,7 @@ package struct ProxyServerOptions {
     package var hasListenFlag: Bool
     package var hasHostFlag: Bool
     package var hasPortFlag: Bool
-    package var hasXcodePidFlag: Bool
+    package var hasXcodePIDFlag: Bool
     package var hasLazyInitFlag: Bool
     package var forceRestart: Bool
     package var dryRun: Bool
@@ -21,7 +21,7 @@ package struct ProxyServerOptions {
         hasListenFlag: Bool,
         hasHostFlag: Bool,
         hasPortFlag: Bool,
-        hasXcodePidFlag: Bool,
+        hasXcodePIDFlag: Bool,
         hasLazyInitFlag: Bool,
         forceRestart: Bool,
         dryRun: Bool
@@ -31,7 +31,7 @@ package struct ProxyServerOptions {
         self.hasListenFlag = hasListenFlag
         self.hasHostFlag = hasHostFlag
         self.hasPortFlag = hasPortFlag
-        self.hasXcodePidFlag = hasXcodePidFlag
+        self.hasXcodePIDFlag = hasXcodePIDFlag
         self.hasLazyInitFlag = hasLazyInitFlag
         self.forceRestart = forceRestart
         self.dryRun = dryRun
@@ -54,7 +54,7 @@ package struct XcodeMCPProxyServerCommand {
         package var bootstrapLogging: ([String: String]) -> Void
         package var stdout: (String) -> Void
         package var stderr: (String) -> Void
-        package var resolveXcodePid: () -> String?
+        package var resolveXcodePID: () -> String?
         package var terminateExistingServer: (String, Int) -> Bool
         package var makeServer: (ProxyConfig) -> any ProxyServerCommandServer
         package var isAddressAlreadyInUse: (Error) -> Bool
@@ -64,7 +64,7 @@ package struct XcodeMCPProxyServerCommand {
             bootstrapLogging: @escaping ([String: String]) -> Void,
             stdout: @escaping (String) -> Void,
             stderr: @escaping (String) -> Void,
-            resolveXcodePid: @escaping () -> String?,
+            resolveXcodePID: @escaping () -> String?,
             terminateExistingServer: @escaping (String, Int) -> Bool,
             makeServer: @escaping (ProxyConfig) -> any ProxyServerCommandServer,
             isAddressAlreadyInUse: @escaping (Error) -> Bool,
@@ -73,7 +73,7 @@ package struct XcodeMCPProxyServerCommand {
             self.bootstrapLogging = bootstrapLogging
             self.stdout = stdout
             self.stderr = stderr
-            self.resolveXcodePid = resolveXcodePid
+            self.resolveXcodePID = resolveXcodePID
             self.terminateExistingServer = terminateExistingServer
             self.makeServer = makeServer
             self.isAddressAlreadyInUse = isAddressAlreadyInUse
@@ -85,7 +85,7 @@ package struct XcodeMCPProxyServerCommand {
                 bootstrapLogging: ProxyLogging.bootstrap,
                 stdout: { print($0) },
                 stderr: { FileHandle.writeLine($0, to: .standardError) },
-                resolveXcodePid: XcodeMCPProxyServerCommand.resolveXcodePid,
+                resolveXcodePID: XcodeMCPProxyServerCommand.resolveXcodePID,
                 terminateExistingServer: XcodeMCPProxyServerCommand.terminateExistingProxyServerIfNeeded,
                 makeServer: { ProxyServer(config: $0) },
                 isAddressAlreadyInUse: XcodeMCPProxyServerCommand.isAddressAlreadyInUse,

--- a/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
@@ -12,7 +12,7 @@ struct ServerCommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePid: { "4321" },
+                resolveXcodePID: { "4321" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in IntegrationRecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -41,7 +41,7 @@ struct ServerCommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 stderr: { _ in },
-                resolveXcodePid: { "1234" },
+                resolveXcodePID: { "1234" },
                 terminateExistingServer: { host, port in
                     restarted.append("\(host):\(port)")
                     return true

--- a/Tests/ProxyCLITests/ServerCommandTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandTests.swift
@@ -28,7 +28,7 @@ struct ServerCommandTests {
             hasListenFlag: false,
             hasHostFlag: false,
             hasPortFlag: false,
-            hasXcodePidFlag: false,
+            hasXcodePIDFlag: false,
             hasLazyInitFlag: false,
             forceRestart: false,
             dryRun: false
@@ -41,7 +41,7 @@ struct ServerCommandTests {
                 "LAZY_INIT": "1",
             ],
             to: &options,
-            resolveXcodePid: { "4242" },
+            resolveXcodePID: { "4242" },
             stderr: { _ in }
         )
 
@@ -93,7 +93,7 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 stderr: { _ in },
-                resolveXcodePid: { "1234" },
+                resolveXcodePID: { "1234" },
                 terminateExistingServer: { host, port in
                     restarted.append("\(host):\(port)")
                     return true
@@ -132,7 +132,7 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePid: { "5678" },
+                resolveXcodePID: { "5678" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -164,7 +164,7 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { errors.append($0) },
-                resolveXcodePid: { "7777" },
+                resolveXcodePID: { "7777" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -197,7 +197,7 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { errors.append($0) },
-                resolveXcodePid: { "7777" },
+                resolveXcodePID: { "7777" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },

--- a/Tests/ProxyIntegrationTests/DiscoveryTests.swift
+++ b/Tests/ProxyIntegrationTests/DiscoveryTests.swift
@@ -43,7 +43,7 @@ struct DiscoveryTests {
         #expect(Discovery.read(overrideURL: url) == nil)
     }
 
-    @Test func discoveryRejectsDeadPid() async throws {
+    @Test func discoveryRejectsDeadPID() async throws {
         let url = makeTempDiscoveryURL()
         defer { cleanupTempDiscoveryURL(url) }
         let record = DiscoveryRecord(


### PR DESCRIPTION
Summary:
- Rename `hasXcodePidFlag` to `hasXcodePIDFlag` across CLI scanner state and server option parsing.
- Rename `resolveXcodePid` to `resolveXcodePID` across command wiring and test doubles.
- Rename the discovery regression test to `discoveryRejectsDeadPID` for naming consistency.

Testing:
- `swift test --filter ProxyCLITests`
- `swift test`
- `swift test --filter ProxyIntegrationTests`

Related:
- None