### PR TITLE
fix(proxy): bound refresh diagnostics internals and expose debug state

### DIFF
--- a/Sources/ProxyFeatureXcode/RefreshCodeIssuesCoordinator.swift
+++ b/Sources/ProxyFeatureXcode/RefreshCodeIssuesCoordinator.swift
@@ -18,9 +18,9 @@ package actor RefreshCodeIssuesCoordinator {
         let continuation: CheckedContinuation<Permit, Error>
     }
 
-    private let maxPendingPerKey: Int
-    private let maxPendingTotal: Int
-    private let queueWaitTimeoutNanoseconds: UInt64
+    package nonisolated let maxPendingPerKey: Int
+    package nonisolated let maxPendingTotal: Int
+    package nonisolated let queueWaitTimeoutNanoseconds: UInt64
     private var nextWaiterID: UInt64 = 0
     private var busyKeys: Set<String> = []
     private var pendingWaiterCount = 0
@@ -44,6 +44,10 @@ package actor RefreshCodeIssuesCoordinator {
         self.maxPendingPerKey = max(0, maxPendingPerKey)
         self.maxPendingTotal = max(0, maxPendingTotal)
         self.queueWaitTimeoutNanoseconds = Self.nanoseconds(from: queueWaitTimeout)
+    }
+
+    package nonisolated var queueWaitTimeoutSeconds: Double {
+        Double(queueWaitTimeoutNanoseconds) / 1_000_000_000
     }
 
     package func withPermit<T: Sendable>(

--- a/Sources/ProxyFeatureXcode/RefreshCodeIssuesDebugState.swift
+++ b/Sources/ProxyFeatureXcode/RefreshCodeIssuesDebugState.swift
@@ -1,0 +1,363 @@
+import Foundation
+
+package struct RefreshCodeIssuesQueueDebugSnapshot: Codable, Sendable {
+    package let maxPendingPerKey: Int
+    package let maxPendingTotal: Int
+    package let queueWaitTimeoutSeconds: Double
+    package let activeByQueueKey: [String: Int]
+    package let waitingByQueueKey: [String: Int]
+    package let activeRequestCount: Int
+    package let waitingRequestCount: Int
+
+    package init(
+        maxPendingPerKey: Int,
+        maxPendingTotal: Int,
+        queueWaitTimeoutSeconds: Double,
+        activeByQueueKey: [String: Int],
+        waitingByQueueKey: [String: Int],
+        activeRequestCount: Int,
+        waitingRequestCount: Int
+    ) {
+        self.maxPendingPerKey = maxPendingPerKey
+        self.maxPendingTotal = maxPendingTotal
+        self.queueWaitTimeoutSeconds = queueWaitTimeoutSeconds
+        self.activeByQueueKey = activeByQueueKey
+        self.waitingByQueueKey = waitingByQueueKey
+        self.activeRequestCount = activeRequestCount
+        self.waitingRequestCount = waitingRequestCount
+    }
+}
+
+package struct RefreshCodeIssuesRequestDebugSnapshot: Codable, Sendable {
+    package let id: String
+    package let sessionID: String
+    package let queueKey: String
+    package let tabIdentifier: String?
+    package let filePath: String?
+    package let mode: String
+    package let state: String
+    package let step: String
+    package let startedAt: Date
+    package let lastUpdatedAt: Date
+    package let lastQueuePosition: Int?
+    package let metadata: [String: String]
+
+    package init(
+        id: String,
+        sessionID: String,
+        queueKey: String,
+        tabIdentifier: String?,
+        filePath: String?,
+        mode: String,
+        state: String,
+        step: String,
+        startedAt: Date,
+        lastUpdatedAt: Date,
+        lastQueuePosition: Int?,
+        metadata: [String: String]
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.queueKey = queueKey
+        self.tabIdentifier = tabIdentifier
+        self.filePath = filePath
+        self.mode = mode
+        self.state = state
+        self.step = step
+        self.startedAt = startedAt
+        self.lastUpdatedAt = lastUpdatedAt
+        self.lastQueuePosition = lastQueuePosition
+        self.metadata = metadata
+    }
+}
+
+package struct RefreshCodeIssuesCompletedRequestDebugSnapshot: Codable, Sendable {
+    package let id: String
+    package let sessionID: String
+    package let queueKey: String
+    package let tabIdentifier: String?
+    package let filePath: String?
+    package let mode: String
+    package let finalState: String
+    package let finalStep: String
+    package let startedAt: Date
+    package let completedAt: Date
+    package let lastQueuePosition: Int?
+    package let outcome: String
+    package let metadata: [String: String]
+
+    package init(
+        id: String,
+        sessionID: String,
+        queueKey: String,
+        tabIdentifier: String?,
+        filePath: String?,
+        mode: String,
+        finalState: String,
+        finalStep: String,
+        startedAt: Date,
+        completedAt: Date,
+        lastQueuePosition: Int?,
+        outcome: String,
+        metadata: [String: String]
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.queueKey = queueKey
+        self.tabIdentifier = tabIdentifier
+        self.filePath = filePath
+        self.mode = mode
+        self.finalState = finalState
+        self.finalStep = finalStep
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+        self.lastQueuePosition = lastQueuePosition
+        self.outcome = outcome
+        self.metadata = metadata
+    }
+}
+
+package struct RefreshCodeIssuesDebugSnapshot: Codable, Sendable {
+    package let queue: RefreshCodeIssuesQueueDebugSnapshot
+    package let activeRequests: [RefreshCodeIssuesRequestDebugSnapshot]
+    package let recentCompletedRequests: [RefreshCodeIssuesCompletedRequestDebugSnapshot]
+
+    package init(
+        queue: RefreshCodeIssuesQueueDebugSnapshot,
+        activeRequests: [RefreshCodeIssuesRequestDebugSnapshot],
+        recentCompletedRequests: [RefreshCodeIssuesCompletedRequestDebugSnapshot]
+    ) {
+        self.queue = queue
+        self.activeRequests = activeRequests
+        self.recentCompletedRequests = recentCompletedRequests
+    }
+}
+
+package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
+    private struct RequestRecord: Sendable {
+        let id: String
+        let sessionID: String
+        let queueKey: String
+        let tabIdentifier: String?
+        let filePath: String?
+        let mode: String
+        let startedAt: Date
+        var lastUpdatedAt: Date
+        var state: String
+        var step: String
+        var lastQueuePosition: Int?
+        var metadata: [String: String]
+    }
+
+    private struct State {
+        var activeRequests: [String: RequestRecord] = [:]
+        var recentCompletedRequests: [RefreshCodeIssuesCompletedRequestDebugSnapshot] = []
+    }
+
+    private let lock = NSLock()
+    private var state = State()
+    private let maxPendingPerKey: Int
+    private let maxPendingTotal: Int
+    private let queueWaitTimeoutSeconds: Double
+    private let recentCompletedLimit: Int
+
+    package init(
+        maxPendingPerKey: Int,
+        maxPendingTotal: Int,
+        queueWaitTimeoutSeconds: Double,
+        recentCompletedLimit: Int = 20
+    ) {
+        self.maxPendingPerKey = maxPendingPerKey
+        self.maxPendingTotal = maxPendingTotal
+        self.queueWaitTimeoutSeconds = queueWaitTimeoutSeconds
+        self.recentCompletedLimit = recentCompletedLimit
+    }
+
+    package func beginRequest(
+        sessionID: String,
+        queueKey: String,
+        tabIdentifier: String?,
+        filePath: String?,
+        mode: String
+    ) -> String {
+        let now = Date()
+        let requestID = UUID().uuidString
+        let record = RequestRecord(
+            id: requestID,
+            sessionID: sessionID,
+            queueKey: queueKey,
+            tabIdentifier: tabIdentifier,
+            filePath: filePath,
+            mode: mode,
+            startedAt: now,
+            lastUpdatedAt: now,
+            state: "waiting_for_permit",
+            step: "waiting_for_permit",
+            lastQueuePosition: nil,
+            metadata: [:]
+        )
+        lock.lock()
+        state.activeRequests[requestID] = record
+        lock.unlock()
+        return requestID
+    }
+
+    package func markPermitAcquired(
+        requestID: String,
+        queuePosition: Int,
+        pendingForKey: Int,
+        pendingTotal: Int
+    ) {
+        updateRequest(requestID: requestID) { record, now in
+            record.state = "running"
+            record.step = "permit_acquired"
+            record.lastQueuePosition = queuePosition
+            record.lastUpdatedAt = now
+            record.metadata["pending_for_key"] = "\(pendingForKey)"
+            record.metadata["pending_total"] = "\(pendingTotal)"
+        }
+    }
+
+    package func updateStep(
+        requestID: String,
+        step: String,
+        state overrideState: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        updateRequest(requestID: requestID) { record, now in
+            if let overrideState {
+                record.state = overrideState
+            }
+            record.step = step
+            record.lastUpdatedAt = now
+            for (key, value) in metadata {
+                record.metadata[key] = value
+            }
+        }
+    }
+
+    package func finishRequest(
+        requestID: String,
+        outcome: String,
+        metadata: [String: String] = [:]
+    ) {
+        let now = Date()
+        lock.lock()
+        guard var record = state.activeRequests.removeValue(forKey: requestID) else {
+            lock.unlock()
+            return
+        }
+        record.lastUpdatedAt = now
+        record.state = Self.finalState(for: outcome)
+        for (key, value) in metadata {
+            record.metadata[key] = value
+        }
+        let completed = RefreshCodeIssuesCompletedRequestDebugSnapshot(
+            id: record.id,
+            sessionID: record.sessionID,
+            queueKey: record.queueKey,
+            tabIdentifier: record.tabIdentifier,
+            filePath: record.filePath,
+            mode: record.mode,
+            finalState: record.state,
+            finalStep: record.step,
+            startedAt: record.startedAt,
+            completedAt: now,
+            lastQueuePosition: record.lastQueuePosition,
+            outcome: outcome,
+            metadata: record.metadata
+        )
+        state.recentCompletedRequests.append(completed)
+        if state.recentCompletedRequests.count > recentCompletedLimit {
+            state.recentCompletedRequests.removeFirst(
+                state.recentCompletedRequests.count - recentCompletedLimit
+            )
+        }
+        lock.unlock()
+    }
+
+    private static func finalState(for outcome: String) -> String {
+        switch outcome {
+        case "success":
+            return "completed"
+        case "timeout", "queue_wait_timed_out":
+            return "timed_out"
+        case "cancelled":
+            return "cancelled"
+        case "queue_limit_exceeded", "overloaded":
+            return "rejected"
+        default:
+            return "failed"
+        }
+    }
+
+    package func snapshot() -> RefreshCodeIssuesDebugSnapshot {
+        lock.lock()
+        let activeRecords = Array(state.activeRequests.values)
+        let recentCompleted = state.recentCompletedRequests
+        lock.unlock()
+
+        var activeByQueueKey: [String: Int] = [:]
+        var waitingByQueueKey: [String: Int] = [:]
+        for record in activeRecords {
+            if record.state == "running" {
+                activeByQueueKey[record.queueKey, default: 0] += 1
+            } else {
+                waitingByQueueKey[record.queueKey, default: 0] += 1
+            }
+        }
+
+        let activeRequests = activeRecords
+            .sorted { lhs, rhs in
+                if lhs.startedAt == rhs.startedAt {
+                    return lhs.id < rhs.id
+                }
+                return lhs.startedAt < rhs.startedAt
+            }
+            .map { record in
+                RefreshCodeIssuesRequestDebugSnapshot(
+                    id: record.id,
+                    sessionID: record.sessionID,
+                    queueKey: record.queueKey,
+                    tabIdentifier: record.tabIdentifier,
+                    filePath: record.filePath,
+                    mode: record.mode,
+                    state: record.state,
+                    step: record.step,
+                    startedAt: record.startedAt,
+                    lastUpdatedAt: record.lastUpdatedAt,
+                    lastQueuePosition: record.lastQueuePosition,
+                    metadata: record.metadata
+                )
+            }
+        let queue = RefreshCodeIssuesQueueDebugSnapshot(
+            maxPendingPerKey: maxPendingPerKey,
+            maxPendingTotal: maxPendingTotal,
+            queueWaitTimeoutSeconds: queueWaitTimeoutSeconds,
+            activeByQueueKey: activeByQueueKey,
+            waitingByQueueKey: waitingByQueueKey,
+            activeRequestCount: activeRequests.filter { $0.state == "running" }.count,
+            waitingRequestCount: activeRequests.filter { $0.state != "running" }.count
+        )
+        return RefreshCodeIssuesDebugSnapshot(
+            queue: queue,
+            activeRequests: activeRequests,
+            recentCompletedRequests: recentCompleted
+        )
+    }
+
+    private func updateRequest(
+        requestID: String,
+        mutate: (inout RequestRecord, Date) -> Void
+    ) {
+        let now = Date()
+        lock.lock()
+        guard var record = state.activeRequests[requestID] else {
+            lock.unlock()
+            return
+        }
+        mutate(&record, now)
+        state.activeRequests[requestID] = record
+        lock.unlock()
+    }
+}

