### PR TITLE
fix(cli): detect proxy server listeners from lsof

### DIFF
--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+ProcessControl.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+ProcessControl.swift
@@ -141,9 +141,17 @@ extension XcodeMCPProxyServerCommand {
     }
 
     private static func extractListenerHost(fromLsofName name: String) -> String? {
-        guard name.hasPrefix("TCP ") else { return nil }
-        let rest = name.dropFirst(4)
-        guard let endpoint = rest.split(whereSeparator: \.isWhitespace).first else { return nil }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let endpointSource: Substring
+        if trimmed.hasPrefix("TCP ") {
+            endpointSource = trimmed.dropFirst(4)
+        } else {
+            endpointSource = trimmed[...]
+        }
+
+        guard let endpoint = endpointSource.split(whereSeparator: \.isWhitespace).first else { return nil }
         let endpointString = String(endpoint)
         if endpointString.hasPrefix("["),
            let close = endpointString.firstIndex(of: "]") {
@@ -155,10 +163,6 @@ extension XcodeMCPProxyServerCommand {
     }
 
     private static func listeningPIDs(onTCPPort port: Int, matchingHost host: String) -> [Int] {
-        if isWildcardHost(host) {
-            return listeningPIDs(onTCPPort: port)
-        }
-
         guard let output = runCommand(
             "/usr/sbin/lsof",
             ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-Fpn"]
@@ -166,11 +170,17 @@ extension XcodeMCPProxyServerCommand {
             return []
         }
 
+        return listeningPIDs(fromLsofOutput: output, matchingHost: host)
+    }
+
+    package static func listeningPIDs(fromLsofOutput output: String, matchingHost host: String) -> [Int] {
+        let matchAllHosts = isWildcardHost(host)
+
         var pids: [Int] = []
         pids.reserveCapacity(4)
 
         var currentPID: Int?
-        var currentMatched = false
+        var currentMatched = matchAllHosts
 
         func flush() {
             if let pid = currentPID, currentMatched {
@@ -183,10 +193,10 @@ extension XcodeMCPProxyServerCommand {
             if first == "p" {
                 flush()
                 currentPID = Int(rawLine.dropFirst())
-                currentMatched = false
+                currentMatched = matchAllHosts
                 continue
             }
-            if first == "n" {
+            if first == "n", !matchAllHosts {
                 let name = String(rawLine.dropFirst())
                 if let listenerHost = extractListenerHost(fromLsofName: name),
                    hostMatches(requestedHost: host, actualHost: listenerHost) {
@@ -198,17 +208,6 @@ extension XcodeMCPProxyServerCommand {
 
         var seen = Set<Int>()
         return pids.filter { seen.insert($0).inserted }
-    }
-
-    private static func listeningPIDs(onTCPPort port: Int) -> [Int] {
-        guard let output = runCommand(
-            "/usr/sbin/lsof",
-            ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-t"]
-        ) else {
-            return []
-        }
-        let lines = output.split(whereSeparator: \.isNewline)
-        return lines.compactMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
     }
 
     private static func isProxyServerProcess(pid: Int) -> Bool {

--- a/Tests/ProxyCLITests/ServerCommandTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandTests.swift
@@ -85,6 +85,59 @@ struct ServerCommandTests {
         )
     }
 
+    @Test func serverCommandExtractsListeningPIDsFromLsofFieldOutputForLocalhost() throws {
+        let output = """
+        p51731
+        f9
+        n127.0.0.1:8765
+        f13
+        n[::1]:8765
+        p60000
+        f8
+        n10.0.0.5:8765
+        """
+
+        #expect(
+            XcodeMCPProxyServerCommand.listeningPIDs(fromLsofOutput: output, matchingHost: "localhost")
+                == [51731]
+        )
+    }
+
+    @Test func serverCommandExtractsListeningPIDsFromLsofFieldOutputSkipsNonMatchingHosts() throws {
+        let output = """
+        p51731
+        f9
+        n[::1]:8765
+        p60000
+        f8
+        n10.0.0.5:8765
+        """
+
+        #expect(
+            XcodeMCPProxyServerCommand.listeningPIDs(fromLsofOutput: output, matchingHost: "127.0.0.1")
+                .isEmpty
+        )
+    }
+
+    @Test func serverCommandExtractsListeningPIDsFromLegacyTCPNames() throws {
+        let output = """
+        p111
+        f9
+        nTCP 127.0.0.1:8765 (LISTEN)
+        p222
+        f13
+        nTCP [::1]:8765 (LISTEN)
+        p333
+        f8
+        nTCP 10.0.0.5:8765 (LISTEN)
+        """
+
+        #expect(
+            XcodeMCPProxyServerCommand.listeningPIDs(fromLsofOutput: output, matchingHost: "localhost")
+                == [111, 222]
+        )
+    }
+
     @Test func serverCommandInvokesForceRestartBeforeStartingInjectedServer() async throws {
         let restarted = CapturedLines()
         let fakeServer = RecordingProxyServer()


### PR DESCRIPTION
Summary:
- Parse `lsof -Fpn` listener names from both field output and legacy `TCP ...` output so `--force-restart` can detect running proxy server listeners without relying on discovery metadata
- Reuse the parsed listener PID path for both restart and port-in-use reporting, and add CLI tests covering localhost matching, host mismatch filtering, and legacy output compatibility

Testing:
- `swift test -Xswiftc -strict-concurrency=minimal --filter ServerCommandTests`
- `swift test -Xswiftc -strict-concurrency=minimal --filter ServerCommandIntegrationTests`
- Manual check: launched `xcode-mcp-proxy-server` on `127.0.0.1:9876`, removed the discovery file, and verified `--force-restart` terminated the old process and restarted successfully
- `./scripts/codex-review-quiet.sh -C /Users/kn/Dev/XcodeMCPKit --uncommitted`