### PR TITLE
fix: restore MCP_XCODE_PID pass-through

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -120,18 +120,17 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 #### オプション
 
 | オプション | 説明 |
-|-----------|------|
-| `--upstream-command cmd` | `mcpbridge` コマンド |
+|--------|-------------|
+| `--upstream-command cmd` | `mcpbridge` 実行コマンド |
 | `--upstream-args a,b,c` | `mcpbridge` 引数（カンマ区切り） |
-| `--upstream-arg value` | `mcpbridge` 引数を1つ追加 |
-| `--upstream-processes n` | upstream `mcpbridge` を `n` プロセス起動（default: 1, max: 10） |
-| `--xcode-pid pid` | 対象 Xcode の PID |
+| `--upstream-arg value` | `mcpbridge` 引数の追加（単一項目） |
+| `--upstream-processes n` | アップストリーム `mcpbridge` プロセスの起動数（デフォルト: 1、最大: 10） |
 | `--session-id id` | 明示的な Xcode MCP セッション ID |
-| `--max-body-bytes n` | 最大ボディサイズ |
-| `--request-timeout seconds` | リクエストタイムアウト（`0` で通常リクエストは無制限、`initialize` はハンドシェイク保護のため有界タイムアウトを維持） |
-| `--config path` | upstream へ送る handshake を上書きする proxy config TOML のパス |
-| `--refresh-code-issues-mode proxy|upstream` | `XcodeRefreshCodeIssuesInFile` を proxy 側の navigator issues 経由（既定）で返すか、Xcode の live diagnostics へ直通するかを切り替え |
-| `--force-restart` | listen ポートが使用中の場合、既存の `xcode-mcp-proxy-server` を終了して起動し直す |
+| `--max-body-bytes n` | リクエストボディの最大サイズ |
+| `--request-timeout seconds` | リクエストタイムアウト設定（`0` で初期化以外のタイムアウトを無効化。`initialize` 時のハンドシェイクには固定のタイムアウトが適用されます） |
+| `--config path` | アップストリームのハンドシェイクを上書きするためのプロキシ設定（TOML）のパス |
+| `--refresh-code-issues-mode mode` | `XcodeRefreshCodeIssuesInFile` の提供モード。プロキシ側のナビゲーター問題として処理（`proxy`、デフォルト）、または Xcode のライブ診断へパススルー（`upstream`） |
+| `--force-restart` | ポートが使用中の場合、既存の `xcode-mcp-proxy-server` を終了して再起動 |
 
 #### 環境変数
 
@@ -140,8 +139,7 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 | `LISTEN` | listen アドレス。例: `127.0.0.1:8765` |
 | `HOST` | listen ホスト。`LISTEN` 未指定時に `PORT` と組み合わせて使用 |
 | `PORT` | listen ポート。`LISTEN` 未指定時に `HOST` と組み合わせて使用 |
-| `XCODE_PID` | Xcode PID |
-| `MCP_XCODE_PID` | Xcode PID のフォールバック |
+| `MCP_XCODE_PID` | upstream `mcpbridge` へそのまま渡す互換 env。proxy 自身は解釈しない |
 | `MCP_XCODE_SESSION_ID` | 任意の明示的 upstream session ID |
 | `MCP_XCODE_CONFIG` | proxy config TOML のパス。`--config` が優先 |
 | `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` または `upstream` |

--- a/README.ja.md
+++ b/README.ja.md
@@ -152,8 +152,8 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 | キー | 型 | 既定値 |
 |------|----|--------|
 | `upstream_handshake.protocolVersion` | string | `"2025-03-26"` |
