### PR TITLE
fix(proxy): preserve refresh timeout fallback

### DIFF
--- a/Sources/ProxyFeatureXcode/RefreshCodeIssuesWorkflow.swift
+++ b/Sources/ProxyFeatureXcode/RefreshCodeIssuesWorkflow.swift
@@ -32,6 +32,12 @@ package enum RefreshForwardAttemptResult: Sendable {
     case invalidUpstreamResponse
 }
 
+package enum RefreshInternalToolResult {
+    case success([String: Any])
+    case timeout
+    case unavailable
+}
+
 package struct RefreshCodeIssuesWorkflow {
     package typealias WindowsProvider =
         @Sendable (
@@ -49,7 +55,7 @@ package struct RefreshCodeIssuesWorkflow {
             _ eventLoop: EventLoop,
             _ upstreamIndexOverride: Int?,
             _ requestTimeoutOverride: TimeAmount?
-        ) async -> [String: Any]?
+        ) async -> RefreshInternalToolResult
     package typealias Forwarder =
         @Sendable (
             _ bodyData: Data,
@@ -64,6 +70,7 @@ package struct RefreshCodeIssuesWorkflow {
         200_000_000,
         500_000_000,
     ]
+    package static let minimumUpstreamFallbackBudgetSeconds: TimeInterval = 0.05
 
     private struct ExecutionBudget: Sendable {
         let deadlineUptimeNs: UInt64?
@@ -88,26 +95,34 @@ package struct RefreshCodeIssuesWorkflow {
             return deadlineUptimeNs - now
         }
 
-        func remainingTimeout(cappedAt capSeconds: TimeInterval? = nil) -> TimeAmount? {
+        func remainingTimeout(
+            cappedAt capSeconds: TimeInterval? = nil,
+            reserving reserveSeconds: TimeInterval = 0
+        ) -> TimeAmount? {
             guard let remainingNs = remainingNanoseconds() else {
                 if let capSeconds {
                     return makeRequestTimeout(capSeconds)
                 }
                 return nil
             }
-            guard remainingNs > 0 else { return nil }
+            let reservedNs = Self.nanoseconds(from: reserveSeconds)
+            guard remainingNs > reservedNs else { return nil }
 
-            var cappedNs = remainingNs
+            var cappedNs = remainingNs - reservedNs
             if let capSeconds {
                 cappedNs = min(cappedNs, Self.nanoseconds(from: capSeconds))
             }
+            guard cappedNs > 0 else { return nil }
 
             let maxTimeAmountNs = UInt64(Int64.max)
             return .nanoseconds(Int64(min(cappedNs, maxTimeAmountNs)))
         }
 
-        func stepTimeout(cappedAt capSeconds: TimeInterval) -> TimeAmount? {
-            remainingTimeout(cappedAt: capSeconds)
+        func stepTimeout(
+            cappedAt capSeconds: TimeInterval,
+            reserving reserveSeconds: TimeInterval = 0
+        ) -> TimeAmount? {
+            remainingTimeout(cappedAt: capSeconds, reserving: reserveSeconds)
         }
 
         func canDelay(_ delayNanoseconds: UInt64) -> Bool {
@@ -386,13 +401,16 @@ package struct RefreshCodeIssuesWorkflow {
             eventLoop: eventLoop,
             windowsProvider: { sessionID, eventLoop in
                 let timeout = executionBudget.stepTimeout(
-                    cappedAt: windowLookupTimeoutSeconds
+                    cappedAt: windowLookupTimeoutSeconds,
+                    reserving: Self.minimumUpstreamFallbackBudgetSeconds
                 )
-                if timeout == nil, executionBudget.isExhausted {
+                if timeout == nil {
                     self.debugState.updateStep(
                         requestID: debugRequestID,
-                        step: "proxy.execution_budget_exhausted",
-                        state: "timed_out"
+                        step: executionBudget.isExhausted
+                            ? "proxy.execution_budget_exhausted"
+                            : "proxy.reserved_upstream_budget",
+                        state: executionBudget.isExhausted ? "timed_out" : nil
                     )
                     return nil
                 }
@@ -449,14 +467,17 @@ package struct RefreshCodeIssuesWorkflow {
             "glob": "**/" + Self.escapeGlobLiteralPath(target.workspaceRelativePath),
         ]
         let navigatorIssuesTimeout = executionBudget.stepTimeout(
-            cappedAt: navigatorIssuesTimeoutSeconds
+            cappedAt: navigatorIssuesTimeoutSeconds,
+            reserving: Self.minimumUpstreamFallbackBudgetSeconds
         )
-        if navigatorIssuesTimeout == nil, executionBudget.isExhausted {
-            let fallbackReason = "execution budget exhausted before navigator issues"
+        if navigatorIssuesTimeout == nil {
+            let fallbackReason = executionBudget.isExhausted
+                ? "execution budget exhausted before navigator issues"
+                : "reserved upstream fallback budget before navigator issues"
             debugState.updateStep(
                 requestID: debugRequestID,
                 step: "proxy.fallback_to_upstream",
-                state: "timed_out",
+                state: executionBudget.isExhausted ? "timed_out" : nil,
                 metadata: ["fallback_reason": fallbackReason]
             )
             logger.debug(
@@ -477,14 +498,41 @@ package struct RefreshCodeIssuesWorkflow {
                 "timeout_ms": Self.timeoutDescription(navigatorIssuesTimeout),
             ]
         )
-        guard let navigatorResult = await internalToolCaller(
+        let navigatorToolResult = await internalToolCaller(
             "XcodeListNavigatorIssues",
             arguments,
             sessionID,
             eventLoop,
             internalUpstreamIndex,
             navigatorIssuesTimeout
-        ) else {
+        )
+        let navigatorResult: [String: Any]
+        switch navigatorToolResult {
+        case .success(let result):
+            navigatorResult = result
+        case .timeout:
+            let fallbackReason = "navigator issues timed out"
+            debugState.updateStep(
+                requestID: debugRequestID,
+                step: "proxy.fallback_to_upstream",
+                state: "timed_out",
+                metadata: [
+                    "fallback_reason": fallbackReason,
+                    "resolved_target": target.resolvedFilePath,
+                ]
+            )
+            logger.debug(
+                "Refresh code issues proxy mode fell back to upstream refresh",
+                metadata: metadata.merging(
+                    [
+                        "fallback_reason": .string(fallbackReason),
+                        "resolved_target": .string(target.resolvedFilePath),
+                    ],
+                    uniquingKeysWith: { _, new in new }
+                )
+            )
+            return nil
+        case .unavailable:
             let fallbackReason = "navigator issues unavailable"
             debugState.updateStep(
                 requestID: debugRequestID,

--- a/Sources/ProxyHTTPTransport/HTTPPostService.swift
+++ b/Sources/ProxyHTTPTransport/HTTPPostService.swift
@@ -438,7 +438,7 @@ package final class HTTPPostService: Sendable {
         eventLoop: EventLoop,
         upstreamIndexOverride: Int? = nil,
         requestTimeoutOverride: TimeAmount? = nil
-    ) async -> [String: Any]? {
+    ) async -> RefreshInternalToolResult {
         await forwardingService.callInternalTool(
             name: name,
             arguments: arguments,
@@ -459,14 +459,19 @@ package final class HTTPPostService: Sendable {
             sessionID: sessionID,
             eventLoop: eventLoop,
             toolCaller: { name, arguments, sessionID, eventLoop in
-                await self.callInternalTool(
+                switch await self.callInternalTool(
                     name: name,
                     arguments: arguments,
                     sessionID: sessionID,
                     eventLoop: eventLoop,
                     upstreamIndexOverride: upstreamIndexOverride,
                     requestTimeoutOverride: requestTimeoutOverride
-                )
+                ) {
+                case .success(let result):
+                    return result
+                case .timeout, .unavailable:
+                    return nil
+                }
             }
         )
     }

--- a/Sources/ProxyHTTPTransport/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPTransport/MCPForwardingService.swift
@@ -179,7 +179,7 @@ package struct MCPForwardingService: Sendable {
         eventLoop: EventLoop,
         upstreamIndexOverride: Int? = nil,
         requestTimeoutOverride: TimeAmount? = nil
-    ) async -> [String: Any]? {
+    ) async -> RefreshInternalToolResult {
         let requestObject: [String: Any] = [
             "jsonrpc": "2.0",
             "id": "__internal-\(UUID().uuidString)",
@@ -192,7 +192,7 @@ package struct MCPForwardingService: Sendable {
 
         guard let bodyData = try? JSONSerialization.data(withJSONObject: requestObject, options: [])
         else {
-            return nil
+            return .unavailable
         }
 
         let prepared: PreparedRequest
@@ -204,11 +204,11 @@ package struct MCPForwardingService: Sendable {
                 shouldPinUpstreamOverride: false,
                 upstreamIndexOverride: upstreamIndexOverride
             ) else {
-                return nil
+                return .unavailable
             }
             prepared = candidate
         } catch {
-            return nil
+            return .unavailable
         }
 
         let session = sessionManager.session(id: sessionID)
@@ -221,7 +221,7 @@ package struct MCPForwardingService: Sendable {
                 requestTimeoutOverride: requestTimeoutOverride
             )
         } catch {
-            return nil
+            return .unavailable
         }
 
         let resolution: ResponseResolution
@@ -243,17 +243,23 @@ package struct MCPForwardingService: Sendable {
             )
         }
 
-        guard case .success(let responseData) = resolution,
-            let object = try? JSONSerialization.jsonObject(with: responseData, options: [])
+        switch resolution {
+        case .success(let responseData):
+            guard let object = try? JSONSerialization.jsonObject(with: responseData, options: [])
                 as? [String: Any],
-            let result = object["result"] as? [String: Any]
-        else {
-            return nil
+                let result = object["result"] as? [String: Any]
+            else {
+                return .unavailable
+            }
+            if let isError = result["isError"] as? Bool, isError {
+                return .unavailable
+            }
+            return .success(result)
+        case .timeout:
+            return .timeout
+        case .invalidUpstreamResponse:
+            return .unavailable
         }
-        if let isError = result["isError"] as? Bool, isError {
-            return nil
-        }
-        return result
     }
 
     private static func rewriteUnsupportedResourcesListResponseIfNeeded(

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -2433,17 +2433,12 @@ struct HTTPHandlerTests {
             internalUpstreamChooser: { _ in 0 },
             internalToolCaller: { name, _, _, _, _, requestTimeoutOverride in
                 guard name == "XcodeListNavigatorIssues" else {
-                    return nil
+                    return .unavailable
                 }
                 observedTimeouts.withLockedValue { values in
                     values.append(requestTimeoutOverride?.nanoseconds ?? -1)
                 }
-                let simulatedDelayNanos: UInt64 = 200_000_000
-                if let requestTimeoutOverride {
-                    let timeoutNanos = UInt64(max(0, requestTimeoutOverride.nanoseconds))
-                    try? await Task.sleep(nanoseconds: min(simulatedDelayNanos, timeoutNanos))
-                }
-                return nil
+                return .timeout
             },
             forwarder: { _, _, _, _, _, _ in
                 .success(upstreamFallbackData)
@@ -3117,7 +3112,7 @@ struct HTTPHandlerTests {
     }
 
     @Test func httpRefreshProxyInternalToolCallsDoNotResetUpstreamSuccessState() async throws {
-        var config = makeConfig(requestTimeout: 0.05)
+        var config = makeConfig(requestTimeout: 0.2)
         config.refreshCodeIssuesMode = .proxy
         let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
         defer { try? FileManager.default.removeItem(atPath: temporaryRoot) }


### PR DESCRIPTION
Summary:
- Preserve upstream fallback budget while proxy-mode refresh code issues performs internal window and navigator issues lookups
- Distinguish internal tool timeout vs unavailable results so navigator timeout fallback is exercised deterministically instead of relying on wall-clock sleeps
- Update refresh timeout coverage to validate the timeout override and fallback path without flaky timing assumptions

Testing:
- `swift test -Xswiftc -strict-concurrency=minimal`