### PR TITLE
refactor(proxy-runtime): replace upstream generations with slot sessions

### DIFF
--- a/Sources/ProxyHTTPTransport/HTTPPostService.swift
+++ b/Sources/ProxyHTTPTransport/HTTPPostService.swift
@@ -665,7 +665,8 @@ package final class HTTPPostService: Sendable {
 
         sessionManager.sendUpstream(
             prepared.transform.upstreamData,
-            upstreamIndex: prepared.upstreamIndex
+            upstreamIndex: prepared.upstreamIndex,
+            ensureRunning: false
         )
         return makeImmediateLeaseResolution(
             .empty(status: .accepted, sessionID: sessionID),

--- a/Sources/ProxyHTTPTransport/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPTransport/MCPForwardingService.swift
@@ -106,7 +106,8 @@ package struct MCPForwardingService: Sendable {
 
         sessionManager.sendUpstream(
             prepared.transform.upstreamData,
-            upstreamIndex: prepared.upstreamIndex
+            upstreamIndex: prepared.upstreamIndex,
+            ensureRunning: false
         )
         return StartedRequest(
             transform: prepared.transform,

--- a/Sources/ProxyRuntime/ManagedUpstreamSlot.swift
+++ b/Sources/ProxyRuntime/ManagedUpstreamSlot.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+package actor ManagedUpstreamSlot: UpstreamSlotControlling {
+    private final class StartAttempt: @unchecked Sendable {
+        let task: Task<any UpstreamSession, Error>
+
+        init(task: Task<any UpstreamSession, Error>) {
+            self.task = task
+        }
+    }
+
+    private final class RunningSessionBox: @unchecked Sendable {
+        let session: any UpstreamSession
+        var eventTask: Task<Void, Never>?
+
+        init(session: any UpstreamSession) {
+            self.session = session
+        }
+    }
+
+    package nonisolated let events: AsyncStream<UpstreamEvent>
+    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    private let factory: any UpstreamSessionFactory
+    private var pendingStart: StartAttempt?
+    private var current: RunningSessionBox?
+    private var isShutdown = false
+
+    package init(
+        factory: any UpstreamSessionFactory,
+        startImmediately: Bool = false
+    ) {
+        self.factory = factory
+
+        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        self.events = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+
+        if startImmediately {
+            Task { [weak self] in
+                await self?.start()
+            }
+        }
+    }
+
+    package func start() async {
+        beginStartIfNeeded()
+    }
+
+    package func stop() async {
+        isShutdown = true
+
+        let running = current
+        current = nil
+
+        let pending = pendingStart
+        pendingStart = nil
+        pending?.task.cancel()
+
+        continuation.finish()
+
+        if let running {
+            await running.session.stop()
+        }
+    }
+
+    package func send(_ data: Data) async -> UpstreamSendResult {
+        guard !isShutdown else {
+            return .overloaded
+        }
+
+        if let current {
+            return await current.session.send(data)
+        }
+
+        guard let pendingStart else {
+            return .overloaded
+        }
+
+        do {
+            let session = try await pendingStart.task.value
+            guard let running = await claimStartedSessionIfNeeded(
+                session: session,
+                attempt: pendingStart
+            ) else {
+                return .overloaded
+            }
+            return await running.session.send(data)
+        } catch {
+            return .overloaded
+        }
+    }
+
+    private func beginStartIfNeeded() {
+        guard !isShutdown, current == nil, pendingStart == nil else {
+            return
+        }
+
+        let attempt = StartAttempt(
+            task: Task {
+                try await factory.startSession()
+            }
+        )
+        pendingStart = attempt
+
+        Task { [weak self, attempt] in
+            await self?.finishStartAttempt(attempt)
+        }
+    }
+
+    private func finishStartAttempt(_ attempt: StartAttempt) async {
+        do {
+            let session = try await attempt.task.value
+            _ = await claimStartedSessionIfNeeded(session: session, attempt: attempt)
+        } catch {
+            guard pendingStart === attempt else {
+                return
+            }
+            pendingStart = nil
+        }
+    }
+
+    private func claimStartedSessionIfNeeded(
+        session: any UpstreamSession,
+        attempt: StartAttempt
+    ) async -> RunningSessionBox? {
+        if let current {
+            return current.session === session ? current : nil
+        }
+
+        guard pendingStart === attempt else {
+            await session.stop()
+            return nil
+        }
+        pendingStart = nil
+
+        guard !isShutdown else {
+            await session.stop()
+            return nil
+        }
+
+        let running = RunningSessionBox(session: session)
+        current = running
+        running.eventTask = Task { [weak self, running] in
+            for await event in session.events {
+                await self?.handleSessionEvent(event, from: running)
+            }
+            await self?.handleSessionStreamFinished(from: running)
+        }
+        return running
+    }
+
+    private func handleSessionEvent(
+        _ event: UpstreamEvent,
+        from running: RunningSessionBox
+    ) {
+        guard current === running else {
+            return
+        }
+
+        continuation.yield(event)
+
+        switch event {
+        case .stdoutProtocolViolation, .exit:
+            current = nil
+        case .message, .stderr, .stdoutBufferSize:
+            break
+        }
+    }
+
+    private func handleSessionStreamFinished(from running: RunningSessionBox) {
+        guard current === running else {
+            return
+        }
+        current = nil
+    }
+}

--- a/Sources/ProxyRuntime/OrderedPipeReader.swift
+++ b/Sources/ProxyRuntime/OrderedPipeReader.swift
@@ -1,0 +1,95 @@
+import Dispatch
+import Foundation
+import NIOConcurrencyHelpers
+
+package final class OrderedPipeReader: @unchecked Sendable {
+    package nonisolated let chunks: AsyncStream<Data>
+    private let continuation: AsyncStream<Data>.Continuation
+    private let fileHandle: FileHandle
+    private let queue: DispatchQueue
+    private let state = NIOLockedValueBox(State())
+
+    private struct State: Sendable {
+        var isStarted = false
+        var isFinished = false
+        var source: DispatchSourceRead?
+    }
+
+    package init(
+        fileHandle: FileHandle,
+        label: String
+    ) {
+        self.fileHandle = fileHandle
+        self.queue = DispatchQueue(label: label)
+
+        var streamContinuation: AsyncStream<Data>.Continuation!
+        self.chunks = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+    }
+
+    package func start() {
+        let source = state.withLockedValue { state -> DispatchSourceRead? in
+            guard !state.isStarted, !state.isFinished else {
+                return nil
+            }
+            state.isStarted = true
+            let source = DispatchSource.makeReadSource(
+                fileDescriptor: fileHandle.fileDescriptor,
+                queue: queue
+            )
+            state.source = source
+            return source
+        }
+        guard let source else { return }
+
+        source.setEventHandler { [weak self] in
+            self?.consumeAvailableData()
+        }
+        source.setCancelHandler { [fileHandle] in
+            try? fileHandle.close()
+        }
+        source.resume()
+    }
+
+    package func stop() {
+        finish()
+    }
+
+    private func consumeAvailableData() {
+        guard state.withLockedValue({ !$0.isFinished }) else {
+            return
+        }
+
+        let chunk = fileHandle.availableData
+        if chunk.isEmpty {
+            finish()
+            return
+        }
+
+        guard state.withLockedValue({ !$0.isFinished }) else {
+            return
+        }
+        continuation.yield(chunk)
+    }
+
+    private func finish() {
+        let result = state.withLockedValue { state -> (shouldFinish: Bool, source: DispatchSourceRead?) in
+            guard !state.isFinished else {
+                return (false, nil)
+            }
+            state.isFinished = true
+            let source = state.source
+            state.source = nil
+            return (true, source)
+        }
+        guard result.shouldFinish else { return }
+        continuation.finish()
+        if let source = result.source {
+            source.cancel()
+        } else {
+            try? fileHandle.close()
+        }
+    }
+}

--- a/Sources/ProxyRuntime/ProcessRunner.swift
+++ b/Sources/ProxyRuntime/ProcessRunner.swift
@@ -22,27 +22,25 @@ final class DispatchGroupLeaveGuard: @unchecked Sendable {
 }
 
 private final class PipeCollector: @unchecked Sendable {
-    private let fileHandle: FileHandle
+    private let reader: OrderedPipeReader
     private let drainGuard: DispatchGroupLeaveGuard
     private let buffer = NIOLockedValueBox(Data())
+    private var task: Task<Void, Never>?
 
-    init(fileHandle: FileHandle, drainGroup: DispatchGroup) {
-        self.fileHandle = fileHandle
+    init(fileHandle: FileHandle, drainGroup: DispatchGroup, label: String) {
+        self.reader = OrderedPipeReader(fileHandle: fileHandle, label: label)
         self.drainGuard = DispatchGroupLeaveGuard(group: drainGroup)
     }
 
     func start() {
-        fileHandle.readabilityHandler = { [buffer, drainGuard] handle in
-            let chunk = handle.availableData
-            if chunk.isEmpty {
-                handle.readabilityHandler = nil
-                try? handle.close()
-                drainGuard.leaveIfNeeded()
-                return
+        reader.start()
+        task = Task { [buffer, drainGuard, reader] in
+            for await chunk in reader.chunks {
+                buffer.withLockedValue { data in
+                    data.append(chunk)
+                }
             }
-            buffer.withLockedValue { data in
-                data.append(chunk)
-            }
+            drainGuard.leaveIfNeeded()
         }
     }
 
@@ -51,8 +49,9 @@ private final class PipeCollector: @unchecked Sendable {
     }
 
     func cancel() {
-        fileHandle.readabilityHandler = nil
-        try? fileHandle.close()
+        reader.stop()
+        task?.cancel()
+        task = nil
         drainGuard.leaveIfNeeded()
     }
 }
@@ -99,11 +98,13 @@ package struct ProcessRunner: ProcessRunning {
             let drainGroup = DispatchGroup()
             let stdoutCollector = PipeCollector(
                 fileHandle: stdoutPipe.fileHandleForReading,
-                drainGroup: drainGroup
+                drainGroup: drainGroup,
+                label: "XcodeMCPProxy.ProcessRunner.stdout"
             )
             let stderrCollector = PipeCollector(
                 fileHandle: stderrPipe.fileHandleForReading,
-                drainGroup: drainGroup
+                drainGroup: drainGroup,
+                label: "XcodeMCPProxy.ProcessRunner.stderr"
             )
             let didResume = NIOLockedValueBox(false)
             let resumeOnce: @Sendable (Result<ProcessOutput, Error>) -> Void = { result in

--- a/Sources/ProxyRuntime/ResponseCorrelationStore.swift
+++ b/Sources/ProxyRuntime/ResponseCorrelationStore.swift
@@ -7,7 +7,7 @@ extension RuntimeCoordinator {
         config: ProxyConfig,
         sharedSessionID: String?,
         count: Int
-    ) -> [UpstreamProcess] {
+    ) -> [ManagedUpstreamSlot] {
         var environment = ProcessInfo.processInfo.environment
         environment.removeValue(forKey: "XCODE_PID")
         if let sharedSessionID, !sharedSessionID.isEmpty {
@@ -30,12 +30,14 @@ extension RuntimeCoordinator {
             }()
         )
         if count <= 1 {
-            return [UpstreamProcess(config: upstreamConfig)]
+            return [ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig), startImmediately: true)]
         }
-        var upstreams: [UpstreamProcess] = []
+        var upstreams: [ManagedUpstreamSlot] = []
         upstreams.reserveCapacity(count)
         for _ in 0..<count {
-            upstreams.append(UpstreamProcess(config: upstreamConfig))
+            upstreams.append(
+                ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig), startImmediately: true)
+            )
         }
         return upstreams
     }

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Health.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Health.swift
@@ -264,7 +264,7 @@ extension RuntimeCoordinator {
 
         let request = makeInternalInitializeRequest(id: upstreamID)
         if let data = try? JSONSerialization.data(withJSONObject: request, options: []) {
-            sendUpstream(data, upstreamIndex: upstreamIndex)
+            sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: true)
         } else {
             clearUpstreamState(upstreamIndex: upstreamIndex)
         }

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
@@ -18,7 +18,7 @@ extension RuntimeCoordinator {
 
         let request = makeInternalInitializeRequest(id: upstreamID)
         if let data = try? JSONSerialization.data(withJSONObject: request, options: []) {
-            sendUpstream(data, upstreamIndex: 0)
+            sendUpstream(data, upstreamIndex: 0, ensureRunning: true)
         } else {
             failInitPending(error: TimeoutError())
         }

--- a/Sources/ProxyRuntime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+UpstreamRouting.swift
@@ -577,12 +577,13 @@ extension RuntimeCoordinator {
     ) {
         debugRecorder.recordProtocolViolation(protocolViolation, upstreamIndex: upstreamIndex)
         let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        let initSnapshot = initializeGate.snapshot()
         let transition = upstreamSelectionPolicy.markProtocolViolation(
             upstreamIndex: upstreamIndex,
             nowUptimeNs: nowUptimeNs
         )
         transition?.cancelledInitTimeout?.cancel()
-        if upstreamIndex == 0, initializeGate.snapshot().initInFlight {
+        if upstreamIndex == 0, initSnapshot.initInFlight {
             failInitPending(error: TimeoutError())
         }
         responseCorrelationStore.reset(upstreamIndex: upstreamIndex)
@@ -603,9 +604,15 @@ extension RuntimeCoordinator {
                 ]
             )
         }
-        Task { [weak self] in
-            guard let self else { return }
-            await self.upstreams[upstreamIndex].start()
+
+        if upstreamIndex == 0 {
+            if initSnapshot.hasInitResult {
+                startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+            } else {
+                startEagerInitializePrimary()
+            }
+        } else if initSnapshot.hasInitResult {
+            startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
         }
     }
 

--- a/Sources/ProxyRuntime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+UpstreamRouting.swift
@@ -220,11 +220,14 @@ extension RuntimeCoordinator {
         markRequestSucceeded(upstreamIndex: upstreamIndex)
     }
 
-    package func sendUpstream(_ data: Data, upstreamIndex: Int) {
+    package func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool = false) {
         guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
             return
         }
         Task {
+            if ensureRunning {
+                await upstreams[upstreamIndex].start()
+            }
             let result = await upstreams[upstreamIndex].send(data)
             if result == .accepted {
                 self.recordTraffic(
@@ -599,6 +602,10 @@ extension RuntimeCoordinator {
                     "uptime_ns": .string("\(nowUptimeNs)"),
                 ]
             )
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            await self.upstreams[upstreamIndex].start()
         }
     }
 

--- a/Sources/ProxyRuntime/RuntimeCoordinator.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator.swift
@@ -53,7 +53,7 @@ package protocol RuntimeCoordinating: Sendable {
     func removeUpstreamIDMapping(sessionID: String, requestIDKey: String, upstreamIndex: Int)
     func onRequestTimeout(sessionID: String, requestIDKey: String, upstreamIndex: Int)
     func onRequestSucceeded(sessionID: String, requestIDKey: String, upstreamIndex: Int)
-    func sendUpstream(_ data: Data, upstreamIndex: Int)
+    func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool)
     func debugSnapshot() -> ProxyDebugSnapshot
     func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebugSnapshot
     func createRequestLease(descriptor: SessionPipelineRequestDescriptor) -> RequestLeaseID
@@ -85,6 +85,10 @@ package protocol RuntimeCoordinating: Sendable {
 }
 
 extension RuntimeCoordinating {
+    func sendUpstream(_ data: Data, upstreamIndex: Int) {
+        sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: false)
+    }
+
     func enqueueOnUpstreamSlot<Output: Sendable>(
         leaseID: RequestLeaseID,
         descriptor: SessionPipelineRequestDescriptor,
@@ -139,7 +143,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let responseCorrelationStore: ResponseCorrelationStore
     package let config: ProxyConfig
     package let logger: Logger = ProxyLogging.make("session")
-    package let upstreams: [any UpstreamClient]
+    package let upstreams: [any UpstreamSlotControlling]
     package let toolsListCache = ToolsListCache()
     package let initializeParamsOverride: [String: JSONValue]?
 
@@ -153,7 +157,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.init(config: config, eventLoop: eventLoop, upstreams: upstreams)
     }
 
-    package init(config: ProxyConfig, eventLoop: EventLoop, upstreams: [any UpstreamClient]) {
+    package init(config: ProxyConfig, eventLoop: EventLoop, upstreams: [any UpstreamSlotControlling]) {
         precondition(!upstreams.isEmpty, "upstreams must not be empty")
         let schedulerProbeStarter = NIOLockedValueBox<(@Sendable ([HealthProbeRequest]) -> Void)?>(nil)
         self.config = config
@@ -460,7 +464,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             markUpstreamInitInFlight(upstreamIndex: 0, upstreamID: upstreamID)
             let initRequest = makeInternalInitializeRequest(id: upstreamID)
             if let data = try? JSONSerialization.data(withJSONObject: initRequest, options: []) {
-                sendUpstream(data, upstreamIndex: 0)
+                sendUpstream(data, upstreamIndex: 0, ensureRunning: true)
             } else {
                 failInitPending(error: TimeoutError())
             }

--- a/Sources/ProxyRuntime/UpstreamClient.swift
+++ b/Sources/ProxyRuntime/UpstreamClient.swift
@@ -14,7 +14,17 @@ package enum UpstreamSendResult: Sendable {
     case overloaded
 }
 
-package protocol UpstreamClient: Sendable {
+package protocol UpstreamSession: AnyObject, Sendable {
+    var events: AsyncStream<UpstreamEvent> { get }
+    func send(_ data: Data) async -> UpstreamSendResult
+    func stop() async
+}
+
+package protocol UpstreamSessionFactory: Sendable {
+    func startSession() async throws -> any UpstreamSession
+}
+
+package protocol UpstreamSlotControlling: Sendable {
     var events: AsyncStream<UpstreamEvent> { get }
     func start() async
     func stop() async

--- a/Sources/ProxyRuntime/UpstreamProcess.swift
+++ b/Sources/ProxyRuntime/UpstreamProcess.swift
@@ -34,10 +34,15 @@ package actor UpstreamProcess: UpstreamClient {
     private var stdinPipe = Pipe()
     private var stdoutPipe = Pipe()
     private var stderrPipe = Pipe()
+    private var stdoutReader: OrderedPipeReader?
+    private var stderrReader: OrderedPipeReader?
+    private var stdoutTask: Task<Void, Never>?
+    private var stderrTask: Task<Void, Never>?
     private var framer = StdioFramer()
     private var isStopping = false
     private var queuedWriteBytes = 0
     private var writeGeneration: UInt64 = 0
+    private var readGeneration: UInt64 = 0
     private var stderrBuffer = ""
     private var lastReportedBufferedStdoutBytes = 0
     private let writeQueue = DispatchQueue(label: "XcodeMCPProxy.UpstreamProcess.write")
@@ -68,6 +73,10 @@ package actor UpstreamProcess: UpstreamClient {
     package func send(_ data: Data) async -> UpstreamSendResult {
         if process == nil {
             startLocked()
+        }
+        guard process != nil else {
+            logger.warning("Upstream send skipped because process is unavailable")
+            return .overloaded
         }
         var payload = data
         if payload.last != 0x0A {
@@ -118,6 +127,7 @@ package actor UpstreamProcess: UpstreamClient {
         framer = StdioFramer()
         queuedWriteBytes = 0
         writeGeneration &+= 1
+        readGeneration &+= 1
         stderrBuffer = ""
         resetBufferedStdoutBytesIfNeeded()
 
@@ -130,27 +140,29 @@ package actor UpstreamProcess: UpstreamClient {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
 
-        stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
-            let data = handle.availableData
-            if data.isEmpty {
-                return
-            }
-            Task {
-                await self?.handleStdoutData(data)
+        let generation = readGeneration
+        let stdoutReader = OrderedPipeReader(
+            fileHandle: stdoutPipe.fileHandleForReading,
+            label: "XcodeMCPProxy.UpstreamProcess.stdout"
+        )
+        let stderrReader = OrderedPipeReader(
+            fileHandle: stderrPipe.fileHandleForReading,
+            label: "XcodeMCPProxy.UpstreamProcess.stderr"
+        )
+        self.stdoutReader = stdoutReader
+        self.stderrReader = stderrReader
+        stdoutReader.start()
+        stderrReader.start()
+        stdoutTask = Task { [weak self, stdoutReader] in
+            for await data in stdoutReader.chunks {
+                await self?.handleStdoutData(data, generation: generation)
             }
         }
-
-        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            if data.isEmpty {
-                Task { [weak self] in
-                    await self?.handleStderrEOF()
-                }
-                return
+        stderrTask = Task { [weak self, stderrReader] in
+            for await data in stderrReader.chunks {
+                await self?.handleStderrData(data, generation: generation)
             }
-            Task { [weak self] in
-                await self?.handleStderrData(data)
-            }
+            await self?.handleStderrEOF(generation: generation)
         }
 
         process.terminationHandler = { [weak self] proc in
@@ -164,13 +176,19 @@ package actor UpstreamProcess: UpstreamClient {
             self.process = process
         } catch {
             logger.error("Failed to start upstream process", metadata: ["error": "\(error)"])
+            cleanupFailedStart()
         }
     }
 
     private func stopLocked() {
         flushBufferedStderrIfNeeded()
-        stdoutPipe.fileHandleForReading.readabilityHandler = nil
-        stderrPipe.fileHandleForReading.readabilityHandler = nil
+        readGeneration &+= 1
+        stdoutReader?.stop()
+        stderrReader?.stop()
+        stdoutReader = nil
+        stderrReader = nil
+        stdoutTask = nil
+        stderrTask = nil
         queuedWriteBytes = 0
         writeGeneration &+= 1
         stderrBuffer = ""
@@ -182,7 +200,27 @@ package actor UpstreamProcess: UpstreamClient {
         process = nil
     }
 
-    private func handleStdoutData(_ data: Data) {
+    private func cleanupFailedStart() {
+        stdoutReader?.stop()
+        stderrReader?.stop()
+        stdoutReader = nil
+        stderrReader = nil
+        stdoutTask = nil
+        stderrTask = nil
+        try? stdinPipe.fileHandleForWriting.close()
+        try? stdoutPipe.fileHandleForWriting.close()
+        try? stderrPipe.fileHandleForWriting.close()
+        framer = StdioFramer()
+        queuedWriteBytes = 0
+        writeGeneration &+= 1
+        readGeneration &+= 1
+        stderrBuffer = ""
+        resetBufferedStdoutBytesIfNeeded()
+        process = nil
+    }
+
+    private func handleStdoutData(_ data: Data, generation: UInt64) {
+        guard generation == readGeneration else { return }
         let result = framer.append(data)
         for message in result.messages {
             guard isValidJSONPayload(message) else {
@@ -215,6 +253,8 @@ package actor UpstreamProcess: UpstreamClient {
                 "reason": .string(protocolViolation.reason.rawValue),
                 "buffered_bytes": .string("\(protocolViolation.bufferedByteCount)"),
                 "preview": .string(protocolViolation.preview),
+                "preview_hex": .string(protocolViolation.previewHex),
+                "leading_byte_hex": .string(protocolViolation.leadingByteHex ?? ""),
             ]
         )
         continuation.yield(.stdoutProtocolViolation(protocolViolation))
@@ -254,7 +294,8 @@ package actor UpstreamProcess: UpstreamClient {
         continuation.yield(.exit(status))
     }
 
-    private func handleStderrData(_ data: Data) {
+    private func handleStderrData(_ data: Data, generation: UInt64) {
+        guard generation == readGeneration else { return }
         if let message = String(data: data, encoding: .utf8) {
             stderrBuffer.append(message)
             let parts = stderrBuffer.split(separator: "\n", omittingEmptySubsequences: false)
@@ -270,7 +311,8 @@ package actor UpstreamProcess: UpstreamClient {
         }
     }
 
-    private func handleStderrEOF() {
+    private func handleStderrEOF(generation: UInt64) {
+        guard generation == readGeneration else { return }
         flushBufferedStderrIfNeeded()
     }
 

--- a/Sources/ProxyRuntime/UpstreamProcess.swift
+++ b/Sources/ProxyRuntime/UpstreamProcess.swift
@@ -3,7 +3,79 @@ import Darwin
 import Logging
 import ProxyCore
 
-package actor UpstreamProcess: UpstreamClient {
+private final class StdinWriter: @unchecked Sendable {
+    private struct State: Sendable {
+        var queuedBytes = 0
+        var isClosed = false
+    }
+
+    private let fileHandle: FileHandle
+    private let maxQueuedWriteBytes: Int
+    private let queue: DispatchQueue
+    private let state = NSLock()
+    private var queuedBytes = 0
+    private var isClosed = false
+    private let onComplete: @Sendable (_ bytes: Int, _ error: Error?) -> Void
+
+    init(
+        fileHandle: FileHandle,
+        maxQueuedWriteBytes: Int,
+        label: String,
+        onComplete: @escaping @Sendable (_ bytes: Int, _ error: Error?) -> Void
+    ) {
+        self.fileHandle = fileHandle
+        self.maxQueuedWriteBytes = maxQueuedWriteBytes
+        self.queue = DispatchQueue(label: label)
+        self.onComplete = onComplete
+    }
+
+    func send(_ payload: Data) -> UpstreamSendResult {
+        state.lock()
+        defer { state.unlock() }
+
+        guard !isClosed else {
+            return .overloaded
+        }
+        guard queuedBytes + payload.count <= maxQueuedWriteBytes else {
+            return .overloaded
+        }
+
+        queuedBytes += payload.count
+        queue.async { [fileHandle, onComplete] in
+            var writeError: Error?
+            do {
+                try fileHandle.write(contentsOf: payload)
+            } catch {
+                writeError = error
+            }
+            onComplete(payload.count, writeError)
+        }
+        return .accepted
+    }
+
+    func completeWrite(bytes: Int) {
+        state.lock()
+        queuedBytes = max(0, queuedBytes - bytes)
+        state.unlock()
+    }
+
+    func close() {
+        state.lock()
+        let shouldClose = !isClosed
+        isClosed = true
+        state.unlock()
+
+        guard shouldClose else {
+            return
+        }
+
+        queue.async { [fileHandle] in
+            try? fileHandle.close()
+        }
+    }
+}
+
+package struct UpstreamProcess: UpstreamSessionFactory {
     package struct Config {
         package var command: String
         package var args: [String]
@@ -23,34 +95,53 @@ package actor UpstreamProcess: UpstreamClient {
         }
     }
 
-    typealias Event = UpstreamEvent
+    private let config: Config
 
+    package init(config: Config) {
+        self.config = config
+    }
+
+    package func startSession() async throws -> any UpstreamSession {
+        try await ProcessBackedUpstreamSession.start(config: config)
+    }
+}
+
+package actor ProcessBackedUpstreamSession: UpstreamSession {
     package nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
 
-    private let config: Config
+    private let config: UpstreamProcess.Config
+    private let logger: Logger = ProxyLogging.make("upstream")
+    private let maxBufferedStderrBytes = 16 * 1024
+
     private var process: Process?
-    private var terminatingProcess: Process?
     private var stdinPipe = Pipe()
     private var stdoutPipe = Pipe()
     private var stderrPipe = Pipe()
+    private var stdinWriter: StdinWriter?
     private var stdoutReader: OrderedPipeReader?
     private var stderrReader: OrderedPipeReader?
     private var stdoutTask: Task<Void, Never>?
     private var stderrTask: Task<Void, Never>?
     private var framer = StdioFramer()
-    private var isStopping = false
-    private var queuedWriteBytes = 0
-    private var writeGeneration: UInt64 = 0
-    private var readGeneration: UInt64 = 0
     private var stderrBuffer = ""
     private var lastReportedBufferedStdoutBytes = 0
-    private let writeQueue = DispatchQueue(label: "XcodeMCPProxy.UpstreamProcess.write")
-    private let logger: Logger = ProxyLogging.make("upstream")
-    private let maxBufferedStderrBytes = 16 * 1024
+    private var terminationObserved = false
+    private var stdoutDrained = false
+    private var stderrDrained = false
+    private var suppressExitEvent = false
+    private var didFinishEvents = false
+    private var isStopping = false
 
-    package init(config: Config) {
+    package static func start(config: UpstreamProcess.Config) async throws -> ProcessBackedUpstreamSession {
+        let session = ProcessBackedUpstreamSession(config: config)
+        try await session.runProcess()
+        return session
+    }
+
+    private init(config: UpstreamProcess.Config) {
         self.config = config
+
         var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
@@ -58,78 +149,72 @@ package actor UpstreamProcess: UpstreamClient {
         self.continuation = streamContinuation
     }
 
-    package func start() async {
-        isStopping = false
-        startLocked()
-    }
-
-    package func stop() async {
-        isStopping = true
-        stopLocked()
-        terminatingProcess = nil
-        continuation.finish()
-    }
-
     package func send(_ data: Data) async -> UpstreamSendResult {
-        if process == nil {
-            startLocked()
-        }
-        guard process != nil else {
-            logger.warning("Upstream send skipped because process is unavailable")
+        guard !didFinishEvents, !isStopping, !terminationObserved, process != nil, let stdinWriter else {
+            logger.warning("Upstream send skipped because session is unavailable")
             return .overloaded
         }
+
         var payload = data
         if payload.last != 0x0A {
             payload.append(0x0A)
         }
-        if queuedWriteBytes + payload.count > config.maxQueuedWriteBytes {
+
+        let result = stdinWriter.send(payload)
+        if result == .overloaded {
             logger.warning(
                 "Upstream write queue overloaded",
                 metadata: [
-                    "queued_bytes": "\(queuedWriteBytes)",
                     "payload_bytes": "\(payload.count)",
                     "limit_bytes": "\(config.maxQueuedWriteBytes)",
                 ]
             )
-            return .overloaded
         }
-
-        let queuedPayload = payload
-        let queuedPayloadBytes = queuedPayload.count
-        queuedWriteBytes += queuedPayloadBytes
-        let handle = stdinPipe.fileHandleForWriting
-        let generation = writeGeneration
-        writeQueue.async { [weak self] in
-            var writeError: Error?
-            do {
-                try handle.write(contentsOf: queuedPayload)
-            } catch {
-                writeError = error
-            }
-            Task { [weak self] in
-                await self?.completeQueuedWrite(
-                    bytes: queuedPayloadBytes,
-                    generation: generation,
-                    error: writeError
-                )
-            }
-        }
-        return .accepted
+        return result
     }
 
-    private func startLocked() {
-        guard process == nil else { return }
+    package func stop() async {
+        guard !isStopping else {
+            return
+        }
 
+        isStopping = true
+        suppressExitEvent = true
+        stdinWriter?.close()
+        stdoutReader?.stop()
+        stderrReader?.stop()
+
+        if let process {
+            if process.isRunning {
+                process.terminate()
+            } else {
+                terminationObserved = true
+            }
+        } else {
+            terminationObserved = true
+        }
+
+        await stdoutTask?.value
+        await stderrTask?.value
+        finishEventsIfNeeded(force: true)
+    }
+}
+
+private extension ProcessBackedUpstreamSession {
+    func runProcess() async throws {
         stdinPipe = Pipe()
         stdoutPipe = Pipe()
         stderrPipe = Pipe()
         configureNoSigPipe(on: stdinPipe.fileHandleForWriting)
         framer = StdioFramer()
-        queuedWriteBytes = 0
-        writeGeneration &+= 1
-        readGeneration &+= 1
         stderrBuffer = ""
         resetBufferedStdoutBytesIfNeeded()
+        terminationObserved = false
+        stdoutDrained = false
+        stderrDrained = false
+        suppressExitEvent = false
+        didFinishEvents = false
+        isStopping = false
 
         let (executableURL, args) = resolveCommand(command: config.command, args: config.args)
         let process = Process()
@@ -139,88 +224,70 @@ package actor UpstreamProcess: UpstreamClient {
         process.standardInput = stdinPipe
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
+        process.terminationHandler = { [weak self] proc in
+            Task {
+                await self?.handleTermination(status: proc.terminationStatus)
+            }
+        }
 
-        let generation = readGeneration
         let stdoutReader = OrderedPipeReader(
             fileHandle: stdoutPipe.fileHandleForReading,
-            label: "XcodeMCPProxy.UpstreamProcess.stdout"
+            label: "XcodeMCPProxy.UpstreamSession.stdout"
         )
         let stderrReader = OrderedPipeReader(
             fileHandle: stderrPipe.fileHandleForReading,
-            label: "XcodeMCPProxy.UpstreamProcess.stderr"
+            label: "XcodeMCPProxy.UpstreamSession.stderr"
         )
-        self.stdoutReader = stdoutReader
-        self.stderrReader = stderrReader
-        stdoutReader.start()
-        stderrReader.start()
-        stdoutTask = Task { [weak self, stdoutReader] in
-            for await data in stdoutReader.chunks {
-                await self?.handleStdoutData(data, generation: generation)
-            }
-        }
-        stderrTask = Task { [weak self, stderrReader] in
-            for await data in stderrReader.chunks {
-                await self?.handleStderrData(data, generation: generation)
-            }
-            await self?.handleStderrEOF(generation: generation)
-        }
-
-        process.terminationHandler = { [weak self] proc in
-            Task {
-                await self?.handleTermination(process: proc, status: proc.terminationStatus)
-            }
-        }
 
         do {
             try process.run()
-            self.process = process
         } catch {
-            logger.error("Failed to start upstream process", metadata: ["error": "\(error)"])
-            cleanupFailedStart()
+            stdoutReader.stop()
+            stderrReader.stop()
+            try? stdoutPipe.fileHandleForWriting.close()
+            try? stderrPipe.fileHandleForWriting.close()
+            try? stdinPipe.fileHandleForWriting.close()
+            continuation.finish()
+            throw error
         }
-    }
 
-    private func stopLocked() {
-        flushBufferedStderrIfNeeded()
-        readGeneration &+= 1
-        stdoutReader?.stop()
-        stderrReader?.stop()
-        stdoutReader = nil
-        stderrReader = nil
-        stdoutTask = nil
-        stderrTask = nil
-        queuedWriteBytes = 0
-        writeGeneration &+= 1
-        stderrBuffer = ""
-        resetBufferedStdoutBytesIfNeeded()
-        if let process = process {
-            terminatingProcess = process
-            process.terminate()
+        self.process = process
+        self.stdoutReader = stdoutReader
+        self.stderrReader = stderrReader
+        self.stdinWriter = StdinWriter(
+            fileHandle: stdinPipe.fileHandleForWriting,
+            maxQueuedWriteBytes: config.maxQueuedWriteBytes,
+            label: "XcodeMCPProxy.UpstreamSession.stdin"
+        ) { [weak self] bytes, error in
+            Task {
+                await self?.completeQueuedWrite(bytes: bytes, error: error)
+            }
         }
-        process = nil
-    }
 
-    private func cleanupFailedStart() {
-        stdoutReader?.stop()
-        stderrReader?.stop()
-        stdoutReader = nil
-        stderrReader = nil
-        stdoutTask = nil
-        stderrTask = nil
-        try? stdinPipe.fileHandleForWriting.close()
+        stdoutReader.start()
+        stderrReader.start()
         try? stdoutPipe.fileHandleForWriting.close()
         try? stderrPipe.fileHandleForWriting.close()
-        framer = StdioFramer()
-        queuedWriteBytes = 0
-        writeGeneration &+= 1
-        readGeneration &+= 1
-        stderrBuffer = ""
-        resetBufferedStdoutBytesIfNeeded()
-        process = nil
+
+        stdoutTask = Task { [weak self, stdoutReader] in
+            for await data in stdoutReader.chunks {
+                await self?.handleStdoutData(data)
+            }
+            await self?.handleStdoutEOF()
+        }
+        stderrTask = Task { [weak self, stderrReader] in
+            for await data in stderrReader.chunks {
+                await self?.handleStderrData(data)
+            }
+            await self?.handleStderrEOF()
+        }
     }
 
-    private func handleStdoutData(_ data: Data, generation: UInt64) {
-        guard generation == readGeneration else { return }
+    func handleStdoutData(_ data: Data) async {
+        guard !didFinishEvents else {
+            return
+        }
+
         let result = framer.append(data)
         for message in result.messages {
             guard isValidJSONPayload(message) else {
@@ -260,42 +327,19 @@ package actor UpstreamProcess: UpstreamClient {
         continuation.yield(.stdoutProtocolViolation(protocolViolation))
         framer = StdioFramer()
         resetBufferedStdoutBytesIfNeeded()
+        await terminateSession(suppressExitEvent: true)
     }
 
-    private func resetBufferedStdoutBytesIfNeeded() {
-        guard lastReportedBufferedStdoutBytes != 0 else { return }
-        lastReportedBufferedStdoutBytes = 0
-        continuation.yield(.stdoutBufferSize(0))
+    func handleStdoutEOF() {
+        stdoutDrained = true
+        finishEventsIfNeeded()
     }
 
-    private func handleTermination(process terminated: Process, status: Int32) {
-        let wasCurrent = process.map { terminated === $0 } ?? false
-        let wasTerminating = terminatingProcess.map { terminated === $0 } ?? false
-
-        if wasCurrent {
-            process = nil
-        } else if wasTerminating {
-            terminatingProcess = nil
-        } else {
-            // Stale termination for an older process we no longer track.
+    func handleStderrData(_ data: Data) {
+        guard !didFinishEvents else {
             return
         }
 
-        guard !isStopping else {
-            return
-        }
-
-        if wasTerminating, process != nil {
-            logger.debug("Upstream process exited (superseded)", metadata: ["status": "\(status)"])
-            return
-        }
-
-        logger.warning("Upstream process exited", metadata: ["status": "\(status)"])
-        continuation.yield(.exit(status))
-    }
-
-    private func handleStderrData(_ data: Data, generation: UInt64) {
-        guard generation == readGeneration else { return }
         if let message = String(data: data, encoding: .utf8) {
             stderrBuffer.append(message)
             let parts = stderrBuffer.split(separator: "\n", omittingEmptySubsequences: false)
@@ -311,17 +355,83 @@ package actor UpstreamProcess: UpstreamClient {
         }
     }
 
-    private func handleStderrEOF(generation: UInt64) {
-        guard generation == readGeneration else { return }
+    func handleStderrEOF() {
         flushBufferedStderrIfNeeded()
+        stderrDrained = true
+        finishEventsIfNeeded()
     }
 
-    private func flushBufferedStderrIfNeeded() {
+    func handleTermination(status: Int32) async {
+        guard !terminationObserved else {
+            return
+        }
+
+        terminationObserved = true
+        process = nil
+        if !suppressExitEvent {
+            continuation.yield(.exit(status))
+        }
+        stdoutReader?.stop()
+        stderrReader?.stop()
+        finishEventsIfNeeded()
+    }
+
+    func terminateSession(suppressExitEvent: Bool) async {
+        guard !isStopping else {
+            return
+        }
+
+        isStopping = true
+        if suppressExitEvent {
+            self.suppressExitEvent = true
+        }
+        stdinWriter?.close()
+        stdoutReader?.stop()
+        stderrReader?.stop()
+
+        if let process, process.isRunning {
+            process.terminate()
+        } else {
+            terminationObserved = true
+            finishEventsIfNeeded()
+        }
+    }
+
+    func completeQueuedWrite(bytes: Int, error: Error?) {
+        stdinWriter?.completeWrite(bytes: bytes)
+        guard let error else {
+            return
+        }
+        logger.warning("Upstream async write failed", metadata: ["error": "\(error)"])
+    }
+
+    func finishEventsIfNeeded(force: Bool = false) {
+        guard !didFinishEvents else {
+            return
+        }
+        guard force || (terminationObserved && stdoutDrained && stderrDrained) else {
+            return
+        }
+
+        didFinishEvents = true
+        resetBufferedStdoutBytesIfNeeded()
+        continuation.finish()
+    }
+
+    func resetBufferedStdoutBytesIfNeeded() {
+        guard lastReportedBufferedStdoutBytes != 0 else {
+            return
+        }
+        lastReportedBufferedStdoutBytes = 0
+        continuation.yield(.stdoutBufferSize(0))
+    }
+
+    func flushBufferedStderrIfNeeded() {
         emitStderrLine(stderrBuffer)
         stderrBuffer = ""
     }
 
-    private func flushBufferedStderrChunkIfNeeded() {
+    func flushBufferedStderrChunkIfNeeded() {
         while stderrBuffer.utf8.count > maxBufferedStderrBytes {
             let prefixData = Data(stderrBuffer.utf8.prefix(maxBufferedStderrBytes))
             emitStderrLine(String(decoding: prefixData, as: UTF8.self), suffix: " [truncated]")
@@ -329,15 +439,17 @@ package actor UpstreamProcess: UpstreamClient {
         }
     }
 
-    private func emitStderrLine(_ line: String, suffix: String = "") {
+    func emitStderrLine(_ line: String, suffix: String = "") {
         let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else {
+            return
+        }
         let message = suffix.isEmpty ? trimmed : trimmed + suffix
         logger.error("Upstream stderr: \(message)")
         continuation.yield(.stderr(message))
     }
 
-    private func resolveCommand(command: String, args: [String]) -> (URL, [String]) {
+    func resolveCommand(command: String, args: [String]) -> (URL, [String]) {
         if command.contains("/") {
             return (URL(fileURLWithPath: command), args)
         }
@@ -345,7 +457,7 @@ package actor UpstreamProcess: UpstreamClient {
         return (URL(fileURLWithPath: env), [command] + args)
     }
 
-    private func configureNoSigPipe(on handle: FileHandle) {
+    func configureNoSigPipe(on handle: FileHandle) {
         let fd = handle.fileDescriptor
         let result = fcntl(fd, F_SETNOSIGPIPE, 1)
         if result == -1 {
@@ -354,17 +466,5 @@ package actor UpstreamProcess: UpstreamClient {
                 metadata: ["errno": "\(errno)"]
             )
         }
-    }
-
-    private func completeQueuedWrite(
-        bytes: Int,
-        generation: UInt64,
-        error: Error?
-    ) {
-        if generation == writeGeneration {
-            queuedWriteBytes = max(0, queuedWriteBytes - bytes)
-        }
-        guard let error else { return }
-        logger.warning("Upstream async write failed", metadata: ["error": "\(error)"])
     }
 }

--- a/Sources/ProxyRuntime/UpstreamProcess.swift
+++ b/Sources/ProxyRuntime/UpstreamProcess.swift
@@ -113,6 +113,7 @@ package actor ProcessBackedUpstreamSession: UpstreamSession {
     private let config: UpstreamProcess.Config
     private let logger: Logger = ProxyLogging.make("upstream")
     private let maxBufferedStderrBytes = 16 * 1024
+    private let terminationDrainGraceNanoseconds: UInt64 = 250_000_000
 
     private var process: Process?
     private var stdinPipe = Pipe()
@@ -130,6 +131,8 @@ package actor ProcessBackedUpstreamSession: UpstreamSession {
     private var stdoutDrained = false
     private var stderrDrained = false
     private var suppressExitEvent = false
+    private var pendingExitStatus: Int32?
+    private var terminationDrainTimeoutTask: Task<Void, Never>?
     private var didFinishEvents = false
     private var isStopping = false
 
@@ -180,6 +183,8 @@ package actor ProcessBackedUpstreamSession: UpstreamSession {
 
         isStopping = true
         suppressExitEvent = true
+        terminationDrainTimeoutTask?.cancel()
+        terminationDrainTimeoutTask = nil
         stdinWriter?.close()
         stdoutReader?.stop()
         stderrReader?.stop()
@@ -213,6 +218,9 @@ private extension ProcessBackedUpstreamSession {
         stdoutDrained = false
         stderrDrained = false
         suppressExitEvent = false
+        pendingExitStatus = nil
+        terminationDrainTimeoutTask?.cancel()
+        terminationDrainTimeoutTask = nil
         didFinishEvents = false
         isStopping = false
 
@@ -369,10 +377,10 @@ private extension ProcessBackedUpstreamSession {
         terminationObserved = true
         process = nil
         if !suppressExitEvent {
-            continuation.yield(.exit(status))
+            pendingExitStatus = status
+            scheduleTerminationDrainTimeoutIfNeeded()
         }
-        stdoutReader?.stop()
-        stderrReader?.stop()
+        // Let pipe readers drain any bytes the kernel still holds after process exit.
         finishEventsIfNeeded()
     }
 
@@ -385,6 +393,8 @@ private extension ProcessBackedUpstreamSession {
         if suppressExitEvent {
             self.suppressExitEvent = true
         }
+        terminationDrainTimeoutTask?.cancel()
+        terminationDrainTimeoutTask = nil
         stdinWriter?.close()
         stdoutReader?.stop()
         stderrReader?.stop()
@@ -414,8 +424,43 @@ private extension ProcessBackedUpstreamSession {
         }
 
         didFinishEvents = true
+        terminationDrainTimeoutTask?.cancel()
+        terminationDrainTimeoutTask = nil
         resetBufferedStdoutBytesIfNeeded()
+        if let exitStatus = pendingExitStatus {
+            pendingExitStatus = nil
+            continuation.yield(.exit(exitStatus))
+        }
         continuation.finish()
+    }
+
+    func scheduleTerminationDrainTimeoutIfNeeded() {
+        guard pendingExitStatus != nil, !stdoutDrained || !stderrDrained else {
+            return
+        }
+
+        let grace = terminationDrainGraceNanoseconds
+        terminationDrainTimeoutTask?.cancel()
+        terminationDrainTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: grace)
+            guard !Task.isCancelled else {
+                return
+            }
+            await self?.forceTerminateDrainIfNeeded()
+        }
+    }
+
+    func forceTerminateDrainIfNeeded() {
+        guard terminationObserved, !didFinishEvents, pendingExitStatus != nil else {
+            return
+        }
+        guard !stdoutDrained || !stderrDrained else {
+            return
+        }
+
+        stdoutReader?.stop()
+        stderrReader?.stop()
+        finishEventsIfNeeded()
     }
 
     func resetBufferedStdoutBytesIfNeeded() {

--- a/Sources/ProxyRuntime/UpstreamSelectionPolicy.swift
+++ b/Sources/ProxyRuntime/UpstreamSelectionPolicy.swift
@@ -222,16 +222,12 @@ package final class UpstreamSelectionPolicy: Sendable {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
             let quarantineUntil = nowUptimeNs &+ 15_000_000_000
-            let cancelledInitTimeout = state.upstreamStates[upstreamIndex].initInFlight
-                ? state.upstreamStates[upstreamIndex].initTimeout
-                : nil
-            if state.upstreamStates[upstreamIndex].initInFlight {
-                state.upstreamStates[upstreamIndex].isInitialized = false
-                state.upstreamStates[upstreamIndex].initInFlight = false
-                state.upstreamStates[upstreamIndex].initTimeout = nil
-                state.upstreamStates[upstreamIndex].initUpstreamID = nil
-                state.upstreamStates[upstreamIndex].didSendInitialized = false
-            }
+            let cancelledInitTimeout = state.upstreamStates[upstreamIndex].initTimeout
+            state.upstreamStates[upstreamIndex].isInitialized = false
+            state.upstreamStates[upstreamIndex].initInFlight = false
+            state.upstreamStates[upstreamIndex].initTimeout = nil
+            state.upstreamStates[upstreamIndex].initUpstreamID = nil
+            state.upstreamStates[upstreamIndex].didSendInitialized = false
             state.upstreamStates[upstreamIndex].healthState = .quarantined(
                 untilUptimeNs: quarantineUntil
             )

--- a/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
@@ -732,10 +732,10 @@ private struct TestHTTPServer {
     let channel: Channel
     let url: URL
     let sessionManager: RuntimeCoordinator
-    let upstream: any UpstreamClient
+    let upstream: any UpstreamSlotControlling
 
     static func start(
-        upstream providedUpstream: (any UpstreamClient)? = nil,
+        upstream providedUpstream: (any UpstreamSlotControlling)? = nil,
         requestTimeout: TimeInterval = 5
     ) throws -> TestHTTPServer {
         ProxyLogging.bootstrap(environment: ["MCP_LOG_LEVEL": "critical"])
@@ -798,7 +798,7 @@ private struct TestHTTPServer {
     }
 }
 
-private actor EchoUpstreamClient: UpstreamClient {
+private actor EchoUpstreamClient: UpstreamSlotControlling {
     nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
 
@@ -860,7 +860,7 @@ private actor EchoUpstreamClient: UpstreamClient {
     }
 }
 
-private actor ControlledUpstreamClient: UpstreamClient {
+private actor ControlledUpstreamClient: UpstreamSlotControlling {
     struct SentRequest: Sendable {
         let label: String
         let responseData: Data?
@@ -972,7 +972,7 @@ private actor ControlledUpstreamClient: UpstreamClient {
     }
 }
 
-private actor RefreshSensitiveUpstreamClient: UpstreamClient {
+private actor RefreshSensitiveUpstreamClient: UpstreamSlotControlling {
     nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
     private var activeTabs: Set<String> = []
@@ -1099,7 +1099,7 @@ private actor RefreshSensitiveUpstreamClient: UpstreamClient {
     }
 }
 
-private actor SingleFlightRefreshUpstreamClient: UpstreamClient {
+private actor SingleFlightRefreshUpstreamClient: UpstreamSlotControlling {
     nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
     private var hasActiveRefresh = false
@@ -1219,7 +1219,7 @@ private actor SingleFlightRefreshUpstreamClient: UpstreamClient {
     }
 }
 
-private actor NotifyingUpstreamClient: UpstreamClient {
+private actor NotifyingUpstreamClient: UpstreamSlotControlling {
     nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
 

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -3631,7 +3631,8 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         }
     }
 
-    func sendUpstream(_ data: Data, upstreamIndex: Int) {
+    func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool) {
+        _ = ensureRunning
         state.withLockedValue { state in
             state.upstreamSendCount += 1
         }

--- a/Tests/ProxyRuntimeTests/ProcessRunnerTests.swift
+++ b/Tests/ProxyRuntimeTests/ProcessRunnerTests.swift
@@ -29,4 +29,49 @@ struct ProcessRunnerTests {
         #expect(output.terminationStatus == 0)
         #expect(output.stdout.utf8.count == 200000)
     }
+
+    @Test func processRunnerPreservesLargeChunkedStdoutOrder() async throws {
+        let runner = ProcessRunner()
+        let segments = (0..<64).map { index in
+            let prefix = "[\(String(index).leftPadding(toLength: 3, withPad: "0"))]"
+            let scalar = UnicodeScalar(65 + (index % 26))!
+            return prefix + String(repeating: Character(scalar), count: 2048)
+        }
+        let expected = segments.joined()
+        let output = try await runner.run(
+            ProcessRequest(
+                label: "ordered-large-stdout",
+                executablePath: "/usr/bin/python3",
+                arguments: makePythonSegmentEmitterArgs(segments: segments, pauseSeconds: 0.0005),
+                input: nil
+            )
+        )
+
+        #expect(output.terminationStatus == 0)
+        #expect(output.stdout == expected)
+    }
+}
+
+private extension String {
+    func leftPadding(toLength length: Int, withPad pad: String) -> String {
+        guard count < length else { return self }
+        return String(repeating: pad, count: length - count) + self
+    }
+}
+
+private func makePythonSegmentEmitterArgs(
+    segments: [String],
+    pauseSeconds: Double
+) -> [String] {
+    let script = """
+    import sys
+    import time
+
+    pause = float(sys.argv[1])
+    for segment in sys.argv[2:]:
+        sys.stdout.write(segment)
+        sys.stdout.flush()
+        time.sleep(pause)
+    """
+    return ["-c", script, "\(pauseSeconds)"] + segments
 }

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -2969,6 +2969,37 @@ struct RuntimeCoordinatorTests {
         #expect(manager.chooseUpstreamIndex(sessionID: "session-A", shouldPin: true) == nil)
     }
 
+    @Test func sessionManagerProtocolViolationRequestsFreshUpstreamSession() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdown() }
+
+        #expect(
+            await waitUntil(timeout: .seconds(2)) {
+                await upstream.startCount() == 1
+            }
+        )
+
+        manager.handleUpstreamProtocolViolation(
+            StdioFramerProtocolViolation(
+                reason: .invalidJSON,
+                bufferedByteCount: 128,
+                preview: "{broken"
+            ),
+            upstreamIndex: 0
+        )
+
+        #expect(
+            await waitUntil(timeout: .seconds(2)) {
+                await upstream.startCount() == 2
+            }
+        )
+    }
+
     @Test func sessionManagerProtocolViolationFailsQueuedRequestsWhenNoHealthyUpstreamRemains() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -3688,11 +3719,16 @@ private func defaultUpstreamEnvironment(sharedSessionID: String?) throws -> [Str
     return try upstreamEnvironment(from: upstream)
 }
 
-private func upstreamEnvironment(from upstream: UpstreamProcess) throws -> [String: String] {
-    let mirror = Mirror(reflecting: upstream)
+private func upstreamEnvironment(from upstream: ManagedUpstreamSlot) throws -> [String: String] {
+    let upstreamMirror = Mirror(reflecting: upstream)
+    let factory = try #require(
+        upstreamMirror.children.first(where: { $0.label == "factory" })?.value,
+        "ManagedUpstreamSlot should expose a stored factory for tests"
+    )
+    let factoryMirror = Mirror(reflecting: factory)
     let config = try #require(
-        mirror.children.first(where: { $0.label == "config" })?.value,
-        "UpstreamProcess should expose a stored config for tests"
+        factoryMirror.children.first(where: { $0.label == "config" })?.value,
+        "UpstreamProcess factory should expose a stored config for tests"
     )
     let configMirror = Mirror(reflecting: config)
     return try #require(
@@ -3727,7 +3763,7 @@ private func withEnvironmentVariables<T>(
     return try body()
 }
 
-private actor AlwaysOverloadedUpstreamClient: UpstreamClient {
+private actor AlwaysOverloadedUpstreamClient: UpstreamSlotControlling {
     nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
     private let sentMessages = RecordedValues<Data>()
@@ -3768,7 +3804,7 @@ private actor AlwaysOverloadedUpstreamClient: UpstreamClient {
     }
 }
 
-private actor ToggleableOverloadUpstreamClient: UpstreamClient {
+private actor ToggleableOverloadUpstreamClient: UpstreamSlotControlling {
     nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
     private let sentMessages = RecordedValues<Data>()

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -2969,7 +2969,7 @@ struct RuntimeCoordinatorTests {
         #expect(manager.chooseUpstreamIndex(sessionID: "session-A", shouldPin: true) == nil)
     }
 
-    @Test func sessionManagerProtocolViolationRequestsFreshUpstreamSession() async throws {
+    @Test func sessionManagerProtocolViolationRestartsWarmInitializeForPrimary() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
@@ -2978,11 +2978,16 @@ struct RuntimeCoordinatorTests {
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdown() }
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                await upstream.startCount() == 1
-            }
+        let initFuture = manager.registerInitialize(
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
         )
+        let initRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let initUpstreamID = try extractUpstreamID(from: initRequest)
+        await upstream.yield(.message(try makeInitializeResponse(id: initUpstreamID)))
+        _ = try await initFuture.get()
+        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
         manager.handleUpstreamProtocolViolation(
             StdioFramerProtocolViolation(
@@ -2995,9 +3000,15 @@ struct RuntimeCoordinatorTests {
 
         #expect(
             await waitUntil(timeout: .seconds(2)) {
-                await upstream.startCount() == 2
+                await upstream.sentCount() >= 3
             }
         )
+
+        let restartedInitRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        let object = try #require(
+            JSONSerialization.jsonObject(with: restartedInitRequest, options: []) as? [String: Any]
+        )
+        #expect(object["method"] as? String == "initialize")
     }
 
     @Test func sessionManagerProtocolViolationFailsQueuedRequestsWhenNoHealthyUpstreamRemains() async throws {

--- a/Tests/ProxyRuntimeTests/TestUpstreamClient.swift
+++ b/Tests/ProxyRuntimeTests/TestUpstreamClient.swift
@@ -3,7 +3,7 @@ import XcodeMCPTestSupport
 
 @testable import ProxyRuntime
 
-actor TestUpstreamClient: UpstreamClient {
+actor TestUpstreamClient: UpstreamSlotControlling {
     nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
     private let sentMessages = RecordedValues<Data>()

--- a/Tests/ProxyRuntimeTests/UpstreamProcessTests.swift
+++ b/Tests/ProxyRuntimeTests/UpstreamProcessTests.swift
@@ -231,6 +231,114 @@ struct UpstreamProcessTests {
             #expect(postViolationMessage == #"{"jsonrpc":"2.0","result":{}}"#)
         }
     }
+
+    @Test func upstreamProcessReturnsOverloadedWhenLaunchFails() async throws {
+        let config = UpstreamProcess.Config(
+            command: "/path/that/does/not/exist",
+            args: [],
+            environment: ProcessInfo.processInfo.environment,
+            maxQueuedWriteBytes: 1024
+        )
+        try await withUpstreamProcess(config: config) { upstream in
+            let first = await upstream.send(Data(#"{"jsonrpc":"2.0","id":1}"#.utf8))
+            let second = await upstream.send(Data(#"{"jsonrpc":"2.0","id":2}"#.utf8))
+
+            switch first {
+            case .accepted:
+                Issue.record("failed launch should not accept writes into orphaned pipes")
+            case .overloaded:
+                break
+            }
+
+            switch second {
+            case .accepted:
+                Issue.record("subsequent sends should retry launch and still fail fast")
+            case .overloaded:
+                break
+            }
+        }
+    }
+
+    @Test func upstreamProcessReassemblesLargeJSONSplitAcrossOrderedChunks() async throws {
+        let payload = try makeJSONRPCResponse(
+            id: 41,
+            text: String(repeating: "x", count: 128 * 1024)
+        )
+        let config = UpstreamProcess.Config(
+            command: "/usr/bin/python3",
+            args: makePythonChunkEmitterArgs(
+                payloads: [payload],
+                chunkSize: 4096,
+                pauseSeconds: 0.001,
+                keepAliveSeconds: 1
+            ),
+            environment: ProcessInfo.processInfo.environment,
+            maxQueuedWriteBytes: 1024
+        )
+        try await withUpstreamProcess(config: config) { upstream in
+            let message = try await waitWithTimeout(
+                "large split JSON should be reconstructed as one message",
+                timeout: .seconds(5)
+            ) {
+                for await event in upstream.events {
+                    switch event {
+                    case .message(let message):
+                        return String(decoding: message, as: UTF8.self)
+                    case .stdoutProtocolViolation(let violation):
+                        return "VIOLATION:\(violation.reason.rawValue)"
+                    case .stderr, .stdoutBufferSize, .exit:
+                        continue
+                    }
+                }
+                return ""
+            }
+
+            #expect(message == payload)
+        }
+    }
+
+    @Test func upstreamProcessPreservesBackToBackLargeJSONMessageOrder() async throws {
+        let payloads = try [
+            makeJSONRPCResponse(id: 51, text: String(repeating: "a", count: 96 * 1024)),
+            makeJSONRPCResponse(id: 52, text: String(repeating: "b", count: 96 * 1024)),
+            makeJSONRPCResponse(id: 53, text: String(repeating: "c", count: 96 * 1024)),
+        ]
+        let config = UpstreamProcess.Config(
+            command: "/usr/bin/python3",
+            args: makePythonChunkEmitterArgs(
+                payloads: payloads,
+                chunkSize: 2048,
+                pauseSeconds: 0.0005,
+                keepAliveSeconds: 1
+            ),
+            environment: ProcessInfo.processInfo.environment,
+            maxQueuedWriteBytes: 1024
+        )
+        try await withUpstreamProcess(config: config) { upstream in
+            let messages = try await waitWithTimeout(
+                "back-to-back large JSON payloads should preserve order",
+                timeout: .seconds(5)
+            ) {
+                var messages: [String] = []
+                for await event in upstream.events {
+                    switch event {
+                    case .message(let message):
+                        messages.append(String(decoding: message, as: UTF8.self))
+                        if messages.count == payloads.count {
+                            return messages
+                        }
+                    case .stdoutProtocolViolation(let violation):
+                        return ["VIOLATION:\(violation.reason.rawValue)"]
+                    case .stderr, .stdoutBufferSize, .exit:
+                        continue
+                    }
+                }
+                return messages
+            }
+
+            #expect(messages == payloads)
+        }
+    }
 }
 
 private func withUpstreamProcess<T: Sendable>(
@@ -247,4 +355,44 @@ private func withUpstreamProcess<T: Sendable>(
         await upstream.stop()
         throw error
     }
+}
+
+private func makeJSONRPCResponse(id: Int, text: String) throws -> String {
+    let payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": [
+            "text": text,
+        ],
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    return String(decoding: data, as: UTF8.self)
+}
+
+private func makePythonChunkEmitterArgs(
+    payloads: [String],
+    chunkSize: Int,
+    pauseSeconds: Double,
+    keepAliveSeconds: Double
+) -> [String] {
+    let script = """
+    import sys
+    import time
+
+    chunk_size = int(sys.argv[1])
+    pause = float(sys.argv[2])
+    keep_alive = float(sys.argv[3])
+    payloads = sys.argv[4:]
+
+    for payload in payloads:
+        for start in range(0, len(payload), chunk_size):
+            sys.stdout.write(payload[start:start + chunk_size])
+            sys.stdout.flush()
+            time.sleep(pause)
+        sys.stdout.write("\\n")
+        sys.stdout.flush()
+
+    time.sleep(keep_alive)
+    """
+    return ["-c", script, "\(chunkSize)", "\(pauseSeconds)", "\(keepAliveSeconds)"] + payloads
 }

--- a/Tests/ProxyRuntimeTests/UpstreamProcessTests.swift
+++ b/Tests/ProxyRuntimeTests/UpstreamProcessTests.swift
@@ -327,6 +327,141 @@ struct UpstreamProcessTests {
             #expect(messages == payloads)
         }
     }
+
+    @Test func upstreamSessionDrainsFinalStdoutAfterImmediateExit() async throws {
+        let payload = try makeJSONRPCResponse(
+            id: 61,
+            text: String(repeating: "z", count: 256 * 1024)
+        )
+        let config = UpstreamProcess.Config(
+            command: "/usr/bin/python3",
+            args: makePythonImmediateExitResponseArgs(id: 61, character: "z", repeatCount: 256 * 1024),
+            environment: ProcessInfo.processInfo.environment,
+            maxQueuedWriteBytes: 1024
+        )
+
+        for _ in 0..<10 {
+            try await withUpstreamSession(config: config) { session in
+                let events = try await waitWithTimeout(
+                    "final stdout should be drained before exit even when the process exits immediately",
+                    timeout: .seconds(5)
+                ) {
+                    var observedEvents: [UpstreamEvent] = []
+                    for await event in session.events {
+                        observedEvents.append(event)
+
+                        let sawMessage = observedEvents.contains {
+                            if case .message = $0 { return true }
+                            return false
+                        }
+                        let sawExit = observedEvents.contains {
+                            if case .exit = $0 { return true }
+                            return false
+                        }
+                        if sawMessage && sawExit {
+                            return observedEvents
+                        }
+                    }
+                    return observedEvents
+                }
+
+                let message = events.compactMap { event -> String? in
+                    guard case .message(let data) = event else {
+                        return nil
+                    }
+                    return String(decoding: data, as: UTF8.self)
+                }.first
+                let messageIndex = events.firstIndex {
+                    if case .message = $0 { return true }
+                    return false
+                }
+                let exitIndex = events.firstIndex {
+                    if case .exit = $0 { return true }
+                    return false
+                }
+
+                if let message {
+                    #expect(try canonicalJSONString(message) == canonicalJSONString(payload))
+                } else {
+                    Issue.record("expected a final stdout message before exit")
+                }
+                #expect(messageIndex != nil)
+                #expect(exitIndex != nil)
+                if let messageIndex, let exitIndex {
+                    #expect(messageIndex < exitIndex)
+                }
+            }
+        }
+    }
+
+    @Test func upstreamSessionEmitsExitWhenDescendantKeepsPipeOpen() async throws {
+        let payload = try makeJSONRPCResponse(
+            id: 62,
+            text: String(repeating: "y", count: 8 * 1024)
+        )
+        let config = UpstreamProcess.Config(
+            command: "/usr/bin/python3",
+            args: makePythonForkingExitResponseArgs(
+                id: 62,
+                character: "y",
+                repeatCount: 8 * 1024,
+                childSleepSeconds: 2
+            ),
+            environment: ProcessInfo.processInfo.environment,
+            maxQueuedWriteBytes: 1024
+        )
+
+        try await withUpstreamSession(config: config) { session in
+            let events = try await waitWithTimeout(
+                "exit should not wait indefinitely for descendant-held pipe descriptors",
+                timeout: .seconds(1)
+            ) {
+                var observedEvents: [UpstreamEvent] = []
+                for await event in session.events {
+                    observedEvents.append(event)
+
+                    let sawMessage = observedEvents.contains {
+                        if case .message = $0 { return true }
+                        return false
+                    }
+                    let sawExit = observedEvents.contains {
+                        if case .exit = $0 { return true }
+                        return false
+                    }
+                    if sawMessage && sawExit {
+                        return observedEvents
+                    }
+                }
+                return observedEvents
+            }
+
+            let message = events.compactMap { event -> String? in
+                guard case .message(let data) = event else {
+                    return nil
+                }
+                return String(decoding: data, as: UTF8.self)
+            }.first
+            let messageIndex = events.firstIndex {
+                if case .message = $0 { return true }
+                return false
+            }
+            let exitIndex = events.firstIndex {
+                if case .exit = $0 { return true }
+                return false
+            }
+
+            if let message {
+                #expect(try canonicalJSONString(message) == canonicalJSONString(payload))
+            } else {
+                Issue.record("expected the parent process response before exit")
+            }
+            #expect(messageIndex != nil)
+            #expect(exitIndex != nil)
+            if let messageIndex, let exitIndex {
+                #expect(messageIndex < exitIndex)
+            }
+        }
+    }
 }
 
 private func withUpstreamSession<T: Sendable>(
@@ -382,4 +517,66 @@ private func makePythonChunkEmitterArgs(
     time.sleep(keep_alive)
     """
     return ["-c", script, "\(chunkSize)", "\(pauseSeconds)", "\(keepAliveSeconds)"] + payloads
+}
+
+private func makePythonImmediateExitResponseArgs(
+    id: Int,
+    character: String,
+    repeatCount: Int
+) -> [String] {
+    let script = """
+    import json
+    import sys
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": int(sys.argv[1]),
+        "result": {
+            "text": sys.argv[2] * int(sys.argv[3]),
+        },
+    }
+    sys.stdout.write(json.dumps(payload, separators=(",", ":")))
+    sys.stdout.write("\\n")
+    sys.stdout.flush()
+    """
+    return ["-c", script, "\(id)", character, "\(repeatCount)"]
+}
+
+private func makePythonForkingExitResponseArgs(
+    id: Int,
+    character: String,
+    repeatCount: Int,
+    childSleepSeconds: Int
+) -> [String] {
+    let script = """
+    import json
+    import os
+    import sys
+    import time
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": int(sys.argv[1]),
+        "result": {
+            "text": sys.argv[2] * int(sys.argv[3]),
+        },
+    }
+
+    pid = os.fork()
+    if pid == 0:
+        time.sleep(float(sys.argv[4]))
+        os._exit(0)
+
+    sys.stdout.write(json.dumps(payload, separators=(",", ":")))
+    sys.stdout.write("\\n")
+    sys.stdout.flush()
+    os._exit(0)
+    """
+    return ["-c", script, "\(id)", character, "\(repeatCount)", "\(childSleepSeconds)"]
+}
+
+private func canonicalJSONString(_ string: String) throws -> String {
+    let object = try JSONSerialization.jsonObject(with: Data(string.utf8))
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    return String(decoding: data, as: UTF8.self)
 }

--- a/Tests/ProxyRuntimeTests/UpstreamProcessTests.swift
+++ b/Tests/ProxyRuntimeTests/UpstreamProcessTests.swift
@@ -6,20 +6,20 @@ import XcodeMCPTestSupport
 
 @Suite(.serialized)
 struct UpstreamProcessTests {
-    @Test func upstreamProcessSendRemainsResponsiveUnderStdinBackpressure() async throws {
+    @Test func upstreamSessionSendRemainsResponsiveUnderStdinBackpressure() async throws {
         let config = UpstreamProcess.Config(
             command: "/bin/cat",
             args: [],
             environment: ProcessInfo.processInfo.environment,
             maxQueuedWriteBytes: 550_000
         )
-        try await withUpstreamProcess(config: config) { upstream in
+        try await withUpstreamSession(config: config) { session in
             let payload = Data(repeating: 0x41, count: 500_000)
             let first = try await waitWithTimeout(
                 "first send should complete before backpressure timeout",
                 timeout: .seconds(5)
             ) {
-                await upstream.send(payload)
+                await session.send(payload)
             }
             switch first {
             case .accepted:
@@ -32,7 +32,7 @@ struct UpstreamProcessTests {
                 "second send should return promptly under backpressure",
                 timeout: .seconds(5)
             ) {
-                await upstream.send(payload)
+                await session.send(payload)
             }
             switch second {
             case .accepted:
@@ -43,19 +43,19 @@ struct UpstreamProcessTests {
         }
     }
 
-    @Test func upstreamProcessFlushesTrailingStderrLineWithoutNewline() async throws {
+    @Test func upstreamSessionFlushesTrailingStderrLineWithoutNewline() async throws {
         let config = UpstreamProcess.Config(
             command: "/bin/sh",
             args: ["-c", "printf 'fatal stderr' >&2"],
             environment: ProcessInfo.processInfo.environment,
             maxQueuedWriteBytes: 1024
         )
-        try await withUpstreamProcess(config: config) { upstream in
+        try await withUpstreamSession(config: config) { session in
             let stderr = try await waitWithTimeout(
                 "stderr line should be flushed without newline",
                 timeout: .seconds(2)
             ) {
-                for await event in upstream.events {
+                for await event in session.events {
                     switch event {
                     case .stderr(let message):
                         return message
@@ -70,19 +70,19 @@ struct UpstreamProcessTests {
         }
     }
 
-    @Test func upstreamProcessFlushesLargeStderrChunkWithoutWaitingForEOF() async throws {
+    @Test func upstreamSessionFlushesLargeStderrChunkWithoutWaitingForEOF() async throws {
         let config = UpstreamProcess.Config(
             command: "/bin/sh",
             args: ["-c", "head -c 20000 /dev/zero | tr '\\0' 'x' >&2; sleep 1"],
             environment: ProcessInfo.processInfo.environment,
             maxQueuedWriteBytes: 1024
         )
-        try await withUpstreamProcess(config: config) { upstream in
+        try await withUpstreamSession(config: config) { session in
             let stderr = try await waitWithTimeout(
                 "large stderr chunk should flush before EOF",
                 timeout: .seconds(1)
             ) {
-                for await event in upstream.events {
+                for await event in session.events {
                     switch event {
                     case .stderr(let message):
                         return message
@@ -97,25 +97,24 @@ struct UpstreamProcessTests {
         }
     }
 
-    @Test func upstreamProcessEmitsBufferedStdoutResetWhenStopping() async throws {
+    @Test func upstreamSessionEmitsBufferedStdoutResetWhenStopping() async throws {
         let config = UpstreamProcess.Config(
             command: "/bin/cat",
             args: [],
             environment: ProcessInfo.processInfo.environment,
             maxQueuedWriteBytes: 1024
         )
-        let upstream = UpstreamProcess(config: config)
-        await upstream.start()
+        let session = try await UpstreamProcess(config: config).startSession()
         defer {
             Task {
-                await upstream.stop()
+                await session.stop()
             }
         }
 
         let observedSizesRecorder = RecordedValues<Int>()
         let observedSizes = Task { () -> [Int] in
             var sizes: [Int] = []
-            for await event in upstream.events {
+            for await event in session.events {
                 switch event {
                 case .stdoutBufferSize(let size):
                     sizes.append(size)
@@ -130,7 +129,7 @@ struct UpstreamProcessTests {
             return sizes
         }
 
-        let sendResult = await upstream.send(Data("{".utf8))
+        let sendResult = await session.send(Data("{".utf8))
         switch sendResult {
         case .accepted:
             break
@@ -143,7 +142,7 @@ struct UpstreamProcessTests {
                 await observedSizesRecorder.snapshot().contains(where: { $0 > 0 })
             }
         )
-        await upstream.stop()
+        await session.stop()
 
         let sizes = try await waitWithTimeout(
             "buffered stdout should reset to zero after stop",
@@ -156,22 +155,22 @@ struct UpstreamProcessTests {
         #expect(sizes.contains(0))
     }
 
-    @Test func upstreamProcessTreatsInvalidStdoutAsFatalProtocolViolation() async throws {
+    @Test func upstreamSessionTreatsInvalidStdoutAsFatalProtocolViolation() async throws {
         let config = UpstreamProcess.Config(
             command: "/bin/sh",
             args: ["-c", "printf 'Content-Length: abc\\r\\n\\r\\n{}'; sleep 5"],
             environment: ProcessInfo.processInfo.environment,
             maxQueuedWriteBytes: 1024
         )
-        try await withUpstreamProcess(config: config) { upstream in
-        let events = try await waitWithTimeout(
-                "invalid stdout should emit a protocol violation without auto-restart",
+        try await withUpstreamSession(config: config) { session in
+            let events = try await waitWithTimeout(
+                "invalid stdout should emit a protocol violation",
                 timeout: .seconds(3)
             ) {
                 var sawViolation = false
                 var bufferedSizes: [Int] = []
 
-                for await event in upstream.events {
+                for await event in session.events {
                     switch event {
                     case .stdoutProtocolViolation(let violation):
                         sawViolation = true
@@ -194,72 +193,61 @@ struct UpstreamProcessTests {
         }
     }
 
-    @Test func upstreamProcessResetsFramerAfterProtocolViolation() async throws {
-        let config = UpstreamProcess.Config(
-            command: "/bin/sh",
-            args: [
-                "-c",
-                "printf 'Content-Length: abc\\r\\n\\r\\n{}'; sleep 1; printf '{\"jsonrpc\":\"2.0\",\"result\":{}}\\n'; sleep 5",
-            ],
-            environment: ProcessInfo.processInfo.environment,
-            maxQueuedWriteBytes: 1024
-        )
-        try await withUpstreamProcess(config: config) { upstream in
-            let postViolationMessage = try await waitWithTimeout(
-                "valid stdout should still be parsed after resetting the framer",
-                timeout: .seconds(4)
-            ) {
-                var sawViolation = false
-
-                for await event in upstream.events {
-                    switch event {
-                    case .stdoutProtocolViolation(let violation):
-                        sawViolation = true
-                        #expect(violation.reason == .invalidContentLengthHeader)
-                    case .message(let message):
-                        if sawViolation {
-                            return String(decoding: message, as: UTF8.self)
-                        }
-                    case .stderr, .stdoutBufferSize, .exit:
-                        continue
-                    }
-                }
-
-                return ""
-            }
-
-            #expect(postViolationMessage == #"{"jsonrpc":"2.0","result":{}}"#)
-        }
-    }
-
-    @Test func upstreamProcessReturnsOverloadedWhenLaunchFails() async throws {
+    @Test func upstreamSessionReturnsOverloadedWhenLaunchFails() async throws {
         let config = UpstreamProcess.Config(
             command: "/path/that/does/not/exist",
             args: [],
             environment: ProcessInfo.processInfo.environment,
             maxQueuedWriteBytes: 1024
         )
-        try await withUpstreamProcess(config: config) { upstream in
-            let first = await upstream.send(Data(#"{"jsonrpc":"2.0","id":1}"#.utf8))
-            let second = await upstream.send(Data(#"{"jsonrpc":"2.0","id":2}"#.utf8))
+        let slot = ManagedUpstreamSlot(factory: UpstreamProcess(config: config))
+        await slot.start()
 
-            switch first {
-            case .accepted:
-                Issue.record("failed launch should not accept writes into orphaned pipes")
-            case .overloaded:
-                break
-            }
+        let first = await slot.send(Data(#"{"jsonrpc":"2.0","id":1}"#.utf8))
+        let second = await slot.send(Data(#"{"jsonrpc":"2.0","id":2}"#.utf8))
+        await slot.stop()
 
-            switch second {
-            case .accepted:
-                Issue.record("subsequent sends should retry launch and still fail fast")
-            case .overloaded:
-                break
-            }
+        switch first {
+        case .accepted:
+            Issue.record("failed launch should not accept writes into an unavailable slot")
+        case .overloaded:
+            break
+        }
+
+        switch second {
+        case .accepted:
+            Issue.record("subsequent sends should still fail fast after launch failure")
+        case .overloaded:
+            break
         }
     }
 
-    @Test func upstreamProcessReassemblesLargeJSONSplitAcrossOrderedChunks() async throws {
+    @Test func upstreamSessionRejectsWritesAfterExitEvent() async throws {
+        let config = UpstreamProcess.Config(
+            command: "/bin/sh",
+            args: ["-c", "printf '{\"jsonrpc\":\"2.0\",\"result\":{}}\\n'; exit 0"],
+            environment: ProcessInfo.processInfo.environment,
+            maxQueuedWriteBytes: 1024
+        )
+        try await withUpstreamSession(config: config) { session in
+            _ = try await waitWithTimeout(
+                "session should emit exit before accepting more writes",
+                timeout: .seconds(2)
+            ) {
+                for await event in session.events {
+                    if case .exit = event {
+                        return true
+                    }
+                }
+                return false
+            }
+
+            let result = await session.send(Data(#"{"jsonrpc":"2.0","id":7}"#.utf8))
+            #expect(result == .overloaded)
+        }
+    }
+
+    @Test func upstreamSessionReassemblesLargeJSONSplitAcrossOrderedChunks() async throws {
         let payload = try makeJSONRPCResponse(
             id: 41,
             text: String(repeating: "x", count: 128 * 1024)
@@ -275,12 +263,12 @@ struct UpstreamProcessTests {
             environment: ProcessInfo.processInfo.environment,
             maxQueuedWriteBytes: 1024
         )
-        try await withUpstreamProcess(config: config) { upstream in
+        try await withUpstreamSession(config: config) { session in
             let message = try await waitWithTimeout(
                 "large split JSON should be reconstructed as one message",
                 timeout: .seconds(5)
             ) {
-                for await event in upstream.events {
+                for await event in session.events {
                     switch event {
                     case .message(let message):
                         return String(decoding: message, as: UTF8.self)
@@ -297,7 +285,7 @@ struct UpstreamProcessTests {
         }
     }
 
-    @Test func upstreamProcessPreservesBackToBackLargeJSONMessageOrder() async throws {
+    @Test func upstreamSessionPreservesBackToBackLargeJSONMessageOrder() async throws {
         let payloads = try [
             makeJSONRPCResponse(id: 51, text: String(repeating: "a", count: 96 * 1024)),
             makeJSONRPCResponse(id: 52, text: String(repeating: "b", count: 96 * 1024)),
@@ -314,13 +302,13 @@ struct UpstreamProcessTests {
             environment: ProcessInfo.processInfo.environment,
             maxQueuedWriteBytes: 1024
         )
-        try await withUpstreamProcess(config: config) { upstream in
+        try await withUpstreamSession(config: config) { session in
             let messages = try await waitWithTimeout(
                 "back-to-back large JSON payloads should preserve order",
                 timeout: .seconds(5)
             ) {
                 var messages: [String] = []
-                for await event in upstream.events {
+                for await event in session.events {
                     switch event {
                     case .message(let message):
                         messages.append(String(decoding: message, as: UTF8.self))
@@ -341,18 +329,17 @@ struct UpstreamProcessTests {
     }
 }
 
-private func withUpstreamProcess<T: Sendable>(
+private func withUpstreamSession<T: Sendable>(
     config: UpstreamProcess.Config,
-    _ body: @escaping @Sendable (UpstreamProcess) async throws -> T
+    _ body: @escaping @Sendable (any UpstreamSession) async throws -> T
 ) async throws -> T {
-    let upstream = UpstreamProcess(config: config)
-    await upstream.start()
+    let session = try await UpstreamProcess(config: config).startSession()
     do {
-        let result = try await body(upstream)
-        await upstream.stop()
+        let result = try await body(session)
+        await session.stop()
         return result
     } catch {
-        await upstream.stop()
+        await session.stop()
         throw error
     }
 }


### PR DESCRIPTION
## Purpose
Replace `UpstreamProcess` generation-based stale callback guards with a session/slot lifecycle model so restart, protocol-violation, and shutdown paths are handled structurally.

## Main changes
- Split upstream runtime responsibilities into session factory/session/slot controller contracts and added `ManagedUpstreamSlot` as the long-lived supervisor for each upstream slot.
- Reworked process-backed upstream execution into single-run sessions with session-local stdin/stdout/stderr ownership, buffered write tracking, protocol-violation handling, shutdown semantics, and delayed terminal exit emission so final stdout/stderr can drain before downstream cleanup.
- Added a bounded termination-drain fallback so exited upstreams still complete cleanly when descendant processes keep stdout/stderr descriptors open after the parent exits.
- Updated `RuntimeCoordinator` and HTTP transport send paths to target slot controllers, explicitly ensure startup for initialize/warm-init traffic, and request fresh sessions after protocol violations.
- Rewrote upstream runtime tests around session-level and slot-level behavior, plus added regressions for protocol-violation restart, immediate-exit drain ordering, descendant-held pipe fallback, and post-exit write rejection.

## Testing
- `swift test`
- `./scripts/codex-review-quiet.sh -C /Users/kn/Dev/XcodeMCPKit --uncommitted`
- `swift Tools/mcp_bench.swift --url http://localhost:8765/mcp --mode call --tool DocumentationSearch --args &#39;{&#34;query&#34;:&#34;URLSession data task&#34;}&#39; --requests 1000 --concurrency 5 --sessions 1 --warmup 5 --timeout 60 --verbose`