-| `upstream_handshake.clientName` | string | `"Codex"` |
-| `upstream_handshake.clientVersion` | string | `auto` |
+| `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
+| `upstream_handshake.clientVersion` | string | `"dev"` |
 | `upstream_handshake.capabilities` | table | `{}` |
 
 `clientVersion` を省略した場合、`clientName` に対応する Xcode の `IDEChat*Version` があれば、その version を自動で使います。

--- a/README.md
+++ b/README.md
@@ -125,12 +125,11 @@ See Quick Start for how to launch.
 | `--upstream-args a,b,c` | `mcpbridge` args (comma-separated) |
 | `--upstream-arg value` | Append a single `mcpbridge` arg |
 | `--upstream-processes n` | Spawn `n` upstream `mcpbridge` processes (default: 1, max: 10) |
-| `--xcode-pid pid` | Xcode PID |
 | `--session-id id` | Explicit Xcode MCP session ID |
 | `--max-body-bytes n` | Max request body size |
 | `--request-timeout seconds` | Request timeout (`0` disables non-initialize timeouts; `initialize` still uses a bounded handshake timeout) |
 | `--config path` | Path to proxy config TOML for overriding the upstream handshake |
-| `--refresh-code-issues-mode proxy|upstream` | Serve `XcodeRefreshCodeIssuesInFile` via proxy navigator issues (`proxy`, default) or pass through to Xcode live diagnostics (`upstream`) |
+| `--refresh-code-issues-mode mode` | Serve `XcodeRefreshCodeIssuesInFile` via proxy navigator issues (`proxy`, default) or pass through to Xcode live diagnostics (`upstream`) |
 | `--force-restart` | If the listen port is in use, terminate an existing `xcode-mcp-proxy-server` and restart |
 
 #### Environment Variables
@@ -140,8 +139,7 @@ See Quick Start for how to launch.
 | `LISTEN` | Listen address; example: `127.0.0.1:8765` |
 | `HOST` | Listen host; used with `PORT` when `LISTEN` is unset |
 | `PORT` | Listen port; used with `HOST` when `LISTEN` is unset |
-| `XCODE_PID` | Xcode PID |
-| `MCP_XCODE_PID` | Xcode PID fallback |
+| `MCP_XCODE_PID` | Passed through to upstream `mcpbridge`; the proxy itself does not parse it |
 | `MCP_XCODE_SESSION_ID` | Optional explicit upstream session ID |
 | `MCP_XCODE_CONFIG` | Proxy config TOML path; `--config` takes precedence |
 | `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` or `upstream` |

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Logs are written to stderr.
 | Key | Type | Default |
 |-----|------|---------|
 | `upstream_handshake.protocolVersion` | string | `"2025-03-26"` |
-| `upstream_handshake.clientName` | string | `"Codex"` |
-| `upstream_handshake.clientVersion` | string | `auto` |
+| `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
+| `upstream_handshake.clientVersion` | string | `"dev"` |
 | `upstream_handshake.capabilities` | table | `{}` |
 
 If `clientVersion` is omitted, the proxy auto-resolves it from the Xcode `IDEChat*Version` entry matching `clientName` when available.

