### PR TITLE
fix(release): ad-hoc sign packaged binaries

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -102,7 +102,7 @@ for product in "${products[@]}"; do
   cp "$source_path" "$target_path"
   chmod +x "$target_path"
   if command -v codesign >/dev/null 2>&1; then
-    codesign --remove-signature "$target_path" >/dev/null 2>&1 || true
+    codesign --force --sign - "$target_path" >/dev/null
   fi
 done
 

--- a/scripts/package-universal.sh
+++ b/scripts/package-universal.sh
@@ -110,7 +110,7 @@ for product in "${products[@]}"; do
   lipo -create -output "$target" "$arm_bin/$product" "$x86_bin/$product"
   chmod +x "$target"
   if command -v codesign >/dev/null 2>&1; then
-    codesign --remove-signature "$target" >/dev/null 2>&1 || true
+    codesign --force --sign - "$target" >/dev/null
   fi
 done
 


### PR DESCRIPTION
Summary:
- Re-sign staged release binaries with ad-hoc signatures in `scripts/build-release.sh` instead of stripping code signatures
- Re-sign universal binaries after `lipo` in `scripts/package-universal.sh` so packaged release archives keep executable code signatures

Testing:
- `swift test -Xswiftc -strict-concurrency=minimal`
- `scripts/build-release.sh --arch arm64 --version vlocal-check --dist-root dist`
- `scripts/build-release.sh --arch x86_64 --version vlocal-check --dist-root dist`
- `scripts/package-universal.sh --dist-root dist --output-dir release`
- Verified `codesign --verify` and `xcode-mcp-proxy-server --help` for generated release archives