--- a/Sources/ProxyFeatureXcode/RefreshCodeIssuesWorkflow.swift
+++ b/Sources/ProxyFeatureXcode/RefreshCodeIssuesWorkflow.swift
@@ -34,32 +34,132 @@ package enum RefreshForwardAttemptResult: Sendable {
 
 package struct RefreshCodeIssuesWorkflow {
     package typealias WindowsProvider =
-        @Sendable (_ sessionID: String, _ eventLoop: EventLoop, _ upstreamIndexOverride: Int?) async -> [XcodeWindowInfo]?
+        @Sendable (
+            _ sessionID: String,
+            _ eventLoop: EventLoop,
+            _ upstreamIndexOverride: Int?,
+            _ requestTimeoutOverride: TimeAmount?
+        ) async -> [XcodeWindowInfo]?
     package typealias InternalUpstreamChooser = @Sendable (_ sessionID: String) async -> Int?
     package typealias InternalToolCaller =
-        @Sendable (_ name: String, _ arguments: [String: Any], _ sessionID: String, _ eventLoop: EventLoop, _ upstreamIndexOverride: Int?) async -> [String: Any]?
+        @Sendable (
+            _ name: String,
+            _ arguments: [String: Any],
+            _ sessionID: String,
+            _ eventLoop: EventLoop,
+            _ upstreamIndexOverride: Int?,
+            _ requestTimeoutOverride: TimeAmount?
+        ) async -> [String: Any]?
     package typealias Forwarder =
-        @Sendable (_ bodyData: Data, _ sessionID: String, _ requestIDs: [RPCID], _ requestIsBatch: Bool, _ eventLoop: EventLoop) async -> RefreshForwardAttemptResult
+        @Sendable (
+            _ bodyData: Data,
+            _ sessionID: String,
+            _ requestIDs: [RPCID],
+            _ requestIsBatch: Bool,
+            _ eventLoop: EventLoop,
+            _ requestTimeoutOverride: TimeAmount?
+        ) async -> RefreshForwardAttemptResult
 
     package static let retryDelaysNanos: [UInt64] = [
         200_000_000,
         500_000_000,
     ]
 
+    private struct ExecutionBudget: Sendable {
+        let deadlineUptimeNs: UInt64?
+
+        init(requestTimeout: TimeInterval) {
+            if requestTimeout > 0 {
+                let timeoutNs = Self.nanoseconds(from: requestTimeout)
+                self.deadlineUptimeNs = DispatchTime.now().uptimeNanoseconds &+ timeoutNs
+            } else {
+                self.deadlineUptimeNs = nil
+            }
+        }
+
+        func remainingNanoseconds() -> UInt64? {
+            guard let deadlineUptimeNs else {
+                return nil
+            }
+            let now = DispatchTime.now().uptimeNanoseconds
+            if now >= deadlineUptimeNs {
+                return 0
+            }
+            return deadlineUptimeNs - now
+        }
+
+        func remainingTimeout(cappedAt capSeconds: TimeInterval? = nil) -> TimeAmount? {
+            guard let remainingNs = remainingNanoseconds() else {
+                if let capSeconds {
+                    return makeRequestTimeout(capSeconds)
+                }
+                return nil
+            }
+            guard remainingNs > 0 else { return nil }
+
+            var cappedNs = remainingNs
+            if let capSeconds {
+                cappedNs = min(cappedNs, Self.nanoseconds(from: capSeconds))
+            }
+
+            let maxTimeAmountNs = UInt64(Int64.max)
+            return .nanoseconds(Int64(min(cappedNs, maxTimeAmountNs)))
+        }
+
+        func stepTimeout(cappedAt capSeconds: TimeInterval) -> TimeAmount? {
+            remainingTimeout(cappedAt: capSeconds)
+        }
+
+        func canDelay(_ delayNanoseconds: UInt64) -> Bool {
+            guard let remainingNanoseconds = remainingNanoseconds() else {
+                return true
+            }
+            return remainingNanoseconds > delayNanoseconds
+        }
+
+        var isExhausted: Bool {
+            guard let remainingNanoseconds = remainingNanoseconds() else {
+                return false
+            }
+            return remainingNanoseconds == 0
+        }
+
+        private static func nanoseconds(from interval: TimeInterval) -> UInt64 {
+            let clamped = max(0, interval)
+            let nanoseconds = clamped * 1_000_000_000
+            if nanoseconds >= Double(UInt64.max) {
+                return UInt64.max
+            }
+            return UInt64(nanoseconds.rounded(.up))
+        }
+    }
+
     private let mode: RefreshCodeIssuesMode
+    private let requestTimeout: TimeInterval
     private let coordinator: RefreshCodeIssuesCoordinator
     private let targetResolver: RefreshCodeIssuesTargetResolver
+    private let debugState: RefreshCodeIssuesDebugState
+    private let windowLookupTimeoutSeconds: TimeInterval
+    private let navigatorIssuesTimeoutSeconds: TimeInterval
     private let logger: Logger
 
     package init(
         mode: RefreshCodeIssuesMode,
+        requestTimeout: TimeInterval,
         coordinator: RefreshCodeIssuesCoordinator,
         targetResolver: RefreshCodeIssuesTargetResolver,
+        debugState: RefreshCodeIssuesDebugState,
+        windowLookupTimeout: TimeInterval = 5,
+        navigatorIssuesTimeout: TimeInterval = 15,
         logger: Logger
     ) {
         self.mode = mode
+        self.requestTimeout = requestTimeout
         self.coordinator = coordinator
         self.targetResolver = targetResolver
+        self.debugState = debugState
+        self.windowLookupTimeoutSeconds = windowLookupTimeout
+        self.navigatorIssuesTimeoutSeconds = navigatorIssuesTimeout
         self.logger = logger
     }
 
@@ -75,6 +175,13 @@ package struct RefreshCodeIssuesWorkflow {
         internalToolCaller: InternalToolCaller,
         forwarder: Forwarder
     ) async -> RefreshForwardAttemptResult {
+        let debugRequestID = debugState.beginRequest(
+            sessionID: sessionID,
+            queueKey: refreshRequest.queueKey,
+            tabIdentifier: refreshRequest.tabIdentifier,
+            filePath: refreshRequest.filePath,
+            mode: mode.rawValue
+        )
         let baseMetadata: Logger.Metadata = [
             "session": .string(sessionID),
             "mode": .string(mode.rawValue),
@@ -108,6 +215,25 @@ package struct RefreshCodeIssuesWorkflow {
                     )
                 )
 
+                debugState.markPermitAcquired(
+                    requestID: debugRequestID,
+                    queuePosition: permit.queuePosition,
+                    pendingForKey: permit.pendingForKey,
+                    pendingTotal: permit.pendingTotal
+                )
+
+                let executionBudget = ExecutionBudget(requestTimeout: requestTimeout)
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: "execution_budget_started",
+                    metadata: [
+                        "execution_timeout_ms": Self.timeoutDescription(
+                            executionBudget.remainingTimeout()
+                        )
+                    ]
+                )
+
+                let result: RefreshForwardAttemptResult
                 if mode == .proxy,
                     let proxyResponseData = await runProxyRefresh(
                         refreshRequest: refreshRequest,
@@ -115,23 +241,37 @@ package struct RefreshCodeIssuesWorkflow {
                         requestIDs: requestIDs,
                         eventLoop: eventLoop,
                         baseMetadata: baseMetadata,
+                        executionBudget: executionBudget,
+                        debugRequestID: debugRequestID,
                         windowsProvider: windowsProvider,
                         internalUpstreamChooser: internalUpstreamChooser,
                         internalToolCaller: internalToolCaller
                     )
                 {
-                    return .success(proxyResponseData)
+                    debugState.updateStep(
+                        requestID: debugRequestID,
+                        step: "proxy.completed"
+                    )
+                    result = .success(proxyResponseData)
+                } else {
+                    result = await runForwardAttempts(
+                        bodyData: bodyData,
+                        sessionID: sessionID,
+                        requestIDs: requestIDs,
+                        requestIsBatch: requestIsBatch,
+                        eventLoop: eventLoop,
+                        baseMetadata: baseMetadata,
+                        executionBudget: executionBudget,
+                        debugRequestID: debugRequestID,
+                        forwarder: forwarder
+                    )
                 }
 
-                return await runForwardAttempts(
-                    bodyData: bodyData,
-                    sessionID: sessionID,
-                    requestIDs: requestIDs,
-                    requestIsBatch: requestIsBatch,
-                    eventLoop: eventLoop,
-                    baseMetadata: baseMetadata,
-                    forwarder: forwarder
+                debugState.finishRequest(
+                    requestID: debugRequestID,
+                    outcome: Self.debugOutcome(for: result)
                 )
+                return result
             }
         } catch RefreshCodeIssuesCoordinator.AcquireError.queueLimitExceeded {
             logger.warning(
@@ -142,6 +282,14 @@ package struct RefreshCodeIssuesWorkflow {
                     "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
                     "queue_key": .string(refreshRequest.queueKey),
                 ]
+            )
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "queue_limit_exceeded"
+            )
+            debugState.finishRequest(
+                requestID: debugRequestID,
+                outcome: "queue_limit_exceeded"
             )
             return .overloaded(responseIDs: requestIDs, isBatch: requestIsBatch)
         } catch RefreshCodeIssuesCoordinator.AcquireError.queueWaitTimedOut {
@@ -154,6 +302,14 @@ package struct RefreshCodeIssuesWorkflow {
                     "queue_key": .string(refreshRequest.queueKey),
                 ]
             )
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "queue_wait_timed_out"
+            )
+            debugState.finishRequest(
+                requestID: debugRequestID,
+                outcome: "queue_wait_timed_out"
+            )
             return .overloaded(responseIDs: requestIDs, isBatch: requestIsBatch)
         } catch is CancellationError {
             logger.debug(
@@ -165,8 +321,26 @@ package struct RefreshCodeIssuesWorkflow {
                     "queue_key": .string(refreshRequest.queueKey),
                 ]
             )
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "cancelled",
+                state: "cancelled"
+            )
+            debugState.finishRequest(
+                requestID: debugRequestID,
+                outcome: "cancelled"
+            )
             return .overloaded(responseIDs: requestIDs, isBatch: requestIsBatch)
         } catch {
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "invalid_request",
+                state: "failed"
+            )
+            debugState.finishRequest(
+                requestID: debugRequestID,
+                outcome: "invalid_request"
+            )
             return .invalidRequest
         }
     }
