### PR TITLE
fix(proxy): methods not conforming to schemas

### DIFF
--- a/Sources/ProxyCore/RequestInspector.swift
+++ b/Sources/ProxyCore/RequestInspector.swift
@@ -7,6 +7,7 @@ package struct RequestTransform {
     package let idKey: String?
     package let responseIDs: [RPCID]
     package let method: String?
+    package let toolName: String?
     package let originalID: RPCID?
     package let isCacheableToolsListRequest: Bool
 }
@@ -20,6 +21,7 @@ package enum RequestInspector {
         let json = try JSONSerialization.jsonObject(with: data, options: [])
         if var object = json as? [String: Any] {
             let method = object["method"] as? String
+            let toolName = toolName(for: method, in: object)
             // We intentionally treat tools/list as stable and cache it regardless of params.
             // Some clients attach pagination-like params even when they expect the full list.
             let isCacheableToolsListRequest = (method == "tools/list")
@@ -34,6 +36,7 @@ package enum RequestInspector {
                     idKey: rpcID.key,
                     responseIDs: [rpcID],
                     method: method,
+                    toolName: toolName,
                     originalID: rpcID,
                     isCacheableToolsListRequest: isCacheableToolsListRequest
                 )
@@ -46,6 +49,7 @@ package enum RequestInspector {
                 idKey: nil,
                 responseIDs: [],
                 method: method,
+                toolName: toolName,
                 originalID: nil,
                 isCacheableToolsListRequest: isCacheableToolsListRequest
             )
@@ -75,6 +79,7 @@ package enum RequestInspector {
                 idKey: nil,
                 responseIDs: responseIDs,
                 method: nil,
+                toolName: nil,
                 originalID: nil,
                 isCacheableToolsListRequest: false
             )
@@ -87,8 +92,20 @@ package enum RequestInspector {
             idKey: nil,
             responseIDs: [],
             method: nil,
+            toolName: nil,
             originalID: nil,
             isCacheableToolsListRequest: false
         )
+    }
+
+    private static func toolName(for method: String?, in object: [String: Any]) -> String? {
+        guard method == "tools/call",
+            let params = object["params"] as? [String: Any],
+            let toolName = params["name"] as? String,
+            toolName.isEmpty == false
+        else {
+            return nil
+        }
+        return toolName
     }
 }

--- a/Sources/ProxyFeatureXcode/RefreshCodeIssuesToolsListRewriter.swift
+++ b/Sources/ProxyFeatureXcode/RefreshCodeIssuesToolsListRewriter.swift
@@ -20,6 +20,9 @@ package enum RefreshCodeIssuesToolsListRewriter {
                 return toolValue
             }
             toolObject["description"] = .string(description(for: mode))
+            if mode == .proxy {
+                toolObject["outputSchema"] = proxyOutputSchema
+            }
             return .object(toolObject)
         }
         resultObject["tools"] = .array(rewrittenTools)
