### PR TITLE
feat(proxy): add configurable upstream handshake

### DIFF
--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -82,8 +82,5 @@ When the proxy runs in `--refresh-code-issues-mode upstream`, Xcode's live diagn
 - If a client bursts too many queued refreshes for the same tab in `upstream` mode, the proxy may return `refresh queue overloaded` instead of letting the queue grow without bound.
 - If you need Xcode's native live diagnostics behavior, start the proxy with `--refresh-code-issues-mode upstream` (or `MCP_XCODE_REFRESH_CODE_ISSUES_MODE=upstream`).
 
-## Xcode dialog does not appear
-Make sure `--lazy-init` is not set (when enabled, the dialog appears on the first request instead of at startup).
-
 ## `session not found`
 Ensure the client is using the same session.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0467fec770930145344ca4da019ea4b8d5e2ee9be71ce6bfc011c2d830feda27",
+  "originHash" : "0c784fd28af75184c7b06f205f2c0aaa321c261e63501cd609d304b0486ce051",
   "pins" : [
     {
       "identity" : "swift-atomics",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "tomldecoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dduan/TOMLDecoder.git",
+      "state" : {
+        "revision" : "f4388e05c035d6430e94022c353123abc020f1c4",
+        "version" : "0.4.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+        .package(url: "https://github.com/dduan/TOMLDecoder.git", from: "0.4.3"),
     ],
     targets: [
         .target(
@@ -51,6 +52,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIO", package: "swift-nio"),
+                .product(name: "TOMLDecoder", package: "TOMLDecoder"),
             ],
             path: "Sources/ProxyCore",
             swiftSettings: strictSwiftSettings

--- a/README.ja.md
+++ b/README.ja.md
@@ -116,16 +116,6 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 - max body size: `1048576` bytes
 - initialization: eager at startup
 - discovery: `~/Library/Caches/XcodeMCPProxy/endpoint.json`
-#### 環境変数
-
-- `MCP_XCODE_PID`（`--xcode-pid` の代替）
-- `MCP_XCODE_SESSION_ID`（Xcode MCP セッション ID を固定。通常は不要）
-- `MCP_XCODE_REFRESH_CODE_ISSUES_MODE`（`proxy` または `upstream`。`XcodeRefreshCodeIssuesInFile` の実装モードを切り替え）
-- `MCP_LOG_LEVEL`（ログレベル: trace|debug|info|notice|warning|error|critical）
-
-ログは stderr に出力されます。
-
-Note: `--upstream-processes` > 1 を使う場合、`--session-id` / `MCP_XCODE_SESSION_ID` でセッション ID を固定すると、Xcode の許可ダイアログを減らせる場合があります。
 
 #### オプション
 
@@ -136,12 +126,39 @@ Note: `--upstream-processes` > 1 を使う場合、`--session-id` / `MCP_XCODE_S
 | `--upstream-arg value` | `mcpbridge` 引数を1つ追加 |
 | `--upstream-processes n` | upstream `mcpbridge` を `n` プロセス起動（default: 1, max: 10） |
 | `--xcode-pid pid` | 対象 Xcode の PID |
-| `--session-id id` | Xcode MCP セッション ID（通常は不要） |
+| `--session-id id` | 明示的な Xcode MCP セッション ID |
 | `--max-body-bytes n` | 最大ボディサイズ |
-| `--request-timeout seconds` | リクエストタイムアウト（`0` で無制限） |
+| `--request-timeout seconds` | リクエストタイムアウト（`0` で通常リクエストは無制限、`initialize` はハンドシェイク保護のため有界タイムアウトを維持） |
+| `--config path` | upstream へ送る handshake を上書きする proxy config TOML のパス |
 | `--refresh-code-issues-mode proxy|upstream` | `XcodeRefreshCodeIssuesInFile` を proxy 側の navigator issues 経由（既定）で返すか、Xcode の live diagnostics へ直通するかを切り替え |
-| `--lazy-init` | 初回リクエストまで初期化を遅延 |
 | `--force-restart` | listen ポートが使用中の場合、既存の `xcode-mcp-proxy-server` を終了して起動し直す |
+
+#### 環境変数
+
+| 変数 | 説明 |
+|------|------|
+| `LISTEN` | listen アドレス。例: `127.0.0.1:8765` |
+| `HOST` | listen ホスト。`LISTEN` 未指定時に `PORT` と組み合わせて使用 |
+| `PORT` | listen ポート。`LISTEN` 未指定時に `HOST` と組み合わせて使用 |
+| `XCODE_PID` | Xcode PID |
+| `MCP_XCODE_PID` | Xcode PID のフォールバック |
+| `MCP_XCODE_SESSION_ID` | 任意の明示的 upstream session ID |
+| `MCP_XCODE_CONFIG` | proxy config TOML のパス。`--config` が優先 |
+| `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` または `upstream` |
+| `MCP_LOG_LEVEL` | ログレベル: `trace`, `debug`, `info`, `notice`, `warning`, `error`, `critical` |
+
+ログは stderr に出力されます。
+
+#### Proxy Config
+
+| キー | 型 | 既定値 |
+|------|----|--------|
+| `upstream_handshake.protocolVersion` | string | `"2025-03-26"` |
+| `upstream_handshake.clientName` | string | `"Codex"` |
+| `upstream_handshake.clientVersion` | string | `auto` |
+| `upstream_handshake.capabilities` | table | `{}` |
+
+`clientVersion` を省略した場合、`clientName` に対応する Xcode の `IDEChat*Version` があれば、その version を自動で使います。
 
 ### アダプタ: `xcode-mcp-proxy`
 
@@ -154,7 +171,9 @@ Note: `--upstream-processes` > 1 を使う場合、`--session-id` / `MCP_XCODE_S
 
 #### 環境変数
 
-- `XCODE_MCP_PROXY_ENDPOINT`（上流 URL を上書き。`--url` が優先）
+| 変数 | 説明 |
+|------|------|
+| `XCODE_MCP_PROXY_ENDPOINT` | 上流 URL を上書き。`--url` が優先 |
 
 ## トラブルシューティング
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -120,18 +120,17 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 #### オプション
 
 | オプション | 説明 |
-|-----------|------|
-| `--upstream-command cmd` | `mcpbridge` コマンド |
+|--------|-------------|
+| `--upstream-command cmd` | `mcpbridge` 実行コマンド |
 | `--upstream-args a,b,c` | `mcpbridge` 引数（カンマ区切り） |
-| `--upstream-arg value` | `mcpbridge` 引数を1つ追加 |
-| `--upstream-processes n` | upstream `mcpbridge` を `n` プロセス起動（default: 1, max: 10） |
-| `--xcode-pid pid` | 対象 Xcode の PID |
+| `--upstream-arg value` | `mcpbridge` 引数の追加（単一項目） |
+| `--upstream-processes n` | アップストリーム `mcpbridge` プロセスの起動数（デフォルト: 1、最大: 10） |
 | `--session-id id` | 明示的な Xcode MCP セッション ID |
-| `--max-body-bytes n` | 最大ボディサイズ |
-| `--request-timeout seconds` | リクエストタイムアウト（`0` で通常リクエストは無制限、`initialize` はハンドシェイク保護のため有界タイムアウトを維持） |
-| `--config path` | upstream へ送る handshake を上書きする proxy config TOML のパス |
-| `--refresh-code-issues-mode proxy|upstream` | `XcodeRefreshCodeIssuesInFile` を proxy 側の navigator issues 経由（既定）で返すか、Xcode の live diagnostics へ直通するかを切り替え |
-| `--force-restart` | listen ポートが使用中の場合、既存の `xcode-mcp-proxy-server` を終了して起動し直す |
+| `--max-body-bytes n` | リクエストボディの最大サイズ |
+| `--request-timeout seconds` | リクエストタイムアウト設定（`0` で初期化以外のタイムアウトを無効化。`initialize` 時のハンドシェイクには固定のタイムアウトが適用されます） |
+| `--config path` | アップストリームのハンドシェイクを上書きするためのプロキシ設定（TOML）のパス |
+| `--refresh-code-issues-mode mode` | `XcodeRefreshCodeIssuesInFile` の提供モード。プロキシ側のナビゲーター問題として処理（`proxy`、デフォルト）、または Xcode のライブ診断へパススルー（`upstream`） |
+| `--force-restart` | ポートが使用中の場合、既存の `xcode-mcp-proxy-server` を終了して再起動 |
 
 #### 環境変数
 
@@ -140,8 +139,7 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 | `LISTEN` | listen アドレス。例: `127.0.0.1:8765` |
 | `HOST` | listen ホスト。`LISTEN` 未指定時に `PORT` と組み合わせて使用 |
 | `PORT` | listen ポート。`LISTEN` 未指定時に `HOST` と組み合わせて使用 |
-| `XCODE_PID` | Xcode PID |
-| `MCP_XCODE_PID` | Xcode PID のフォールバック |
+| `MCP_XCODE_PID` | upstream `mcpbridge` へそのまま渡す互換 env。proxy 自身は解釈しない |
 | `MCP_XCODE_SESSION_ID` | 任意の明示的 upstream session ID |
 | `MCP_XCODE_CONFIG` | proxy config TOML のパス。`--config` が優先 |
 | `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` または `upstream` |

--- a/README.ja.md
+++ b/README.ja.md
@@ -152,8 +152,8 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 | キー | 型 | 既定値 |
 |------|----|--------|
 | `upstream_handshake.protocolVersion` | string | `"2025-03-26"` |
-| `upstream_handshake.clientName` | string | `"Codex"` |
-| `upstream_handshake.clientVersion` | string | `auto` |
+| `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
+| `upstream_handshake.clientVersion` | string | `"dev"` |
 | `upstream_handshake.capabilities` | table | `{}` |
 
 `clientVersion` を省略した場合、`clientName` に対応する Xcode の `IDEChat*Version` があれば、その version を自動で使います。

--- a/README.md
+++ b/README.md
@@ -125,12 +125,11 @@ See Quick Start for how to launch.
 | `--upstream-args a,b,c` | `mcpbridge` args (comma-separated) |
 | `--upstream-arg value` | Append a single `mcpbridge` arg |
 | `--upstream-processes n` | Spawn `n` upstream `mcpbridge` processes (default: 1, max: 10) |
-| `--xcode-pid pid` | Xcode PID |
 | `--session-id id` | Explicit Xcode MCP session ID |
 | `--max-body-bytes n` | Max request body size |
 | `--request-timeout seconds` | Request timeout (`0` disables non-initialize timeouts; `initialize` still uses a bounded handshake timeout) |
 | `--config path` | Path to proxy config TOML for overriding the upstream handshake |
-| `--refresh-code-issues-mode proxy|upstream` | Serve `XcodeRefreshCodeIssuesInFile` via proxy navigator issues (`proxy`, default) or pass through to Xcode live diagnostics (`upstream`) |
+| `--refresh-code-issues-mode mode` | Serve `XcodeRefreshCodeIssuesInFile` via proxy navigator issues (`proxy`, default) or pass through to Xcode live diagnostics (`upstream`) |
 | `--force-restart` | If the listen port is in use, terminate an existing `xcode-mcp-proxy-server` and restart |
 
 #### Environment Variables
@@ -140,8 +139,7 @@ See Quick Start for how to launch.
 | `LISTEN` | Listen address; example: `127.0.0.1:8765` |
 | `HOST` | Listen host; used with `PORT` when `LISTEN` is unset |
 | `PORT` | Listen port; used with `HOST` when `LISTEN` is unset |
-| `XCODE_PID` | Xcode PID |
-| `MCP_XCODE_PID` | Xcode PID fallback |
+| `MCP_XCODE_PID` | Passed through to upstream `mcpbridge`; the proxy itself does not parse it |
 | `MCP_XCODE_SESSION_ID` | Optional explicit upstream session ID |
 | `MCP_XCODE_CONFIG` | Proxy config TOML path; `--config` takes precedence |
 | `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` or `upstream` |

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Logs are written to stderr.
 | Key | Type | Default |
 |-----|------|---------|
 | `upstream_handshake.protocolVersion` | string | `"2025-03-26"` |
-| `upstream_handshake.clientName` | string | `"Codex"` |
-| `upstream_handshake.clientVersion` | string | `auto` |
+| `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
+| `upstream_handshake.clientVersion` | string | `"dev"` |
 | `upstream_handshake.capabilities` | table | `{}` |
 
 If `clientVersion` is omitted, the proxy auto-resolves it from the Xcode `IDEChat*Version` entry matching `clientName` when available.

--- a/README.md
+++ b/README.md
@@ -117,17 +117,6 @@ See Quick Start for how to launch.
 - initialization: eager at startup
 - discovery: `~/Library/Caches/XcodeMCPProxy/endpoint.json`
 
-#### Environment Variables
-
-- `MCP_XCODE_PID` (alternative to `--xcode-pid`)
-- `MCP_XCODE_SESSION_ID` (fixes the Xcode MCP session ID; usually not needed)
-- `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` (`proxy` or `upstream`; controls how `XcodeRefreshCodeIssuesInFile` is served)
-- `MCP_LOG_LEVEL` (log level: trace|debug|info|notice|warning|error|critical)
-
-Logs are written to stderr.
-
-Note: when using `--upstream-processes` > 1, fixing the session id via `--session-id` / `MCP_XCODE_SESSION_ID` can help reduce permission dialog prompts in Xcode.
-
 #### Options
 
 | Option | Description |
@@ -137,12 +126,39 @@ Note: when using `--upstream-processes` > 1, fixing the session id via `--sessio
 | `--upstream-arg value` | Append a single `mcpbridge` arg |
 | `--upstream-processes n` | Spawn `n` upstream `mcpbridge` processes (default: 1, max: 10) |
 | `--xcode-pid pid` | Xcode PID |
-| `--session-id id` | Xcode MCP session ID (usually not needed) |
+| `--session-id id` | Explicit Xcode MCP session ID |
 | `--max-body-bytes n` | Max request body size |
-| `--request-timeout seconds` | Request timeout (`0` disables) |
+| `--request-timeout seconds` | Request timeout (`0` disables non-initialize timeouts; `initialize` still uses a bounded handshake timeout) |
+| `--config path` | Path to proxy config TOML for overriding the upstream handshake |
 | `--refresh-code-issues-mode proxy|upstream` | Serve `XcodeRefreshCodeIssuesInFile` via proxy navigator issues (`proxy`, default) or pass through to Xcode live diagnostics (`upstream`) |
-| `--lazy-init` | Delay initialization until first request |
 | `--force-restart` | If the listen port is in use, terminate an existing `xcode-mcp-proxy-server` and restart |
+
+#### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LISTEN` | Listen address; example: `127.0.0.1:8765` |
+| `HOST` | Listen host; used with `PORT` when `LISTEN` is unset |
+| `PORT` | Listen port; used with `HOST` when `LISTEN` is unset |
+| `XCODE_PID` | Xcode PID |
+| `MCP_XCODE_PID` | Xcode PID fallback |
+| `MCP_XCODE_SESSION_ID` | Optional explicit upstream session ID |
+| `MCP_XCODE_CONFIG` | Proxy config TOML path; `--config` takes precedence |
+| `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` or `upstream` |
+| `MCP_LOG_LEVEL` | Log level: `trace`, `debug`, `info`, `notice`, `warning`, `error`, `critical` |
+
+Logs are written to stderr.
+
+#### Proxy Config
+
+| Key | Type | Default |
+|-----|------|---------|
+| `upstream_handshake.protocolVersion` | string | `"2025-03-26"` |
+| `upstream_handshake.clientName` | string | `"Codex"` |
+| `upstream_handshake.clientVersion` | string | `auto` |
+| `upstream_handshake.capabilities` | table | `{}` |
+
+If `clientVersion` is omitted, the proxy auto-resolves it from the Xcode `IDEChat*Version` entry matching `clientName` when available.
 
 ### Adapter: `xcode-mcp-proxy`
 
@@ -155,7 +171,9 @@ Note: when using `--upstream-processes` > 1, fixing the session id via `--sessio
 
 #### Environment Variables
 
-- `XCODE_MCP_PROXY_ENDPOINT` (override upstream URL; `--url` takes precedence)
+| Variable | Description |
+|----------|-------------|
+| `XCODE_MCP_PROXY_ENDPOINT` | Override upstream URL; `--url` takes precedence |
 
 ## Troubleshooting
 

--- a/Sources/ProxyCLI/CLICommandRuntime.swift
+++ b/Sources/ProxyCLI/CLICommandRuntime.swift
@@ -25,6 +25,11 @@ package struct CLICommandRuntime {
             return 1
         }
 
+        if let removedFlagMessage = invocation.removedFlagMessage {
+            logSink.error(removedFlagMessage)
+            return 1
+        }
+
         if invocation.serverOnlyFlag != nil {
             logSink.error(
                 "This option is only supported by xcode-mcp-proxy-server (proxy server)."

--- a/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
+++ b/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
@@ -1,8 +1,10 @@
 import Foundation
+import XcodeMCPProxy
 
 package struct ProxyCLIAdapterScan {
     package var showHelp = false
     package var usesRemovedURLHelper = false
+    package var removedFlagMessage: String?
     package var hasExplicitURL = false
     package var hasStdioFlag = false
     package var serverOnlyFlag: String?
@@ -14,8 +16,8 @@ package struct ProxyCLIServerScan {
     package var hasListenFlag = false
     package var hasHostFlag = false
     package var hasPortFlag = false
+    package var hasConfigFlag = false
     package var hasXcodePIDFlag = false
-    package var hasLazyInitFlag = false
     package var hasRefreshCodeIssuesModeFlag = false
     package var forceRestart = false
     package var dryRun = false
@@ -27,6 +29,7 @@ package struct ProxyCLIInstallScan {
 
 package enum ProxyCLIInvocationScanner {
     private static let serverOnlyFlags: Set<String> = [
+        "--config",
         "--listen",
         "--host",
         "--port",
@@ -38,10 +41,10 @@ package enum ProxyCLIInvocationScanner {
         "--xcode-pid",
         "--session-id",
         "--refresh-code-issues-mode",
-        "--lazy-init",
     ]
 
     private static let serverOnlyValueFlags: Set<String> = [
+        "--config",
         "--listen",
         "--host",
         "--port",
@@ -56,6 +59,7 @@ package enum ProxyCLIInvocationScanner {
     ]
 
     private static let serverForwardedValueFlags: Set<String> = [
+        "--config",
         "--listen",
         "--host",
         "--port",
@@ -94,6 +98,11 @@ package enum ProxyCLIInvocationScanner {
             case "--stdio":
                 scan.hasStdioFlag = true
                 cursor.advancePastCurrentAndOptionalValue(where: { !$0.hasPrefix("-") })
+            case "--lazy-init":
+                if scan.removedFlagMessage == nil {
+                    scan.removedFlagMessage = CLIParser.removedLazyInitMessage
+                }
+                cursor.advance()
             case "--request-timeout":
                 cursor.advancePastCurrentAndOptionalValue(where: shouldConsumeRequestTimeoutValue)
             case let flag where serverOnlyFlags.contains(flag):
@@ -139,16 +148,15 @@ package enum ProxyCLIInvocationScanner {
                     "--url is not supported in server mode (use xcode-mcp-proxy)"
                 )
             case "--lazy-init":
-                scan.hasLazyInitFlag = true
-                scan.forwardedArgs.append(arg)
-                cursor.advance()
-                continue
+                throw ProxyServerCommandError.message(CLIParser.removedLazyInitMessage)
             case "--listen":
                 scan.hasListenFlag = true
             case "--host":
                 scan.hasHostFlag = true
             case "--port":
                 scan.hasPortFlag = true
+            case "--config":
+                scan.hasConfigFlag = true
             case "--xcode-pid":
                 scan.hasXcodePIDFlag = true
             case "--refresh-code-issues-mode":

--- a/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
+++ b/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
@@ -17,7 +17,6 @@ package struct ProxyCLIServerScan {
     package var hasHostFlag = false
     package var hasPortFlag = false
     package var hasConfigFlag = false
-    package var hasXcodePIDFlag = false
     package var hasRefreshCodeIssuesModeFlag = false
     package var forceRestart = false
     package var dryRun = false
@@ -38,7 +37,6 @@ package enum ProxyCLIInvocationScanner {
         "--upstream-args",
         "--upstream-arg",
         "--upstream-processes",
-        "--xcode-pid",
         "--session-id",
         "--refresh-code-issues-mode",
     ]
@@ -53,7 +51,6 @@ package enum ProxyCLIInvocationScanner {
         "--upstream-args",
         "--upstream-arg",
         "--upstream-processes",
-        "--xcode-pid",
         "--session-id",
         "--refresh-code-issues-mode",
     ]
@@ -67,7 +64,6 @@ package enum ProxyCLIInvocationScanner {
         "--upstream-args",
         "--upstream-arg",
         "--upstream-processes",
-        "--xcode-pid",
         "--session-id",
         "--max-body-bytes",
         "--request-timeout",
@@ -103,6 +99,11 @@ package enum ProxyCLIInvocationScanner {
                     scan.removedFlagMessage = CLIParser.removedLazyInitMessage
                 }
                 cursor.advance()
+            case "--xcode-pid":
+                if scan.removedFlagMessage == nil {
+                    scan.removedFlagMessage = CLIParser.removedXcodePIDMessage
+                }
+                cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
             case "--request-timeout":
                 cursor.advancePastCurrentAndOptionalValue(where: shouldConsumeRequestTimeoutValue)
             case let flag where serverOnlyFlags.contains(flag):
@@ -147,6 +148,8 @@ package enum ProxyCLIInvocationScanner {
                 throw ProxyServerCommandError.message(
                     "--url is not supported in server mode (use xcode-mcp-proxy)"
                 )
+            case "--xcode-pid":
+                throw ProxyServerCommandError.message(CLIParser.removedXcodePIDMessage)
             case "--lazy-init":
                 throw ProxyServerCommandError.message(CLIParser.removedLazyInitMessage)
             case "--listen":
@@ -157,8 +160,6 @@ package enum ProxyCLIInvocationScanner {
                 scan.hasPortFlag = true
             case "--config":
                 scan.hasConfigFlag = true
-            case "--xcode-pid":
-                scan.hasXcodePIDFlag = true
             case "--refresh-code-issues-mode":
                 scan.hasRefreshCodeIssuesModeFlag = true
             default:

--- a/Sources/ProxyCLI/ProxyServerCommandRuntime.swift
+++ b/Sources/ProxyCLI/ProxyServerCommandRuntime.swift
@@ -15,12 +15,7 @@ package struct ProxyServerCommandRuntime {
                 dependencies.stdout(XcodeMCPProxyServerCommand.serverUsage())
                 return 0
             }
-            try XcodeMCPProxyServerCommand.applyDefaults(
-                from: environment,
-                to: &options,
-                resolveXcodePID: dependencies.resolveXcodePID,
-                stderr: dependencies.stderr
-            )
+            try XcodeMCPProxyServerCommand.applyDefaults(from: environment, to: &options)
 
             let isDryRun = options.dryRun || XcodeMCPProxyServerCommand.isTruthy(environment["DRY_RUN"])
             if isDryRun {

--- a/Sources/ProxyCLI/ProxyServerCommandRuntime.swift
+++ b/Sources/ProxyCLI/ProxyServerCommandRuntime.swift
@@ -15,12 +15,12 @@ package struct ProxyServerCommandRuntime {
                 dependencies.stdout(XcodeMCPProxyServerCommand.serverUsage())
                 return 0
             }
-        XcodeMCPProxyServerCommand.applyDefaults(
-            from: environment,
-            to: &options,
-            resolveXcodePID: dependencies.resolveXcodePID,
-            stderr: dependencies.stderr
-        )
+            try XcodeMCPProxyServerCommand.applyDefaults(
+                from: environment,
+                to: &options,
+                resolveXcodePID: dependencies.resolveXcodePID,
+                stderr: dependencies.stderr
+            )
 
             let isDryRun = options.dryRun || XcodeMCPProxyServerCommand.isTruthy(environment["DRY_RUN"])
             if isDryRun {

--- a/Sources/ProxyCLI/XcodeMCPProxyCLICommand+Parsing.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyCLICommand+Parsing.swift
@@ -7,6 +7,7 @@ extension XcodeMCPProxyCLICommand {
         var invocation = CLICommandInvocation()
         invocation.showHelp = scan.showHelp
         invocation.usesRemovedURLHelper = scan.usesRemovedURLHelper
+        invocation.removedFlagMessage = scan.removedFlagMessage
         invocation.hasExplicitURL = scan.hasExplicitURL
         invocation.hasStdioFlag = scan.hasStdioFlag
         invocation.serverOnlyFlag = scan.serverOnlyFlag
@@ -79,6 +80,7 @@ extension XcodeMCPProxyCLICommand {
 
         Notes:
           - Proxy server: xcode-mcp-proxy-server
+          - --config is only supported by xcode-mcp-proxy-server
           - Discovery file: \(discoveryFileURL.path)
         """
     }

--- a/Sources/ProxyCLI/XcodeMCPProxyCLICommand.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyCLICommand.swift
@@ -20,6 +20,7 @@ package struct CLICommandLogSink {
 package struct CLICommandInvocation {
     package var showHelp = false
     package var usesRemovedURLHelper = false
+    package var removedFlagMessage: String?
     package var hasExplicitURL = false
     package var hasStdioFlag = false
     package var serverOnlyFlag: String?

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
@@ -10,8 +10,8 @@ extension XcodeMCPProxyServerCommand {
             hasListenFlag: scan.hasListenFlag,
             hasHostFlag: scan.hasHostFlag,
             hasPortFlag: scan.hasPortFlag,
+            hasConfigFlag: scan.hasConfigFlag,
             hasXcodePIDFlag: scan.hasXcodePIDFlag,
-            hasLazyInitFlag: scan.hasLazyInitFlag,
             hasRefreshCodeIssuesModeFlag: scan.hasRefreshCodeIssuesModeFlag,
             forceRestart: scan.forceRestart,
             dryRun: scan.dryRun
@@ -23,7 +23,7 @@ extension XcodeMCPProxyServerCommand {
         to options: inout ProxyServerOptions,
         resolveXcodePID: () -> String?,
         stderr: (String) -> Void
-    ) {
+    ) throws {
         if !options.hasListenFlag && !options.hasHostFlag && !options.hasPortFlag {
             if let listen = nonEmpty(environment["LISTEN"]) {
                 options.forwardedArgs += ["--listen", listen]
@@ -44,6 +44,12 @@ extension XcodeMCPProxyServerCommand {
             options.forwardedArgs += ["--port", "8765"]
         }
 
+        if !options.hasConfigFlag,
+           let configPath = nonEmpty(environment[CLIParser.configPathEnv])
+        {
+            options.forwardedArgs += ["--config", configPath]
+        }
+
         if !options.hasXcodePIDFlag {
             if let explicit = nonEmpty(environment["XCODE_PID"]) ?? nonEmpty(environment["MCP_XCODE_PID"]) {
                 options.forwardedArgs += ["--xcode-pid", explicit]
@@ -54,8 +60,8 @@ extension XcodeMCPProxyServerCommand {
             }
         }
 
-        if !options.hasLazyInitFlag, isTruthy(environment["LAZY_INIT"]) {
-            options.forwardedArgs.append("--lazy-init")
+        if isTruthy(environment["LAZY_INIT"]) {
+            throw ProxyServerCommandError.message(CLIParser.removedLazyInitMessage)
         }
 
         if !options.hasRefreshCodeIssuesModeFlag,
@@ -74,10 +80,10 @@ extension XcodeMCPProxyServerCommand {
           --listen host:port
           --host host
           --port port
+          --config path
           --upstream-processes n
           --xcode-pid pid
           --refresh-code-issues-mode proxy|upstream
-          --lazy-init
           --force-restart
           --dry-run
           -h, --help
@@ -86,6 +92,7 @@ extension XcodeMCPProxyServerCommand {
           - Starts the HTTP/SSE proxy server (and spawns xcrun mcpbridge as upstream processes).
           - Use xcode-mcp-proxy as a STDIO adapter for Codex / Claude Code.
           - Default listen: localhost:8765 (override via --listen / --host / --port or env LISTEN/HOST/PORT).
+          - Initialize config path: --config or env \(CLIParser.configPathEnv)
           - Xcode PID is detected automatically when not specified.
           - When the listen port is already in use, rerun with --force-restart to terminate an existing xcode-mcp-proxy-server.
         """

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
@@ -11,7 +11,6 @@ extension XcodeMCPProxyServerCommand {
             hasHostFlag: scan.hasHostFlag,
             hasPortFlag: scan.hasPortFlag,
             hasConfigFlag: scan.hasConfigFlag,
-            hasXcodePIDFlag: scan.hasXcodePIDFlag,
             hasRefreshCodeIssuesModeFlag: scan.hasRefreshCodeIssuesModeFlag,
             forceRestart: scan.forceRestart,
             dryRun: scan.dryRun
@@ -20,9 +19,7 @@ extension XcodeMCPProxyServerCommand {
 
     package static func applyDefaults(
         from environment: [String: String],
-        to options: inout ProxyServerOptions,
-        resolveXcodePID: () -> String?,
-        stderr: (String) -> Void
+        to options: inout ProxyServerOptions
     ) throws {
         if !options.hasListenFlag && !options.hasHostFlag && !options.hasPortFlag {
             if let listen = nonEmpty(environment["LISTEN"]) {
@@ -50,16 +47,6 @@ extension XcodeMCPProxyServerCommand {
             options.forwardedArgs += ["--config", configPath]
         }
 
-        if !options.hasXcodePIDFlag {
-            if let explicit = nonEmpty(environment["XCODE_PID"]) ?? nonEmpty(environment["MCP_XCODE_PID"]) {
-                options.forwardedArgs += ["--xcode-pid", explicit]
-            } else if let resolved = resolveXcodePID() {
-                options.forwardedArgs += ["--xcode-pid", resolved]
-            } else {
-                stderr("warning: Xcode PID not found; running without --xcode-pid.")
-            }
-        }
-
         if isTruthy(environment["LAZY_INIT"]) {
             throw ProxyServerCommandError.message(CLIParser.removedLazyInitMessage)
         }
@@ -82,7 +69,6 @@ extension XcodeMCPProxyServerCommand {
           --port port
           --config path
           --upstream-processes n
-          --xcode-pid pid
           --refresh-code-issues-mode proxy|upstream
           --force-restart
           --dry-run
@@ -93,7 +79,6 @@ extension XcodeMCPProxyServerCommand {
           - Use xcode-mcp-proxy as a STDIO adapter for Codex / Claude Code.
           - Default listen: localhost:8765 (override via --listen / --host / --port or env LISTEN/HOST/PORT).
           - Initialize config path: --config or env \(CLIParser.configPathEnv)
-          - Xcode PID is detected automatically when not specified.
           - When the listen port is already in use, rerun with --force-restart to terminate an existing xcode-mcp-proxy-server.
         """
     }

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+ProcessControl.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+ProcessControl.swift
@@ -20,31 +20,6 @@ extension XcodeMCPProxyServerCommand {
         return requested == actual
     }
 
-    static func resolveXcodePID() -> String? {
-        if let pid = firstLine(runCommand("/usr/bin/pgrep", ["-x", "Xcode"])) {
-            return pid
-        }
-        if let pid = firstLine(
-            runCommand("/usr/bin/pgrep", ["-f", "/Applications/Xcode.*\\.app/Contents/MacOS/Xcode"])
-        ) {
-            return pid
-        }
-        if let pid = firstLine(
-            runCommand("/usr/bin/pgrep", ["-f", "Xcode.app/Contents/MacOS/Xcode"])
-        ) {
-            return pid
-        }
-
-        _ = runCommand("/usr/bin/open", ["-a", "Xcode"])
-        for _ in 0..<40 {
-            if let pid = firstLine(runCommand("/usr/bin/pgrep", ["-x", "Xcode"])) {
-                return pid
-            }
-            Thread.sleep(forTimeInterval: 0.25)
-        }
-        return nil
-    }
-
     @discardableResult
     static func terminateExistingProxyServerIfNeeded(host: String, port: Int) -> Bool {
         if let record = Discovery.read(),

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
@@ -11,7 +11,6 @@ package struct ProxyServerOptions {
     package var hasHostFlag: Bool
     package var hasPortFlag: Bool
     package var hasConfigFlag: Bool
-    package var hasXcodePIDFlag: Bool
     package var hasRefreshCodeIssuesModeFlag: Bool
     package var forceRestart: Bool
     package var dryRun: Bool
@@ -23,7 +22,6 @@ package struct ProxyServerOptions {
         hasHostFlag: Bool,
         hasPortFlag: Bool,
         hasConfigFlag: Bool,
-        hasXcodePIDFlag: Bool,
         hasRefreshCodeIssuesModeFlag: Bool,
         forceRestart: Bool,
         dryRun: Bool
@@ -34,7 +32,6 @@ package struct ProxyServerOptions {
         self.hasHostFlag = hasHostFlag
         self.hasPortFlag = hasPortFlag
         self.hasConfigFlag = hasConfigFlag
-        self.hasXcodePIDFlag = hasXcodePIDFlag
         self.hasRefreshCodeIssuesModeFlag = hasRefreshCodeIssuesModeFlag
         self.forceRestart = forceRestart
         self.dryRun = dryRun
@@ -57,7 +54,6 @@ package struct XcodeMCPProxyServerCommand {
         package var bootstrapLogging: ([String: String]) -> Void
         package var stdout: (String) -> Void
         package var stderr: (String) -> Void
-        package var resolveXcodePID: () -> String?
         package var terminateExistingServer: (String, Int) -> Bool
         package var makeServer: (ProxyConfig) -> any ProxyServerCommandServer
         package var isAddressAlreadyInUse: (Error) -> Bool
@@ -67,7 +63,6 @@ package struct XcodeMCPProxyServerCommand {
             bootstrapLogging: @escaping ([String: String]) -> Void,
             stdout: @escaping (String) -> Void,
             stderr: @escaping (String) -> Void,
-            resolveXcodePID: @escaping () -> String?,
             terminateExistingServer: @escaping (String, Int) -> Bool,
             makeServer: @escaping (ProxyConfig) -> any ProxyServerCommandServer,
             isAddressAlreadyInUse: @escaping (Error) -> Bool,
@@ -76,7 +71,6 @@ package struct XcodeMCPProxyServerCommand {
             self.bootstrapLogging = bootstrapLogging
             self.stdout = stdout
             self.stderr = stderr
-            self.resolveXcodePID = resolveXcodePID
             self.terminateExistingServer = terminateExistingServer
             self.makeServer = makeServer
             self.isAddressAlreadyInUse = isAddressAlreadyInUse
@@ -88,7 +82,6 @@ package struct XcodeMCPProxyServerCommand {
                 bootstrapLogging: ProxyLogging.bootstrap,
                 stdout: { print($0) },
                 stderr: { FileHandle.writeLine($0, to: .standardError) },
-                resolveXcodePID: XcodeMCPProxyServerCommand.resolveXcodePID,
                 terminateExistingServer: XcodeMCPProxyServerCommand.terminateExistingProxyServerIfNeeded,
                 makeServer: { ProxyServer(config: $0) },
                 isAddressAlreadyInUse: XcodeMCPProxyServerCommand.isAddressAlreadyInUse,

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
@@ -10,8 +10,8 @@ package struct ProxyServerOptions {
     package var hasListenFlag: Bool
     package var hasHostFlag: Bool
     package var hasPortFlag: Bool
+    package var hasConfigFlag: Bool
     package var hasXcodePIDFlag: Bool
-    package var hasLazyInitFlag: Bool
     package var hasRefreshCodeIssuesModeFlag: Bool
     package var forceRestart: Bool
     package var dryRun: Bool
@@ -22,8 +22,8 @@ package struct ProxyServerOptions {
         hasListenFlag: Bool,
         hasHostFlag: Bool,
         hasPortFlag: Bool,
+        hasConfigFlag: Bool,
         hasXcodePIDFlag: Bool,
-        hasLazyInitFlag: Bool,
         hasRefreshCodeIssuesModeFlag: Bool,
         forceRestart: Bool,
         dryRun: Bool
@@ -33,8 +33,8 @@ package struct ProxyServerOptions {
         self.hasListenFlag = hasListenFlag
         self.hasHostFlag = hasHostFlag
         self.hasPortFlag = hasPortFlag
+        self.hasConfigFlag = hasConfigFlag
         self.hasXcodePIDFlag = hasXcodePIDFlag
-        self.hasLazyInitFlag = hasLazyInitFlag
         self.hasRefreshCodeIssuesModeFlag = hasRefreshCodeIssuesModeFlag
         self.forceRestart = forceRestart
         self.dryRun = dryRun

--- a/Sources/ProxyCore/MCPMethodDispatcher.swift
+++ b/Sources/ProxyCore/MCPMethodDispatcher.swift
@@ -7,9 +7,11 @@ package enum MCPMethodDispatcher {
         "resources/list",
         "resources/templates/list",
     ]
+    private static let initializeFallbackTimeoutSeconds: TimeInterval = 60
 
     package static func timeoutForInitialize(defaultSeconds: TimeInterval) -> TimeAmount? {
-        timeout(defaultSeconds: defaultSeconds, capSeconds: 60)
+        let effectiveDefault = defaultSeconds > 0 ? defaultSeconds : initializeFallbackTimeoutSeconds
+        return timeout(defaultSeconds: effectiveDefault, capSeconds: initializeFallbackTimeoutSeconds)
     }
 
     package static func timeoutForMethod(

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -27,7 +27,7 @@ public struct ProxyConfig: Sendable {
     public var upstreamSessionID: String?
     public var maxBodyBytes: Int
     public var requestTimeout: TimeInterval
-    public var eagerInitialize: Bool
+    public var configPath: String?
     public var transport: ProxyTransport
     public var stdioUpstreamURL: URL?
     public var stdioUpstreamSource: StdioUpstreamSource?
@@ -44,7 +44,7 @@ public struct ProxyConfig: Sendable {
         upstreamSessionID: String? = nil,
         maxBodyBytes: Int,
         requestTimeout: TimeInterval,
-        eagerInitialize: Bool = true,
+        configPath: String? = nil,
         transport: ProxyTransport = .http,
         stdioUpstreamURL: URL? = nil,
         stdioUpstreamSource: StdioUpstreamSource? = nil,
@@ -60,7 +60,7 @@ public struct ProxyConfig: Sendable {
         self.upstreamSessionID = upstreamSessionID
         self.maxBodyBytes = maxBodyBytes
         self.requestTimeout = requestTimeout
-        self.eagerInitialize = eagerInitialize
+        self.configPath = configPath
         self.transport = transport
         self.stdioUpstreamURL = stdioUpstreamURL
         self.stdioUpstreamSource = stdioUpstreamSource
@@ -84,6 +84,9 @@ public struct CLIParser {
     private static let defaultStdioUpstream = "http://localhost:8765/mcp"
     private static let stdioEndpointEnv = "XCODE_MCP_PROXY_ENDPOINT"
     private static let refreshCodeIssuesModeEnv = "MCP_XCODE_REFRESH_CODE_ISSUES_MODE"
+    public static let configPathEnv = "MCP_XCODE_CONFIG"
+    public static let removedLazyInitMessage =
+        "The proxy always uses eager initialization; --lazy-init has been removed."
 
     public static func parse(args: [String], environment: [String: String]) throws -> ProxyConfig {
         return try parse(args: args, environment: environment, discoveryOverrideURL: nil)
@@ -103,7 +106,7 @@ public struct CLIParser {
         var upstreamSessionID: String?
         var maxBodyBytes = 1_048_576
         var requestTimeout: TimeInterval = 300
-        var eagerInitialize = true
+        var configPath: String?
         var stdioUpstreamURL: URL?
         var stdioUpstreamSource: StdioUpstreamSource?
         var refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy
@@ -193,6 +196,12 @@ public struct CLIParser {
                 }
                 requestTimeout = TimeInterval(args[index + 1]) ?? requestTimeout
                 index += 2
+            case "--config":
+                guard index + 1 < args.count else {
+                    throw CLIError.message("--config requires a value")
+                }
+                configPath = args[index + 1]
+                index += 2
             case "--refresh-code-issues-mode":
                 guard index + 1 < args.count else {
                     throw CLIError.message("--refresh-code-issues-mode requires proxy|upstream")
@@ -204,8 +213,7 @@ public struct CLIParser {
                 hasExplicitRefreshCodeIssuesMode = true
                 index += 2
             case "--lazy-init":
-                eagerInitialize = false
-                index += 1
+                throw CLIError.message(Self.removedLazyInitMessage)
             case "--stdio":
                 if index + 1 < args.count {
                     let candidate = args[index + 1]
@@ -242,6 +250,9 @@ public struct CLIParser {
             }
             refreshCodeIssuesMode = parsed
         }
+        if configPath == nil, let value = nonEmpty(environment[configPathEnv]) {
+            configPath = value
+        }
         let transport: ProxyTransport = stdioUpstreamURL == nil ? .http : .stdio
 
         return ProxyConfig(
@@ -254,7 +265,7 @@ public struct CLIParser {
             upstreamSessionID: upstreamSessionID,
             maxBodyBytes: maxBodyBytes,
             requestTimeout: requestTimeout,
-            eagerInitialize: eagerInitialize,
+            configPath: configPath,
             transport: transport,
             stdioUpstreamURL: stdioUpstreamURL,
             stdioUpstreamSource: stdioUpstreamSource,
@@ -277,10 +288,10 @@ public struct CLIParser {
           --xcode-pid pid            Xcode PID (env MCP_XCODE_PID)
           --session-id id            Upstream session id (env MCP_XCODE_SESSION_ID)
           --max-body-bytes n         Max request body size (default: 1048576)
-          --request-timeout seconds  Request timeout (default: 300, 0 disables)
+          --request-timeout seconds  Request timeout (default: 300, 0 disables non-initialize timeouts)
+          --config path              Path to proxy config TOML (env \(configPathEnv))
           --refresh-code-issues-mode proxy|upstream
                                      Refresh implementation (default: proxy; env \(refreshCodeIssuesModeEnv))
-          --lazy-init                Initialize upstream only on first client request
           --stdio [url]              Run in STDIO mode (default: discovery -> http://localhost:8765/mcp)
           -h, --help                 Show help
         """

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -23,7 +23,6 @@ public struct ProxyConfig: Sendable {
     public var upstreamCommand: String
     public var upstreamArgs: [String]
     public var upstreamProcessCount: Int
-    public var xcodePID: Int?
     public var upstreamSessionID: String?
     public var maxBodyBytes: Int
     public var requestTimeout: TimeInterval
@@ -40,7 +39,6 @@ public struct ProxyConfig: Sendable {
         upstreamCommand: String,
         upstreamArgs: [String],
         upstreamProcessCount: Int = 1,
-        xcodePID: Int? = nil,
         upstreamSessionID: String? = nil,
         maxBodyBytes: Int,
         requestTimeout: TimeInterval,
@@ -56,7 +54,6 @@ public struct ProxyConfig: Sendable {
         self.upstreamCommand = upstreamCommand
         self.upstreamArgs = upstreamArgs
         self.upstreamProcessCount = upstreamProcessCount
-        self.xcodePID = xcodePID
         self.upstreamSessionID = upstreamSessionID
         self.maxBodyBytes = maxBodyBytes
         self.requestTimeout = requestTimeout
@@ -87,6 +84,8 @@ public struct CLIParser {
     public static let configPathEnv = "MCP_XCODE_CONFIG"
     public static let removedLazyInitMessage =
         "The proxy always uses eager initialization; --lazy-init has been removed."
+    public static let removedXcodePIDMessage =
+        "Xcode PID support has been removed; --xcode-pid is no longer supported."
 
     public static func parse(args: [String], environment: [String: String]) throws -> ProxyConfig {
         return try parse(args: args, environment: environment, discoveryOverrideURL: nil)
@@ -102,7 +101,6 @@ public struct CLIParser {
         var upstreamCommand = "xcrun"
         var upstreamArgs = ["mcpbridge"]
         var upstreamProcessCount = 1
-        var xcodePID: Int?
         var upstreamSessionID: String?
         var maxBodyBytes = 1_048_576
         var requestTimeout: TimeInterval = 300
@@ -173,11 +171,7 @@ public struct CLIParser {
                 upstreamProcessCount = parsed
                 index += 2
             case "--xcode-pid":
-                guard index + 1 < args.count else {
-                    throw CLIError.message("--xcode-pid requires a value")
-                }
-                xcodePID = Int(args[index + 1])
-                index += 2
+                throw CLIError.message(Self.removedXcodePIDMessage)
             case "--session-id":
                 guard index + 1 < args.count else {
                     throw CLIError.message("--session-id requires a value")
@@ -236,9 +230,6 @@ public struct CLIParser {
             }
         }
 
-        if xcodePID == nil, let value = environment["MCP_XCODE_PID"], let parsed = Int(value) {
-            xcodePID = parsed
-        }
         if upstreamSessionID == nil, let value = environment["MCP_XCODE_SESSION_ID"], !value.isEmpty {
             upstreamSessionID = value
         }
@@ -261,7 +252,6 @@ public struct CLIParser {
             upstreamCommand: upstreamCommand,
             upstreamArgs: upstreamArgs,
             upstreamProcessCount: upstreamProcessCount,
-            xcodePID: xcodePID,
             upstreamSessionID: upstreamSessionID,
             maxBodyBytes: maxBodyBytes,
             requestTimeout: requestTimeout,
@@ -285,7 +275,6 @@ public struct CLIParser {
           --upstream-args a,b,c      Upstream args (default: mcpbridge)
           --upstream-arg value       Append a single upstream arg
           --upstream-processes n     Upstream process count (default: 1, max: 10)
-          --xcode-pid pid            Xcode PID (env MCP_XCODE_PID)
           --session-id id            Upstream session id (env MCP_XCODE_SESSION_ID)
           --max-body-bytes n         Max request body size (default: 1048576)
           --request-timeout seconds  Request timeout (default: 300, 0 disables non-initialize timeouts)

--- a/Sources/ProxyCore/ProxyFileConfig.swift
+++ b/Sources/ProxyCore/ProxyFileConfig.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Logging
+import TOMLDecoder
+
+package enum ProxyFileConfigLoader {
+    package static func loadInitializeParamsOverride(
+        configPath: String?,
+        logger: Logger
+    ) -> [String: JSONValue]? {
+        guard let rawPath = nonEmpty(configPath) else { return nil }
+        let expandedPath = NSString(string: rawPath).expandingTildeInPath
+        let url = URL(fileURLWithPath: expandedPath)
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            logger.warning(
+                "Failed to read proxy config; using built-in initialize params",
+                metadata: [
+                    "path": .string(expandedPath),
+                    "error": .string(String(describing: error)),
+                ]
+            )
+            return nil
+        }
+
+        let rootTable: TOMLTable
+        do {
+            rootTable = try TOMLTable(source: data)
+        } catch {
+            logger.warning(
+                "Failed to decode proxy config; using built-in initialize params",
+                metadata: [
+                    "path": .string(expandedPath),
+                    "error": .string(String(describing: error)),
+                ]
+            )
+            return nil
+        }
+
+        let handshakeTable: TOMLTable
+        do {
+            handshakeTable = try rootTable.table(forKey: "upstream_handshake")
+        } catch {
+            logger.warning(
+                "Proxy config does not define upstream_handshake; using built-in initialize params",
+                metadata: ["path": .string(expandedPath)]
+            )
+            return nil
+        }
+
+        var params: [String: JSONValue] = [:]
+
+        if handshakeTable.contains(key: "protocolVersion") {
+            do {
+                params["protocolVersion"] = .string(try handshakeTable.string(forKey: "protocolVersion"))
+            } catch {
+                logger.warning(
+                    "Proxy config protocolVersion is invalid; using built-in initialize params",
+                    metadata: [
+                        "path": .string(expandedPath),
+                        "error": .string(String(describing: error)),
+                    ]
+                )
+                return nil
+            }
+        }
+
+        var clientInfo: [String: JSONValue] = [:]
+        if handshakeTable.contains(key: "clientName") {
+            do {
+                clientInfo["name"] = .string(try handshakeTable.string(forKey: "clientName"))
+            } catch {
+                logger.warning(
+                    "Proxy config clientName is invalid; using built-in initialize params",
+                    metadata: [
+                        "path": .string(expandedPath),
+                        "error": .string(String(describing: error)),
+                    ]
+                )
+                return nil
+            }
+        }
+        if handshakeTable.contains(key: "clientVersion") {
+            do {
+                clientInfo["version"] = .string(try handshakeTable.string(forKey: "clientVersion"))
+            } catch {
+                logger.warning(
+                    "Proxy config clientVersion is invalid; using built-in initialize params",
+                    metadata: [
+                        "path": .string(expandedPath),
+                        "error": .string(String(describing: error)),
+                    ]
+                )
+                return nil
+            }
+        }
+        if !clientInfo.isEmpty {
+            params["clientInfo"] = .object(clientInfo)
+        }
+
+        if handshakeTable.contains(key: "capabilities") {
+            let capabilitiesTable: TOMLTable
+            do {
+                capabilitiesTable = try handshakeTable.table(forKey: "capabilities")
+            } catch {
+                logger.warning(
+                    "Proxy config capabilities is invalid; using built-in initialize params",
+                    metadata: [
+                        "path": .string(expandedPath),
+                        "error": .string(String(describing: error)),
+                    ]
+                )
+                return nil
+            }
+
+            let capabilitiesObject: [String: Any]
+            do {
+                capabilitiesObject = try Dictionary(capabilitiesTable)
+            } catch {
+                logger.warning(
+                    "Failed to materialize proxy config capabilities; using built-in initialize params",
+                    metadata: [
+                        "path": .string(expandedPath),
+                        "error": .string(String(describing: error)),
+                    ]
+                )
+                return nil
+            }
+
+            let capabilities = capabilitiesObject.compactMapValues(JSONValue.init(any:))
+            guard capabilities.count == capabilitiesObject.count else {
+                logger.warning(
+                    "Proxy config capabilities are not JSON-compatible; using built-in initialize params",
+                    metadata: ["path": .string(expandedPath)]
+                )
+                return nil
+            }
+            params["capabilities"] = .object(capabilities)
+        }
+
+        return params.isEmpty ? nil : params
+    }
+
+    package static func mergeJSONObjects(
+        _ base: [String: JSONValue],
+        overriding override: [String: JSONValue]
+    ) -> [String: JSONValue] {
+        var merged = base
+        for (key, value) in override {
+            if case .object(let overrideObject) = value,
+               case .object(let baseObject)? = merged[key]
+            {
+                merged[key] = .object(
+                    mergeJSONObjects(baseObject, overriding: overrideObject)
+                )
+            } else {
+                merged[key] = value
+            }
+        }
+        return merged
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let raw = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else {
+            return nil
+        }
+        return raw
+    }
+}

--- a/Sources/ProxyRuntime/ResponseCorrelationStore.swift
+++ b/Sources/ProxyRuntime/ResponseCorrelationStore.swift
@@ -9,9 +9,7 @@ extension RuntimeCoordinator {
         count: Int
     ) -> [UpstreamProcess] {
         var environment = ProcessInfo.processInfo.environment
-        if let pid = config.xcodePID {
-            environment["MCP_XCODE_PID"] = String(pid)
-        }
+        environment.removeValue(forKey: "XCODE_PID")
         if let sharedSessionID, !sharedSessionID.isEmpty {
             environment["MCP_XCODE_SESSION_ID"] = sharedSessionID
         } else {

--- a/Sources/ProxyRuntime/ResponseCorrelationStore.swift
+++ b/Sources/ProxyRuntime/ResponseCorrelationStore.swift
@@ -5,14 +5,18 @@ import ProxyCore
 extension RuntimeCoordinator {
     static func makeDefaultUpstreams(
         config: ProxyConfig,
-        sharedSessionID: String,
+        sharedSessionID: String?,
         count: Int
     ) -> [UpstreamProcess] {
         var environment = ProcessInfo.processInfo.environment
         if let pid = config.xcodePID {
             environment["MCP_XCODE_PID"] = String(pid)
         }
-        environment["MCP_XCODE_SESSION_ID"] = sharedSessionID
+        if let sharedSessionID, !sharedSessionID.isEmpty {
+            environment["MCP_XCODE_SESSION_ID"] = sharedSessionID
+        } else {
+            environment.removeValue(forKey: "MCP_XCODE_SESSION_ID")
+        }
         let upstreamConfig = UpstreamProcess.Config(
             command: config.upstreamCommand,
             args: config.upstreamArgs,

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Health.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Health.swift
@@ -306,7 +306,7 @@ extension RuntimeCoordinator {
         guard shouldClear else { return }
         responseCorrelationStore.remove(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
 
-        guard upstreamIndex == 0, config.eagerInitialize else { return }
+        guard upstreamIndex == 0 else { return }
         let shouldRetryEagerInit = initializeGate.consumeRetryAfterWarmInitFailureIfNeeded()
         if shouldRetryEagerInit {
             startEagerInitializePrimary()

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
@@ -293,10 +293,17 @@ extension RuntimeCoordinator {
     }
 
     func xcodeChatClientVersion(for clientName: String) -> String? {
+        let defaults = UserDefaults(suiteName: "com.apple.dt.Xcode")?.dictionaryRepresentation() ?? [:]
+        return xcodeChatClientVersion(for: clientName, defaults: defaults)
+    }
+
+    func xcodeChatClientVersion(for clientName: String, defaults: [String: Any]) -> String? {
         let normalizedName = normalizedChatClientName(clientName)
         guard !normalizedName.isEmpty else { return nil }
 
-        let defaults = UserDefaults(suiteName: "com.apple.dt.Xcode")?.dictionaryRepresentation() ?? [:]
+        var exactMatches: [(stem: String, version: String)] = []
+        var aliasMatches: [(stem: String, version: String)] = []
+
         for (key, value) in defaults {
             guard key.hasPrefix("IDEChat"), key.hasSuffix("Version") else { continue }
             guard let raw = value as? String, let version = xcodeChatVersionValue(from: raw) else {
@@ -308,11 +315,29 @@ extension RuntimeCoordinator {
                     .dropFirst("IDEChat".count)
                     .dropLast("Version".count)
             )
+
+            let normalizedStem = normalizedChatClientName(stem)
+            if normalizedStem == normalizedName {
+                exactMatches.append((stem, version))
+                continue
+            }
+
             if chatClientAliases(forVersionStem: stem).contains(normalizedName) {
-                return version
+                aliasMatches.append((stem, version))
             }
         }
-        return nil
+
+        let orderedExactMatches = exactMatches.sorted { lhs, rhs in
+            lhs.stem.localizedStandardCompare(rhs.stem) == .orderedAscending
+        }
+        if let match = orderedExactMatches.first {
+            return match.version
+        }
+
+        let orderedAliasMatches = aliasMatches.sorted { lhs, rhs in
+            lhs.stem.localizedStandardCompare(rhs.stem) == .orderedAscending
+        }
+        return orderedAliasMatches.first?.version
     }
 
     func xcodeChatVersionValue(forDefaultsKey defaultsKey: String) -> String? {

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
@@ -138,7 +138,7 @@ extension RuntimeCoordinator {
             }
         }
 
-        if result.shouldRetryEagerInitialize, config.eagerInitialize {
+        if result.shouldRetryEagerInitialize {
             startEagerInitializePrimary()
         }
     }
@@ -189,7 +189,7 @@ extension RuntimeCoordinator {
             }
         }
 
-        if result.shouldRetryEagerInitialize, config.eagerInitialize {
+        if result.shouldRetryEagerInitialize {
             startEagerInitializePrimary()
         }
     }
@@ -225,18 +225,128 @@ extension RuntimeCoordinator {
     }
 
     func makeInternalInitializeRequest(id: Int64) -> [String: Any] {
-        [
+        let mergedParams = resolvedInitializeParams().mapValues(\.foundationObject)
+
+        return [
             "jsonrpc": "2.0",
             "id": id,
             "method": "initialize",
-            "params": [
-                "protocolVersion": "2025-03-26",
-                "capabilities": [:],
-                "clientInfo": [
-                    "name": "xcode-mcp-proxy",
-                    "version": "0.0",
-                ],
-            ],
+            "params": mergedParams,
         ]
+    }
+
+    func resolvedInitializeParams() -> [String: JSONValue] {
+        let mergedParams = ProxyFileConfigLoader.mergeJSONObjects(
+            defaultInitializeParams(),
+            overriding: initializeParamsOverride ?? [:]
+        )
+        guard hasExplicitClientVersionOverride() == false else {
+            return mergedParams
+        }
+        return applyingAutomaticClientVersion(to: mergedParams)
+    }
+
+    func defaultInitializeParams() -> [String: JSONValue] {
+        [
+            "protocolVersion": .string("2025-03-26"),
+            "capabilities": .object([:]),
+            "clientInfo": .object([
+                "name": .string("Codex"),
+                "version": .string(defaultClientVersion(for: "Codex")),
+            ]),
+        ]
+    }
+
+    func hasExplicitClientVersionOverride() -> Bool {
+        guard case .object(let clientInfo)? = initializeParamsOverride?["clientInfo"] else {
+            return false
+        }
+        return clientInfo["version"] != nil
+    }
+
+    func applyingAutomaticClientVersion(to params: [String: JSONValue]) -> [String: JSONValue] {
+        guard case .object(var clientInfo)? = params["clientInfo"],
+              case .string(let clientName)? = clientInfo["name"] else {
+            return params
+        }
+
+        clientInfo["version"] = .string(defaultClientVersion(for: clientName))
+        var updated = params
+        updated["clientInfo"] = .object(clientInfo)
+        return updated
+    }
+
+    func defaultClientVersion(for clientName: String) -> String {
+        xcodeChatClientVersion(for: clientName) ?? defaultCodexClientVersion()
+    }
+
+    func defaultCodexClientVersion() -> String {
+        let fallback = "0.87.0"
+        return xcodeChatVersionValue(forDefaultsKey: "IDEChatCodexVersion") ?? fallback
+    }
+
+    func xcodeChatClientVersion(for clientName: String) -> String? {
+        let normalizedName = normalizedChatClientName(clientName)
+        guard !normalizedName.isEmpty else { return nil }
+
+        let defaults = UserDefaults(suiteName: "com.apple.dt.Xcode")?.dictionaryRepresentation() ?? [:]
+        for (key, value) in defaults {
+            guard key.hasPrefix("IDEChat"), key.hasSuffix("Version") else { continue }
+            guard let raw = value as? String, let version = xcodeChatVersionValue(from: raw) else {
+                continue
+            }
+
+            let stem = String(
+                key
+                    .dropFirst("IDEChat".count)
+                    .dropLast("Version".count)
+            )
+            if chatClientAliases(forVersionStem: stem).contains(normalizedName) {
+                return version
+            }
+        }
+        return nil
+    }
+
+    func xcodeChatVersionValue(forDefaultsKey defaultsKey: String) -> String? {
+        guard let raw = UserDefaults(suiteName: "com.apple.dt.Xcode")?.string(forKey: defaultsKey) else {
+            return nil
+        }
+        return xcodeChatVersionValue(from: raw)
+    }
+
+    func xcodeChatVersionValue(from raw: String) -> String? {
+        guard
+            let data = raw.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            let version = object["version"] as? String,
+            !version.isEmpty
+        else {
+            return nil
+        }
+        return version
+    }
+
+    func chatClientAliases(forVersionStem stem: String) -> Set<String> {
+        var aliases: Set<String> = []
+        let normalizedStem = normalizedChatClientName(stem)
+        if !normalizedStem.isEmpty {
+            aliases.insert(normalizedStem)
+        }
+
+        if stem.hasSuffix("Code") {
+            let baseStem = String(stem.dropLast("Code".count))
+            let normalizedBaseStem = normalizedChatClientName(baseStem)
+            if !normalizedBaseStem.isEmpty {
+                aliases.insert(normalizedBaseStem)
+            }
+        }
+
+        return aliases
+    }
+
+    func normalizedChatClientName(_ name: String) -> String {
+        let scalars = name.unicodeScalars.filter(CharacterSet.alphanumerics.contains)
+        return String(String.UnicodeScalarView(scalars)).lowercased()
     }
 }

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
@@ -251,8 +251,8 @@ extension RuntimeCoordinator {
             "protocolVersion": .string("2025-03-26"),
             "capabilities": .object([:]),
             "clientInfo": .object([
-                "name": .string("Codex"),
-                "version": .string(defaultClientVersion(for: "Codex")),
+                "name": .string(defaultProxyClientName()),
+                "version": .string(defaultProxyClientVersion()),
             ]),
         ]
     }
@@ -270,19 +270,26 @@ extension RuntimeCoordinator {
             return params
         }
 
-        clientInfo["version"] = .string(defaultClientVersion(for: clientName))
+        guard let resolvedVersion = xcodeChatClientVersion(for: clientName) else {
+            return params
+        }
+
+        clientInfo["version"] = .string(resolvedVersion)
         var updated = params
         updated["clientInfo"] = .object(clientInfo)
         return updated
     }
 
     func defaultClientVersion(for clientName: String) -> String {
-        xcodeChatClientVersion(for: clientName) ?? defaultCodexClientVersion()
+        xcodeChatClientVersion(for: clientName) ?? defaultProxyClientVersion()
     }
 
-    func defaultCodexClientVersion() -> String {
-        let fallback = "0.87.0"
-        return xcodeChatVersionValue(forDefaultsKey: "IDEChatCodexVersion") ?? fallback
+    func defaultProxyClientName() -> String {
+        "XcodeMCPKit"
+    }
+
+    func defaultProxyClientVersion() -> String {
+        "dev"
     }
 
     func xcodeChatClientVersion(for clientName: String) -> String? {

--- a/Sources/ProxyRuntime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+UpstreamRouting.swift
@@ -119,27 +119,25 @@ extension RuntimeCoordinator {
             initializeGate.resetCachedInitializeResult()
         }
 
-        if config.eagerInitialize {
-            if upstreamIndex == 0 {
-                if shouldResetGlobalInit || !globalInit.hadGlobalInit {
-                    startEagerInitializePrimary()
-                } else {
-                    startUpstreamWarmInitialize(upstreamIndex: 0)
-                }
-            } else if globalInit.hadGlobalInit {
-                if shouldResetGlobalInit {
-                    let primaryInitInFlight = upstreamSelectionPolicy.primaryInitInFlight()
-                    if primaryInitInFlight {
-                        initializeGate
-                            .setShouldRetryEagerInitializePrimaryAfterWarmInitFailure(true)
-                    } else {
-                        initializeGate
-                            .setShouldRetryEagerInitializePrimaryAfterWarmInitFailure(false)
-                        startEagerInitializePrimary()
-                    }
-                }
-                startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+        if upstreamIndex == 0 {
+            if shouldResetGlobalInit || !globalInit.hadGlobalInit {
+                startEagerInitializePrimary()
+            } else {
+                startUpstreamWarmInitialize(upstreamIndex: 0)
             }
+        } else if globalInit.hadGlobalInit {
+            if shouldResetGlobalInit {
+                let primaryInitInFlight = upstreamSelectionPolicy.primaryInitInFlight()
+                if primaryInitInFlight {
+                    initializeGate
+                        .setShouldRetryEagerInitializePrimaryAfterWarmInitFailure(true)
+                } else {
+                    initializeGate
+                        .setShouldRetryEagerInitializePrimaryAfterWarmInitFailure(false)
+                    startEagerInitializePrimary()
+                }
+            }
+            startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
         }
     }
 

--- a/Sources/ProxyRuntime/RuntimeCoordinator.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator.swift
@@ -85,14 +85,14 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let logger: Logger = ProxyLogging.make("session")
     package let upstreams: [any UpstreamClient]
     package let toolsListCache = ToolsListCache()
+    package let initializeParamsOverride: [String: JSONValue]?
 
     package let upstreamSelectionPolicy: UpstreamSelectionPolicy
 
     package convenience init(config: ProxyConfig, eventLoop: EventLoop) {
         let count = max(1, min(config.upstreamProcessCount, 10))
-        let sharedSessionID = config.upstreamSessionID ?? UUID().uuidString
         let upstreams = Self.makeDefaultUpstreams(
-            config: config, sharedSessionID: sharedSessionID, count: count)
+            config: config, sharedSessionID: config.upstreamSessionID, count: count)
         self.init(config: config, eventLoop: eventLoop, upstreams: upstreams)
     }
 
@@ -105,6 +105,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.debugRecorder = ProxyDebugRecorder(upstreamCount: upstreams.count)
         self.responseCorrelationStore = ResponseCorrelationStore(upstreamCount: upstreams.count)
         self.upstreamSelectionPolicy = UpstreamSelectionPolicy(upstreamCount: upstreams.count)
+        self.initializeParamsOverride = ProxyFileConfigLoader.loadInitializeParamsOverride(
+            configPath: config.configPath,
+            logger: ProxyLogging.make("config")
+        )
 
         var tasks: [Task<Void, Never>] = []
         tasks.reserveCapacity(upstreams.count)
@@ -135,9 +139,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             taskBox = tasks
         }
 
-        if config.eagerInitialize {
-            startEagerInitializePrimary()
-        }
+        startEagerInitializePrimary()
     }
 
     package func session(id: String) -> SessionContext {
@@ -392,11 +394,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
 
         if shouldSend {
-            var initRequest = requestObject
             let upstreamID = responseCorrelationStore.assignInitialize(upstreamIndex: 0)
             initializeGate.setPrimaryInitUpstreamID(upstreamID)
             markUpstreamInitInFlight(upstreamIndex: 0, upstreamID: upstreamID)
-            initRequest["id"] = upstreamID
+            let initRequest = makeInternalInitializeRequest(id: upstreamID)
             if let data = try? JSONSerialization.data(withJSONObject: initRequest, options: []) {
                 sendUpstream(data, upstreamIndex: 0)
             } else {

--- a/Tests/ProxyCLITests/CLICommandTests.swift
+++ b/Tests/ProxyCLITests/CLICommandTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import ProxyCLI
+import XcodeMCPProxy
 
 @Suite
 struct CLICommandTests {
@@ -80,6 +81,63 @@ struct CLICommandTests {
             "This option is only supported by xcode-mcp-proxy-server (proxy server).",
             "Run: xcode-mcp-proxy-server --help",
         ])
+    }
+
+    @Test func cliCommandRejectsConfigFlag() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { output.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { _, _, _, _ in RecordingCLIAdapter() },
+                input: .standardInput,
+                output: .standardOutput
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy", "--config", "/tmp/proxy-config.toml"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [
+            "This option is only supported by xcode-mcp-proxy-server (proxy server).",
+            "Run: xcode-mcp-proxy-server --help",
+        ])
+    }
+
+    @Test func cliCommandRejectsRemovedLazyInitFlag() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { output.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { _, _, _, _ in RecordingCLIAdapter() },
+                input: .standardInput,
+                output: .standardOutput
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy", "--lazy-init"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [CLIParser.removedLazyInitMessage])
     }
 
     @Test func cliCommandBuildsAdapterFromResolvedEnvironmentURL() async throws {

--- a/Tests/ProxyCLITests/CLICommandTests.swift
+++ b/Tests/ProxyCLITests/CLICommandTests.swift
@@ -140,6 +140,33 @@ struct CLICommandTests {
         #expect(output.snapshot() == [CLIParser.removedLazyInitMessage])
     }
 
+    @Test func cliCommandRejectsRemovedXcodePIDFlag() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { output.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { _, _, _, _ in RecordingCLIAdapter() },
+                input: .standardInput,
+                output: .standardOutput
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy", "--xcode-pid", "1234"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [CLIParser.removedXcodePIDMessage])
+    }
+
     @Test func cliCommandBuildsAdapterFromResolvedEnvironmentURL() async throws {
         let createdAdapter = RecordingCLIAdapter()
         let captured = LockedBox<(url: URL?, timeout: TimeInterval?)>((nil, nil))

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -57,6 +57,25 @@ struct CLIParserTests {
         }
     }
 
+    @Test func cliRejectsRemovedXcodePID() async throws {
+        #expect(throws: CLIError.self) {
+            _ = try CLIParser.parse(
+                args: ["xcode-mcp-proxy", "--xcode-pid", "1234"],
+                environment: [:]
+            )
+        }
+
+        do {
+            _ = try CLIParser.parse(
+                args: ["xcode-mcp-proxy", "--xcode-pid", "1234"],
+                environment: [:]
+            )
+            #expect(Bool(false))
+        } catch let error as CLIError {
+            #expect(error.description == CLIParser.removedXcodePIDMessage)
+        }
+    }
+
     @Test func cliParsesRefreshCodeIssuesMode() async throws {
         let config = try CLIParser.parse(
             args: ["xcode-mcp-proxy", "--refresh-code-issues-mode", "upstream"],
@@ -114,15 +133,26 @@ struct CLIParserTests {
             args: ["xcode-mcp-proxy"],
             environment: [
                 "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
-                "MCP_XCODE_PID": "1234",
                 "MCP_XCODE_SESSION_ID": "session-xyz",
                 "MCP_XCODE_REFRESH_CODE_ISSUES_MODE": "upstream",
             ]
         )
         #expect(config.configPath == "/tmp/proxy-config.toml")
-        #expect(config.xcodePID == 1234)
         #expect(config.upstreamSessionID == "session-xyz")
         #expect(config.refreshCodeIssuesMode == .upstream)
+    }
+
+    @Test func cliIgnoresRemovedXcodePIDEnvironment() async throws {
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy"],
+            environment: [
+                "XCODE_PID": "1234",
+                "MCP_XCODE_PID": "5678",
+                "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
+            ]
+        )
+
+        #expect(config.configPath == "/tmp/proxy-config.toml")
     }
 
     @Test func cliExplicitConfigOverridesEnvironment() async throws {

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -38,13 +38,23 @@ struct CLIParserTests {
         #expect(config.listenPort == 0)
     }
 
-    @Test func cliParsesTimeoutAndLazyInit() async throws {
-        let config = try CLIParser.parse(
-            args: ["xcode-mcp-proxy", "--request-timeout", "12", "--lazy-init"],
-            environment: [:]
-        )
-        #expect(config.requestTimeout == 12)
-        #expect(config.eagerInitialize == false)
+    @Test func cliRejectsRemovedLazyInit() async throws {
+        #expect(throws: CLIError.self) {
+            _ = try CLIParser.parse(
+                args: ["xcode-mcp-proxy", "--request-timeout", "12", "--lazy-init"],
+                environment: [:]
+            )
+        }
+
+        do {
+            _ = try CLIParser.parse(
+                args: ["xcode-mcp-proxy", "--request-timeout", "12", "--lazy-init"],
+                environment: [:]
+            )
+            #expect(Bool(false))
+        } catch let error as CLIError {
+            #expect(error.description == CLIParser.removedLazyInitMessage)
+        }
     }
 
     @Test func cliParsesRefreshCodeIssuesMode() async throws {
@@ -54,6 +64,15 @@ struct CLIParserTests {
         )
 
         #expect(config.refreshCodeIssuesMode == .upstream)
+    }
+
+    @Test func cliParsesConfigPath() async throws {
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--config", "/tmp/proxy-config.toml"],
+            environment: [:]
+        )
+
+        #expect(config.configPath == "/tmp/proxy-config.toml")
     }
 
     @Test func cliParsesUpstreamProcesses() async throws {
@@ -94,14 +113,27 @@ struct CLIParserTests {
         let config = try CLIParser.parse(
             args: ["xcode-mcp-proxy"],
             environment: [
+                "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
                 "MCP_XCODE_PID": "1234",
                 "MCP_XCODE_SESSION_ID": "session-xyz",
                 "MCP_XCODE_REFRESH_CODE_ISSUES_MODE": "upstream",
             ]
         )
+        #expect(config.configPath == "/tmp/proxy-config.toml")
         #expect(config.xcodePID == 1234)
         #expect(config.upstreamSessionID == "session-xyz")
         #expect(config.refreshCodeIssuesMode == .upstream)
+    }
+
+    @Test func cliExplicitConfigOverridesEnvironment() async throws {
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--config", "/tmp/explicit.toml"],
+            environment: [
+                "MCP_XCODE_CONFIG": "/tmp/environment.toml"
+            ]
+        )
+
+        #expect(config.configPath == "/tmp/explicit.toml")
     }
 
     @Test func cliExplicitRefreshCodeIssuesModeOverridesEnvironment() async throws {

--- a/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
@@ -12,7 +12,6 @@ struct ServerCommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePID: { "4321" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in IntegrationRecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -30,7 +29,7 @@ struct ServerCommandIntegrationTests {
 
         #expect(exitCode == 0)
         let line = try #require(output.snapshot().first)
-        #expect(line == "xcode-mcp-proxy-server --listen 127.0.0.1:7777 --config /tmp/proxy-config.toml --xcode-pid 4321")
+        #expect(line == "xcode-mcp-proxy-server --listen 127.0.0.1:7777 --config /tmp/proxy-config.toml")
     }
 
     @Test func serverCommandStartsInjectedProxyServer() async throws {
@@ -41,7 +40,6 @@ struct ServerCommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 stderr: { _ in },
-                resolveXcodePID: { "1234" },
                 terminateExistingServer: { host, port in
                     restarted.append("\(host):\(port)")
                     return true

--- a/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
@@ -24,13 +24,13 @@ struct ServerCommandIntegrationTests {
             args: ["xcode-mcp-proxy-server", "--dry-run"],
             environment: [
                 "LISTEN": "127.0.0.1:7777",
-                "LAZY_INIT": "yes",
+                "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
             ]
         )
 
         #expect(exitCode == 0)
         let line = try #require(output.snapshot().first)
-        #expect(line == "xcode-mcp-proxy-server --listen 127.0.0.1:7777 --xcode-pid 4321 --lazy-init")
+        #expect(line == "xcode-mcp-proxy-server --listen 127.0.0.1:7777 --config /tmp/proxy-config.toml --xcode-pid 4321")
     }
 
     @Test func serverCommandStartsInjectedProxyServer() async throws {

--- a/Tests/ProxyCLITests/ServerCommandTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandTests.swift
@@ -27,7 +27,7 @@ struct ServerCommandTests {
         #expect(options.dryRun == true)
     }
 
-    @Test func serverCommandAppliesEnvironmentDefaultsAndResolvedXcodePID() throws {
+    @Test func serverCommandAppliesEnvironmentDefaultsWithoutXcodePID() throws {
         var options = ProxyServerOptions(
             forwardedArgs: [],
             showHelp: false,
@@ -35,7 +35,6 @@ struct ServerCommandTests {
             hasHostFlag: false,
             hasPortFlag: false,
             hasConfigFlag: false,
-            hasXcodePIDFlag: false,
             hasRefreshCodeIssuesModeFlag: false,
             forceRestart: false,
             dryRun: false
@@ -48,15 +47,12 @@ struct ServerCommandTests {
                 "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
                 "MCP_XCODE_REFRESH_CODE_ISSUES_MODE": "upstream",
             ],
-            to: &options,
-            resolveXcodePID: { "4242" },
-            stderr: { _ in }
+            to: &options
         )
 
         #expect(options.forwardedArgs == [
             "--listen", "127.0.0.1:9999",
             "--config", "/tmp/proxy-config.toml",
-            "--xcode-pid", "4242",
             "--refresh-code-issues-mode", "upstream",
         ])
     }
@@ -69,7 +65,6 @@ struct ServerCommandTests {
             hasHostFlag: false,
             hasPortFlag: false,
             hasConfigFlag: true,
-            hasXcodePIDFlag: false,
             hasRefreshCodeIssuesModeFlag: false,
             forceRestart: false,
             dryRun: false
@@ -79,14 +74,40 @@ struct ServerCommandTests {
             from: [
                 "MCP_XCODE_CONFIG": "/tmp/environment.toml",
             ],
-            to: &options,
-            resolveXcodePID: { nil },
-            stderr: { _ in }
+            to: &options
         )
 
         #expect(options.forwardedArgs.contains("--config"))
         #expect(options.forwardedArgs.contains("/tmp/explicit.toml"))
         #expect(options.forwardedArgs.contains("/tmp/environment.toml") == false)
+    }
+
+    @Test func serverCommandIgnoresRemovedXcodePIDEnvironment() throws {
+        var options = ProxyServerOptions(
+            forwardedArgs: [],
+            showHelp: false,
+            hasListenFlag: false,
+            hasHostFlag: false,
+            hasPortFlag: false,
+            hasConfigFlag: false,
+            hasRefreshCodeIssuesModeFlag: false,
+            forceRestart: false,
+            dryRun: false
+        )
+
+        try XcodeMCPProxyServerCommand.applyDefaults(
+            from: [
+                "HOST": "127.0.0.1",
+                "PORT": "9999",
+                "XCODE_PID": "1234",
+                "MCP_XCODE_PID": "5678",
+            ],
+            to: &options
+        )
+
+        #expect(options.forwardedArgs == [
+            "--listen", "127.0.0.1:9999",
+        ])
     }
 
     @Test func serverCommandRejectsRemovedLazyInitEnvironment() async throws {
@@ -96,7 +117,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePID: { "5678" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -123,7 +143,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePID: { "5678" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -139,6 +158,32 @@ struct ServerCommandTests {
         #expect(exitCode == 1)
         #expect(output.snapshot() == [
             "error: \(CLIParser.removedLazyInitMessage)",
+            "run with --help for usage",
+        ])
+    }
+
+    @Test func serverCommandRejectsRemovedXcodePIDFlagBeforeDryRun() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyServerCommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { output.append($0) },
+                stderr: { output.append($0) },
+                terminateExistingServer: { _, _ in false },
+                makeServer: { _ in RecordingProxyServer() },
+                isAddressAlreadyInUse: { _ in false },
+                detectExistingProxyServerPIDs: { _, _ in [] }
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy-server", "--xcode-pid", "1234", "--dry-run"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [
+            "error: \(CLIParser.removedXcodePIDMessage)",
             "run with --help for usage",
         ])
     }
@@ -237,7 +282,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 stderr: { _ in },
-                resolveXcodePID: { "1234" },
                 terminateExistingServer: { host, port in
                     restarted.append("\(host):\(port)")
                     return true
@@ -276,7 +320,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { output.append($0) },
-                resolveXcodePID: { "5678" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -297,7 +340,6 @@ struct ServerCommandTests {
         let line = try #require(output.snapshot().first)
         #expect(line.contains("--listen 127.0.0.1:9999"))
         #expect(line.contains("--config /tmp/proxy-config.toml"))
-        #expect(line.contains("--xcode-pid 5678"))
         #expect(line.contains("--lazy-init") == false)
     }
 
@@ -309,7 +351,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { errors.append($0) },
-                resolveXcodePID: { "7777" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },
@@ -330,7 +371,6 @@ struct ServerCommandTests {
         #expect(errors.snapshot().isEmpty)
         let line = try #require(output.snapshot().first)
         #expect(line.contains("--upstream-arg --help"))
-        #expect(line.contains("--xcode-pid 7777"))
         #expect(line.contains("Usage:") == false)
     }
 
@@ -342,7 +382,6 @@ struct ServerCommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 stderr: { errors.append($0) },
-                resolveXcodePID: { "7777" },
                 terminateExistingServer: { _, _ in false },
                 makeServer: { _ in RecordingProxyServer() },
                 isAddressAlreadyInUse: { _ in false },

--- a/Tests/ProxyCLITests/ServerCommandTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandTests.swift
@@ -34,18 +34,18 @@ struct ServerCommandTests {
             hasListenFlag: false,
             hasHostFlag: false,
             hasPortFlag: false,
+            hasConfigFlag: false,
             hasXcodePIDFlag: false,
-            hasLazyInitFlag: false,
             hasRefreshCodeIssuesModeFlag: false,
             forceRestart: false,
             dryRun: false
         )
 
-        XcodeMCPProxyServerCommand.applyDefaults(
+        try XcodeMCPProxyServerCommand.applyDefaults(
             from: [
                 "HOST": "127.0.0.1",
                 "PORT": "9999",
-                "LAZY_INIT": "1",
+                "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
                 "MCP_XCODE_REFRESH_CODE_ISSUES_MODE": "upstream",
             ],
             to: &options,
@@ -55,9 +55,91 @@ struct ServerCommandTests {
 
         #expect(options.forwardedArgs == [
             "--listen", "127.0.0.1:9999",
+            "--config", "/tmp/proxy-config.toml",
             "--xcode-pid", "4242",
-            "--lazy-init",
             "--refresh-code-issues-mode", "upstream",
+        ])
+    }
+
+    @Test func serverCommandExplicitConfigOverridesEnvironment() throws {
+        var options = ProxyServerOptions(
+            forwardedArgs: ["--config", "/tmp/explicit.toml"],
+            showHelp: false,
+            hasListenFlag: false,
+            hasHostFlag: false,
+            hasPortFlag: false,
+            hasConfigFlag: true,
+            hasXcodePIDFlag: false,
+            hasRefreshCodeIssuesModeFlag: false,
+            forceRestart: false,
+            dryRun: false
+        )
+
+        try XcodeMCPProxyServerCommand.applyDefaults(
+            from: [
+                "MCP_XCODE_CONFIG": "/tmp/environment.toml",
+            ],
+            to: &options,
+            resolveXcodePID: { nil },
+            stderr: { _ in }
+        )
+
+        #expect(options.forwardedArgs.contains("--config"))
+        #expect(options.forwardedArgs.contains("/tmp/explicit.toml"))
+        #expect(options.forwardedArgs.contains("/tmp/environment.toml") == false)
+    }
+
+    @Test func serverCommandRejectsRemovedLazyInitEnvironment() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyServerCommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { output.append($0) },
+                stderr: { output.append($0) },
+                resolveXcodePID: { "5678" },
+                terminateExistingServer: { _, _ in false },
+                makeServer: { _ in RecordingProxyServer() },
+                isAddressAlreadyInUse: { _ in false },
+                detectExistingProxyServerPIDs: { _, _ in [] }
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy-server", "--dry-run"],
+            environment: ["LAZY_INIT": "true"]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [
+            "error: \(CLIParser.removedLazyInitMessage)",
+            "run with --help for usage",
+        ])
+    }
+
+    @Test func serverCommandRejectsRemovedLazyInitFlagBeforeDryRun() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyServerCommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { output.append($0) },
+                stderr: { output.append($0) },
+                resolveXcodePID: { "5678" },
+                terminateExistingServer: { _, _ in false },
+                makeServer: { _ in RecordingProxyServer() },
+                isAddressAlreadyInUse: { _ in false },
+                detectExistingProxyServerPIDs: { _, _ in [] }
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy-server", "--lazy-init", "--dry-run"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [
+            "error: \(CLIParser.removedLazyInitMessage)",
+            "run with --help for usage",
         ])
     }
 
@@ -205,17 +287,18 @@ struct ServerCommandTests {
         let exitCode = await command.run(
             args: ["xcode-mcp-proxy-server", "--dry-run"],
             environment: [
+                "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
                 "HOST": "127.0.0.1",
                 "PORT": "9999",
-                "LAZY_INIT": "true",
             ]
         )
 
         #expect(exitCode == 0)
         let line = try #require(output.snapshot().first)
         #expect(line.contains("--listen 127.0.0.1:9999"))
+        #expect(line.contains("--config /tmp/proxy-config.toml"))
         #expect(line.contains("--xcode-pid 5678"))
-        #expect(line.contains("--lazy-init"))
+        #expect(line.contains("--lazy-init") == false)
     }
 
     @Test func serverCommandTreatsHelpOnlyAsTopLevelFlag() async throws {

--- a/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
@@ -207,7 +207,6 @@ private struct TestHTTPServer {
             upstreamSessionID: nil,
             maxBodyBytes: 1_048_576,
             requestTimeout: 5,
-            eagerInitialize: false,
             refreshCodeIssuesMode: .upstream
         )
         let upstream = providedUpstream ?? EchoUpstreamClient()

--- a/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
@@ -203,7 +203,6 @@ private struct TestHTTPServer {
             listenPort: 0,
             upstreamCommand: "xcrun",
             upstreamArgs: ["mcpbridge"],
-            xcodePID: nil,
             upstreamSessionID: nil,
             maxBodyBytes: 1_048_576,
             requestTimeout: 5,

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -3610,7 +3610,6 @@ private func makeConfig(
         listenPort: 0,
         upstreamCommand: "xcrun",
         upstreamArgs: ["mcpbridge"],
-        xcodePID: nil,
         upstreamSessionID: nil,
         maxBodyBytes: maxBodyBytes,
         requestTimeout: requestTimeout

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -3613,8 +3613,7 @@ private func makeConfig(
         xcodePID: nil,
         upstreamSessionID: nil,
         maxBodyBytes: maxBodyBytes,
-        requestTimeout: requestTimeout,
-        eagerInitialize: false
+        requestTimeout: requestTimeout
     )
 }
 

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -572,7 +572,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(params["protocolVersion"] as? String == "2025-03-26")
         #expect(clientInfo["name"] as? String == "custom-proxy")
-        #expect(clientInfo["version"] as? String == manager.defaultCodexClientVersion())
+        #expect(clientInfo["version"] as? String == manager.defaultProxyClientVersion())
         #expect(capabilities["roots"] as? Bool == true)
     }
 
@@ -641,7 +641,8 @@ struct RuntimeCoordinatorTests {
         let clientInfo = try #require(params["clientInfo"] as? [String: Any])
 
         #expect(params["protocolVersion"] as? String == "2025-03-26")
-        #expect(clientInfo["name"] as? String == "Codex")
+        #expect(clientInfo["name"] as? String == manager.defaultProxyClientName())
+        #expect(clientInfo["version"] as? String == manager.defaultProxyClientVersion())
     }
 
     @Test func sessionManagerUsesConfiguredInitializeParamsAfterEagerInitTimesOut()
@@ -697,7 +698,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(params["protocolVersion"] as? String == "2025-03-26")
         #expect(clientInfo["name"] as? String == "configured-proxy")
-        #expect(clientInfo["version"] as? String == manager.defaultCodexClientVersion())
+        #expect(clientInfo["version"] as? String == manager.defaultProxyClientVersion())
     }
 
     @Test func sessionManagerSendsInitializedOnce() async throws {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -7,12 +7,24 @@ import XcodeMCPTestSupport
 
 @Suite(.serialized)
 struct RuntimeCoordinatorTests {
+    @Test func defaultUpstreamsDoNotInjectSessionIDWhenConfigDoesNotSpecifyOne() async throws {
+        let environment = try defaultUpstreamEnvironment(sharedSessionID: nil)
+
+        #expect(environment["MCP_XCODE_SESSION_ID"] == nil)
+    }
+
+    @Test func defaultUpstreamsInjectExplicitSessionIDWhenConfigured() async throws {
+        let environment = try defaultUpstreamEnvironment(sharedSessionID: "session-explicit")
+
+        #expect(environment["MCP_XCODE_SESSION_ID"] == "session-explicit")
+    }
+
     @Test func sessionManagerQueuesInitializeRequests() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -51,7 +63,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -92,7 +104,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -133,7 +145,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -180,7 +192,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -209,7 +221,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -255,7 +267,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
 
@@ -316,7 +328,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 1)
+        let config = makeConfig(requestTimeout: 1)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -355,7 +367,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -380,7 +392,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 0.1)
+        let config = makeConfig(requestTimeout: 0.1)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -423,7 +435,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -482,7 +494,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
         #expect(manager.isInitialized() == false)
@@ -494,12 +506,186 @@ struct RuntimeCoordinatorTests {
         _ = manager
     }
 
+    @Test func initializeTimeoutRemainsBoundedWhenRequestTimeoutIsDisabled() throws {
+        let timeout = MCPMethodDispatcher.timeoutForInitialize(defaultSeconds: 0)
+        #expect(timeout?.nanoseconds == TimeAmount.seconds(60).nanoseconds)
+    }
+
+    @Test func sessionManagerStillAutoInitializesWhenRequestTimeoutIsDisabled() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 0)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        _ = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+    }
+
+    @Test func sessionManagerUsesInitializeParamsOverrideFromConfigFile() async throws {
+        let configPath = try makeTempProxyConfigFile(
+            """
+            [upstream_handshake]
+            clientName = "custom-proxy"
+
+            [upstream_handshake.capabilities]
+            roots = true
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        var config = makeConfig(requestTimeout: 5)
+        config.configPath = configPath
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let object = try JSONSerialization.jsonObject(with: sent, options: []) as? [String: Any]
+        let params = try #require(object?["params"] as? [String: Any])
+        let clientInfo = try #require(params["clientInfo"] as? [String: Any])
+        let capabilities = try #require(params["capabilities"] as? [String: Any])
+
+        #expect(params["protocolVersion"] as? String == "2025-03-26")
+        #expect(clientInfo["name"] as? String == "custom-proxy")
+        #expect(clientInfo["version"] as? String == manager.defaultCodexClientVersion())
+        #expect(capabilities["roots"] as? Bool == true)
+    }
+
+    @Test func sessionManagerAutoResolvesInitializeVersionFromConfiguredClientName() async throws {
+        let configPath = try makeTempProxyConfigFile(
+            """
+            [upstream_handshake]
+            clientName = "Claude"
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        var config = makeConfig(requestTimeout: 5)
+        config.configPath = configPath
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let object = try JSONSerialization.jsonObject(with: sent, options: []) as? [String: Any]
+        let params = try #require(object?["params"] as? [String: Any])
+        let clientInfo = try #require(params["clientInfo"] as? [String: Any])
+
+        #expect(clientInfo["name"] as? String == "Claude")
+        #expect(clientInfo["version"] as? String == manager.defaultClientVersion(for: "Claude"))
+    }
+
+    @Test func defaultClientVersionTreatsClaudeAndClaudeCodeAsSameAutoVersion() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        #expect(manager.defaultClientVersion(for: "Claude") == manager.defaultClientVersion(for: "Claude Code"))
+    }
+
+    @Test func sessionManagerFallsBackToDefaultInitializeParamsWhenConfigFileIsInvalid()
+        async throws
+    {
+        let configPath = try makeTempProxyConfigFile(
+            """
+            [upstream_handshake
+            protocolVersion = "broken"
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        var config = makeConfig(requestTimeout: 5)
+        config.configPath = configPath
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let object = try JSONSerialization.jsonObject(with: sent, options: []) as? [String: Any]
+        let params = try #require(object?["params"] as? [String: Any])
+        let clientInfo = try #require(params["clientInfo"] as? [String: Any])
+
+        #expect(params["protocolVersion"] as? String == "2025-03-26")
+        #expect(clientInfo["name"] as? String == "Codex")
+    }
+
+    @Test func sessionManagerUsesConfiguredInitializeParamsAfterEagerInitTimesOut()
+        async throws
+    {
+        let configPath = try makeTempProxyConfigFile(
+            """
+            [upstream_handshake]
+            clientName = "configured-proxy"
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        var config = makeConfig(requestTimeout: 0.1)
+        config.configPath = configPath
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        _ = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(
+            await waitUntil(timeout: .seconds(2)) {
+                let snapshot = manager.testStateSnapshot()
+                return snapshot.initInFlight == false && snapshot.hasInitResult == false
+            }
+        )
+
+        _ = manager.registerInitialize(
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: [
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": [
+                    "protocolVersion": "2099-01-01",
+                    "capabilities": [String: Any](),
+                    "clientInfo": [
+                        "name": "downstream-client",
+                        "version": "9.9",
+                    ],
+                ],
+            ],
+            on: eventLoop
+        )
+
+        let resent = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
+        let object = try JSONSerialization.jsonObject(with: resent, options: []) as? [String: Any]
+        let params = try #require(object?["params"] as? [String: Any])
+        let clientInfo = try #require(params["clientInfo"] as? [String: Any])
+
+        #expect(params["protocolVersion"] as? String == "2025-03-26")
+        #expect(clientInfo["name"] as? String == "configured-proxy")
+        #expect(clientInfo["version"] as? String == manager.defaultCodexClientVersion())
+    }
+
     @Test func sessionManagerSendsInitializedOnce() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -534,7 +720,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -578,7 +764,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 5)
+        let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -647,7 +833,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
+        let config = makeConfig(requestTimeout: 0.3)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -703,7 +889,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
+        let config = makeConfig(requestTimeout: 0.3)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -757,7 +943,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -834,7 +1020,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -898,7 +1084,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -947,7 +1133,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -972,7 +1158,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -1073,7 +1259,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        var config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+        var config = makeConfig(requestTimeout: 2)
         config.prewarmToolsList = true
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
@@ -1152,7 +1338,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -1204,7 +1390,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -1245,7 +1431,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 0.3)
+        let config = makeConfig(requestTimeout: 0.3)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -1313,7 +1499,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = AlwaysOverloadedUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -1354,7 +1540,7 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = AlwaysOverloadedUpstreamClient()
-        let config = makeConfig(eagerInitialize: false, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
@@ -1384,7 +1570,7 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = ToggleableOverloadUpstreamClient()
         let upstream1 = TestUpstreamClient()
-        let config = makeConfig(eagerInitialize: true, requestTimeout: 2)
+        let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(
             config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
         defer { manager.shutdown() }
@@ -1450,7 +1636,7 @@ struct RuntimeCoordinatorTests {
     }
 }
 
-private func makeConfig(eagerInitialize: Bool, requestTimeout: TimeInterval) -> ProxyConfig {
+private func makeConfig(requestTimeout: TimeInterval) -> ProxyConfig {
     ProxyConfig(
         listenHost: "127.0.0.1",
         listenPort: 0,
@@ -1460,8 +1646,33 @@ private func makeConfig(eagerInitialize: Bool, requestTimeout: TimeInterval) -> 
         upstreamSessionID: nil,
         maxBodyBytes: 1024,
         requestTimeout: requestTimeout,
-        eagerInitialize: eagerInitialize,
         prewarmToolsList: false
+    )
+}
+
+private func defaultUpstreamEnvironment(sharedSessionID: String?) throws -> [String: String] {
+    var config = makeConfig(requestTimeout: 5)
+    config.upstreamSessionID = sharedSessionID
+    let upstreams = RuntimeCoordinator.makeDefaultUpstreams(
+        config: config,
+        sharedSessionID: sharedSessionID,
+        count: 1
+    )
+    let upstream = try #require(upstreams.first)
+    return try upstreamEnvironment(from: upstream)
+}
+
+private func upstreamEnvironment(from upstream: UpstreamProcess) throws -> [String: String] {
+    let mirror = Mirror(reflecting: upstream)
+    let config = try #require(
+        mirror.children.first(where: { $0.label == "config" })?.value,
+        "UpstreamProcess should expose a stored config for tests"
+    )
+    let configMirror = Mirror(reflecting: config)
+    return try #require(
+        configMirror.children.first(where: { $0.label == "environment" })?.value
+            as? [String: String],
+        "UpstreamProcess.Config should include environment for tests"
     )
 }
 
@@ -1570,6 +1781,15 @@ private func makeInitializeRequest(id: Int) -> [String: Any] {
             ],
         ],
     ]
+}
+
+private func makeTempProxyConfigFile(_ contents: String) throws -> String {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let fileURL = directory.appendingPathComponent("proxy-config.toml")
+    try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+    return fileURL.path
 }
 
 private func makeInitializeResponse(id: Int64) throws -> Data {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -603,7 +603,7 @@ struct RuntimeCoordinatorTests {
         #expect(clientInfo["version"] as? String == manager.defaultClientVersion(for: "Claude"))
     }
 
-    @Test func defaultClientVersionTreatsClaudeAndClaudeCodeAsSameAutoVersion() async throws {
+    @Test func xcodeChatClientVersionFallsBackToCodeAliasWhenExactStemMissing() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
@@ -612,7 +612,34 @@ struct RuntimeCoordinatorTests {
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
-        #expect(manager.defaultClientVersion(for: "Claude") == manager.defaultClientVersion(for: "Claude Code"))
+        let version = manager.xcodeChatClientVersion(
+            for: "Claude",
+            defaults: [
+                "IDEChatClaudeCodeVersion": #"{"version":"9.9.9"}"#,
+            ]
+        )
+
+        #expect(version == "9.9.9")
+    }
+
+    @Test func xcodeChatClientVersionPrefersExactStemMatchOverGenericCodeAlias() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        let version = manager.xcodeChatClientVersion(
+            for: "Claude",
+            defaults: [
+                "IDEChatClaudeVersion": #"{"version":"1.2.3"}"#,
+                "IDEChatClaudeCodeVersion": #"{"version":"9.9.9"}"#,
+            ]
+        )
+
+        #expect(version == "1.2.3")
     }
 
     @Test func sessionManagerFallsBackToDefaultInitializeParamsWhenConfigFileIsInvalid()

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -7,6 +7,26 @@ import XcodeMCPTestSupport
 
 @Suite(.serialized)
 struct RuntimeCoordinatorTests {
+    @Test func defaultUpstreamsDoNotInjectXcodePIDEnvironment() async throws {
+        let environment = try defaultUpstreamEnvironment(sharedSessionID: nil)
+
+        #expect(environment["MCP_XCODE_PID"] == nil)
+    }
+
+    @Test func defaultUpstreamsPassThroughInheritedMCPXcodePIDEnvironment() async throws {
+        let environment = try withEnvironmentVariables(
+            [
+                "XCODE_PID": "1234",
+                "MCP_XCODE_PID": "5678",
+            ]
+        ) {
+            try defaultUpstreamEnvironment(sharedSessionID: nil)
+        }
+
+        #expect(environment["XCODE_PID"] == nil)
+        #expect(environment["MCP_XCODE_PID"] == "5678")
+    }
+
     @Test func defaultUpstreamsDoNotInjectSessionIDWhenConfigDoesNotSpecifyOne() async throws {
         let environment = try defaultUpstreamEnvironment(sharedSessionID: nil)
 
@@ -1642,7 +1662,6 @@ private func makeConfig(requestTimeout: TimeInterval) -> ProxyConfig {
         listenPort: 0,
         upstreamCommand: "xcrun",
         upstreamArgs: ["mcpbridge"],
-        xcodePID: nil,
         upstreamSessionID: nil,
         maxBodyBytes: 1024,
         requestTimeout: requestTimeout,
@@ -1674,6 +1693,31 @@ private func upstreamEnvironment(from upstream: UpstreamProcess) throws -> [Stri
             as? [String: String],
         "UpstreamProcess.Config should include environment for tests"
     )
+}
+
+private func withEnvironmentVariables<T>(
+    _ values: [String: String],
+    body: () throws -> T
+) throws -> T {
+    let originalValues = values.keys.reduce(into: [String: String?]()) { result, key in
+        result[key] = ProcessInfo.processInfo.environment[key]
+    }
+
+    for (key, value) in values {
+        _ = unsafe setenv(key, value, 1)
+    }
+
+    defer {
+        for (key, value) in originalValues {
+            if let value {
+                _ = unsafe setenv(key, value, 1)
+            } else {
+                _ = unsafe unsetenv(key)
+            }
+        }
+    }
+
+    return try body()
 }
 
 private actor AlwaysOverloadedUpstreamClient: UpstreamClient {


### PR DESCRIPTION
Summary:
- Remove `--lazy-init` and make proxy initialization consistently eager
- Add TOML-based upstream handshake configuration via `upstream_handshake`
- Keep `MCP_XCODE_PID` as upstream pass-through compatibility while removing proxy-side Xcode PID configuration paths
- Update default handshake identity and related docs/tests

Testing:
- `swift build`
- `swift test`
- `/Users/kn/Dev/PDSkillsSPI/Frameworks/PDSkills/skills/codex/codex-review/scripts/codex-review-quiet.sh -C /Users/kn/Dev/XcodeMCPKit --uncommitted`
- Manual verification in Xcode (user-reported)