@@ -177,15 +351,28 @@ package struct RefreshCodeIssuesWorkflow {
         requestIDs: [RPCID],
         eventLoop: EventLoop,
         baseMetadata: Logger.Metadata,
+        executionBudget: ExecutionBudget,
+        debugRequestID: String,
         windowsProvider: WindowsProvider,
         internalUpstreamChooser: InternalUpstreamChooser,
         internalToolCaller: InternalToolCaller
     ) async -> Data? {
+        debugState.updateStep(
+            requestID: debugRequestID,
+            step: "proxy.select_internal_upstream"
+        )
+
         guard let internalUpstreamIndex = await internalUpstreamChooser(sessionID) else {
+            let fallbackReason = "internal upstream unavailable"
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "proxy.fallback_to_upstream",
+                metadata: ["fallback_reason": fallbackReason]
+            )
             logger.debug(
                 "Refresh code issues proxy mode fell back to upstream refresh",
                 metadata: baseMetadata.merging(
-                    ["fallback_reason": .string("internal upstream unavailable")],
+                    ["fallback_reason": .string(fallbackReason)],
                     uniquingKeysWith: { _, new in new }
                 )
             )
@@ -198,7 +385,31 @@ package struct RefreshCodeIssuesWorkflow {
             sessionID: sessionID,
             eventLoop: eventLoop,
             windowsProvider: { sessionID, eventLoop in
-                await windowsProvider(sessionID, eventLoop, internalUpstreamIndex)
+                let timeout = executionBudget.stepTimeout(
+                    cappedAt: windowLookupTimeoutSeconds
+                )
+                if timeout == nil, executionBudget.isExhausted {
+                    self.debugState.updateStep(
+                        requestID: debugRequestID,
+                        step: "proxy.execution_budget_exhausted",
+                        state: "timed_out"
+                    )
+                    return nil
+                }
+                self.debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: "proxy.list_windows",
+                    metadata: [
+                        "internal_upstream": "\(internalUpstreamIndex)",
+                        "timeout_ms": Self.timeoutDescription(timeout),
+                    ]
+                )
+                return await windowsProvider(
+                    sessionID,
+                    eventLoop,
+                    internalUpstreamIndex,
+                    timeout
+                )
             }
         )
         let metadata = baseMetadata.merging(
@@ -212,10 +423,20 @@ package struct RefreshCodeIssuesWorkflow {
         )
 
         guard let target = resolution.target else {
+            let fallbackReason = resolution.failureReason ?? "unknown"
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "proxy.fallback_to_upstream",
+                metadata: [
+                    "fallback_reason": fallbackReason,
+                    "workspace_path": resolution.workspacePath ?? "none",
+                    "resolved_file_path": resolution.resolvedFilePath ?? "none",
+                ]
+            )
             logger.debug(
                 "Refresh code issues proxy mode fell back to upstream refresh",
                 metadata: metadata.merging(
-                    ["fallback_reason": .string(resolution.failureReason ?? "unknown")],
+                    ["fallback_reason": .string(fallbackReason)],
                     uniquingKeysWith: { _, new in new }
                 )
             )
@@ -227,52 +448,57 @@ package struct RefreshCodeIssuesWorkflow {
             "severity": "remark",
             "glob": "**/" + Self.escapeGlobLiteralPath(target.workspaceRelativePath),
         ]
+        let navigatorIssuesTimeout = executionBudget.stepTimeout(
+            cappedAt: navigatorIssuesTimeoutSeconds
+        )
+        if navigatorIssuesTimeout == nil, executionBudget.isExhausted {
+            let fallbackReason = "execution budget exhausted before navigator issues"
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "proxy.fallback_to_upstream",
+                state: "timed_out",
+                metadata: ["fallback_reason": fallbackReason]
+            )
+            logger.debug(
+                "Refresh code issues proxy mode fell back to upstream refresh",
+                metadata: metadata.merging(
+                    ["fallback_reason": .string(fallbackReason)],
+                    uniquingKeysWith: { _, new in new }
+                )
+            )
+            return nil
+        }
+        debugState.updateStep(
+            requestID: debugRequestID,
+            step: "proxy.list_navigator_issues",
+            metadata: [
+                "internal_upstream": "\(internalUpstreamIndex)",
+                "resolved_target": target.resolvedFilePath,
+                "timeout_ms": Self.timeoutDescription(navigatorIssuesTimeout),
+            ]
+        )
         guard let navigatorResult = await internalToolCaller(
             "XcodeListNavigatorIssues",
             arguments,
             sessionID,
             eventLoop,
-            internalUpstreamIndex
+            internalUpstreamIndex,
+            navigatorIssuesTimeout
         ) else {
+            let fallbackReason = "navigator issues unavailable"
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "proxy.fallback_to_upstream",
+                metadata: [
+                    "fallback_reason": fallbackReason,
+                    "resolved_target": target.resolvedFilePath,
+                ]
+            )
             logger.debug(
                 "Refresh code issues proxy mode fell back to upstream refresh",
                 metadata: metadata.merging(
                     [
-                        "fallback_reason": .string("navigator issues unavailable"),
-                        "resolved_target": .string(target.resolvedFilePath),
-                    ],
-                    uniquingKeysWith: { _, new in new }
-                )
-            )
-            return nil
-        }
-        guard let filteredNavigatorResult = Self.filterNavigatorIssuesResult(
-            navigatorResult,
-            matchingResolvedFilePath: target.resolvedFilePath
-        ) else {
-            logger.debug(
-                "Refresh code issues proxy mode fell back to upstream refresh",
-                metadata: metadata.merging(
-                    [
-                        "fallback_reason": .string("navigator issues payload malformed"),
-                        "resolved_target": .string(target.resolvedFilePath),
-                    ],
-                    uniquingKeysWith: { _, new in new }
-                )
-            )
-            return nil
-        }
-        guard let responseID = requestIDs.first,
-            let responseData = Self.makeToolResponseData(
-                id: responseID,
-                result: filteredNavigatorResult
-            )
-        else {
-            logger.debug(
-                "Refresh code issues proxy mode fell back to upstream refresh",
-                metadata: metadata.merging(
-                    [
-                        "fallback_reason": .string("invalid proxy response encoding"),
+                        "fallback_reason": .string(fallbackReason),
                         "resolved_target": .string(target.resolvedFilePath),
                     ],
                     uniquingKeysWith: { _, new in new }
@@ -281,6 +507,75 @@ package struct RefreshCodeIssuesWorkflow {
             return nil
         }
 
+        debugState.updateStep(
+            requestID: debugRequestID,
+            step: "proxy.filter_navigator_issues",
+            metadata: ["resolved_target": target.resolvedFilePath]
+        )
+        guard let filteredNavigatorResult = Self.filterNavigatorIssuesResult(
+            navigatorResult,
+            matchingResolvedFilePath: target.resolvedFilePath
+        ) else {
+            let fallbackReason = "navigator issues payload malformed"
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "proxy.fallback_to_upstream",
+                metadata: [
+                    "fallback_reason": fallbackReason,
+                    "resolved_target": target.resolvedFilePath,
+                ]
+            )
+            logger.debug(
+                "Refresh code issues proxy mode fell back to upstream refresh",
+                metadata: metadata.merging(
+                    [
+                        "fallback_reason": .string(fallbackReason),
+                        "resolved_target": .string(target.resolvedFilePath),
+                    ],
+                    uniquingKeysWith: { _, new in new }
+                )
+            )
+            return nil
+        }
+
+        debugState.updateStep(
+            requestID: debugRequestID,
+            step: "proxy.encode_response",
+            metadata: ["resolved_target": target.resolvedFilePath]
+        )
+        guard let responseID = requestIDs.first,
+            let responseData = Self.makeToolResponseData(
+                id: responseID,
+                result: filteredNavigatorResult
+            )
+        else {
+            let fallbackReason = "invalid proxy response encoding"
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "proxy.fallback_to_upstream",
+                metadata: [
+                    "fallback_reason": fallbackReason,
+                    "resolved_target": target.resolvedFilePath,
+                ]
+            )
+            logger.debug(
+                "Refresh code issues proxy mode fell back to upstream refresh",
+                metadata: metadata.merging(
+                    [
+                        "fallback_reason": .string(fallbackReason),
+                        "resolved_target": .string(target.resolvedFilePath),
+                    ],
+                    uniquingKeysWith: { _, new in new }
+                )
+            )
+            return nil
+        }
+
+        debugState.updateStep(
+            requestID: debugRequestID,
+            step: "proxy.success",
+            metadata: ["resolved_target": target.resolvedFilePath]
+        )
         logger.debug(
             "Refresh code issues served via proxy navigator issues",
             metadata: metadata.merging(
@@ -298,12 +593,30 @@ package struct RefreshCodeIssuesWorkflow {
         requestIsBatch: Bool,
         eventLoop: EventLoop,
         baseMetadata: Logger.Metadata,
+        executionBudget: ExecutionBudget,
+        debugRequestID: String,
         forwarder: Forwarder
     ) async -> RefreshForwardAttemptResult {
         var finalResult: RefreshForwardAttemptResult = .invalidRequest
 
         resultLoop: for attemptIndex in 0...Self.retryDelaysNanos.count {
             let attempt = attemptIndex + 1
+            let attemptTimeout = executionBudget.remainingTimeout()
+            if executionBudget.isExhausted {
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: "upstream.execution_budget_exhausted",
+                    state: "timed_out"
+                )
+                finalResult = .timeout(responseIDs: requestIDs, isBatch: requestIsBatch)
+                break resultLoop
+            }
+
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "upstream.attempt_\(attempt)",
+                metadata: ["timeout_ms": Self.timeoutDescription(attemptTimeout)]
+            )
             let attemptMetadata = baseMetadata.merging(
                 ["attempt": .string("\(attempt)")],
                 uniquingKeysWith: { _, new in new }
@@ -313,7 +626,8 @@ package struct RefreshCodeIssuesWorkflow {
                 sessionID,
                 requestIDs,
                 requestIsBatch,
-                eventLoop
+                eventLoop,
+                attemptTimeout
             )
 
             switch result {
@@ -321,6 +635,20 @@ package struct RefreshCodeIssuesWorkflow {
                 let retryable = Self.isRetryableRefreshCodeIssuesFailure(responseData)
                 if retryable, attemptIndex < Self.retryDelaysNanos.count {
                     let delayNanos = Self.retryDelaysNanos[attemptIndex]
+                    if !executionBudget.canDelay(delayNanos) {
+                        debugState.updateStep(
+                            requestID: debugRequestID,
+                            step: "upstream.retry_budget_exhausted",
+                            state: "timed_out"
+                        )
+                        finalResult = .timeout(responseIDs: requestIDs, isBatch: requestIsBatch)
+                        break resultLoop
+                    }
+                    debugState.updateStep(
+                        requestID: debugRequestID,
+                        step: "upstream.retry_delay",
+                        metadata: ["delay_ms": "\(delayNanos / 1_000_000)"]
+                    )
                     logger.debug(
                         "Retrying refresh code issues request after error 5",
                         metadata: attemptMetadata.merging(
@@ -337,10 +665,50 @@ package struct RefreshCodeIssuesWorkflow {
                         metadata: attemptMetadata
                     )
                 }
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: retryable ? "upstream.retry_exhausted" : "upstream.success"
+                )
                 finalResult = .success(responseData)
                 break resultLoop
-            case .timeout, .upstreamUnavailable, .overloaded, .invalidRequest,
-                .invalidUpstreamResponse:
+            case .timeout:
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: "upstream.timeout",
+                    state: "timed_out"
+                )
+                finalResult = result
+                break resultLoop
+            case .upstreamUnavailable:
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: "upstream.unavailable",
+                    state: "failed"
+                )
+                finalResult = result
+                break resultLoop
+            case .overloaded:
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: "upstream.overloaded",
+                    state: "failed"
+                )
+                finalResult = result
+                break resultLoop
+            case .invalidRequest:
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: "upstream.invalid_request",
+                    state: "failed"
+                )
+                finalResult = result
+                break resultLoop
+            case .invalidUpstreamResponse:
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: "upstream.invalid_response",
+                    state: "failed"
+                )
                 finalResult = result
                 break resultLoop
             }
@@ -441,5 +809,27 @@ package struct RefreshCodeIssuesWorkflow {
         }
 
         return false
+    }
+
+    private static func timeoutDescription(_ timeout: TimeAmount?) -> String {
+        guard let timeout else { return "none" }
+        return "\(timeout.nanoseconds / 1_000_000)"
+    }
+
+    private static func debugOutcome(for result: RefreshForwardAttemptResult) -> String {
+        switch result {
+        case .success:
+            return "success"
+        case .timeout:
+            return "timeout"
+        case .upstreamUnavailable:
+            return "upstream_unavailable"
+        case .overloaded:
+            return "overloaded"
+        case .invalidRequest:
+            return "invalid_request"
+        case .invalidUpstreamResponse:
+            return "invalid_upstream_response"
+        }
     }
 }