@@ -66,4 +69,68 @@ package enum RefreshCodeIssuesToolsListRewriter {
             """
         }
     }
+
+    private static let proxyOutputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "required": .array([
+            .string("issues"),
+            .string("truncated"),
+            .string("totalFound"),
+        ]),
+        "properties": .object([
+            "message": .object([
+                "type": .string("string"),
+                "description": .string("Optional message with additional information about the search results"),
+            ]),
+            "truncated": .object([
+                "type": .string("boolean"),
+                "description": .string("Whether results were truncated due to exceeding 100 issues"),
+            ]),
+            "totalFound": .object([
+                "type": .string("integer"),
+                "description": .string("Total number of issues before truncation"),
+            ]),
+            "issues": .object([
+                "type": .string("array"),
+                "description": .string("The list of current issues matching the input filters"),
+                "items": .object([
+                    "type": .string("object"),
+                    "required": .array([
+                        .string("message"),
+                        .string("severity"),
+                    ]),
+                    "properties": .object([
+                        "severity": .object([
+                            "type": .string("string"),
+                            "description": .string("The severity of issue (error, warning, remark)"),
+                        ]),
+                        "line": .object([
+                            "type": .string("integer"),
+                            "description": .string("The line number where the issue was detected, if known"),
+                        ]),
+                        "vitality": .object([
+                            "type": .string("string"),
+                            "enum": .array([
+                                .string("fresh"),
+                                .string("stale"),
+                            ]),
+                            "description": .string("Whether an issue from a previous build is known to still be relevant or whether something might have changed since it was emitted (for example if the source file has been edited and it isn't yet known whether that edit fixes the issue). Possible values: (fresh, stale)"),
+                        ]),
+                        "path": .object([
+                            "type": .string("string"),
+                            "description": .string("The file path where the issue was detected, if any"),
+                        ]),
+                        "message": .object([
+                            "type": .string("string"),
+                            "description": .string("The message describing the issue"),
+                        ]),
+                        "category": .object([
+                            "type": .string("string"),
+                            "description": .string("The category of the issue, if known"),
+                        ]),
+                    ]),
+                ]),
+            ]),
+        ]),
+    ])
 }

--- a/Sources/ProxyHTTPTransport/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPTransport/MCPForwardingService.swift
@@ -586,6 +586,7 @@ package struct MCPForwardingService: Sendable {
 
             var normalizedIssues: [[String: Any]] = []
             normalizedIssues.reserveCapacity(emittedIssues.count)
+            var entryChanged = false
 
             for issue in emittedIssues {
                 guard issue["line"] == nil else {
@@ -596,17 +597,17 @@ package struct MCPForwardingService: Sendable {
                 var normalizedIssue = issue
                 normalizedIssue["line"] = 0
                 normalizedIssues.append(normalizedIssue)
+                entryChanged = true
+            }
+
+            if entryChanged {
+                var normalizedEntry = entry
+                normalizedEntry["emittedIssues"] = normalizedIssues
+                normalizedEntries.append(normalizedEntry)
                 changed = true
-            }
-
-            guard changed else {
+            } else {
                 normalizedEntries.append(entry)
-                continue
             }
-
-            var normalizedEntry = entry
-            normalizedEntry["emittedIssues"] = normalizedIssues
-            normalizedEntries.append(normalizedEntry)
         }
 
         guard changed else {

--- a/Sources/ProxyHTTPTransport/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPTransport/MCPForwardingService.swift
@@ -463,17 +463,19 @@ package struct MCPForwardingService: Sendable {
             let toolName,
             toolHasOutputSchema(named: toolName, in: cachedToolsListResult),
             let object = try? JSONSerialization.jsonObject(with: upstreamData, options: []) as? [String: Any],
-            var result = object["result"] as? [String: Any],
-            result["structuredContent"] == nil,
-            (result["isError"] as? Bool) != true,
-            let structuredContent = structuredToolContent(from: result)
+            let result = object["result"] as? [String: Any],
+            (result["isError"] as? Bool) != true
         else {
             return upstreamData
         }
 
-        result["structuredContent"] = structuredContent
+        let rewrittenResult = rewrittenToolCallResult(toolName: toolName, result: result)
+        guard rewrittenResult.changed else {
+            return upstreamData
+        }
+
         var rewrittenObject = object
-        rewrittenObject["result"] = result
+        rewrittenObject["result"] = rewrittenResult.result
         guard JSONSerialization.isValidJSONObject(rewrittenObject),
             let rewrittenData = try? JSONSerialization.data(withJSONObject: rewrittenObject, options: [])
         else {
@@ -522,6 +524,98 @@ package struct MCPForwardingService: Sendable {
         }
 
         return nil
+    }
+
+    private static func rewrittenToolCallResult(toolName: String, result: [String: Any]) -> (
+        result: [String: Any], changed: Bool
+    ) {
+        var rewrittenResult = result
+        var changed = false
+
+        if rewrittenResult["structuredContent"] == nil,
+            let structuredContent = structuredToolContent(from: rewrittenResult)
+        {
+            rewrittenResult["structuredContent"] = structuredContent
+            changed = true
+        }
+
+        if let structuredContent = rewrittenResult["structuredContent"],
+            let normalizedStructuredContent = normalizeStructuredContentIfNeeded(
+                toolName: toolName,
+                structuredContent: structuredContent
+            )
+        {
+            rewrittenResult["structuredContent"] = normalizedStructuredContent
+            changed = true
+        }
+
+        return (rewrittenResult, changed)
+    }
+
+    private static func normalizeStructuredContentIfNeeded(
+        toolName: String,
+        structuredContent: Any
+    ) -> Any? {
+        switch toolName {
+        case "GetBuildLog":
+            guard let object = structuredContent as? [String: Any] else {
+                return nil
+            }
+            return normalizeGetBuildLogStructuredContentIfNeeded(object)
+        default:
+            return nil
+        }
+    }
+
+    private static func normalizeGetBuildLogStructuredContentIfNeeded(
+        _ structuredContent: [String: Any]
+    ) -> [String: Any]? {
+        guard let buildLogEntries = structuredContent["buildLogEntries"] as? [[String: Any]] else {
+            return nil
+        }
+
+        var normalizedEntries: [[String: Any]] = []
+        normalizedEntries.reserveCapacity(buildLogEntries.count)
+        var changed = false
+
+        for entry in buildLogEntries {
+            guard let emittedIssues = entry["emittedIssues"] as? [[String: Any]] else {
+                normalizedEntries.append(entry)
+                continue
+            }
+
+            var normalizedIssues: [[String: Any]] = []
+            normalizedIssues.reserveCapacity(emittedIssues.count)
+
+            for issue in emittedIssues {
+                guard issue["line"] == nil else {
+                    normalizedIssues.append(issue)
+                    continue
+                }
+
+                var normalizedIssue = issue
+                normalizedIssue["line"] = 0
+                normalizedIssues.append(normalizedIssue)
+                changed = true
+            }
+
+            guard changed else {
+                normalizedEntries.append(entry)
+                continue
+            }
+
+            var normalizedEntry = entry
+            normalizedEntry["emittedIssues"] = normalizedIssues
+            normalizedEntries.append(normalizedEntry)
+        }
+
+        guard changed else {
+            return nil
+        }
+
+        var normalizedStructuredContent = structuredContent
+        normalizedStructuredContent["buildLogEntries"] = normalizedEntries
+        return normalizedStructuredContent
     }
 
     private static func shouldNotifyUpstreamSuccess(for responseData: Data) -> Bool {

--- a/Sources/ProxyHTTPTransport/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPTransport/MCPForwardingService.swift
@@ -140,15 +140,21 @@ package struct MCPForwardingService: Sendable {
                 upstreamData: rewrittenResourcesData,
                 mode: config.refreshCodeIssuesMode
             )
+            let normalizedToolCallData = Self.rewriteToolCallStructuredContentIfNeeded(
+                method: started.transform.method,
+                toolName: started.transform.toolName,
+                upstreamData: responseData,
+                cachedToolsListResult: sessionManager.cachedToolsListResult()
+            )
             if started.transform.isCacheableToolsListRequest,
-                let object = try? JSONSerialization.jsonObject(with: responseData, options: [])
+                let object = try? JSONSerialization.jsonObject(with: normalizedToolCallData, options: [])
                     as? [String: Any],
                 let resultAny = object["result"],
                 let result = JSONValue(any: resultAny)
             {
                 sessionManager.setCachedToolsListResult(result)
             }
-            if accountSuccess, Self.shouldNotifyUpstreamSuccess(for: responseData) {
+            if accountSuccess, Self.shouldNotifyUpstreamSuccess(for: normalizedToolCallData) {
                 for responseID in started.transform.responseIDs {
                     sessionManager.onRequestSucceeded(
                         sessionID: sessionID,
@@ -157,7 +163,7 @@ package struct MCPForwardingService: Sendable {
                     )
                 }
             }
-            return .success(responseData)
+            return .success(normalizedToolCallData)
 
         case .failure:
             if let firstResponseID = started.transform.responseIDs.first {
@@ -445,6 +451,77 @@ package struct MCPForwardingService: Sendable {
             upstreamData,
             mode: mode
         )
+    }
+
+    private static func rewriteToolCallStructuredContentIfNeeded(
+        method: String?,
+        toolName: String?,
+        upstreamData: Data,
+        cachedToolsListResult: JSONValue?
+    ) -> Data {
+        guard method == "tools/call",
+            let toolName,
+            toolHasOutputSchema(named: toolName, in: cachedToolsListResult),
+            let object = try? JSONSerialization.jsonObject(with: upstreamData, options: []) as? [String: Any],
+            var result = object["result"] as? [String: Any],
+            result["structuredContent"] == nil,
+            (result["isError"] as? Bool) != true,
+            let structuredContent = structuredToolContent(from: result)
+        else {
+            return upstreamData
+        }
+
+        result["structuredContent"] = structuredContent
+        var rewrittenObject = object
+        rewrittenObject["result"] = result
+        guard JSONSerialization.isValidJSONObject(rewrittenObject),
+            let rewrittenData = try? JSONSerialization.data(withJSONObject: rewrittenObject, options: [])
+        else {
+            return upstreamData
+        }
+        return rewrittenData
+    }
+
+    private static func toolHasOutputSchema(named toolName: String, in toolsListResult: JSONValue?) -> Bool {
+        guard let toolsListResult,
+            case .object(let resultObject) = toolsListResult,
+            case .array(let tools) = resultObject["tools"]
+        else {
+            return false
+        }
+
+        for tool in tools {
+            guard case .object(let toolObject) = tool,
+                case .string(let candidateName) = toolObject["name"],
+                candidateName == toolName
+            else {
+                continue
+            }
+            return toolObject["outputSchema"] != nil
+        }
+        return false
+    }
+
+    private static func structuredToolContent(from result: [String: Any]) -> Any? {
+        guard let content = result["content"] as? [[String: Any]] else {
+            return nil
+        }
+
+        for item in content {
+            guard let text = item["text"] as? String,
+                text.isEmpty == false,
+                let textData = text.data(using: .utf8),
+                let structuredContent = try? JSONSerialization.jsonObject(with: textData, options: [])
+            else {
+                continue
+            }
+
+            if structuredContent is [String: Any] || structuredContent is [Any] {
+                return structuredContent
+            }
+        }
+
+        return nil
     }
 
     private static func shouldNotifyUpstreamSuccess(for responseData: Data) -> Bool {

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -2868,6 +2868,83 @@ struct HTTPHandlerTests {
         await server.shutdown()
     }
 
+    @Test func httpToolCallNormalizesGetBuildLogIssuesMissingLine() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "GetBuildLog")
+                return .immediate(
+                    try makeToolResultResponse(
+                        id: originalID,
+                        result: [
+                            "content": [[
+                                "type": "text",
+                                "text": "{\"buildResult\":\"The build succeeded\",\"buildIsRunning\":false,\"buildLogEntries\":[{\"buildTask\":\"Build target App\",\"emittedIssues\":[{\"message\":\"Using stub executor library with Swift entry point.\",\"severity\":\"remark\"}]}],\"fullLogPath\":\"/tmp/build.log\",\"totalFound\":1,\"truncated\":false}",
+                            ]],
+                            "structuredContent": [
+                                "buildResult": "The build succeeded",
+                                "buildIsRunning": false,
+                                "buildLogEntries": [[
+                                    "buildTask": "Build target App",
+                                    "emittedIssues": [[
+                                        "message": "Using stub executor library with Swift entry point.",
+                                        "severity": "remark",
+                                    ]],
+                                ]],
+                                "fullLogPath": "/tmp/build.log",
+                                "totalFound": 1,
+                                "truncated": false,
+                            ],
+                        ]
+                    )
+                )
+            }
+        )
+        sessionManager.setCachedToolsListResult(
+            JSONValue(any: [
+                "tools": [[
+                    "name": "GetBuildLog",
+                    "outputSchema": ["type": "object"],
+                ]]
+            ])!
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-build-log-normalized",
+                payload: toolsCallPayload(
+                    id: 15,
+                    name: "GetBuildLog",
+                    arguments: [
+                        "tabIdentifier": "windowtab1",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            let structuredContent = result?["structuredContent"] as? [String: Any]
+            let buildLogEntries = structuredContent?["buildLogEntries"] as? [[String: Any]]
+            let emittedIssues = buildLogEntries?.first?["emittedIssues"] as? [[String: Any]]
+            let content = result?["content"] as? [[String: Any]]
+
+            #expect((emittedIssues?.first?["line"] as? NSNumber)?.intValue == 0)
+            #expect(content?.first?["text"] as? String == "{\"buildResult\":\"The build succeeded\",\"buildIsRunning\":false,\"buildLogEntries\":[{\"buildTask\":\"Build target App\",\"emittedIssues\":[{\"message\":\"Using stub executor library with Swift entry point.\",\"severity\":\"remark\"}]}],\"fullLogPath\":\"/tmp/build.log\",\"totalFound\":1,\"truncated\":false}")
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
     @Test func httpRefreshCodeIssuesReturnsBackpressureErrorWhenQueueIsFull() async throws {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .upstream

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1139,6 +1139,16 @@ struct HTTPHandlerTests {
                         [
                             "name": "XcodeRefreshCodeIssuesInFile",
                             "description": "original description",
+                            "outputSchema": [
+                                "type": "object",
+                                "required": ["filePath", "diagnosticsCount", "content", "success"],
+                                "properties": [
+                                    "filePath": ["type": "string"],
+                                    "diagnosticsCount": ["type": "integer"],
+                                    "content": ["type": "string"],
+                                    "success": ["type": "boolean"],
+                                ],
+                            ],
                         ]
                     ]
                 ],
@@ -1193,8 +1203,11 @@ struct HTTPHandlerTests {
         let result = object?["result"] as? [String: Any]
         let tools = result?["tools"] as? [[String: Any]]
         let description = tools?.first?["description"] as? String
+        let outputSchema = tools?.first?["outputSchema"] as? [String: Any]
+        let required = outputSchema?["required"] as? [String]
         #expect(description?.contains("avoid switching Spaces") == true)
         #expect(description?.contains("--refresh-code-issues-mode upstream") == true)
+        #expect(required == ["issues", "truncated", "totalFound"])
     }
 
     @Test func httpToolsListRewritesRefreshDescriptionOnCachedResponse() async throws {
@@ -1209,6 +1222,16 @@ struct HTTPHandlerTests {
                     [
                         "name": "XcodeRefreshCodeIssuesInFile",
                         "description": "original description",
+                        "outputSchema": [
+                            "type": "object",
+                            "required": ["filePath", "diagnosticsCount", "content", "success"],
+                            "properties": [
+                                "filePath": ["type": "string"],
+                                "diagnosticsCount": ["type": "integer"],
+                                "content": ["type": "string"],
+                                "success": ["type": "boolean"],
+                            ],
+                        ],
                     ]
                 ]
             ])!
@@ -1261,7 +1284,10 @@ struct HTTPHandlerTests {
         let result = object?["result"] as? [String: Any]
         let tools = result?["tools"] as? [[String: Any]]
         let description = tools?.first?["description"] as? String
+        let outputSchema = tools?.first?["outputSchema"] as? [String: Any]
+        let required = outputSchema?["required"] as? [String]
         #expect(description?.contains("native live diagnostics path") == true)
+        #expect(required == ["filePath", "diagnosticsCount", "content", "success"])
     }
 
     @Test func httpToolsListPrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -2814,6 +2814,60 @@ struct HTTPHandlerTests {
         await server.shutdown()
     }
 
+    @Test func httpToolCallAddsStructuredContentFromJSONStringWhenToolHasOutputSchema() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "XcodeListWindows")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text:
+                            "{\"message\":\"* tabIdentifier: windowtab1, workspacePath: /tmp/Sample.xcodeproj\\n\"}"
+                    )
+                )
+            }
+        )
+        sessionManager.setCachedToolsListResult(
+            JSONValue(any: [
+                "tools": [[
+                    "name": "XcodeListWindows",
+                    "outputSchema": ["type": "object"],
+                ]]
+            ])!
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-structured-tool-call",
+                payload: toolsCallPayload(
+                    id: 14,
+                    name: "XcodeListWindows",
+                    arguments: [:]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            let structuredContent = result?["structuredContent"] as? [String: Any]
+            let content = result?["content"] as? [[String: Any]]
+            #expect(structuredContent?["message"] as? String == "* tabIdentifier: windowtab1, workspacePath: /tmp/Sample.xcodeproj\n")
+            #expect(content?.first?["text"] as? String == "{\"message\":\"* tabIdentifier: windowtab1, workspacePath: /tmp/Sample.xcodeproj\\n\"}")
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
     @Test func httpRefreshCodeIssuesReturnsBackpressureErrorWhenQueueIsFull() async throws {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .upstream


### PR DESCRIPTION
The proxy exposed valid tool schemas via `tools/list`, but some upstream tool responses did not actually conform to those schemas. This caused MCP clients to reject otherwise successful Xcode tool calls, including `XcodeListWindows`, `DocumentationSearch`, and `GetBuildLog`.

- Fixed schema-backed `tools/call` responses so tools that advertised an `outputSchema` return valid `result.structuredContent` instead of only JSON wrapped in `content[].text`.
- Fixed `GetBuildLog` responses by filling missing `emittedIssues[].line` values so the returned structured content matches the advertised schema.
- Added regression coverage for text-only output and `GetBuildLog` schema fix.