--- a/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
+++ b/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
@@ -17,7 +17,6 @@ package struct ProxyCLIServerScan {
     package var hasHostFlag = false
     package var hasPortFlag = false
     package var hasConfigFlag = false
-    package var hasXcodePIDFlag = false
     package var hasRefreshCodeIssuesModeFlag = false
     package var forceRestart = false
     package var dryRun = false
@@ -38,7 +37,6 @@ package enum ProxyCLIInvocationScanner {
         "--upstream-args",
         "--upstream-arg",
         "--upstream-processes",
-        "--xcode-pid",
         "--session-id",
         "--refresh-code-issues-mode",
     ]
@@ -53,7 +51,6 @@ package enum ProxyCLIInvocationScanner {
         "--upstream-args",
         "--upstream-arg",
         "--upstream-processes",
-        "--xcode-pid",
         "--session-id",
         "--refresh-code-issues-mode",
     ]
@@ -67,7 +64,6 @@ package enum ProxyCLIInvocationScanner {
         "--upstream-args",
         "--upstream-arg",
         "--upstream-processes",
-        "--xcode-pid",
         "--session-id",
         "--max-body-bytes",
         "--request-timeout",
@@ -103,6 +99,11 @@ package enum ProxyCLIInvocationScanner {
                     scan.removedFlagMessage = CLIParser.removedLazyInitMessage
                 }
                 cursor.advance()
+            case "--xcode-pid":
+                if scan.removedFlagMessage == nil {
+                    scan.removedFlagMessage = CLIParser.removedXcodePIDMessage
+                }
+                cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
             case "--request-timeout":
                 cursor.advancePastCurrentAndOptionalValue(where: shouldConsumeRequestTimeoutValue)
             case let flag where serverOnlyFlags.contains(flag):
@@ -147,6 +148,8 @@ package enum ProxyCLIInvocationScanner {
                 throw ProxyServerCommandError.message(
                     "--url is not supported in server mode (use xcode-mcp-proxy)"
                 )
+            case "--xcode-pid":
+                throw ProxyServerCommandError.message(CLIParser.removedXcodePIDMessage)
             case "--lazy-init":
                 throw ProxyServerCommandError.message(CLIParser.removedLazyInitMessage)
             case "--listen":
@@ -157,8 +160,6 @@ package enum ProxyCLIInvocationScanner {
                 scan.hasPortFlag = true
             case "--config":
                 scan.hasConfigFlag = true
-            case "--xcode-pid":
-                scan.hasXcodePIDFlag = true
             case "--refresh-code-issues-mode":
                 scan.hasRefreshCodeIssuesModeFlag = true
             default:

--- a/Sources/ProxyCLI/ProxyServerCommandRuntime.swift
+++ b/Sources/ProxyCLI/ProxyServerCommandRuntime.swift
@@ -15,12 +15,7 @@ package struct ProxyServerCommandRuntime {
                 dependencies.stdout(XcodeMCPProxyServerCommand.serverUsage())
                 return 0
             }
-            try XcodeMCPProxyServerCommand.applyDefaults(
-                from: environment,
-                to: &options,
-                resolveXcodePID: dependencies.resolveXcodePID,
-                stderr: dependencies.stderr
-            )
+            try XcodeMCPProxyServerCommand.applyDefaults(from: environment, to: &options)
 
             let isDryRun = options.dryRun || XcodeMCPProxyServerCommand.isTruthy(environment["DRY_RUN"])
             if isDryRun {

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
@@ -11,7 +11,6 @@ extension XcodeMCPProxyServerCommand {
             hasHostFlag: scan.hasHostFlag,
             hasPortFlag: scan.hasPortFlag,
             hasConfigFlag: scan.hasConfigFlag,
-            hasXcodePIDFlag: scan.hasXcodePIDFlag,
             hasRefreshCodeIssuesModeFlag: scan.hasRefreshCodeIssuesModeFlag,
             forceRestart: scan.forceRestart,
             dryRun: scan.dryRun
@@ -20,9 +19,7 @@ extension XcodeMCPProxyServerCommand {
 
     package static func applyDefaults(
         from environment: [String: String],
-        to options: inout ProxyServerOptions,
-        resolveXcodePID: () -> String?,
-        stderr: (String) -> Void
+        to options: inout ProxyServerOptions
     ) throws {
         if !options.hasListenFlag && !options.hasHostFlag && !options.hasPortFlag {
             if let listen = nonEmpty(environment["LISTEN"]) {
@@ -50,16 +47,6 @@ extension XcodeMCPProxyServerCommand {
             options.forwardedArgs += ["--config", configPath]
         }
 
-        if !options.hasXcodePIDFlag {
-            if let explicit = nonEmpty(environment["XCODE_PID"]) ?? nonEmpty(environment["MCP_XCODE_PID"]) {
-                options.forwardedArgs += ["--xcode-pid", explicit]
-            } else if let resolved = resolveXcodePID() {
-                options.forwardedArgs += ["--xcode-pid", resolved]
-            } else {
-                stderr("warning: Xcode PID not found; running without --xcode-pid.")
-            }
-        }
-
         if isTruthy(environment["LAZY_INIT"]) {
             throw ProxyServerCommandError.message(CLIParser.removedLazyInitMessage)
         }
@@ -82,7 +69,6 @@ extension XcodeMCPProxyServerCommand {
           --port port
           --config path
           --upstream-processes n
-          --xcode-pid pid
           --refresh-code-issues-mode proxy|upstream
           --force-restart
           --dry-run
@@ -93,7 +79,6 @@ extension XcodeMCPProxyServerCommand {
           - Use xcode-mcp-proxy as a STDIO adapter for Codex / Claude Code.
           - Default listen: localhost:8765 (override via --listen / --host / --port or env LISTEN/HOST/PORT).
           - Initialize config path: --config or env \(CLIParser.configPathEnv)
-          - Xcode PID is detected automatically when not specified.
           - When the listen port is already in use, rerun with --force-restart to terminate an existing xcode-mcp-proxy-server.
         """
     }

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+ProcessControl.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+ProcessControl.swift
@@ -20,31 +20,6 @@ extension XcodeMCPProxyServerCommand {
         return requested == actual
     }
 
-    static func resolveXcodePID() -> String? {
-        if let pid = firstLine(runCommand("/usr/bin/pgrep", ["-x", "Xcode"])) {
-            return pid
-        }
-        if let pid = firstLine(
-            runCommand("/usr/bin/pgrep", ["-f", "/Applications/Xcode.*\\.app/Contents/MacOS/Xcode"])
-        ) {
-            return pid
-        }
-        if let pid = firstLine(
-            runCommand("/usr/bin/pgrep", ["-f", "Xcode.app/Contents/MacOS/Xcode"])
-        ) {
-            return pid
-        }
-
-        _ = runCommand("/usr/bin/open", ["-a", "Xcode"])
-        for _ in 0..<40 {
-            if let pid = firstLine(runCommand("/usr/bin/pgrep", ["-x", "Xcode"])) {
-                return pid
-            }
-            Thread.sleep(forTimeInterval: 0.25)
-        }
-        return nil
-    }
-
     @discardableResult
     static func terminateExistingProxyServerIfNeeded(host: String, port: Int) -> Bool {
         if let record = Discovery.read(),

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
@@ -11,7 +11,6 @@ package struct ProxyServerOptions {
     package var hasHostFlag: Bool
     package var hasPortFlag: Bool
     package var hasConfigFlag: Bool
-    package var hasXcodePIDFlag: Bool
     package var hasRefreshCodeIssuesModeFlag: Bool
     package var forceRestart: Bool
     package var dryRun: Bool
@@ -23,7 +22,6 @@ package struct ProxyServerOptions {
         hasHostFlag: Bool,
         hasPortFlag: Bool,
         hasConfigFlag: Bool,
-        hasXcodePIDFlag: Bool,
         hasRefreshCodeIssuesModeFlag: Bool,
         forceRestart: Bool,
         dryRun: Bool
@@ -34,7 +32,6 @@ package struct ProxyServerOptions {
         self.hasHostFlag = hasHostFlag
         self.hasPortFlag = hasPortFlag
         self.hasConfigFlag = hasConfigFlag
-        self.hasXcodePIDFlag = hasXcodePIDFlag
         self.hasRefreshCodeIssuesModeFlag = hasRefreshCodeIssuesModeFlag
         self.forceRestart = forceRestart
         self.dryRun = dryRun
@@ -57,7 +54,6 @@ package struct XcodeMCPProxyServerCommand {
         package var bootstrapLogging: ([String: String]) -> Void
         package var stdout: (String) -> Void
         package var stderr: (String) -> Void
-        package var resolveXcodePID: () -> String?
         package var terminateExistingServer: (String, Int) -> Bool
         package var makeServer: (ProxyConfig) -> any ProxyServerCommandServer
         package var isAddressAlreadyInUse: (Error) -> Bool
@@ -67,7 +63,6 @@ package struct XcodeMCPProxyServerCommand {
             bootstrapLogging: @escaping ([String: String]) -> Void,
             stdout: @escaping (String) -> Void,
             stderr: @escaping (String) -> Void,
-            resolveXcodePID: @escaping () -> String?,
             terminateExistingServer: @escaping (String, Int) -> Bool,
             makeServer: @escaping (ProxyConfig) -> any ProxyServerCommandServer,
             isAddressAlreadyInUse: @escaping (Error) -> Bool,
@@ -76,7 +71,6 @@ package struct XcodeMCPProxyServerCommand {
             self.bootstrapLogging = bootstrapLogging
             self.stdout = stdout
             self.stderr = stderr
-            self.resolveXcodePID = resolveXcodePID
             self.terminateExistingServer = terminateExistingServer
             self.makeServer = makeServer
             self.isAddressAlreadyInUse = isAddressAlreadyInUse
@@ -88,7 +82,6 @@ package struct XcodeMCPProxyServerCommand {
                 bootstrapLogging: ProxyLogging.bootstrap,
                 stdout: { print($0) },
                 stderr: { FileHandle.writeLine($0, to: .standardError) },
-                resolveXcodePID: XcodeMCPProxyServerCommand.resolveXcodePID,
                 terminateExistingServer: XcodeMCPProxyServerCommand.terminateExistingProxyServerIfNeeded,
                 makeServer: { ProxyServer(config: $0) },
                 isAddressAlreadyInUse: XcodeMCPProxyServerCommand.isAddressAlreadyInUse,

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -23,7 +23,6 @@ public struct ProxyConfig: Sendable {
     public var upstreamCommand: String
     public var upstreamArgs: [String]
     public var upstreamProcessCount: Int
-    public var xcodePID: Int?
     public var upstreamSessionID: String?
     public var maxBodyBytes: Int
     public var requestTimeout: TimeInterval
@@ -40,7 +39,6 @@ public struct ProxyConfig: Sendable {
         upstreamCommand: String,
         upstreamArgs: [String],
         upstreamProcessCount: Int = 1,
-        xcodePID: Int? = nil,
         upstreamSessionID: String? = nil,
         maxBodyBytes: Int,
         requestTimeout: TimeInterval,
@@ -56,7 +54,6 @@ public struct ProxyConfig: Sendable {
         self.upstreamCommand = upstreamCommand
         self.upstreamArgs = upstreamArgs
         self.upstreamProcessCount = upstreamProcessCount
-        self.xcodePID = xcodePID
         self.upstreamSessionID = upstreamSessionID
         self.maxBodyBytes = maxBodyBytes
         self.requestTimeout = requestTimeout
@@ -87,6 +84,8 @@ public struct CLIParser {
     public static let configPathEnv = "MCP_XCODE_CONFIG"
     public static let removedLazyInitMessage =
         "The proxy always uses eager initialization; --lazy-init has been removed."
+    public static let removedXcodePIDMessage =
+        "Xcode PID support has been removed; --xcode-pid is no longer supported."
 
     public static func parse(args: [String], environment: [String: String]) throws -> ProxyConfig {
         return try parse(args: args, environment: environment, discoveryOverrideURL: nil)
@@ -102,7 +101,6 @@ public struct CLIParser {
         var upstreamCommand = "xcrun"
         var upstreamArgs = ["mcpbridge"]
         var upstreamProcessCount = 1
-        var xcodePID: Int?
         var upstreamSessionID: String?
         var maxBodyBytes = 1_048_576
         var requestTimeout: TimeInterval = 300
@@ -173,11 +171,7 @@ public struct CLIParser {
                 upstreamProcessCount = parsed
                 index += 2
             case "--xcode-pid":
-                guard index + 1 < args.count else {
-                    throw CLIError.message("--xcode-pid requires a value")
-                }
-                xcodePID = Int(args[index + 1])
-                index += 2
+                throw CLIError.message(Self.removedXcodePIDMessage)
             case "--session-id":
                 guard index + 1 < args.count else {
                     throw CLIError.message("--session-id requires a value")
@@ -236,9 +230,6 @@ public struct CLIParser {
             }
         }
 
-        if xcodePID == nil, let value = environment["MCP_XCODE_PID"], let parsed = Int(value) {
-            xcodePID = parsed
-        }
         if upstreamSessionID == nil, let value = environment["MCP_XCODE_SESSION_ID"], !value.isEmpty {
             upstreamSessionID = value
         }
@@ -261,7 +252,6 @@ public struct CLIParser {
             upstreamCommand: upstreamCommand,
             upstreamArgs: upstreamArgs,
             upstreamProcessCount: upstreamProcessCount,
-            xcodePID: xcodePID,
             upstreamSessionID: upstreamSessionID,
             maxBodyBytes: maxBodyBytes,
             requestTimeout: requestTimeout,
@@ -285,7 +275,6 @@ public struct CLIParser {
           --upstream-args a,b,c      Upstream args (default: mcpbridge)
           --upstream-arg value       Append a single upstream arg
           --upstream-processes n     Upstream process count (default: 1, max: 10)
-          --xcode-pid pid            Xcode PID (env MCP_XCODE_PID)
           --session-id id            Upstream session id (env MCP_XCODE_SESSION_ID)
           --max-body-bytes n         Max request body size (default: 1048576)
           --request-timeout seconds  Request timeout (default: 300, 0 disables non-initialize timeouts)

--- a/Sources/ProxyRuntime/ResponseCorrelationStore.swift
+++ b/Sources/ProxyRuntime/ResponseCorrelationStore.swift
@@ -9,9 +9,7 @@ extension RuntimeCoordinator {
         count: Int
     ) -> [UpstreamProcess] {
         var environment = ProcessInfo.processInfo.environment
-        if let pid = config.xcodePID {
-            environment["MCP_XCODE_PID"] = String(pid)
-        }
+        environment.removeValue(forKey: "XCODE_PID")
         if let sharedSessionID, !sharedSessionID.isEmpty {
             environment["MCP_XCODE_SESSION_ID"] = sharedSessionID
         } else {

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
@@ -251,8 +251,8 @@ extension RuntimeCoordinator {
             "protocolVersion": .string("2025-03-26"),
             "capabilities": .object([:]),
             "clientInfo": .object([
-                "name": .string("Codex"),
-                "version": .string(defaultClientVersion(for: "Codex")),
+                "name": .string(defaultProxyClientName()),
+                "version": .string(defaultProxyClientVersion()),
             ]),
         ]
     }
@@ -270,19 +270,26 @@ extension RuntimeCoordinator {
             return params
         }
 
-        clientInfo["version"] = .string(defaultClientVersion(for: clientName))
+        guard let resolvedVersion = xcodeChatClientVersion(for: clientName) else {
+            return params
+        }
+
+        clientInfo["version"] = .string(resolvedVersion)
         var updated = params
         updated["clientInfo"] = .object(clientInfo)
         return updated
     }
 
     func defaultClientVersion(for clientName: String) -> String {
-        xcodeChatClientVersion(for: clientName) ?? defaultCodexClientVersion()
+        xcodeChatClientVersion(for: clientName) ?? defaultProxyClientVersion()
     }
 
-    func defaultCodexClientVersion() -> String {
-        let fallback = "0.87.0"
-        return xcodeChatVersionValue(forDefaultsKey: "IDEChatCodexVersion") ?? fallback
+    func defaultProxyClientName() -> String {
+        "XcodeMCPKit"
+    }
+
+    func defaultProxyClientVersion() -> String {
+        "dev"
     }
 
     func xcodeChatClientVersion(for clientName: String) -> String? {

--- a/Tests/ProxyCLITests/CLICommandTests.swift
+++ b/Tests/ProxyCLITests/CLICommandTests.swift
@@ -140,6 +140,33 @@ struct CLICommandTests {
         #expect(output.snapshot() == [CLIParser.removedLazyInitMessage])
     }
 
+    @Test func cliCommandRejectsRemovedXcodePIDFlag() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { output.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { _, _, _, _ in RecordingCLIAdapter() },
+                input: .standardInput,
+                output: .standardOutput
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy", "--xcode-pid", "1234"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [CLIParser.removedXcodePIDMessage])
+    }
+
     @Test func cliCommandBuildsAdapterFromResolvedEnvironmentURL() async throws {
         let createdAdapter = RecordingCLIAdapter()
         let captured = LockedBox<(url: URL?, timeout: TimeInterval?)>((nil, nil))

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -57,6 +57,25 @@ struct CLIParserTests {
         }
     }
 
+    @Test func cliRejectsRemovedXcodePID() async throws {
+        #expect(throws: CLIError.self) {
+            _ = try CLIParser.parse(
+                args: ["xcode-mcp-proxy", "--xcode-pid", "1234"],
+                environment: [:]
+            )
+        }
+
+        do {
+            _ = try CLIParser.parse(
+                args: ["xcode-mcp-proxy", "--xcode-pid", "1234"],
+                environment: [:]
+            )
+            #expect(Bool(false))
+        } catch let error as CLIError {
+            #expect(error.description == CLIParser.removedXcodePIDMessage)
+        }
+    }
+
     @Test func cliParsesRefreshCodeIssuesMode() async throws {
         let config = try CLIParser.parse(
             args: ["xcode-mcp-proxy", "--refresh-code-issues-mode", "upstream"],
@@ -114,15 +133,26 @@ struct CLIParserTests {
             args: ["xcode-mcp-proxy"],
             environment: [
                 "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
-                "MCP_XCODE_PID": "1234",
                 "MCP_XCODE_SESSION_ID": "session-xyz",
                 "MCP_XCODE_REFRESH_CODE_ISSUES_MODE": "upstream",
             ]
         )
         #expect(config.configPath == "/tmp/proxy-config.toml")
-        #expect(config.xcodePID == 1234)
         #expect(config.upstreamSessionID == "session-xyz")
         #expect(config.refreshCodeIssuesMode == .upstream)
+    }
+
+    @Test func cliIgnoresRemovedXcodePIDEnvironment() async throws {
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy"],
+            environment: [
+                "XCODE_PID": "1234",
+                "MCP_XCODE_PID": "5678",
+                "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
+            ]
+        )
+
+        #expect(config.configPath == "/tmp/proxy-config.toml")
     }
 
     @Test func cliExplicitConfigOverridesEnvironment() async throws {

--- a/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
@@ -12,7 +12,6 @@ struct ServerCommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePID: { "4321" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in IntegrationRecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -30,7 +29,7 @@ struct ServerCommandIntegrationTests {
 
         #expect(exitCode == 0)
         let line = try #require(output.snapshot().first)
-        #expect(line == "xcode-mcp-proxy-server --listen 127.0.0.1:7777 --config /tmp/proxy-config.toml --xcode-pid 4321")
+        #expect(line == "xcode-mcp-proxy-server --listen 127.0.0.1:7777 --config /tmp/proxy-config.toml")
     }
 
     @Test func serverCommandStartsInjectedProxyServer() async throws {
@@ -41,7 +40,6 @@ struct ServerCommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 stderr: { _ in },
-                resolveXcodePID: { "1234" },
                 terminateExistingServer: { host, port in
                     restarted.append("\(host):\(port)")
                     return true

--- a/Tests/ProxyCLITests/ServerCommandTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandTests.swift
@@ -27,7 +27,7 @@ struct ServerCommandTests {
         #expect(options.dryRun == true)
     }
 
-    @Test func serverCommandAppliesEnvironmentDefaultsAndResolvedXcodePID() throws {
+    @Test func serverCommandAppliesEnvironmentDefaultsWithoutXcodePID() throws {
         var options = ProxyServerOptions(
             forwardedArgs: [],
             showHelp: false,
@@ -35,7 +35,6 @@ struct ServerCommandTests {
             hasHostFlag: false,
             hasPortFlag: false,
             hasConfigFlag: false,
-            hasXcodePIDFlag: false,
             hasRefreshCodeIssuesModeFlag: false,
             forceRestart: false,
             dryRun: false
@@ -48,15 +47,12 @@ struct ServerCommandTests {
                 "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
                 "MCP_XCODE_REFRESH_CODE_ISSUES_MODE": "upstream",
             ],
-            to: &options,
-            resolveXcodePID: { "4242" },
-            stderr: { _ in }
+            to: &options
         )
 
         #expect(options.forwardedArgs == [
             "--listen", "127.0.0.1:9999",
             "--config", "/tmp/proxy-config.toml",
-            "--xcode-pid", "4242",
             "--refresh-code-issues-mode", "upstream",
         ])
     }
@@ -69,7 +65,6 @@ struct ServerCommandTests {
             hasHostFlag: false,
             hasPortFlag: false,
             hasConfigFlag: true,
-            hasXcodePIDFlag: false,
             hasRefreshCodeIssuesModeFlag: false,
             forceRestart: false,
             dryRun: false
@@ -79,14 +74,40 @@ struct ServerCommandTests {
             from: [
                 "MCP_XCODE_CONFIG": "/tmp/environment.toml",
             ],
-            to: &options,
-            resolveXcodePID: { nil },
-            stderr: { _ in }
+            to: &options
         )
 
         #expect(options.forwardedArgs.contains("--config"))
         #expect(options.forwardedArgs.contains("/tmp/explicit.toml"))
         #expect(options.forwardedArgs.contains("/tmp/environment.toml") == false)
+    }
+
+    @Test func serverCommandIgnoresRemovedXcodePIDEnvironment() throws {
+        var options = ProxyServerOptions(
+            forwardedArgs: [],
+            showHelp: false,
+            hasListenFlag: false,
+            hasHostFlag: false,
+            hasPortFlag: false,
+            hasConfigFlag: false,
+            hasRefreshCodeIssuesModeFlag: false,
+            forceRestart: false,
+            dryRun: false
+        )
+
+        try XcodeMCPProxyServerCommand.applyDefaults(
+            from: [
+                "HOST": "127.0.0.1",
+                "PORT": "9999",
+                "XCODE_PID": "1234",
+                "MCP_XCODE_PID": "5678",
+            ],
+            to: &options
+        )
+
+        #expect(options.forwardedArgs == [
+            "--listen", "127.0.0.1:9999",
+        ])
     }
 
     @Test func serverCommandRejectsRemovedLazyInitEnvironment() async throws {
@@ -96,7 +117,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePID: { "5678" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -123,7 +143,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePID: { "5678" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -139,6 +158,32 @@ struct ServerCommandTests {
         #expect(exitCode == 1)
         #expect(output.snapshot() == [
             "error: \(CLIParser.removedLazyInitMessage)",
+            "run with --help for usage",
+        ])
+    }
+
+    @Test func serverCommandRejectsRemovedXcodePIDFlagBeforeDryRun() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyServerCommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { output.append($0) },
+                stderr: { output.append($0) },
+                terminateExistingServer: { _, _ in false },
+                makeServer: { _ in RecordingProxyServer() },
+                isAddressAlreadyInUse: { _ in false },
+                detectExistingProxyServerPIDs: { _, _ in [] }
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy-server", "--xcode-pid", "1234", "--dry-run"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [
+            "error: \(CLIParser.removedXcodePIDMessage)",
             "run with --help for usage",
         ])
     }
@@ -237,7 +282,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 stderr: { _ in },
-                resolveXcodePID: { "1234" },
                 terminateExistingServer: { host, port in
                     restarted.append("\(host):\(port)")
                     return true
@@ -276,7 +320,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePID: { "5678" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -297,7 +340,6 @@ struct ServerCommandTests {
         let line = try #require(output.snapshot().first)
         #expect(line.contains("--listen 127.0.0.1:9999"))
         #expect(line.contains("--config /tmp/proxy-config.toml"))
-        #expect(line.contains("--xcode-pid 5678"))
         #expect(line.contains("--lazy-init") == false)
     }
 
@@ -309,7 +351,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { errors.append($0) },
-                resolveXcodePID: { "7777" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -330,7 +371,6 @@ struct ServerCommandTests {
         #expect(errors.snapshot().isEmpty)
         let line = try #require(output.snapshot().first)
         #expect(line.contains("--upstream-arg --help"))
-        #expect(line.contains("--xcode-pid 7777"))
         #expect(line.contains("Usage:") == false)
     }
 
@@ -342,7 +382,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { errors.append($0) },
-                resolveXcodePID: { "7777" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },

--- a/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
@@ -203,7 +203,6 @@ private struct TestHTTPServer {
             listenPort: 0,
             upstreamCommand: "xcrun",
             upstreamArgs: ["mcpbridge"],
-            xcodePID: nil,
             upstreamSessionID: nil,
             maxBodyBytes: 1_048_576,
             requestTimeout: 5,

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -3610,7 +3610,6 @@ private func makeConfig(
         listenPort: 0,
         upstreamCommand: "xcrun",
         upstreamArgs: ["mcpbridge"],
-        xcodePID: nil,
         upstreamSessionID: nil,
         maxBodyBytes: maxBodyBytes,
         requestTimeout: requestTimeout

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -572,7 +572,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(params["protocolVersion"] as? String == "2025-03-26")
         #expect(clientInfo["name"] as? String == "custom-proxy")
-        #expect(clientInfo["version"] as? String == manager.defaultCodexClientVersion())
+        #expect(clientInfo["version"] as? String == manager.defaultProxyClientVersion())
         #expect(capabilities["roots"] as? Bool == true)
     }
 
@@ -641,7 +641,8 @@ struct RuntimeCoordinatorTests {
         let clientInfo = try #require(params["clientInfo"] as? [String: Any])
 
         #expect(params["protocolVersion"] as? String == "2025-03-26")
-        #expect(clientInfo["name"] as? String == "Codex")
+        #expect(clientInfo["name"] as? String == manager.defaultProxyClientName())
+        #expect(clientInfo["version"] as? String == manager.defaultProxyClientVersion())
     }
 
     @Test func sessionManagerUsesConfiguredInitializeParamsAfterEagerInitTimesOut()
@@ -697,7 +698,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(params["protocolVersion"] as? String == "2025-03-26")
         #expect(clientInfo["name"] as? String == "configured-proxy")
-        #expect(clientInfo["version"] as? String == manager.defaultCodexClientVersion())
+        #expect(clientInfo["version"] as? String == manager.defaultProxyClientVersion())
     }
 
     @Test func sessionManagerSendsInitializedOnce() async throws {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -7,6 +7,26 @@ import XcodeMCPTestSupport
 
 @Suite(.serialized)
 struct RuntimeCoordinatorTests {
+    @Test func defaultUpstreamsDoNotInjectXcodePIDEnvironment() async throws {
+        let environment = try defaultUpstreamEnvironment(sharedSessionID: nil)
+
+        #expect(environment["MCP_XCODE_PID"] == nil)
+    }
+
+    @Test func defaultUpstreamsPassThroughInheritedMCPXcodePIDEnvironment() async throws {
+        let environment = try withEnvironmentVariables(
+            [
+                "XCODE_PID": "1234",
+                "MCP_XCODE_PID": "5678",
+            ]
+        ) {
+            try defaultUpstreamEnvironment(sharedSessionID: nil)
+        }
+
+        #expect(environment["XCODE_PID"] == nil)
+        #expect(environment["MCP_XCODE_PID"] == "5678")
+    }
+
     @Test func defaultUpstreamsDoNotInjectSessionIDWhenConfigDoesNotSpecifyOne() async throws {
         let environment = try defaultUpstreamEnvironment(sharedSessionID: nil)
 
@@ -1642,7 +1662,6 @@ private func makeConfig(requestTimeout: TimeInterval) -> ProxyConfig {
         listenPort: 0,
         upstreamCommand: "xcrun",
         upstreamArgs: ["mcpbridge"],
-        xcodePID: nil,
         upstreamSessionID: nil,
         maxBodyBytes: 1024,
         requestTimeout: requestTimeout,
@@ -1674,6 +1693,31 @@ private func upstreamEnvironment(from upstream: UpstreamProcess) throws -> [Stri
             as? [String: String],
         "UpstreamProcess.Config should include environment for tests"
     )
+}
+
+private func withEnvironmentVariables<T>(
+    _ values: [String: String],
+    body: () throws -> T
+) throws -> T {
+    let originalValues = values.keys.reduce(into: [String: String?]()) { result, key in
+        result[key] = ProcessInfo.processInfo.environment[key]
+    }
+
+    for (key, value) in values {
+        _ = unsafe setenv(key, value, 1)
+    }
+
+    defer {
+        for (key, value) in originalValues {
+            if let value {
+                _ = unsafe setenv(key, value, 1)
+            } else {
+                _ = unsafe unsetenv(key)
+            }
+        }
+    }
+
+    return try body()
 }
 
 private actor AlwaysOverloadedUpstreamClient: UpstreamClient {


### PR DESCRIPTION
Summary:
- Restore `MCP_XCODE_PID` pass-through to spawned upstream processes while keeping `XCODE_PID` and `--xcode-pid` removed
- Switch the default upstream handshake identity to `XcodeMCPKit` / `dev` while preserving auto-version lookup for explicit well-known client names
- Update runtime assertions and README docs for the new upstream env and handshake defaults

Testing:
- `swift build`
- `swift test`
- `/Users/kn/Dev/PDSkillsSPI/Frameworks/PDSkills/skills/codex/codex-review/scripts/codex-review-quiet.sh -C /Users/kn/Dev/XcodeMCPKit --uncommitted`
- Manual verification in Xcode (user-reported)