--- a/Sources/ProxyHTTPTransport/HTTPControlService.swift
+++ b/Sources/ProxyHTTPTransport/HTTPControlService.swift
@@ -1,6 +1,30 @@
 import Foundation
 import NIO
+import ProxyFeatureXcode
 import ProxyRuntime
+
+package struct HTTPDebugSnapshot: Codable, Sendable {
+    package let generatedAt: Date
+    package let proxyInitialized: Bool
+    package let cachedToolsListAvailable: Bool
+    package let warmupInFlight: Bool
+    package let upstreams: [ProxyUpstreamDebugSnapshot]
+    package let recentTraffic: [ProxyDebugTrafficEvent]
+    package let refreshCodeIssues: RefreshCodeIssuesDebugSnapshot?
+
+    package init(
+        base: ProxyDebugSnapshot,
+        refreshCodeIssues: RefreshCodeIssuesDebugSnapshot?
+    ) {
+        self.generatedAt = base.generatedAt
+        self.proxyInitialized = base.proxyInitialized
+        self.cachedToolsListAvailable = base.cachedToolsListAvailable
+        self.warmupInFlight = base.warmupInFlight
+        self.upstreams = base.upstreams
+        self.recentTraffic = base.recentTraffic
+        self.refreshCodeIssues = refreshCodeIssues
+    }
+}
 
 package struct HTTPSSEOpenResult {
     package let bufferedNotifications: [Data]
@@ -12,16 +36,26 @@ package struct HTTPSSEOpenResult {
 
 package final class HTTPControlService: Sendable {
     private let runtimeCoordinator: any RuntimeCoordinating
+    private let refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState?
 
-    package init(runtimeCoordinator: any RuntimeCoordinating) {
+    package init(
+        runtimeCoordinator: any RuntimeCoordinating,
+        refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState? = nil
+    ) {
         self.runtimeCoordinator = runtimeCoordinator
+        self.refreshCodeIssuesDebugState = refreshCodeIssuesDebugState
     }
 
     package func debugSnapshotData() -> Data? {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
-        return try? encoder.encode(runtimeCoordinator.debugSnapshot())
+        return try? encoder.encode(
+            HTTPDebugSnapshot(
+                base: runtimeCoordinator.debugSnapshot(),
+                refreshCodeIssues: refreshCodeIssuesDebugState?.snapshot()
+            )
+        )
     }
 
     package func openSSE(sessionID: String, channel: Channel) -> HTTPSSEOpenResult {

--- a/Sources/ProxyHTTPTransport/HTTPHandler.swift
+++ b/Sources/ProxyHTTPTransport/HTTPHandler.swift
@@ -38,15 +38,32 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         config: ProxyConfig,
         sessionManager: any RuntimeCoordinating,
         refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
-        refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver()
+        refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver(),
+        refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState? = nil
     ) {
+        let refreshCoordinator =
+            refreshCodeIssuesCoordinator
+            ?? RefreshCodeIssuesCoordinator.makeDefault(
+                requestTimeout: config.requestTimeout
+            )
+        let refreshDebugState =
+            refreshCodeIssuesDebugState
+            ?? RefreshCodeIssuesDebugState(
+                maxPendingPerKey: refreshCoordinator.maxPendingPerKey,
+                maxPendingTotal: refreshCoordinator.maxPendingTotal,
+                queueWaitTimeoutSeconds: refreshCoordinator.queueWaitTimeoutSeconds
+            )
         self.config = config
-        self.controlService = HTTPControlService(runtimeCoordinator: sessionManager)
+        self.controlService = HTTPControlService(
+            runtimeCoordinator: sessionManager,
+            refreshCodeIssuesDebugState: refreshDebugState
+        )
         self.postService = HTTPPostService(
             config: config,
             sessionManager: sessionManager,
-            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
+            refreshCodeIssuesCoordinator: refreshCoordinator,
             refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
+            refreshCodeIssuesDebugState: refreshDebugState,
             logger: ProxyLogging.make("http")
         )
         self.responseWriter = HTTPResponseWriter(logger: ProxyLogging.make("http.response"))

--- a/Sources/ProxyHTTPTransport/HTTPPostService.swift
+++ b/Sources/ProxyHTTPTransport/HTTPPostService.swift
@@ -44,8 +44,9 @@ package final class HTTPPostService: Sendable {
     package init(
         config: ProxyConfig,
         sessionManager: any RuntimeCoordinating,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
+        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator,
         refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver(),
+        refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState,
         logger: Logger = ProxyLogging.make("http")
     ) {
         self.sessionManager = sessionManager
@@ -58,16 +59,13 @@ package final class HTTPPostService: Sendable {
             config: config,
             sessionManager: sessionManager
         )
-        let refreshCoordinator =
-            refreshCodeIssuesCoordinator
-            ?? RefreshCodeIssuesCoordinator.makeDefault(
-                requestTimeout: config.requestTimeout
-            )
         self.windowQueryService = XcodeWindowQueryService()
         self.refreshWorkflow = RefreshCodeIssuesWorkflow(
             mode: config.refreshCodeIssuesMode,
-            coordinator: refreshCoordinator,
+            requestTimeout: config.requestTimeout,
+            coordinator: refreshCodeIssuesCoordinator,
             targetResolver: refreshCodeIssuesTargetResolver,
+            debugState: refreshCodeIssuesDebugState,
             logger: ProxyLogging.make("http.refresh")
         )
         self.logger = logger
@@ -438,21 +436,24 @@ package final class HTTPPostService: Sendable {
         arguments: [String: Any],
         sessionID: String,
         eventLoop: EventLoop,
-        upstreamIndexOverride: Int? = nil
+        upstreamIndexOverride: Int? = nil,
+        requestTimeoutOverride: TimeAmount? = nil
     ) async -> [String: Any]? {
         await forwardingService.callInternalTool(
             name: name,
             arguments: arguments,
             sessionID: sessionID,
             eventLoop: eventLoop,
-            upstreamIndexOverride: upstreamIndexOverride
+            upstreamIndexOverride: upstreamIndexOverride,
+            requestTimeoutOverride: requestTimeoutOverride
         )
     }
 
     private func listXcodeWindows(
         sessionID: String,
         eventLoop: EventLoop,
-        upstreamIndexOverride: Int? = nil
+        upstreamIndexOverride: Int? = nil,
+        requestTimeoutOverride: TimeAmount? = nil
     ) async -> [XcodeWindowInfo]? {
         await windowQueryService.listWindows(
             sessionID: sessionID,
@@ -463,7 +464,8 @@ package final class HTTPPostService: Sendable {
                     arguments: arguments,
                     sessionID: sessionID,
                     eventLoop: eventLoop,
-                    upstreamIndexOverride: upstreamIndexOverride
+                    upstreamIndexOverride: upstreamIndexOverride,
+                    requestTimeoutOverride: requestTimeoutOverride
                 )
             }
         )
@@ -474,7 +476,8 @@ package final class HTTPPostService: Sendable {
         sessionID: String,
         requestIDs: [RPCID],
         requestIsBatch: Bool,
-        eventLoop: EventLoop
+        eventLoop: EventLoop,
+        requestTimeoutOverride: TimeAmount? = nil
     ) async -> RefreshForwardAttemptResult {
         let parsedRequestJSON: Any
         do {
@@ -506,7 +509,8 @@ package final class HTTPPostService: Sendable {
             started = try forwardingService.startRequest(
                 prepared,
                 session: session,
-                on: eventLoop
+                on: eventLoop,
+                requestTimeoutOverride: requestTimeoutOverride
             )
         } catch {
             return .invalidRequest
@@ -556,32 +560,37 @@ package final class HTTPPostService: Sendable {
             requestIDs: requestIDs,
             requestIsBatch: requestIsBatch,
             eventLoop: eventLoop,
-            windowsProvider: { sessionID, eventLoop, upstreamIndexOverride in
+            windowsProvider: { sessionID, eventLoop, upstreamIndexOverride, requestTimeoutOverride in
                 await self.listXcodeWindows(
                     sessionID: sessionID,
                     eventLoop: eventLoop,
-                    upstreamIndexOverride: upstreamIndexOverride
+                    upstreamIndexOverride: upstreamIndexOverride,
+                    requestTimeoutOverride: requestTimeoutOverride
                 )
             },
             internalUpstreamChooser: { sessionID in
                 self.sessionManager.chooseInitializeUpstreamIndex(sessionID: sessionID)
             },
-            internalToolCaller: { name, arguments, sessionID, eventLoop, upstreamIndexOverride in
+            internalToolCaller: {
+                name, arguments, sessionID, eventLoop, upstreamIndexOverride, requestTimeoutOverride in
                 await self.callInternalTool(
                     name: name,
                     arguments: arguments,
                     sessionID: sessionID,
                     eventLoop: eventLoop,
-                    upstreamIndexOverride: upstreamIndexOverride
+                    upstreamIndexOverride: upstreamIndexOverride,
+                    requestTimeoutOverride: requestTimeoutOverride
                 )
             },
-            forwarder: { bodyData, sessionID, requestIDs, requestIsBatch, eventLoop in
+            forwarder: {
+                bodyData, sessionID, requestIDs, requestIsBatch, eventLoop, requestTimeoutOverride in
                 await self.forwardOnce(
                     bodyData: bodyData,
                     sessionID: sessionID,
                     requestIDs: requestIDs,
                     requestIsBatch: requestIsBatch,
-                    eventLoop: eventLoop
+                    eventLoop: eventLoop,
+                    requestTimeoutOverride: requestTimeoutOverride
                 )
             }
         )

--- a/Sources/ProxyHTTPTransport/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPTransport/MCPForwardingService.swift
@@ -69,12 +69,15 @@ package struct MCPForwardingService: Sendable {
     package func startRequest(
         _ prepared: PreparedRequest,
         session: SessionContext,
-        on eventLoop: EventLoop
+        on eventLoop: EventLoop,
+        requestTimeoutOverride: TimeAmount? = nil
     ) throws -> StartedRequest {
-        let requestTimeout = MCPMethodDispatcher.timeoutForMethod(
-            prepared.transform.method,
-            defaultSeconds: config.requestTimeout
-        )
+        let requestTimeout =
+            requestTimeoutOverride
+            ?? MCPMethodDispatcher.timeoutForMethod(
+                prepared.transform.method,
+                defaultSeconds: config.requestTimeout
+            )
         let future: EventLoopFuture<ByteBuffer>
         if prepared.transform.isBatch {
             future = session.router.registerBatch(on: eventLoop, timeout: requestTimeout)
@@ -174,7 +177,8 @@ package struct MCPForwardingService: Sendable {
         arguments: [String: Any],
         sessionID: String,
         eventLoop: EventLoop,
-        upstreamIndexOverride: Int? = nil
+        upstreamIndexOverride: Int? = nil,
+        requestTimeoutOverride: TimeAmount? = nil
     ) async -> [String: Any]? {
         let requestObject: [String: Any] = [
             "jsonrpc": "2.0",
@@ -210,7 +214,12 @@ package struct MCPForwardingService: Sendable {
         let session = sessionManager.session(id: sessionID)
         let started: StartedRequest
         do {
-            started = try startRequest(prepared, session: session, on: eventLoop)
+            started = try startRequest(
+                prepared,
+                session: session,
+                on: eventLoop,
+                requestTimeoutOverride: requestTimeoutOverride
+            )
         } catch {
             return nil
         }

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -13,6 +13,7 @@ public final class ProxyServer {
     private let sessionManager: RuntimeCoordinator
     private let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator
     private let refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver
+    private let refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState
     private var channels: [Channel] = []
     private let logger: Logger = ProxyLogging.make("server")
 
@@ -25,6 +26,11 @@ public final class ProxyServer {
             requestTimeout: config.requestTimeout
         )
         self.refreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver()
+        self.refreshCodeIssuesDebugState = RefreshCodeIssuesDebugState(
+            maxPendingPerKey: refreshCodeIssuesCoordinator.maxPendingPerKey,
+            maxPendingTotal: refreshCodeIssuesCoordinator.maxPendingTotal,
+            queueWaitTimeoutSeconds: refreshCodeIssuesCoordinator.queueWaitTimeoutSeconds
+        )
     }
 
     public func run() async throws {
@@ -49,14 +55,16 @@ public final class ProxyServer {
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-            .childChannelInitializer { [sessionManager, config, refreshCodeIssuesCoordinator, refreshCodeIssuesTargetResolver] channel in
+            .childChannelInitializer {
+                [sessionManager, config, refreshCodeIssuesCoordinator, refreshCodeIssuesTargetResolver, refreshCodeIssuesDebugState] channel in
                 channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
                     channel.pipeline.addHandler(
                         HTTPHandler(
                             config: config,
                             sessionManager: sessionManager,
                             refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
-                            refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver
+                            refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
+                            refreshCodeIssuesDebugState: refreshCodeIssuesDebugState
                         )
                     )
                 }

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -7,6 +7,7 @@ import Testing
 import ProxyCore
 import ProxyRuntime
 import ProxyFeatureXcode
+import XcodeMCPTestSupport
 
 @testable import ProxyHTTPTransport
 
@@ -67,6 +68,118 @@ struct HTTPHandlerTests {
         let response = try collectResponse(from: channel)
         #expect(response.head.status == .notFound)
         #expect(response.body == "not found")
+    }
+
+    @Test func httpDebugUpstreamsIncludesActiveRefreshCodeIssuesState() async throws {
+        var config = makeConfig(requestTimeout: 2)
+        config.refreshCodeIssuesMode = .proxy
+        let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: temporaryRoot) }
+
+        let target = URL(fileURLWithPath: temporaryRoot).appendingPathComponent("A.swift")
+        try "".write(to: target, atomically: true, encoding: .utf8)
+        let firstSent = SyncSignal()
+
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                switch toolName {
+                case "XcodeListWindows":
+                    return .immediate(
+                        try makeToolSuccessResponse(
+                            id: originalID,
+                            text:
+                                "{\"message\":\"* tabIdentifier: windowtab-debug-state, workspacePath: \(temporaryRoot)\"}"
+                        )
+                    )
+                case "XcodeListNavigatorIssues":
+                    firstSent.signal()
+                    return .manual(
+                        try makeToolResultResponse(
+                            id: originalID,
+                            result: [
+                                "content": [[
+                                    "type": "text",
+                                    "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"warn\",\"line\":1,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
+                                ]],
+                                "structuredContent": [
+                                    "issues": [[
+                                        "path": target.path,
+                                        "message": "warn",
+                                        "line": 1,
+                                        "severity": "warning",
+                                    ]],
+                                    "totalFound": 1,
+                                    "truncated": false,
+                                ],
+                            ]
+                        )
+                    )
+                default:
+                    return .immediate(
+                        try makeToolErrorResponse(
+                            id: originalID,
+                            text: "unexpected tool"
+                        )
+                    )
+                }
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let refreshTask = Task<Void, Error> {
+                _ = try await postHTTPJSON(
+                    url: server.url,
+                    sessionID: "session-debug-state",
+                    payload: toolsCallPayload(
+                        id: 34,
+                        name: "XcodeRefreshCodeIssuesInFile",
+                        arguments: [
+                            "tabIdentifier": "windowtab-debug-state",
+                            "filePath": "A.swift",
+                        ]
+                    )
+                )
+            }
+
+            await firstSent.wait()
+
+            let (httpResponse, data) = try await getHTTPData(url: makeDebugSnapshotURL(from: server.url))
+            #expect(httpResponse.statusCode == 200)
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let snapshot = try decoder.decode(HTTPDebugSnapshot.self, from: data)
+            let refreshSnapshot = try #require(snapshot.refreshCodeIssues)
+            #expect(refreshSnapshot.queue.activeRequestCount == 1)
+            #expect(refreshSnapshot.activeRequests.count == 1)
+            #expect(refreshSnapshot.activeRequests.first?.queueKey == "windowtab-debug-state")
+            #expect(refreshSnapshot.activeRequests.first?.step == "proxy.list_navigator_issues")
+            #expect(refreshSnapshot.activeRequests.first?.state == "running")
+
+            sessionManager.deliverNextPendingResponse()
+            _ = try await refreshTask.value
+
+            let (completedResponse, completedData) = try await getHTTPData(
+                url: makeDebugSnapshotURL(from: server.url)
+            )
+            #expect(completedResponse.statusCode == 200)
+            let completedSnapshot = try decoder.decode(HTTPDebugSnapshot.self, from: completedData)
+            let completedRefreshSnapshot = try #require(completedSnapshot.refreshCodeIssues)
+            #expect(completedRefreshSnapshot.queue.activeRequestCount == 0)
+            #expect(completedRefreshSnapshot.recentCompletedRequests.first?.finalState == "completed")
+            #expect(completedRefreshSnapshot.recentCompletedRequests.first?.outcome == "success")
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
     }
 
     @Test func httpSSERequiresAcceptHeader() async throws {
@@ -2245,6 +2358,201 @@ struct HTTPHandlerTests {
         await server.shutdown()
     }
 
+    @Test func refreshWorkflowFallsBackToUpstreamWhenNavigatorIssuesTimesOut() async throws {
+        let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: temporaryRoot) }
+
+        let target = URL(fileURLWithPath: temporaryRoot)
+            .appendingPathComponent("App/Sources/App.swift")
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: target, atomically: true, encoding: .utf8)
+
+        let workspacePath = URL(fileURLWithPath: temporaryRoot)
+            .appendingPathComponent("SampleProject.xcworkspace").path
+        try FileManager.default.createDirectory(
+            atPath: workspacePath,
+            withIntermediateDirectories: true
+        )
+
+        let config = makeConfig(requestTimeout: 1)
+        let coordinator = RefreshCodeIssuesCoordinator(queueWaitTimeout: 1)
+        let debugState = RefreshCodeIssuesDebugState(
+            maxPendingPerKey: coordinator.maxPendingPerKey,
+            maxPendingTotal: coordinator.maxPendingTotal,
+            queueWaitTimeoutSeconds: coordinator.queueWaitTimeoutSeconds
+        )
+        let workflow = RefreshCodeIssuesWorkflow(
+            mode: .proxy,
+            requestTimeout: config.requestTimeout,
+            coordinator: coordinator,
+            targetResolver: RefreshCodeIssuesTargetResolver(),
+            debugState: debugState,
+            windowLookupTimeout: 0.2,
+            navigatorIssuesTimeout: 0.05,
+            logger: ProxyLogging.make("test.refresh")
+        )
+        let observedTimeouts = NIOLockedValueBox<[Int64]>([])
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let requestID = RPCID(any: NSNumber(value: 33))!
+        let requestPayload = toolsCallPayload(
+            id: 33,
+            name: "XcodeRefreshCodeIssuesInFile",
+            arguments: [
+                "tabIdentifier": "windowtab-navigator-timeout",
+                "filePath": "App/Sources/App.swift",
+            ]
+        )
+        let requestData = try JSONSerialization.data(withJSONObject: requestPayload, options: [])
+        let upstreamFallbackData = try makeToolSuccessResponse(
+            id: requestID,
+            text: "upstream-after-navigator-timeout"
+        )
+
+        let result = await workflow.run(
+            refreshRequest: RefreshCodeIssuesRequest(
+                tabIdentifier: "windowtab-navigator-timeout",
+                filePath: "App/Sources/App.swift"
+            ),
+            bodyData: requestData,
+            sessionID: "session-navigator-timeout",
+            requestIDs: [requestID],
+            requestIsBatch: false,
+            eventLoop: group.next(),
+            windowsProvider: { _, _, _, _ in
+                [
+                    XcodeWindowInfo(
+                        tabIdentifier: "windowtab-navigator-timeout",
+                        workspacePath: workspacePath
+                    )
+                ]
+            },
+            internalUpstreamChooser: { _ in 0 },
+            internalToolCaller: { name, _, _, _, _, requestTimeoutOverride in
+                guard name == "XcodeListNavigatorIssues" else {
+                    return nil
+                }
+                observedTimeouts.withLockedValue { values in
+                    values.append(requestTimeoutOverride?.nanoseconds ?? -1)
+                }
+                let simulatedDelayNanos: UInt64 = 200_000_000
+                if let requestTimeoutOverride {
+                    let timeoutNanos = UInt64(max(0, requestTimeoutOverride.nanoseconds))
+                    try? await Task.sleep(nanoseconds: min(simulatedDelayNanos, timeoutNanos))
+                }
+                return nil
+            },
+            forwarder: { _, _, _, _, _, _ in
+                .success(upstreamFallbackData)
+            }
+        )
+
+        switch result {
+        case .success(let responseData):
+            let object = try #require(
+                JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any]
+            )
+            let responseResult: [String: Any]? = object["result"] as? [String: Any]
+            let content: [[String: Any]]? = responseResult?["content"] as? [[String: Any]]
+            #expect(content?.first?["text"] as? String == "upstream-after-navigator-timeout")
+        default:
+            Issue.record("expected workflow to fall back to upstream after navigator timeout")
+        }
+
+        #expect(observedTimeouts.withLockedValue { $0.first } == 50_000_000)
+    }
+
+    @Test func httpRefreshCodeIssuesFallsBackToUpstreamWithUnlimitedTimeout() async throws {
+        var config = makeConfig(requestTimeout: 0)
+        config.refreshCodeIssuesMode = .proxy
+        let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: temporaryRoot) }
+
+        let target = URL(fileURLWithPath: temporaryRoot).appendingPathComponent("App.swift")
+        try "".write(to: target, atomically: true, encoding: .utf8)
+        let workspacePath = URL(fileURLWithPath: temporaryRoot)
+            .appendingPathComponent("SampleProject.xcworkspace").path
+        try FileManager.default.createDirectory(
+            atPath: workspacePath,
+            withIntermediateDirectories: true
+        )
+
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                switch toolName {
+                case "XcodeListWindows":
+                    return .immediate(
+                        try makeToolSuccessResponse(
+                            id: originalID,
+                            text:
+                                "{\"message\":\"* tabIdentifier: windowtab-unlimited-timeout, workspacePath: \(workspacePath)\"}"
+                        )
+                    )
+                case "XcodeListNavigatorIssues":
+                    return .immediate(
+                        try makeToolErrorResponse(
+                            id: originalID,
+                            text: "navigator failed"
+                        )
+                    )
+                case "XcodeRefreshCodeIssuesInFile":
+                    return .immediate(
+                        try makeToolSuccessResponse(
+                            id: originalID,
+                            text: "upstream-after-unlimited-timeout-fallback"
+                        )
+                    )
+                default:
+                    return .immediate(
+                        try makeToolErrorResponse(
+                            id: originalID,
+                            text: "unexpected tool"
+                        )
+                    )
+                }
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-unlimited-timeout",
+                payload: toolsCallPayload(
+                    id: 35,
+                    name: "XcodeRefreshCodeIssuesInFile",
+                    arguments: [
+                        "tabIdentifier": "windowtab-unlimited-timeout",
+                        "filePath": "App.swift",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            let content = result?["content"] as? [[String: Any]]
+            #expect(content?.first?["text"] as? String == "upstream-after-unlimited-timeout-fallback")
+            #expect(sessionManager.sentToolNames() == [
+                "XcodeListWindows",
+                "XcodeListNavigatorIssues",
+                "XcodeRefreshCodeIssuesInFile",
+            ])
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
     @Test func httpRefreshCodeIssuesRetriesSourceEditorErrorFive() async throws {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .upstream
@@ -3322,13 +3630,15 @@ private func addHTTPHandler(
     config: ProxyConfig,
     sessionManager: any RuntimeCoordinating,
     refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
-    refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver()
+    refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver(),
+    refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState? = nil
 ) throws {
     let handler = HTTPHandler(
         config: config,
         sessionManager: sessionManager,
         refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
-        refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver
+        refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
+        refreshCodeIssuesDebugState: refreshCodeIssuesDebugState
     )
     try channel.pipeline.addHandler(handler).wait()
 }
@@ -3412,6 +3722,16 @@ private struct TestHTTPHandlerServer {
         refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver()
     ) throws -> TestHTTPHandlerServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let refreshCoordinator =
+            refreshCodeIssuesCoordinator
+            ?? RefreshCodeIssuesCoordinator.makeDefault(
+                requestTimeout: config.requestTimeout
+            )
+        let refreshDebugState = RefreshCodeIssuesDebugState(
+            maxPendingPerKey: refreshCoordinator.maxPendingPerKey,
+            maxPendingTotal: refreshCoordinator.maxPendingTotal,
+            queueWaitTimeoutSeconds: refreshCoordinator.queueWaitTimeoutSeconds
+        )
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -3421,8 +3741,9 @@ private struct TestHTTPHandlerServer {
                         HTTPHandler(
                             config: config,
                             sessionManager: sessionManager,
-                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
-                            refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver
+                            refreshCodeIssuesCoordinator: refreshCoordinator,
+                            refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
+                            refreshCodeIssuesDebugState: refreshDebugState
                         )
                     )
                 }
@@ -3472,6 +3793,21 @@ private func postHTTPJSON(
         (try? JSONSerialization.jsonObject(with: responseData, options: [])) as? [String: Any]
         ?? [:]
     return (httpResponse, object)
+}
+
+private func getHTTPData(url: URL) async throws -> (HTTPURLResponse, Data) {
+    let (data, response) = try await URLSession.shared.data(from: url)
+    guard let httpResponse = response as? HTTPURLResponse else {
+        throw HTTPTestError.missingResponseHead
+    }
+    return (httpResponse, data)
+}
+
+private func makeDebugSnapshotURL(from mcpURL: URL) -> URL {
+    var components = URLComponents(url: mcpURL, resolvingAgainstBaseURL: false)!
+    components.path = "/debug/upstreams"
+    components.query = nil
+    return components.url!
 }
 
 private actor AsyncSignal {


### PR DESCRIPTION
Summary:
- Add a shared refresh debug snapshot model and expose refresh queue / active request state from `/debug/upstreams`
- Thread internal timeout overrides through `XcodeRefreshCodeIssuesInFile` proxy refresh calls without regressing `requestTimeout == 0`
- Add regression coverage for refresh timeout fallback, unlimited-timeout behavior, and completed debug state reporting

Testing:
- `swift test`