### PR TITLE
Add opt-in auto-approval for the Xcode permission dialog

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -129,6 +129,7 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 | `--max-body-bytes n` | リクエストボディの最大サイズ |
 | `--request-timeout seconds` | リクエストタイムアウト設定（`0` で初期化以外のタイムアウトを無効化。`initialize` 時のハンドシェイクには固定のタイムアウトが適用されます） |
 | `--config path` | アップストリームのハンドシェイクを上書きするためのプロキシ設定（TOML）のパス |
+| `--auto-approve` | Xcode の許可ダイアログ自動承認を有効化する opt-in フラグ |
 | `--refresh-code-issues-mode mode` | `XcodeRefreshCodeIssuesInFile` の提供モード。プロキシ側のナビゲーター問題として処理（`proxy`、デフォルト）、または Xcode のライブ診断へパススルー（`upstream`） |
 | `--force-restart` | ポートが使用中の場合、既存の `xcode-mcp-proxy-server` を終了して再起動 |
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See Quick Start for how to launch.
 | `--max-body-bytes n` | Max request body size |
 | `--request-timeout seconds` | Request timeout (`0` disables non-initialize timeouts; `initialize` still uses a bounded handshake timeout) |
 | `--config path` | Path to proxy config TOML for overriding the upstream handshake |
+| `--auto-approve` | Opt in to auto-approve the Xcode permission dialog |
 | `--refresh-code-issues-mode mode` | Serve `XcodeRefreshCodeIssuesInFile` via proxy navigator issues (`proxy`, default) or pass through to Xcode live diagnostics (`upstream`) |
 | `--force-restart` | If the listen port is in use, terminate an existing `xcode-mcp-proxy-server` and restart |
 

--- a/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
+++ b/Sources/ProxyCLI/ProxyCLIInvocationScanner.swift
@@ -19,6 +19,7 @@ package struct ProxyCLIServerScan {
     package var hasHostFlag = false
     package var hasPortFlag = false
     package var hasConfigFlag = false
+    package var hasAutoApproveFlag = false
     package var hasRefreshCodeIssuesModeFlag = false
     package var forceRestart = false
     package var dryRun = false
@@ -32,6 +33,7 @@ package struct ProxyCLIInstallScan {
 package enum ProxyCLIInvocationScanner {
     private static let serverOnlyFlags: Set<String> = [
         "--config",
+        "--auto-approve",
         "--listen",
         "--host",
         "--port",
@@ -187,6 +189,8 @@ package enum ProxyCLIInvocationScanner {
                 scan.hasPortFlag = true
             case "--config":
                 scan.hasConfigFlag = true
+            case "--auto-approve":
+                scan.hasAutoApproveFlag = true
             case "--refresh-code-issues-mode":
                 scan.hasRefreshCodeIssuesModeFlag = true
             default:

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand+Parsing.swift
@@ -12,6 +12,7 @@ extension XcodeMCPProxyServerCommand {
             hasHostFlag: scan.hasHostFlag,
             hasPortFlag: scan.hasPortFlag,
             hasConfigFlag: scan.hasConfigFlag,
+            hasAutoApproveFlag: scan.hasAutoApproveFlag,
             hasRefreshCodeIssuesModeFlag: scan.hasRefreshCodeIssuesModeFlag,
             forceRestart: scan.forceRestart,
             dryRun: scan.dryRun
@@ -69,6 +70,7 @@ extension XcodeMCPProxyServerCommand {
           --host host
           --port port
           --config path
+          --auto-approve
           --upstream-processes n
           --refresh-code-issues-mode proxy|upstream
           --force-restart
@@ -80,6 +82,7 @@ extension XcodeMCPProxyServerCommand {
           - Starts the HTTP/SSE proxy server (and spawns xcrun mcpbridge as upstream processes).
           - Use xcode-mcp-proxy as a STDIO adapter for Codex / Claude Code.
           - Default listen: localhost:8765 (override via --listen / --host / --port or env LISTEN/HOST/PORT).
+          - --auto-approve opt-in enables automatic approval of the Xcode permission dialog.
           - Initialize config path: --config or env \(CLIParser.configPathEnv)
           - When the listen port is already in use, rerun with --force-restart to terminate an existing xcode-mcp-proxy-server.
         """

--- a/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/XcodeMCPProxyServerCommand.swift
@@ -12,6 +12,7 @@ package struct ProxyServerOptions {
     package var hasHostFlag: Bool
     package var hasPortFlag: Bool
     package var hasConfigFlag: Bool
+    package var hasAutoApproveFlag: Bool
     package var hasRefreshCodeIssuesModeFlag: Bool
     package var forceRestart: Bool
     package var dryRun: Bool
@@ -24,6 +25,7 @@ package struct ProxyServerOptions {
         hasHostFlag: Bool,
         hasPortFlag: Bool,
         hasConfigFlag: Bool,
+        hasAutoApproveFlag: Bool,
         hasRefreshCodeIssuesModeFlag: Bool,
         forceRestart: Bool,
         dryRun: Bool
@@ -35,6 +37,7 @@ package struct ProxyServerOptions {
         self.hasHostFlag = hasHostFlag
         self.hasPortFlag = hasPortFlag
         self.hasConfigFlag = hasConfigFlag
+        self.hasAutoApproveFlag = hasAutoApproveFlag
         self.hasRefreshCodeIssuesModeFlag = hasRefreshCodeIssuesModeFlag
         self.forceRestart = forceRestart
         self.dryRun = dryRun

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -31,6 +31,7 @@ public struct ProxyConfig: Sendable {
     public var stdioUpstreamURL: URL?
     public var stdioUpstreamSource: StdioUpstreamSource?
     public var prewarmToolsList: Bool
+    public var autoApproveXcodeDialog: Bool
     public var refreshCodeIssuesMode: RefreshCodeIssuesMode
 
     public init(
@@ -47,6 +48,7 @@ public struct ProxyConfig: Sendable {
         stdioUpstreamURL: URL? = nil,
         stdioUpstreamSource: StdioUpstreamSource? = nil,
         prewarmToolsList: Bool = true,
+        autoApproveXcodeDialog: Bool = false,
         refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy
     ) {
         self.listenHost = listenHost
@@ -62,6 +64,7 @@ public struct ProxyConfig: Sendable {
         self.stdioUpstreamURL = stdioUpstreamURL
         self.stdioUpstreamSource = stdioUpstreamSource
         self.prewarmToolsList = prewarmToolsList
+        self.autoApproveXcodeDialog = autoApproveXcodeDialog
         self.refreshCodeIssuesMode = refreshCodeIssuesMode
     }
 }
@@ -107,6 +110,7 @@ public struct CLIParser {
         var configPath: String?
         var stdioUpstreamURL: URL?
         var stdioUpstreamSource: StdioUpstreamSource?
+        var autoApproveXcodeDialog = false
         var refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy
         var hasExplicitRefreshCodeIssuesMode = false
 
@@ -196,6 +200,9 @@ public struct CLIParser {
                 }
                 configPath = args[index + 1]
                 index += 2
+            case "--auto-approve":
+                autoApproveXcodeDialog = true
+                index += 1
             case "--refresh-code-issues-mode":
                 guard index + 1 < args.count else {
                     throw CLIError.message("--refresh-code-issues-mode requires proxy|upstream")
@@ -259,6 +266,7 @@ public struct CLIParser {
             transport: transport,
             stdioUpstreamURL: stdioUpstreamURL,
             stdioUpstreamSource: stdioUpstreamSource,
+            autoApproveXcodeDialog: autoApproveXcodeDialog,
             refreshCodeIssuesMode: refreshCodeIssuesMode
         )
     }
@@ -279,6 +287,7 @@ public struct CLIParser {
           --max-body-bytes n         Max request body size (default: 1048576)
           --request-timeout seconds  Request timeout (default: 300, 0 disables non-initialize timeouts)
           --config path              Path to proxy config TOML (env \(configPathEnv))
+          --auto-approve             Auto-approve the Xcode permission dialog
           --refresh-code-issues-mode proxy|upstream
                                      Refresh implementation (default: proxy; env \(refreshCodeIssuesModeEnv))
           --stdio [url]              Run in STDIO mode (default: discovery -> http://localhost:8765/mcp)

--- a/Sources/ProxyFeatureXcode/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyFeatureXcode/XcodePermissionDialogAutoApprover.swift
@@ -9,25 +9,71 @@ package enum XcodePermissionDialogAccessibilityStatus: Sendable {
     case untrusted
 }
 
-package struct XcodePermissionDialogWindowSnapshot: Equatable, Sendable {
-    package let title: String
-    package let textValues: [String]
-    package let isModal: Bool
-    package let defaultButtonTitle: String?
-    package let cancelButtonTitle: String?
+package struct XcodePermissionDialogButtonSnapshot: Equatable, Sendable {
+    package let title: String?
+    package let role: String?
+    package let subrole: String?
+    package let identifier: String?
 
     package init(
-        title: String,
-        textValues: [String],
-        isModal: Bool,
-        defaultButtonTitle: String?,
-        cancelButtonTitle: String?
+        title: String? = nil,
+        role: String? = nil,
+        subrole: String? = nil,
+        identifier: String? = nil
     ) {
         self.title = title
+        self.role = role
+        self.subrole = subrole
+        self.identifier = identifier
+    }
+}
+
+package struct XcodePermissionDialogWindowSnapshot: Equatable, Sendable {
+    package let processBundleIdentifier: String?
+    package let title: String
+    package let textValues: [String]
+    package let role: String?
+    package let subrole: String?
+    package let windowIdentifier: String?
+    package let isModal: Bool
+    package let isMain: Bool?
+    package let isMinimized: Bool?
+    package let document: String?
+    package let childCount: Int
+    package let hasProxy: Bool
+    package let defaultButton: XcodePermissionDialogButtonSnapshot?
+    package let cancelButton: XcodePermissionDialogButtonSnapshot?
+
+    package init(
+        processBundleIdentifier: String? = nil,
+        title: String,
+        textValues: [String],
+        role: String? = nil,
+        subrole: String? = nil,
+        windowIdentifier: String? = nil,
+        isModal: Bool,
+        isMain: Bool? = nil,
+        isMinimized: Bool? = nil,
+        document: String? = nil,
+        childCount: Int = 0,
+        hasProxy: Bool = false,
+        defaultButton: XcodePermissionDialogButtonSnapshot? = nil,
+        cancelButton: XcodePermissionDialogButtonSnapshot? = nil
+    ) {
+        self.processBundleIdentifier = processBundleIdentifier
+        self.title = title
         self.textValues = textValues
+        self.role = role
+        self.subrole = subrole
+        self.windowIdentifier = windowIdentifier
         self.isModal = isModal
-        self.defaultButtonTitle = defaultButtonTitle
-        self.cancelButtonTitle = cancelButtonTitle
+        self.isMain = isMain
+        self.isMinimized = isMinimized
+        self.document = document
+        self.childCount = childCount
+        self.hasProxy = hasProxy
+        self.defaultButton = defaultButton
+        self.cancelButton = cancelButton
     }
 }
 
@@ -42,50 +88,44 @@ package struct XcodePermissionDialogMatchDecision: Equatable, Sendable {
 }
 
 package enum XcodePermissionDialogMatcher {
+    private static let allowedProcessBundleIdentifiers = normalizedCandidates([
+        "com.apple.dt.Xcode",
+        "com.apple.dt.ExternalViewService",
+    ])
+    private static let allowedWindowRoles = normalizedCandidates([
+        "AXWindow"
+    ])
+    private static let allowedWindowSubroles = normalizedCandidates([
+        "AXDialog",
+        "AXSystemDialog",
+    ])
+
     package static func decision(
         for snapshot: XcodePermissionDialogWindowSnapshot,
         processID: pid_t,
-        agentPathCandidates: Set<String>,
-        assistantNameCandidates: Set<String>
+        agentPathCandidates: Set<String> = [],
+        assistantNameCandidates: Set<String>,
+        serverProcessIDCandidates: Set<pid_t> = [ProcessInfo.processInfo.processIdentifier]
     ) -> XcodePermissionDialogMatchDecision? {
-        guard snapshot.isModal else {
+        guard passesStructuralChecks(snapshot) else {
             return nil
         }
 
-        guard
-            let defaultButtonTitle = normalizedText(snapshot.defaultButtonTitle)
-        else {
-            return nil
-        }
-
-        let haystacks = normalizedHaystacks(for: snapshot)
-        guard haystacks.contains(where: { $0.contains("xcode") }) else {
-            return nil
-        }
-
-        let normalizedCandidates = normalizedAgentPathCandidates(agentPathCandidates)
-        let normalizedAssistantNames = normalizedAgentPathCandidates(assistantNameCandidates)
-        guard normalizedCandidates.isEmpty == false || normalizedAssistantNames.isEmpty == false else {
-            return nil
-        }
-
-        let containsPath = haystacks.contains { haystack in
-            normalizedCandidates.contains { candidate in
-                haystack.contains(candidate)
-            }
-        }
-        let containsAssistantName = haystacks.contains { haystack in
-            normalizedAssistantNames.contains { candidate in
-                haystack.contains(candidate)
-            }
-        }
-        guard containsPath || containsAssistantName else {
+        let normalizedAgentPaths = normalizedCandidates(agentPathCandidates)
+        let normalizedAssistantNames = normalizedCandidates(assistantNameCandidates)
+        let pidCandidates = normalizedPIDCandidates(serverProcessIDCandidates)
+        guard containsAssistantNameAndPID(
+            in: normalizedTextNodes(for: snapshot),
+            agentPathCandidates: normalizedAgentPaths,
+            assistantNameCandidates: normalizedAssistantNames,
+            serverProcessIDCandidates: pidCandidates
+        ) else {
             return nil
         }
 
         return XcodePermissionDialogMatchDecision(
             fingerprint: fingerprint(for: snapshot, processID: processID),
-            defaultButtonTitle: defaultButtonTitle
+            defaultButtonTitle: normalizedButtonDescription(snapshot.defaultButton)
         )
     }
 
@@ -93,16 +133,118 @@ package enum XcodePermissionDialogMatcher {
         for snapshot: XcodePermissionDialogWindowSnapshot,
         processID: pid_t
     ) -> String {
-        let textFingerprint = normalizedHaystacks(for: snapshot).joined(separator: "\u{1F}")
-        return "\(processID)|\(snapshot.isModal)|\(textFingerprint)"
+        let textFingerprint = normalizedTextNodes(for: snapshot).joined(separator: "\u{1F}")
+        let bundleFingerprint = normalizedText(snapshot.processBundleIdentifier) ?? ""
+        let roleFingerprint = normalizedText(snapshot.role) ?? ""
+        let subroleFingerprint = normalizedText(snapshot.subrole) ?? ""
+        return [
+            "\(processID)",
+            bundleFingerprint,
+            roleFingerprint,
+            subroleFingerprint,
+            "\(snapshot.isModal)",
+            textFingerprint,
+        ].joined(separator: "|")
     }
 
-    package static func normalizedAgentPathCandidates(_ candidates: Set<String>) -> Set<String> {
+    package static func passesStructuralChecks(_ snapshot: XcodePermissionDialogWindowSnapshot) -> Bool {
+        guard
+            let normalizedBundleIdentifier = normalizedText(snapshot.processBundleIdentifier),
+            allowedProcessBundleIdentifiers.contains(normalizedBundleIdentifier)
+        else {
+            return false
+        }
+        guard snapshot.isModal else {
+            return false
+        }
+        guard snapshot.defaultButton != nil else {
+            return false
+        }
+        guard snapshot.isMinimized != true else {
+            return false
+        }
+        if let normalizedRole = normalizedText(snapshot.role),
+           allowedWindowRoles.contains(normalizedRole) == false {
+            return false
+        }
+        if let normalizedSubrole = normalizedText(snapshot.subrole),
+           allowedWindowSubroles.contains(normalizedSubrole) == false {
+            return false
+        }
+        if looksLikeNormalWorkspaceWindow(snapshot) {
+            return false
+        }
+        return true
+    }
+
+    private static func looksLikeNormalWorkspaceWindow(_ snapshot: XcodePermissionDialogWindowSnapshot) -> Bool {
+        let hasDocument = normalizedText(snapshot.document) != nil
+        return snapshot.isMain == true && (hasDocument || snapshot.hasProxy)
+    }
+
+    private static func normalizedTextNodes(for snapshot: XcodePermissionDialogWindowSnapshot) -> [String] {
+        ([snapshot.title] + snapshot.textValues).compactMap(normalizedText)
+    }
+
+    private static func containsAssistantNameAndPID(
+        in normalizedTextNodes: [String],
+        agentPathCandidates: Set<String>,
+        assistantNameCandidates: Set<String>,
+        serverProcessIDCandidates: Set<String>
+    ) -> Bool {
+        let containsPath = normalizedTextNodes.contains { text in
+            agentPathCandidates.contains(where: { text.contains($0) })
+        }
+        if assistantNameCandidates.isEmpty {
+            return containsPath
+        }
+
+        let sameNodeMatch = normalizedTextNodes.contains { text in
+            serverProcessIDCandidates.contains(where: { text.contains($0) })
+                && assistantNameCandidates.contains(where: { text.contains($0) })
+        }
+        if sameNodeMatch {
+            return true
+        }
+
+        let containsAssistantName = normalizedTextNodes.contains { text in
+            assistantNameCandidates.contains(where: { text.contains($0) })
+        }
+        let containsPID = normalizedTextNodes.contains { text in
+            serverProcessIDCandidates.contains(where: { text.contains($0) })
+        }
+        if containsAssistantName && containsPID {
+            return true
+        }
+        guard containsPID == false, containsPath else {
+            return false
+        }
+
+        let sameNodePathMatch = normalizedTextNodes.contains { text in
+            agentPathCandidates.contains(where: { text.contains($0) })
+                && assistantNameCandidates.contains(where: { text.contains($0) })
+        }
+        if sameNodePathMatch {
+            return true
+        }
+        return containsAssistantName
+    }
+
+    private static func normalizedButtonDescription(
+        _ button: XcodePermissionDialogButtonSnapshot?
+    ) -> String {
+        normalizedText(button?.title)
+            ?? normalizedText(button?.identifier)
+            ?? normalizedText(button?.role)
+            ?? "default"
+    }
+
+    private static func normalizedCandidates(_ candidates: some Sequence<String>) -> Set<String> {
         Set(candidates.compactMap(normalizedText))
     }
 
-    private static func normalizedHaystacks(for snapshot: XcodePermissionDialogWindowSnapshot) -> [String] {
-        ([snapshot.title] + snapshot.textValues).compactMap(normalizedText)
+    private static func normalizedPIDCandidates(_ candidates: Set<pid_t>) -> Set<String> {
+        Set(candidates.map(String.init))
     }
 
     private static func normalizedText(_ text: String?) -> String? {
@@ -215,14 +357,25 @@ package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessi
         guard let defaultButton = copyElement(attribute: kAXDefaultButtonAttribute as CFString, from: window) else {
             return nil
         }
+        let children = (try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: window)) ?? []
+        let processBundleIdentifier = NSRunningApplication(processIdentifier: processID)?.bundleIdentifier
 
         let snapshot = XcodePermissionDialogWindowSnapshot(
+            processBundleIdentifier: processBundleIdentifier,
             title: copyString(attribute: kAXTitleAttribute as CFString, from: window) ?? "",
             textValues: collectTextValues(from: window),
+            role: copyString(attribute: kAXRoleAttribute as CFString, from: window),
+            subrole: copyString(attribute: kAXSubroleAttribute as CFString, from: window),
+            windowIdentifier: copyString(attribute: kAXIdentifierAttribute as CFString, from: window),
             isModal: copyBool(attribute: kAXModalAttribute as CFString, from: window) ?? false,
-            defaultButtonTitle: copyButtonLabel(from: defaultButton),
-            cancelButtonTitle: copyElement(attribute: kAXCancelButtonAttribute as CFString, from: window)
-                .flatMap(copyButtonLabel(from:))
+            isMain: copyBool(attribute: kAXMainAttribute as CFString, from: window),
+            isMinimized: copyBool(attribute: kAXMinimizedAttribute as CFString, from: window),
+            document: copyString(attribute: kAXDocumentAttribute as CFString, from: window),
+            childCount: children.count,
+            hasProxy: copyElement(attribute: kAXProxyAttribute as CFString, from: window) != nil,
+            defaultButton: buttonSnapshot(from: defaultButton),
+            cancelButton: copyElement(attribute: kAXCancelButtonAttribute as CFString, from: window)
+                .flatMap(buttonSnapshot(from:))
         )
 
         return XcodePermissionDialogAXWindow(
@@ -266,10 +419,15 @@ package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessi
         }
     }
 
-    private func copyButtonLabel(from element: AXUIElement) -> String? {
-        copyString(attribute: kAXTitleAttribute as CFString, from: element)
-            ?? copyString(attribute: kAXDescriptionAttribute as CFString, from: element)
-            ?? copyString(attribute: kAXValueAttribute as CFString, from: element)
+    private func buttonSnapshot(from element: AXUIElement) -> XcodePermissionDialogButtonSnapshot {
+        XcodePermissionDialogButtonSnapshot(
+            title: copyString(attribute: kAXTitleAttribute as CFString, from: element)
+                ?? copyString(attribute: kAXDescriptionAttribute as CFString, from: element)
+                ?? copyString(attribute: kAXValueAttribute as CFString, from: element),
+            role: copyString(attribute: kAXRoleAttribute as CFString, from: element),
+            subrole: copyString(attribute: kAXSubroleAttribute as CFString, from: element),
+            identifier: copyString(attribute: kAXIdentifierAttribute as CFString, from: element)
+        )
     }
 
     private func copyString(attribute: CFString, from element: AXUIElement) -> String? {
@@ -334,6 +492,7 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
         package var axClient: any XcodePermissionDialogAXAccessing
         package var agentPathCandidates: @Sendable () -> Set<String>
         package var assistantNameCandidates: @Sendable () -> Set<String>
+        package var serverProcessIDCandidates: @Sendable () -> Set<pid_t>
         package var sleep: @Sendable (Duration) async -> Void
         package var pollInterval: Duration
         package var logger: Logger
@@ -342,6 +501,7 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
             axClient: any XcodePermissionDialogAXAccessing,
             agentPathCandidates: @escaping @Sendable () -> Set<String>,
             assistantNameCandidates: @escaping @Sendable () -> Set<String>,
+            serverProcessIDCandidates: @escaping @Sendable () -> Set<pid_t>,
             sleep: @escaping @Sendable (Duration) async -> Void,
             pollInterval: Duration,
             logger: Logger
@@ -349,6 +509,7 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
             self.axClient = axClient
             self.agentPathCandidates = agentPathCandidates
             self.assistantNameCandidates = assistantNameCandidates
+            self.serverProcessIDCandidates = serverProcessIDCandidates
             self.sleep = sleep
             self.pollInterval = pollInterval
             self.logger = logger
@@ -359,13 +520,17 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
                 XcodePermissionDialogAutoApprover.defaultAgentPathCandidates()
             },
             assistantNameCandidates: @escaping @Sendable () -> Set<String> = {
-                []
+                ["XcodeMCPKit"]
+            },
+            serverProcessIDCandidates: @escaping @Sendable () -> Set<pid_t> = {
+                XcodePermissionDialogAutoApprover.defaultServerProcessIDCandidates()
             }
         ) -> Self {
             Self(
                 axClient: LiveXcodePermissionDialogAXClient(),
                 agentPathCandidates: agentPathCandidates,
                 assistantNameCandidates: assistantNameCandidates,
+                serverProcessIDCandidates: serverProcessIDCandidates,
                 sleep: { duration in
                     try? await Task.sleep(for: duration)
                 },
@@ -379,7 +544,14 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
         var started = false
         var task: Task<Void, Never>?
         var lastAttemptUptimeByFingerprint: [String: UInt64] = [:]
+        var loggedInspectionFingerprints: Set<String> = []
         var didLogNoMatch = false
+    }
+
+    private struct MatchedWindow {
+        let processID: pid_t
+        let window: XcodePermissionDialogAXWindow
+        let decision: XcodePermissionDialogMatchDecision
     }
 
     private let dependencies: Dependencies
@@ -428,6 +600,7 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
         let task: Task<Void, Never>? = stateLock.withLock {
             state.started = false
             state.lastAttemptUptimeByFingerprint.removeAll()
+            state.loggedInspectionFingerprints.removeAll()
             let task = state.task
             state.task = nil
             return task
@@ -465,6 +638,22 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
         }
 
         return Set(candidates.filter { $0.isEmpty == false })
+    }
+
+    package static func defaultServerProcessIDCandidates(
+        parentProcessID: pid_t = ProcessInfo.processInfo.processIdentifier
+    ) -> Set<pid_t> {
+        var candidates: Set<pid_t> = [parentProcessID]
+        var pending = [parentProcessID]
+
+        while let currentProcessID = pending.popLast() {
+            for childProcessID in childProcessIDs(of: currentProcessID)
+            where candidates.insert(childProcessID).inserted {
+                pending.append(childProcessID)
+            }
+        }
+
+        return candidates
     }
 
     private func runMonitorLoop(dependencies: Dependencies) async {
@@ -509,8 +698,11 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
         dependencies: Dependencies
     ) -> Set<String> {
         var visibleFingerprints: Set<String> = []
+        var visibleInspectionFingerprints: Set<String> = []
         var inspectedWindowTitles: [String] = []
+        var matchedWindows: [MatchedWindow] = []
         let processIDs = dependencies.axClient.runningXcodeProcessIDs()
+        let serverProcessIDCandidates = dependencies.serverProcessIDCandidates()
         let nowUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
 
         for processID in processIDs {
@@ -532,48 +724,84 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
                 if trimmedTitle.isEmpty == false, inspectedWindowTitles.count < 8 {
                     inspectedWindowTitles.append(trimmedTitle)
                 }
+                let isStructurallyEligible =
+                    XcodePermissionDialogMatcher.passesStructuralChecks(window.snapshot)
                 guard let decision = XcodePermissionDialogMatcher.decision(
                     for: window.snapshot,
                     processID: processID,
                     agentPathCandidates: agentPathCandidates,
-                    assistantNameCandidates: assistantNameCandidates
+                    assistantNameCandidates: assistantNameCandidates,
+                    serverProcessIDCandidates: serverProcessIDCandidates
                 ) else {
+                    if isStructurallyEligible {
+                        visibleInspectionFingerprints.insert(
+                            inspectionFingerprint(processID: processID, snapshot: window.snapshot)
+                        )
+                        logStructurallyEligibleWindowIfNeeded(
+                            processID: processID,
+                            snapshot: window.snapshot,
+                            agentPathCandidates: agentPathCandidates,
+                            assistantNameCandidates: assistantNameCandidates,
+                            dependencies: dependencies
+                        )
+                    }
                     continue
                 }
 
                 visibleFingerprints.insert(decision.fingerprint)
-
-                let shouldPress = stateLock.withLock { () -> Bool in
-                    if let lastAttempt = state.lastAttemptUptimeByFingerprint[decision.fingerprint],
-                       nowUptimeNanoseconds &- lastAttempt < retryIntervalNanoseconds
-                    {
-                        return false
-                    }
-                    state.lastAttemptUptimeByFingerprint[decision.fingerprint] = nowUptimeNanoseconds
-                    return true
-                }
-                guard shouldPress else {
-                    continue
-                }
-
-                do {
-                    try dependencies.axClient.pressDefaultButton(in: window)
-                    dependencies.logger.info(
-                        "Auto-approved the Xcode permission dialog.",
-                        metadata: [
-                            "pid": "\(processID)",
-                            "button": .string(decision.defaultButtonTitle),
-                        ]
+                visibleInspectionFingerprints.insert(decision.fingerprint)
+                matchedWindows.append(
+                    MatchedWindow(
+                        processID: processID,
+                        window: window,
+                        decision: decision
                     )
-                } catch {
-                    dependencies.logger.warning(
-                        "Matched the Xcode permission dialog but could not press its default button.",
-                        metadata: [
-                            "pid": "\(processID)",
-                            "error": "\(error)",
-                        ]
-                    )
+                )
+            }
+        }
+
+        stateLock.withLock {
+            state.loggedInspectionFingerprints =
+                state.loggedInspectionFingerprints.filter { visibleInspectionFingerprints.contains($0) }
+        }
+
+        for matchedWindow in matchedWindows {
+            logMatchedWindowIfNeeded(matchedWindow, dependencies: dependencies)
+
+            let shouldPress = stateLock.withLock { () -> Bool in
+                if let lastAttempt = state.lastAttemptUptimeByFingerprint[matchedWindow.decision.fingerprint],
+                   nowUptimeNanoseconds &- lastAttempt < retryIntervalNanoseconds
+                {
+                    return false
                 }
+                state.lastAttemptUptimeByFingerprint[matchedWindow.decision.fingerprint] =
+                    nowUptimeNanoseconds
+                return true
+            }
+            guard shouldPress else {
+                continue
+            }
+
+            do {
+                try dependencies.axClient.pressDefaultButton(in: matchedWindow.window)
+                dependencies.logger.info(
+                    "Auto-approved the Xcode permission dialog.",
+                    metadata: [
+                        "pid": "\(matchedWindow.processID)",
+                        "button": .string(matchedWindow.decision.defaultButtonTitle),
+                        "server_pid_candidates": .string(
+                            serverProcessIDCandidates.map(String.init).sorted().joined(separator: ",")
+                        ),
+                    ]
+                )
+            } catch {
+                dependencies.logger.warning(
+                    "Matched the Xcode permission dialog but could not press its default button.",
+                    metadata: [
+                        "pid": "\(matchedWindow.processID)",
+                        "error": "\(error)",
+                    ]
+                )
             }
         }
 
@@ -599,6 +827,115 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
         }
 
         return visibleFingerprints
+    }
+
+    private func logStructurallyEligibleWindowIfNeeded(
+        processID: pid_t,
+        snapshot: XcodePermissionDialogWindowSnapshot,
+        agentPathCandidates: Set<String>,
+        assistantNameCandidates: Set<String>,
+        dependencies: Dependencies
+    ) {
+        let fingerprint = inspectionFingerprint(processID: processID, snapshot: snapshot)
+        let shouldLog = stateLock.withLock {
+            state.loggedInspectionFingerprints.insert(fingerprint).inserted
+        }
+        guard shouldLog else {
+            return
+        }
+
+        dependencies.logger.debug(
+            "Observed a structurally eligible Xcode modal window that did not match the assistant-name plus PID/path guard; auto-approve skipped.",
+            metadata: inspectionMetadata(
+                processID: processID,
+                snapshot: snapshot,
+                agentPathCandidates: agentPathCandidates,
+                assistantNameCandidates: assistantNameCandidates,
+                serverProcessIDCandidates: dependencies.serverProcessIDCandidates()
+            )
+        )
+    }
+
+    private func logMatchedWindowIfNeeded(
+        _ matchedWindow: MatchedWindow,
+        dependencies: Dependencies
+    ) {
+        let shouldLog = stateLock.withLock {
+            state.loggedInspectionFingerprints.insert(matchedWindow.decision.fingerprint).inserted
+        }
+        guard shouldLog else {
+            return
+        }
+
+        let snapshot = matchedWindow.window.snapshot
+        dependencies.logger.debug(
+            "Observed AX metadata for a matched Xcode permission dialog candidate.",
+            metadata: inspectionMetadata(
+                processID: matchedWindow.processID,
+                snapshot: snapshot,
+                agentPathCandidates: dependencies.agentPathCandidates(),
+                assistantNameCandidates: dependencies.assistantNameCandidates(),
+                serverProcessIDCandidates: dependencies.serverProcessIDCandidates()
+            )
+        )
+    }
+
+    private func inspectionMetadata(
+        processID: pid_t,
+        snapshot: XcodePermissionDialogWindowSnapshot,
+        agentPathCandidates: Set<String>,
+        assistantNameCandidates: Set<String>,
+        serverProcessIDCandidates: Set<pid_t>
+    ) -> Logger.Metadata {
+        [
+            "pid": "\(processID)",
+            "bundle_id": .string(snapshot.processBundleIdentifier ?? ""),
+            "window_identifier": .string(snapshot.windowIdentifier ?? ""),
+            "window_role": .string(snapshot.role ?? ""),
+            "window_subrole": .string(snapshot.subrole ?? ""),
+            "window_main": .string("\(snapshot.isMain ?? false)"),
+            "window_minimized": .string("\(snapshot.isMinimized ?? false)"),
+            "window_document": .string(snapshot.document ?? ""),
+            "window_children": .string("\(snapshot.childCount)"),
+            "window_has_proxy": .string("\(snapshot.hasProxy)"),
+            "default_button_identifier": .string(snapshot.defaultButton?.identifier ?? ""),
+            "default_button_role": .string(snapshot.defaultButton?.role ?? ""),
+            "cancel_button_identifier": .string(snapshot.cancelButton?.identifier ?? ""),
+            "cancel_button_role": .string(snapshot.cancelButton?.role ?? ""),
+            "agent_paths": .string(agentPathCandidates.sorted().joined(separator: " | ")),
+            "assistant_names": .string(assistantNameCandidates.sorted().joined(separator: " | ")),
+            "server_pid_candidates": .string(
+                serverProcessIDCandidates.map(String.init).sorted().joined(separator: ",")
+            ),
+        ]
+    }
+
+    private func inspectionFingerprint(
+        processID: pid_t,
+        snapshot: XcodePermissionDialogWindowSnapshot
+    ) -> String {
+        "candidate|\(XcodePermissionDialogMatcher.fingerprint(for: snapshot, processID: processID))"
+    }
+
+    private static func childProcessIDs(of parentProcessID: pid_t) -> [pid_t] {
+        let childCount = max(0, proc_listchildpids(parentProcessID, nil, 0))
+        guard childCount > 0 else {
+            return []
+        }
+
+        var childProcessIDs = Array<pid_t>(repeating: 0, count: Int(childCount))
+        let copiedCount = unsafe childProcessIDs.withUnsafeMutableBufferPointer { buffer in
+            unsafe proc_listchildpids(
+                parentProcessID,
+                buffer.baseAddress,
+                Int32(buffer.count * MemoryLayout<pid_t>.stride)
+            )
+        }
+        guard copiedCount > 0 else {
+            return []
+        }
+
+        return childProcessIDs.prefix(Int(copiedCount)).filter { $0 > 0 }
     }
 }
 

--- a/Sources/ProxyFeatureXcode/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyFeatureXcode/XcodePermissionDialogAutoApprover.swift
@@ -1,0 +1,611 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import Logging
+import ProxyCore
+
+package enum XcodePermissionDialogAccessibilityStatus: Sendable {
+    case trusted
+    case untrusted
+}
+
+package struct XcodePermissionDialogWindowSnapshot: Equatable, Sendable {
+    package let title: String
+    package let textValues: [String]
+    package let isModal: Bool
+    package let defaultButtonTitle: String?
+    package let cancelButtonTitle: String?
+
+    package init(
+        title: String,
+        textValues: [String],
+        isModal: Bool,
+        defaultButtonTitle: String?,
+        cancelButtonTitle: String?
+    ) {
+        self.title = title
+        self.textValues = textValues
+        self.isModal = isModal
+        self.defaultButtonTitle = defaultButtonTitle
+        self.cancelButtonTitle = cancelButtonTitle
+    }
+}
+
+package struct XcodePermissionDialogMatchDecision: Equatable, Sendable {
+    package let fingerprint: String
+    package let defaultButtonTitle: String
+
+    package init(fingerprint: String, defaultButtonTitle: String) {
+        self.fingerprint = fingerprint
+        self.defaultButtonTitle = defaultButtonTitle
+    }
+}
+
+package enum XcodePermissionDialogMatcher {
+    package static func decision(
+        for snapshot: XcodePermissionDialogWindowSnapshot,
+        processID: pid_t,
+        agentPathCandidates: Set<String>,
+        assistantNameCandidates: Set<String>
+    ) -> XcodePermissionDialogMatchDecision? {
+        guard snapshot.isModal else {
+            return nil
+        }
+
+        guard
+            let defaultButtonTitle = normalizedText(snapshot.defaultButtonTitle)
+        else {
+            return nil
+        }
+
+        let haystacks = normalizedHaystacks(for: snapshot)
+        guard haystacks.contains(where: { $0.contains("xcode") }) else {
+            return nil
+        }
+
+        let normalizedCandidates = normalizedAgentPathCandidates(agentPathCandidates)
+        let normalizedAssistantNames = normalizedAgentPathCandidates(assistantNameCandidates)
+        guard normalizedCandidates.isEmpty == false || normalizedAssistantNames.isEmpty == false else {
+            return nil
+        }
+
+        let containsPath = haystacks.contains { haystack in
+            normalizedCandidates.contains { candidate in
+                haystack.contains(candidate)
+            }
+        }
+        let containsAssistantName = haystacks.contains { haystack in
+            normalizedAssistantNames.contains { candidate in
+                haystack.contains(candidate)
+            }
+        }
+        guard containsPath || containsAssistantName else {
+            return nil
+        }
+
+        return XcodePermissionDialogMatchDecision(
+            fingerprint: fingerprint(for: snapshot, processID: processID),
+            defaultButtonTitle: defaultButtonTitle
+        )
+    }
+
+    package static func fingerprint(
+        for snapshot: XcodePermissionDialogWindowSnapshot,
+        processID: pid_t
+    ) -> String {
+        let textFingerprint = normalizedHaystacks(for: snapshot).joined(separator: "\u{1F}")
+        return "\(processID)|\(snapshot.isModal)|\(textFingerprint)"
+    }
+
+    package static func normalizedAgentPathCandidates(_ candidates: Set<String>) -> Set<String> {
+        Set(candidates.compactMap(normalizedText))
+    }
+
+    private static func normalizedHaystacks(for snapshot: XcodePermissionDialogWindowSnapshot) -> [String] {
+        ([snapshot.title] + snapshot.textValues).compactMap(normalizedText)
+    }
+
+    private static func normalizedText(_ text: String?) -> String? {
+        guard let text else {
+            return nil
+        }
+        let sanitizedScalars = text.unicodeScalars.filter { scalar in
+            scalar.properties.generalCategory != .format
+        }
+        let sanitized = String(String.UnicodeScalarView(sanitizedScalars))
+        let trimmed = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else {
+            return nil
+        }
+        return trimmed.lowercased()
+    }
+}
+
+package protocol XcodePermissionDialogAXAccessing: Sendable {
+    func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialogAccessibilityStatus
+    func runningXcodeProcessIDs() -> [pid_t]
+    func openWindows(for processID: pid_t) throws -> [XcodePermissionDialogAXWindow]
+    func pressDefaultButton(in window: XcodePermissionDialogAXWindow) throws
+}
+
+package final class XcodePermissionDialogAXWindow {
+    package let processID: pid_t
+    package let snapshot: XcodePermissionDialogWindowSnapshot
+    private let defaultButton: AXUIElement
+
+    package init(
+        processID: pid_t,
+        snapshot: XcodePermissionDialogWindowSnapshot,
+        defaultButton: AXUIElement
+    ) {
+        self.processID = processID
+        self.snapshot = snapshot
+        self.defaultButton = defaultButton
+    }
+
+    fileprivate func pressDefaultButton() throws {
+        let error = AXUIElementPerformAction(defaultButton, kAXPressAction as CFString)
+        guard error == .success else {
+            throw XcodePermissionDialogAXError.performActionFailed(error)
+        }
+    }
+}
+
+package enum XcodePermissionDialogAXError: Error, CustomStringConvertible {
+    case copyAttributeFailed(attribute: String, error: AXError)
+    case performActionFailed(AXError)
+
+    package var description: String {
+        switch self {
+        case .copyAttributeFailed(let attribute, let error):
+            return "AX attribute '\(attribute)' failed: \(error.rawValue)"
+        case .performActionFailed(let error):
+            return "AX action failed: \(error.rawValue)"
+        }
+    }
+}
+
+package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessing {
+    private let maxDescendantCount = 128
+
+    package init() {}
+
+    package func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialogAccessibilityStatus {
+        if promptIfNeeded {
+            let options: NSDictionary = [
+                "AXTrustedCheckOptionPrompt" as NSString: true
+            ]
+            return AXIsProcessTrustedWithOptions(options) ? .trusted : .untrusted
+        }
+        return AXIsProcessTrusted() ? .trusted : .untrusted
+    }
+
+    package func runningXcodeProcessIDs() -> [pid_t] {
+        let bundleIdentifiers: Set<String> = [
+            "com.apple.dt.Xcode",
+            "com.apple.dt.ExternalViewService",
+        ]
+        let processIDs = NSWorkspace.shared.runningApplications.compactMap { application -> pid_t? in
+            guard let bundleIdentifier = application.bundleIdentifier else {
+                return nil
+            }
+            guard bundleIdentifiers.contains(bundleIdentifier), application.isTerminated == false else {
+                return nil
+            }
+            return application.processIdentifier
+        }
+        return Array(Set(processIDs)).sorted()
+    }
+
+    package func openWindows(for processID: pid_t) throws -> [XcodePermissionDialogAXWindow] {
+        let app = AXUIElementCreateApplication(processID)
+        return try copyElementArray(attribute: kAXWindowsAttribute as CFString, from: app).compactMap { window in
+            try makeWindow(processID: processID, window: window)
+        }
+    }
+
+    package func pressDefaultButton(in window: XcodePermissionDialogAXWindow) throws {
+        try window.pressDefaultButton()
+    }
+
+    private func makeWindow(
+        processID: pid_t,
+        window: AXUIElement
+    ) throws -> XcodePermissionDialogAXWindow? {
+        guard let defaultButton = copyElement(attribute: kAXDefaultButtonAttribute as CFString, from: window) else {
+            return nil
+        }
+
+        let snapshot = XcodePermissionDialogWindowSnapshot(
+            title: copyString(attribute: kAXTitleAttribute as CFString, from: window) ?? "",
+            textValues: collectTextValues(from: window),
+            isModal: copyBool(attribute: kAXModalAttribute as CFString, from: window) ?? false,
+            defaultButtonTitle: copyButtonLabel(from: defaultButton),
+            cancelButtonTitle: copyElement(attribute: kAXCancelButtonAttribute as CFString, from: window)
+                .flatMap(copyButtonLabel(from:))
+        )
+
+        return XcodePermissionDialogAXWindow(
+            processID: processID,
+            snapshot: snapshot,
+            defaultButton: defaultButton
+        )
+    }
+
+    private func collectTextValues(from root: AXUIElement) -> [String] {
+        var queue: [AXUIElement] = [root]
+        var values: [String] = []
+        var visited = 0
+
+        while queue.isEmpty == false, visited < maxDescendantCount {
+            let element = queue.removeFirst()
+            visited += 1
+
+            if let title = copyString(attribute: kAXTitleAttribute as CFString, from: element) {
+                values.append(title)
+            }
+            if let value = copyString(attribute: kAXValueAttribute as CFString, from: element) {
+                values.append(value)
+            }
+            if let description = copyString(attribute: kAXDescriptionAttribute as CFString, from: element) {
+                values.append(description)
+            }
+
+            if let children = try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: element) {
+                queue.append(contentsOf: children)
+            }
+        }
+
+        var seen = Set<String>()
+        return values.filter { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard trimmed.isEmpty == false else {
+                return false
+            }
+            return seen.insert(trimmed).inserted
+        }
+    }
+
+    private func copyButtonLabel(from element: AXUIElement) -> String? {
+        copyString(attribute: kAXTitleAttribute as CFString, from: element)
+            ?? copyString(attribute: kAXDescriptionAttribute as CFString, from: element)
+            ?? copyString(attribute: kAXValueAttribute as CFString, from: element)
+    }
+
+    private func copyString(attribute: CFString, from element: AXUIElement) -> String? {
+        guard let value = try? copyAttribute(attribute: attribute, from: element) else {
+            return nil
+        }
+        return value as? String
+    }
+
+    private func copyBool(attribute: CFString, from element: AXUIElement) -> Bool? {
+        guard let value = try? copyAttribute(attribute: attribute, from: element) else {
+            return nil
+        }
+        return value as? Bool
+    }
+
+    private func copyElement(attribute: CFString, from element: AXUIElement) -> AXUIElement? {
+        guard let value = try? copyAttribute(attribute: attribute, from: element) else {
+            return nil
+        }
+        guard CFGetTypeID(value) == AXUIElementGetTypeID() else {
+            return nil
+        }
+        return unsafe unsafeDowncast(value, to: AXUIElement.self)
+    }
+
+    private func copyElementArray(attribute: CFString, from element: AXUIElement) throws -> [AXUIElement] {
+        guard let value = try copyAttribute(attribute: attribute, from: element) else {
+            return []
+        }
+        if let elements = value as? [AXUIElement] {
+            return elements
+        }
+        if let array = value as? [AnyObject] {
+            return array.compactMap { candidate in
+                guard CFGetTypeID(candidate) == AXUIElementGetTypeID() else {
+                    return nil
+                }
+                return unsafe unsafeDowncast(candidate, to: AXUIElement.self)
+            }
+        }
+        return []
+    }
+
+    private func copyAttribute(attribute: CFString, from element: AXUIElement) throws -> CFTypeRef? {
+        var value: CFTypeRef?
+        let error = unsafe AXUIElementCopyAttributeValue(element, attribute, &value)
+        switch error {
+        case .success, .noValue:
+            return value
+        default:
+            throw XcodePermissionDialogAXError.copyAttributeFailed(
+                attribute: attribute as String,
+                error: error
+            )
+        }
+    }
+}
+
+package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
+    package struct Dependencies: Sendable {
+        package var axClient: any XcodePermissionDialogAXAccessing
+        package var agentPathCandidates: @Sendable () -> Set<String>
+        package var assistantNameCandidates: @Sendable () -> Set<String>
+        package var sleep: @Sendable (Duration) async -> Void
+        package var pollInterval: Duration
+        package var logger: Logger
+
+        package init(
+            axClient: any XcodePermissionDialogAXAccessing,
+            agentPathCandidates: @escaping @Sendable () -> Set<String>,
+            assistantNameCandidates: @escaping @Sendable () -> Set<String>,
+            sleep: @escaping @Sendable (Duration) async -> Void,
+            pollInterval: Duration,
+            logger: Logger
+        ) {
+            self.axClient = axClient
+            self.agentPathCandidates = agentPathCandidates
+            self.assistantNameCandidates = assistantNameCandidates
+            self.sleep = sleep
+            self.pollInterval = pollInterval
+            self.logger = logger
+        }
+
+        package static func live(
+            agentPathCandidates: @escaping @Sendable () -> Set<String> = {
+                XcodePermissionDialogAutoApprover.defaultAgentPathCandidates()
+            },
+            assistantNameCandidates: @escaping @Sendable () -> Set<String> = {
+                []
+            }
+        ) -> Self {
+            Self(
+                axClient: LiveXcodePermissionDialogAXClient(),
+                agentPathCandidates: agentPathCandidates,
+                assistantNameCandidates: assistantNameCandidates,
+                sleep: { duration in
+                    try? await Task.sleep(for: duration)
+                },
+                pollInterval: .milliseconds(250),
+                logger: ProxyLogging.make("xcode.permission")
+            )
+        }
+    }
+
+    private struct State {
+        var started = false
+        var task: Task<Void, Never>?
+        var lastAttemptUptimeByFingerprint: [String: UInt64] = [:]
+        var didLogNoMatch = false
+    }
+
+    private let dependencies: Dependencies
+    private let stateLock = NSLock()
+    private var state = State()
+    private let retryIntervalNanoseconds: UInt64 = 500_000_000
+
+    package init(dependencies: Dependencies = .live()) {
+        self.dependencies = dependencies
+    }
+
+    package func start() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard state.started == false else {
+            return
+        }
+        state.started = true
+
+        switch dependencies.axClient.authorizationStatus(promptIfNeeded: false) {
+        case .trusted:
+            let task = Task { [dependencies, weak self] in
+                guard let self else {
+                    return
+                }
+                await self.runMonitorLoop(dependencies: dependencies)
+            }
+            state.task = task
+        case .untrusted:
+            _ = dependencies.axClient.authorizationStatus(promptIfNeeded: true)
+            dependencies.logger.warning(
+                "Accessibility permission is required to auto-approve the Xcode permission dialog; requested the system prompt and will keep waiting for permission."
+            )
+            let task = Task { [dependencies, weak self] in
+                guard let self else {
+                    return
+                }
+                await self.runMonitorLoop(dependencies: dependencies)
+            }
+            state.task = task
+        }
+    }
+
+    package func stop() {
+        let task: Task<Void, Never>? = stateLock.withLock {
+            state.started = false
+            state.lastAttemptUptimeByFingerprint.removeAll()
+            let task = state.task
+            state.task = nil
+            return task
+        }
+
+        task?.cancel()
+    }
+
+    package static func defaultAgentPathCandidates(
+        arguments: [String] = CommandLine.arguments,
+        executableURL: URL? = Bundle.main.executableURL,
+        additionalExecutableCandidates: [String] = []
+    ) -> Set<String> {
+        var candidates: Set<String> = []
+
+        if let raw = arguments.first, raw.isEmpty == false {
+            candidates.insert(raw)
+            let rawURL = URL(fileURLWithPath: raw)
+            candidates.insert(rawURL.standardizedFileURL.path)
+            candidates.insert(rawURL.resolvingSymlinksInPath().path)
+        }
+
+        if let executablePath = executableURL?.path, executablePath.isEmpty == false {
+            let executableURL = URL(fileURLWithPath: executablePath)
+            candidates.insert(executablePath)
+            candidates.insert(executableURL.standardizedFileURL.path)
+            candidates.insert(executableURL.resolvingSymlinksInPath().path)
+        }
+
+        for candidate in additionalExecutableCandidates where candidate.isEmpty == false {
+            let candidateURL = URL(fileURLWithPath: candidate)
+            candidates.insert(candidate)
+            candidates.insert(candidateURL.standardizedFileURL.path)
+            candidates.insert(candidateURL.resolvingSymlinksInPath().path)
+        }
+
+        return Set(candidates.filter { $0.isEmpty == false })
+    }
+
+    private func runMonitorLoop(dependencies: Dependencies) async {
+        let agentPathCandidates = dependencies.agentPathCandidates()
+        let assistantNameCandidates = dependencies.assistantNameCandidates()
+        let pathCandidateText = agentPathCandidates.sorted().joined(separator: " | ")
+        var hasLoggedTrustedMonitoring = false
+
+        while Task.isCancelled == false {
+            if dependencies.axClient.authorizationStatus(promptIfNeeded: false) != .trusted {
+                await dependencies.sleep(dependencies.pollInterval)
+                continue
+            }
+
+            if hasLoggedTrustedMonitoring == false {
+                dependencies.logger.info(
+                    "Xcode permission dialog auto-approver is monitoring Xcode.",
+                    metadata: [
+                        "agent_paths": .string(pathCandidateText)
+                    ]
+                )
+                hasLoggedTrustedMonitoring = true
+            }
+
+            let visibleFingerprints = scanAndApprove(
+                agentPathCandidates: agentPathCandidates,
+                assistantNameCandidates: assistantNameCandidates,
+                dependencies: dependencies
+            )
+            stateLock.withLock {
+                state.lastAttemptUptimeByFingerprint =
+                    state.lastAttemptUptimeByFingerprint.filter { visibleFingerprints.contains($0.key) }
+            }
+
+            await dependencies.sleep(dependencies.pollInterval)
+        }
+    }
+
+    private func scanAndApprove(
+        agentPathCandidates: Set<String>,
+        assistantNameCandidates: Set<String>,
+        dependencies: Dependencies
+    ) -> Set<String> {
+        var visibleFingerprints: Set<String> = []
+        var inspectedWindowTitles: [String] = []
+        let processIDs = dependencies.axClient.runningXcodeProcessIDs()
+        let nowUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
+
+        for processID in processIDs {
+            let windows: [XcodePermissionDialogAXWindow]
+            do {
+                windows = try dependencies.axClient.openWindows(for: processID)
+            } catch {
+                dependencies.logger.warning(
+                    "Failed to inspect AX windows for a running Xcode-related process.",
+                    metadata: [
+                        "pid": "\(processID)",
+                        "error": "\(error)",
+                    ]
+                )
+                continue
+            }
+            for window in windows {
+                let trimmedTitle = window.snapshot.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmedTitle.isEmpty == false, inspectedWindowTitles.count < 8 {
+                    inspectedWindowTitles.append(trimmedTitle)
+                }
+                guard let decision = XcodePermissionDialogMatcher.decision(
+                    for: window.snapshot,
+                    processID: processID,
+                    agentPathCandidates: agentPathCandidates,
+                    assistantNameCandidates: assistantNameCandidates
+                ) else {
+                    continue
+                }
+
+                visibleFingerprints.insert(decision.fingerprint)
+
+                let shouldPress = stateLock.withLock { () -> Bool in
+                    if let lastAttempt = state.lastAttemptUptimeByFingerprint[decision.fingerprint],
+                       nowUptimeNanoseconds &- lastAttempt < retryIntervalNanoseconds
+                    {
+                        return false
+                    }
+                    state.lastAttemptUptimeByFingerprint[decision.fingerprint] = nowUptimeNanoseconds
+                    return true
+                }
+                guard shouldPress else {
+                    continue
+                }
+
+                do {
+                    try dependencies.axClient.pressDefaultButton(in: window)
+                    dependencies.logger.info(
+                        "Auto-approved the Xcode permission dialog.",
+                        metadata: [
+                            "pid": "\(processID)",
+                            "button": .string(decision.defaultButtonTitle),
+                        ]
+                    )
+                } catch {
+                    dependencies.logger.warning(
+                        "Matched the Xcode permission dialog but could not press its default button.",
+                        metadata: [
+                            "pid": "\(processID)",
+                            "error": "\(error)",
+                        ]
+                    )
+                }
+            }
+        }
+
+        let shouldLogNoMatch = stateLock.withLock { () -> Bool in
+            if visibleFingerprints.isEmpty == false {
+                state.didLogNoMatch = false
+                return false
+            }
+            guard processIDs.isEmpty == false, state.didLogNoMatch == false else {
+                return false
+            }
+            state.didLogNoMatch = true
+            return true
+        }
+        if shouldLogNoMatch {
+            dependencies.logger.debug(
+                "Xcode permission dialog auto-approver found running Xcode windows but no matching permission dialog yet.",
+                metadata: [
+                    "xcode_pids": .string(processIDs.map(String.init).joined(separator: ",")),
+                    "window_titles": .string(inspectedWindowTitles.joined(separator: " | ")),
+                ]
+            )
+        }
+
+        return visibleFingerprints
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/Sources/ProxyFeatureXcode/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyFeatureXcode/XcodePermissionDialogAutoApprover.swift
@@ -200,7 +200,7 @@ package enum XcodePermissionDialogMatcher {
         }
 
         let sameNodeMatch = normalizedTextNodes.contains { text in
-            serverProcessIDCandidates.contains(where: { text.contains($0) })
+            serverProcessIDCandidates.contains(where: { containsNumericToken($0, in: text) })
                 && assistantNameCandidates.contains(where: { text.contains($0) })
         }
         if sameNodeMatch {
@@ -211,7 +211,7 @@ package enum XcodePermissionDialogMatcher {
             assistantNameCandidates.contains(where: { text.contains($0) })
         }
         let containsPID = normalizedTextNodes.contains { text in
-            serverProcessIDCandidates.contains(where: { text.contains($0) })
+            serverProcessIDCandidates.contains(where: { containsNumericToken($0, in: text) })
         }
         if containsAssistantName && containsPID {
             return true
@@ -245,6 +245,28 @@ package enum XcodePermissionDialogMatcher {
 
     private static func normalizedPIDCandidates(_ candidates: Set<pid_t>) -> Set<String> {
         Set(candidates.map(String.init))
+    }
+
+    private static func containsNumericToken(_ candidate: String, in text: String) -> Bool {
+        guard candidate.isEmpty == false else {
+            return false
+        }
+
+        var currentDigits = ""
+        currentDigits.reserveCapacity(candidate.count)
+
+        for scalar in text.unicodeScalars {
+            if CharacterSet.decimalDigits.contains(scalar) {
+                currentDigits.unicodeScalars.append(scalar)
+                continue
+            }
+            if currentDigits == candidate {
+                return true
+            }
+            currentDigits.removeAll(keepingCapacity: true)
+        }
+
+        return currentDigits == candidate
     }
 
     private static func normalizedText(_ text: String?) -> String? {

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -97,11 +97,12 @@ public final class ProxyServer {
     }
 
     public func start() throws -> Channel {
+        let logger = self.logger
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer {
-                [runtimeHolder, config, refreshCodeIssuesCoordinator, refreshCodeIssuesTargetResolver, refreshCodeIssuesDebugState] channel in
+                [runtimeHolder, config, refreshCodeIssuesCoordinator, refreshCodeIssuesTargetResolver, refreshCodeIssuesDebugState, logger] channel in
                 runtimeHolder.sessionManager(on: channel.eventLoop).flatMap { sessionManager in
                     channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
                         channel.pipeline.addHandler(
@@ -114,9 +115,19 @@ public final class ProxyServer {
                             )
                         )
                     }
-                }.flatMapError { _ in
-                    channel.close(mode: .all, promise: nil)
-                    return channel.eventLoop.makeSucceededFuture(())
+                }.flatMapError { error in
+                    if case RuntimeHolderError.shuttingDown = error {
+                        channel.close(mode: .all, promise: nil)
+                        return channel.eventLoop.makeSucceededFuture(())
+                    }
+
+                    logger.warning(
+                        "Child channel initialization failed.",
+                        metadata: [
+                            "error": "\(error)"
+                        ]
+                    )
+                    return channel.eventLoop.makeFailedFuture(error)
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -230,16 +241,17 @@ public final class ProxyServer {
         "Xcode MCP proxy listening on http://\(displayHost):\(port) (version \(ProxyBuildInfo.version))"
     }
 
-    private static func additionalPermissionDialogExecutableCandidates(config: ProxyConfig) -> [String] {
+    package static func additionalPermissionDialogExecutableCandidates(config: ProxyConfig) -> [String] {
         var candidates: [String] = []
         if let resolvedUpstreamCommand = resolvedExecutablePath(for: config.upstreamCommand) {
             candidates.append(resolvedUpstreamCommand)
         }
 
-        if let xcrunInvocation = xcrunInvocation(from: config),
-           let toolResolution = resolvedXcrunTool(from: xcrunInvocation.arguments) {
+        if let xcrunInvocation = xcrunInvocation(from: config) {
             candidates.append(xcrunInvocation.commandPath)
-            candidates.append(toolResolution)
+            if let toolResolution = resolvedXcrunTool(from: xcrunInvocation.arguments) {
+                candidates.append(toolResolution)
+            }
         }
 
         return candidates

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -249,7 +249,10 @@ public final class ProxyServer {
 
         if let xcrunInvocation = xcrunInvocation(from: config) {
             candidates.append(xcrunInvocation.commandPath)
-            if let toolResolution = resolvedXcrunTool(from: xcrunInvocation.arguments) {
+            if let toolResolution = resolvedXcrunTool(
+                from: xcrunInvocation.arguments,
+                xcrunCommandPath: xcrunInvocation.commandPath
+            ) {
                 candidates.append(toolResolution)
             }
         }
@@ -281,11 +284,15 @@ public final class ProxyServer {
         return (resolvedCommand, remainingArguments)
     }
 
-    private static func resolvedXcrunTool(from upstreamArgs: [String]) -> String? {
+    private static func resolvedXcrunTool(
+        from upstreamArgs: [String],
+        xcrunCommandPath: String
+    ) -> String? {
         guard let selection = firstXcrunToolSelection(from: upstreamArgs) else {
             return nil
         }
         return resolvedXcrunToolPath(
+            xcrunCommandPath: xcrunCommandPath,
             toolName: selection.toolName,
             preToolArguments: selection.preToolArguments
         )
@@ -351,9 +358,22 @@ public final class ProxyServer {
         return nil
     }
 
-    private static func resolvedXcrunToolPath(toolName: String, preToolArguments: [String]) -> String? {
+    private static func resolvedXcrunToolPath(
+        xcrunCommandPath: String,
+        toolName: String,
+        preToolArguments: [String]
+    ) -> String? {
+        let executablePath: String
+        if xcrunCommandPath.contains("/") {
+            executablePath = URL(fileURLWithPath: xcrunCommandPath).standardizedFileURL.path
+        } else if let resolvedCommandPath = resolvedExecutablePath(for: xcrunCommandPath) {
+            executablePath = resolvedCommandPath
+        } else {
+            executablePath = "/usr/bin/xcrun"
+        }
+
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = preToolArguments + ["--find", toolName]
         let stdout = Pipe()
         process.standardOutput = stdout

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -22,10 +22,10 @@ public final class ProxyServer {
         }
 
         package static func live(config: ProxyConfig) -> Self {
-            let additionalCandidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
             return Self(
                 makeAutoApprover: {
-                    XcodePermissionDialogAutoApprover(
+                    let additionalCandidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
+                    return XcodePermissionDialogAutoApprover(
                         dependencies: .live(
                             agentPathCandidates: {
                                 XcodePermissionDialogAutoApprover.defaultAgentPathCandidates(
@@ -397,9 +397,11 @@ public final class ProxyServer {
                 return true
             }
 
-            let autoApprover = dependencies.makeAutoApprover()
-            autoApprover.start()
-            permissionDialogAutoApprover = autoApprover
+            if config.autoApproveXcodeDialog {
+                let autoApprover = dependencies.makeAutoApprover()
+                autoApprover.start()
+                permissionDialogAutoApprover = autoApprover
+            }
 
             let sessionManager = dependencies.makeRuntimeCoordinator(config, group.next())
             self.sessionManager = sessionManager

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -279,11 +279,10 @@ public final class ProxyServer {
         )
     }
 
-    private static func firstXcrunToolSelection(from args: [String]) -> (toolName: String, preToolArguments: [String])? {
+    package static func firstXcrunToolSelection(from args: [String]) -> (toolName: String, preToolArguments: [String])? {
         let flagsWithValues: Set<String> = [
             "-sdk", "--sdk",
             "-toolchain", "--toolchain",
-            "-log", "--log",
         ]
 
         var index = 0

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -8,20 +8,65 @@ import ProxyHTTPTransport
 import ProxyFeatureXcode
 
 public final class ProxyServer {
+    package struct Dependencies: Sendable {
+        package var makeAutoApprover: @Sendable () -> any ProxyServerPermissionDialogAutoApprover
+        package var makeRuntimeCoordinator:
+            @Sendable (_ config: ProxyConfig, _ eventLoop: EventLoop) -> any RuntimeCoordinating
+
+        package init(
+            makeAutoApprover: @escaping @Sendable () -> any ProxyServerPermissionDialogAutoApprover,
+            makeRuntimeCoordinator: @escaping @Sendable (_ config: ProxyConfig, _ eventLoop: EventLoop) -> any RuntimeCoordinating
+        ) {
+            self.makeAutoApprover = makeAutoApprover
+            self.makeRuntimeCoordinator = makeRuntimeCoordinator
+        }
+
+        package static func live(config: ProxyConfig) -> Self {
+            let additionalCandidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
+            return Self(
+                makeAutoApprover: {
+                    XcodePermissionDialogAutoApprover(
+                        dependencies: .live(
+                            agentPathCandidates: {
+                                XcodePermissionDialogAutoApprover.defaultAgentPathCandidates(
+                                    additionalExecutableCandidates: additionalCandidates
+                                )
+                            },
+                            assistantNameCandidates: {
+                                Set(ProxyServer.permissionDialogAssistantNameCandidates(config: config))
+                            }
+                        )
+                    )
+                },
+                makeRuntimeCoordinator: { config, eventLoop in
+                    RuntimeCoordinator(config: config, eventLoop: eventLoop)
+                }
+            )
+        }
+    }
+
     private let config: ProxyConfig
+    private let dependencies: Dependencies
     private let group: EventLoopGroup
-    private let sessionManager: RuntimeCoordinator
     private let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator
     private let refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver
     private let refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState
     private var channels: [Channel] = []
     private let logger: Logger = ProxyLogging.make("server")
+    private let runtimeLock = NSLock()
+    private let runtimeHolder = RuntimeHolder()
+    private var isShuttingDown = false
+    private var sessionManager: (any RuntimeCoordinating)?
+    private var permissionDialogAutoApprover: (any ProxyServerPermissionDialogAutoApprover)?
 
-    public init(config: ProxyConfig) {
+    public convenience init(config: ProxyConfig) {
+        self.init(config: config, dependencies: .live(config: config))
+    }
+
+    package init(config: ProxyConfig, dependencies: Dependencies) {
         self.config = config
+        self.dependencies = dependencies
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let eventLoop = group.next()
-        self.sessionManager = RuntimeCoordinator(config: config, eventLoop: eventLoop)
         self.refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator.makeDefault(
             requestTimeout: config.requestTimeout
         )
@@ -56,22 +101,32 @@ public final class ProxyServer {
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer {
-                [sessionManager, config, refreshCodeIssuesCoordinator, refreshCodeIssuesTargetResolver, refreshCodeIssuesDebugState] channel in
-                channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
-                    channel.pipeline.addHandler(
-                        HTTPHandler(
-                            config: config,
-                            sessionManager: sessionManager,
-                            refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
-                            refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
-                            refreshCodeIssuesDebugState: refreshCodeIssuesDebugState
+                [runtimeHolder, config, refreshCodeIssuesCoordinator, refreshCodeIssuesTargetResolver, refreshCodeIssuesDebugState] channel in
+                runtimeHolder.sessionManager(on: channel.eventLoop).flatMap { sessionManager in
+                    channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
+                        channel.pipeline.addHandler(
+                            HTTPHandler(
+                                config: config,
+                                sessionManager: sessionManager,
+                                refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
+                                refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
+                                refreshCodeIssuesDebugState: refreshCodeIssuesDebugState
+                            )
                         )
-                    )
+                    }
+                }.flatMapError { _ in
+                    channel.close(mode: .all, promise: nil)
+                    return channel.eventLoop.makeSucceededFuture(())
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
         let boundChannels = try bindChannels(using: bootstrap)
-        self.channels = boundChannels
+        guard installBoundChannelsAndPrepareRuntime(boundChannels) else {
+            for channel in boundChannels {
+                channel.close(promise: nil)
+            }
+            throw ProxyServerError.shutdownInProgress
+        }
         guard let first = boundChannels.first else {
             throw ProxyServerError.failedToBind
         }
@@ -80,8 +135,10 @@ public final class ProxyServer {
 
     public func shutdownGracefully() -> EventLoopFuture<Void> {
         let promise = group.next().makePromise(of: Void.self)
-        sessionManager.shutdown()
-        for channel in channels {
+        let shutdownContext = beginShutdown()
+        shutdownContext.autoApprover?.stop()
+        shutdownContext.sessionManager?.shutdown()
+        for channel in shutdownContext.channels {
             channel.close(promise: nil)
         }
         group.shutdownGracefully { error in
@@ -132,7 +189,7 @@ public final class ProxyServer {
     }
 
     private func waitForHTTP() async throws {
-        let futures = channels.map { $0.closeFuture }
+        let futures = runtimeLock.withLock { channels.map(\.closeFuture) }
         if futures.isEmpty {
             return
         }
@@ -172,8 +229,255 @@ public final class ProxyServer {
     package static func listeningLogLine(displayHost: String, port: Int) -> String {
         "Xcode MCP proxy listening on http://\(displayHost):\(port) (version \(ProxyBuildInfo.version))"
     }
+
+    private static func additionalPermissionDialogExecutableCandidates(config: ProxyConfig) -> [String] {
+        var candidates: [String] = []
+        if let resolvedUpstreamCommand = resolvedExecutablePath(for: config.upstreamCommand) {
+            candidates.append(resolvedUpstreamCommand)
+        }
+
+        if let xcrunInvocation = xcrunInvocation(from: config),
+           let toolResolution = resolvedXcrunTool(from: xcrunInvocation.arguments) {
+            candidates.append(xcrunInvocation.commandPath)
+            candidates.append(toolResolution)
+        }
+
+        return candidates
+    }
+
+    private static func xcrunInvocation(from config: ProxyConfig) -> (commandPath: String, arguments: [String])? {
+        if let resolvedCommand = resolvedExecutablePath(for: config.upstreamCommand),
+           resolvedCommand.hasSuffix("/xcrun") {
+            return (resolvedCommand, config.upstreamArgs)
+        }
+
+        guard let xcrunIndex = config.upstreamArgs.firstIndex(where: { argument in
+            if argument == "xcrun" {
+                return true
+            }
+            guard let resolved = resolvedExecutablePath(for: argument) else {
+                return false
+            }
+            return resolved.hasSuffix("/xcrun")
+        }) else {
+            return nil
+        }
+
+        let commandArgument = config.upstreamArgs[xcrunIndex]
+        let resolvedCommand = resolvedExecutablePath(for: commandArgument) ?? commandArgument
+        let remainingArguments = Array(config.upstreamArgs.dropFirst(xcrunIndex + 1))
+        return (resolvedCommand, remainingArguments)
+    }
+
+    private static func resolvedXcrunTool(from upstreamArgs: [String]) -> String? {
+        guard let selection = firstXcrunToolSelection(from: upstreamArgs) else {
+            return nil
+        }
+        return resolvedXcrunToolPath(
+            toolName: selection.toolName,
+            preToolArguments: selection.preToolArguments
+        )
+    }
+
+    private static func firstXcrunToolSelection(from args: [String]) -> (toolName: String, preToolArguments: [String])? {
+        let flagsWithValues: Set<String> = [
+            "-sdk", "--sdk",
+            "-toolchain", "--toolchain",
+            "-log", "--log",
+        ]
+
+        var index = 0
+        while index < args.count {
+            let argument = args[index]
+            if flagsWithValues.contains(argument) {
+                index += 2
+                continue
+            }
+            if argument.hasPrefix("-") {
+                index += 1
+                continue
+            }
+            return (argument, Array(args.prefix(index)))
+        }
+
+        return nil
+    }
+
+    private static func permissionDialogAssistantNameCandidates(config: ProxyConfig) -> [String] {
+        var candidates = Set<String>(["XcodeMCPKit"])
+        let override = ProxyFileConfigLoader.loadInitializeParamsOverride(
+            configPath: config.configPath,
+            logger: ProxyLogging.make("config")
+        )
+        if case .object(let clientInfo)? = override?["clientInfo"],
+           case .string(let name)? = clientInfo["name"],
+           name.isEmpty == false {
+            candidates.insert(name)
+        }
+        return Array(candidates)
+    }
+
+    private static func resolvedExecutablePath(for command: String) -> String? {
+        guard command.isEmpty == false else {
+            return nil
+        }
+
+        if command.contains("/") {
+            return URL(fileURLWithPath: command).standardizedFileURL.path
+        }
+
+        let pathValue =
+            ProcessInfo.processInfo.environment["PATH"]
+            ?? "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+        for directory in pathValue.split(separator: ":").map(String.init) where directory.isEmpty == false {
+            let candidate = URL(fileURLWithPath: directory).appendingPathComponent(command).path
+            if FileManager.default.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+
+        return nil
+    }
+
+    private static func resolvedXcrunToolPath(toolName: String, preToolArguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = preToolArguments + ["--find", toolName]
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              output.isEmpty == false else {
+            return nil
+        }
+        return output
+    }
+
+    private func beginShutdown() -> (
+        sessionManager: (any RuntimeCoordinating)?,
+        autoApprover: (any ProxyServerPermissionDialogAutoApprover)?,
+        channels: [Channel]
+    ) {
+        runtimeLock.withLock {
+            runtimeHolder.beginShutdown()
+            let context = (
+                sessionManager: sessionManager,
+                autoApprover: permissionDialogAutoApprover,
+                channels: channels
+            )
+            isShuttingDown = true
+            sessionManager = nil
+            permissionDialogAutoApprover = nil
+            return context
+        }
+    }
+
+    private func installBoundChannelsAndPrepareRuntime(_ boundChannels: [Channel]) -> Bool {
+        runtimeLock.withLock {
+            guard isShuttingDown == false else {
+                return false
+            }
+
+            channels = boundChannels
+
+            if let sessionManager {
+                runtimeHolder.activate(sessionManager)
+                return true
+            }
+
+            let autoApprover = dependencies.makeAutoApprover()
+            autoApprover.start()
+            permissionDialogAutoApprover = autoApprover
+
+            let sessionManager = dependencies.makeRuntimeCoordinator(config, group.next())
+            self.sessionManager = sessionManager
+            runtimeHolder.activate(sessionManager)
+            return true
+        }
+    }
 }
 
 private enum ProxyServerError: Error {
     case failedToBind
+    case shutdownInProgress
+}
+
+private enum RuntimeHolderError: Error {
+    case shuttingDown
+}
+
+private final class RuntimeHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var sessionManager: (any RuntimeCoordinating)?
+    private var waiters: [EventLoopPromise<any RuntimeCoordinating>] = []
+    private var isShuttingDown = false
+
+    func sessionManager(on eventLoop: EventLoop) -> EventLoopFuture<any RuntimeCoordinating> {
+        lock.withLock {
+            if isShuttingDown {
+                return eventLoop.makeFailedFuture(RuntimeHolderError.shuttingDown)
+            }
+            if let sessionManager {
+                return eventLoop.makeSucceededFuture(sessionManager)
+            }
+            let promise = eventLoop.makePromise(of: (any RuntimeCoordinating).self)
+            waiters.append(promise)
+            return promise.futureResult
+        }
+    }
+
+    func activate(_ sessionManager: any RuntimeCoordinating) {
+        let waiters = lock.withLock { () -> [EventLoopPromise<any RuntimeCoordinating>] in
+            guard isShuttingDown == false else {
+                return []
+            }
+            self.sessionManager = sessionManager
+            let waiters = self.waiters
+            self.waiters = []
+            return waiters
+        }
+        for waiter in waiters {
+            waiter.succeed(sessionManager)
+        }
+    }
+
+    func beginShutdown() {
+        let waiters = lock.withLock { () -> [EventLoopPromise<any RuntimeCoordinating>] in
+            isShuttingDown = true
+            sessionManager = nil
+            let waiters = self.waiters
+            self.waiters = []
+            return waiters
+        }
+        for waiter in waiters {
+            waiter.fail(RuntimeHolderError.shuttingDown)
+        }
+    }
+}
+
+package protocol ProxyServerPermissionDialogAutoApprover: Sendable {
+    func start()
+    func stop()
+}
+
+extension XcodePermissionDialogAutoApprover: ProxyServerPermissionDialogAutoApprover {}
+
+private extension NSLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
 }

--- a/Tests/ProxyCLITests/CLICommandTests.swift
+++ b/Tests/ProxyCLITests/CLICommandTests.swift
@@ -204,6 +204,36 @@ struct CLICommandTests {
         ])
     }
 
+    @Test func cliCommandRejectsAutoApproveFlag() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { output.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { _, _, _, _ in RecordingCLIAdapter() },
+                input: .standardInput,
+                output: .standardOutput
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy", "--auto-approve"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot() == [
+            "This option is only supported by xcode-mcp-proxy-server (proxy server).",
+            "Run: xcode-mcp-proxy-server --help",
+        ])
+    }
+
     @Test func cliCommandRejectsRemovedLazyInitFlag() async throws {
         let output = CapturedLines()
         let command = XcodeMCPProxyCLICommand(

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -85,6 +85,15 @@ struct CLIParserTests {
         #expect(config.refreshCodeIssuesMode == .upstream)
     }
 
+    @Test func cliParsesAutoApproveFlag() async throws {
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--auto-approve"],
+            environment: [:]
+        )
+
+        #expect(config.autoApproveXcodeDialog == true)
+    }
+
     @Test func cliParsesConfigPath() async throws {
         let config = try CLIParser.parse(
             args: ["xcode-mcp-proxy", "--config", "/tmp/proxy-config.toml"],
@@ -135,11 +144,13 @@ struct CLIParserTests {
                 "MCP_XCODE_CONFIG": "/tmp/proxy-config.toml",
                 "MCP_XCODE_SESSION_ID": "session-xyz",
                 "MCP_XCODE_REFRESH_CODE_ISSUES_MODE": "upstream",
+                "MCP_XCODE_AUTO_APPROVE": "1",
             ]
         )
         #expect(config.configPath == "/tmp/proxy-config.toml")
         #expect(config.upstreamSessionID == "session-xyz")
         #expect(config.refreshCodeIssuesMode == .upstream)
+        #expect(config.autoApproveXcodeDialog == false)
     }
 
     @Test func cliIgnoresRemovedXcodePIDEnvironment() async throws {

--- a/Tests/ProxyCLITests/ServerCommandTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandTests.swift
@@ -10,6 +10,7 @@ struct ServerCommandTests {
             "xcode-mcp-proxy-server",
             "--listen",
             "127.0.0.1:9000",
+            "--auto-approve",
             "--refresh-code-issues-mode",
             "upstream",
             "--force-restart",
@@ -18,11 +19,13 @@ struct ServerCommandTests {
 
         #expect(options.forwardedArgs == [
             "--listen", "127.0.0.1:9000",
+            "--auto-approve",
             "--refresh-code-issues-mode", "upstream",
         ])
         #expect(options.showHelp == false)
         #expect(options.showVersion == false)
         #expect(options.hasListenFlag == true)
+        #expect(options.hasAutoApproveFlag == true)
         #expect(options.hasRefreshCodeIssuesModeFlag == true)
         #expect(options.forceRestart == true)
         #expect(options.dryRun == true)
@@ -124,6 +127,7 @@ struct ServerCommandTests {
             hasHostFlag: false,
             hasPortFlag: false,
             hasConfigFlag: false,
+            hasAutoApproveFlag: false,
             hasRefreshCodeIssuesModeFlag: false,
             forceRestart: false,
             dryRun: false
@@ -155,6 +159,7 @@ struct ServerCommandTests {
             hasHostFlag: false,
             hasPortFlag: false,
             hasConfigFlag: true,
+            hasAutoApproveFlag: false,
             hasRefreshCodeIssuesModeFlag: false,
             forceRestart: false,
             dryRun: false
@@ -181,6 +186,7 @@ struct ServerCommandTests {
             hasHostFlag: false,
             hasPortFlag: false,
             hasConfigFlag: false,
+            hasAutoApproveFlag: false,
             hasRefreshCodeIssuesModeFlag: false,
             forceRestart: false,
             dryRun: false
@@ -431,7 +437,32 @@ struct ServerCommandTests {
         let line = try #require(output.snapshot().first)
         #expect(line.contains("--listen 127.0.0.1:9999"))
         #expect(line.contains("--config /tmp/proxy-config.toml"))
+        #expect(line.contains("--auto-approve") == false)
         #expect(line.contains("--lazy-init") == false)
+    }
+
+    @Test func serverCommandDryRunPrintsAutoApproveWhenExplicitlyEnabled() async throws {
+        let output = CapturedLines()
+        let command = XcodeMCPProxyServerCommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { output.append($0) },
+                stderr: { output.append($0) },
+                terminateExistingServer: { _, _ in false },
+                makeServer: { _ in RecordingProxyServer() },
+                isAddressAlreadyInUse: { _ in false },
+                detectExistingProxyServerPIDs: { _, _ in [] }
+            )
+        )
+
+        let exitCode = await command.run(
+            args: ["xcode-mcp-proxy-server", "--auto-approve", "--dry-run"],
+            environment: [:]
+        )
+
+        #expect(exitCode == 0)
+        let line = try #require(output.snapshot().first)
+        #expect(line.contains("--auto-approve"))
     }
 
     @Test func serverCommandTreatsHelpOnlyAsTopLevelFlag() async throws {

--- a/Tests/ProxyIntegrationTests/ProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/ProxyServerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import XcodeMCPProxy
@@ -26,4 +27,87 @@ struct ProxyServerTests {
 
         #expect(candidates.contains("/usr/bin/xcrun"))
     }
+
+    @Test func additionalPermissionDialogExecutableCandidatesUseConfiguredXcrunCommand() throws {
+        let fixture = try makeXcrunFixture()
+        defer { fixture.cleanup() }
+
+        let config = ProxyConfig(
+            listenHost: "localhost",
+            listenPort: 0,
+            upstreamCommand: fixture.wrapperPath,
+            upstreamArgs: ["--sdk", "macosx", "mcpbridge"],
+            maxBodyBytes: 1_048_576,
+            requestTimeout: 300
+        )
+
+        let candidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
+
+        #expect(candidates.contains(fixture.wrapperPath))
+        #expect(candidates.contains(fixture.toolPath))
+    }
+
+    @Test func additionalPermissionDialogExecutableCandidatesUseConfiguredXcrunFromUpstreamArgs() throws {
+        let fixture = try makeXcrunFixture()
+        defer { fixture.cleanup() }
+
+        let config = ProxyConfig(
+            listenHost: "localhost",
+            listenPort: 0,
+            upstreamCommand: "/bin/echo",
+            upstreamArgs: [fixture.wrapperPath, "--log", "mcpbridge"],
+            maxBodyBytes: 1_048_576,
+            requestTimeout: 300
+        )
+
+        let candidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
+
+        #expect(candidates.contains(fixture.wrapperPath))
+        #expect(candidates.contains(fixture.toolPath))
+    }
+}
+
+private struct XcrunFixture {
+    let wrapperPath: String
+    let toolPath: String
+    let directoryURL: URL
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+}
+
+private func makeXcrunFixture() throws -> XcrunFixture {
+    let fileManager = FileManager.default
+    let directoryURL = fileManager.temporaryDirectory
+        .appendingPathComponent("xcode-mcp-proxy-xcrun-\(UUID().uuidString)", isDirectory: true)
+    try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+    let toolPath = directoryURL.appendingPathComponent("fake-mcpbridge").path
+    let wrapperPath = directoryURL.appendingPathComponent("xcrun").path
+    let script = """
+    #!/bin/sh
+    if [ "$1" = "--sdk" ]; then
+      shift 2
+    fi
+    if [ "$1" = "--log" ]; then
+      shift
+    fi
+    if [ "$1" = "--find" ] && [ "$2" = "mcpbridge" ]; then
+      echo "\(toolPath)"
+      exit 0
+    fi
+    exit 1
+    """
+    try script.write(to: URL(fileURLWithPath: wrapperPath), atomically: true, encoding: .utf8)
+    try fileManager.setAttributes(
+        [.posixPermissions: NSNumber(value: Int16(0o755))],
+        ofItemAtPath: wrapperPath
+    )
+
+    return XcrunFixture(
+        wrapperPath: wrapperPath,
+        toolPath: toolPath,
+        directoryURL: directoryURL
+    )
 }

--- a/Tests/ProxyIntegrationTests/ProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/ProxyServerTests.swift
@@ -1,0 +1,14 @@
+import Testing
+
+@testable import XcodeMCPProxy
+
+struct ProxyServerTests {
+    @Test func firstXcrunToolSelectionTreatsLogAsFlagWithoutValue() {
+        let selection = ProxyServer.firstXcrunToolSelection(
+            from: ["--sdk", "macosx", "--log", "mcpbridge", "--some-flag"]
+        )
+
+        #expect(selection?.toolName == "mcpbridge")
+        #expect(selection?.preToolArguments == ["--sdk", "macosx", "--log"])
+    }
+}

--- a/Tests/ProxyIntegrationTests/ProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/ProxyServerTests.swift
@@ -11,4 +11,19 @@ struct ProxyServerTests {
         #expect(selection?.toolName == "mcpbridge")
         #expect(selection?.preToolArguments == ["--sdk", "macosx", "--log"])
     }
+
+    @Test func additionalPermissionDialogExecutableCandidatesKeepXcrunPathWhenToolResolutionFails() {
+        let config = ProxyConfig(
+            listenHost: "localhost",
+            listenPort: 0,
+            upstreamCommand: "/usr/bin/xcrun",
+            upstreamArgs: ["--foo"],
+            maxBodyBytes: 1_048_576,
+            requestTimeout: 300
+        )
+
+        let candidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
+
+        #expect(candidates.contains("/usr/bin/xcrun"))
+    }
 }

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -123,6 +123,25 @@ struct XcodePermissionDialogAutoApproverTests {
         #expect(decision?.defaultButtonTitle == "allow")
     }
 
+    @Test func matcherRejectsPIDSubstringMatchesInsideLargerNumbers() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
+            textValues: [
+                "The agent XcodeMCPKit, PID 16119 wants to use Xcode's tools."
+            ]
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision == nil)
+    }
+
     @Test func matcherMatchesWhenAssistantNameAndAgentPathAppearWithoutPID() {
         let snapshot = makeSnapshot(
             processBundleIdentifier: "com.apple.dt.Xcode",

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+
+@testable import ProxyCore
+@testable import ProxyFeatureXcode
+
+@Suite(.serialized)
+struct XcodePermissionDialogAutoApproverTests {
+    @Test func matcherRecognizesXcodePermissionDialogAndChoosesDefaultButton() {
+        let snapshot = XcodePermissionDialogWindowSnapshot(
+            title: "Allow “XcodeMCPKit” to access Xcode?",
+            textValues: [
+                "The agent “XcodeMCPKit” at /tmp/xcode-mcp-proxy-server wants to use Xcode's tools."
+            ],
+            isModal: true,
+            defaultButtonTitle: "Allow",
+            cancelButtonTitle: "Don't Allow"
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 6119,
+            agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
+            assistantNameCandidates: []
+        )
+
+        #expect(decision?.defaultButtonTitle == "allow")
+        #expect(decision?.fingerprint.isEmpty == false)
+    }
+
+    @Test func matcherRecognizesDialogWhenPathContainsFormatCharactersAndCancelButtonIsUnavailable() {
+        let snapshot = XcodePermissionDialogWindowSnapshot(
+            title: "",
+            textValues: [
+                "Allow “XcodeMCPKit” to access Xcode?",
+                "The agent “XcodeMCPKit” at /\u{200B}tmp/\u{200B}build/\u{200B}xcode-mcp-proxy-server wants to use Xcode's tools."
+            ],
+            isModal: true,
+            defaultButtonTitle: "Allow",
+            cancelButtonTitle: nil
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            agentPathCandidates: ["/tmp/build/xcode-mcp-proxy-server"],
+            assistantNameCandidates: []
+        )
+
+        #expect(decision?.defaultButtonTitle == "allow")
+    }
+
+    @Test func matcherRecognizesDialogFromAssistantNameWhenExecutablePathIsUnavailable() {
+        let snapshot = XcodePermissionDialogWindowSnapshot(
+            title: "Allow “XcodeMCPKit” to access Xcode?",
+            textValues: [
+                "The agent “XcodeMCPKit” wants to use Xcode's tools."
+            ],
+            isModal: true,
+            defaultButtonTitle: "Allow",
+            cancelButtonTitle: nil
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            agentPathCandidates: [],
+            assistantNameCandidates: ["XcodeMCPKit"]
+        )
+
+        #expect(decision?.defaultButtonTitle == "allow")
+    }
+
+    @Test func matcherIgnoresUnrelatedXcodeDialogWithoutAgentPath() {
+        let snapshot = XcodePermissionDialogWindowSnapshot(
+            title: "Xcode",
+            textValues: [
+                "A build destination could not be found."
+            ],
+            isModal: true,
+            defaultButtonTitle: "OK",
+            cancelButtonTitle: "Cancel"
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 42,
+            agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
+            assistantNameCandidates: []
+        )
+
+        #expect(decision == nil)
+    }
+
+    @Test func defaultAgentPathCandidatesIncludeRawAndResolvedExecutablePaths() throws {
+        let fileManager = FileManager.default
+        let temporaryDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("xcode-mcp-auto-approver-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: temporaryDirectory)
+        }
+
+        let realExecutable = temporaryDirectory.appendingPathComponent("real-server")
+        #expect(fileManager.createFile(atPath: realExecutable.path, contents: Data()))
+        let symlinkExecutable = temporaryDirectory.appendingPathComponent("link-server")
+        try fileManager.createSymbolicLink(at: symlinkExecutable, withDestinationURL: realExecutable)
+
+        let candidates = XcodePermissionDialogAutoApprover.defaultAgentPathCandidates(
+            arguments: [symlinkExecutable.path],
+            executableURL: realExecutable
+        )
+
+        #expect(candidates.contains(symlinkExecutable.path))
+        #expect(candidates.contains(realExecutable.path))
+    }
+
+    @Test func autoApproverPromptsAccessibilityOnceAndRemainsInactiveWhenUntrusted() async {
+        let axClient = RecordingAXClient(status: .untrusted)
+        let approver = XcodePermissionDialogAutoApprover(
+            dependencies: .init(
+                axClient: axClient,
+                agentPathCandidates: { ["/tmp/xcode-mcp-proxy-server"] },
+                assistantNameCandidates: { ["XcodeMCPKit"] },
+                sleep: { _ in },
+                pollInterval: .milliseconds(1),
+                logger: ProxyLogging.make("tests.permission")
+            )
+        )
+
+        approver.start()
+        approver.start()
+        approver.stop()
+
+        let snapshot = axClient.snapshot()
+        #expect(snapshot.promptCalls == 1)
+        #expect(snapshot.windowScanCalls == 0)
+    }
+}
+
+private final class RecordingAXClient: @unchecked Sendable, XcodePermissionDialogAXAccessing {
+    private let status: XcodePermissionDialogAccessibilityStatus
+    private let lock = NSLock()
+    private var promptCalls = 0
+    private var windowScanCalls = 0
+
+    init(status: XcodePermissionDialogAccessibilityStatus) {
+        self.status = status
+    }
+
+    func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialogAccessibilityStatus {
+        lock.withLock {
+            if promptIfNeeded {
+                promptCalls += 1
+            }
+            return status
+        }
+    }
+
+    func runningXcodeProcessIDs() -> [pid_t] {
+        lock.withLock {
+            windowScanCalls += 1
+            return []
+        }
+    }
+
+    func openWindows(for processID: pid_t) throws -> [XcodePermissionDialogAXWindow] {
+        []
+    }
+
+    func pressDefaultButton(in window: XcodePermissionDialogAXWindow) throws {}
+
+    func snapshot() -> (promptCalls: Int, windowScanCalls: Int) {
+        lock.withLock {
+            (promptCalls, windowScanCalls)
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return body()
+    }
+}

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -6,87 +6,200 @@ import Testing
 
 @Suite(.serialized)
 struct XcodePermissionDialogAutoApproverTests {
-    @Test func matcherRecognizesXcodePermissionDialogAndChoosesDefaultButton() {
-        let snapshot = XcodePermissionDialogWindowSnapshot(
-            title: "Allow “XcodeMCPKit” to access Xcode?",
+    @Test func matcherMatchesWhenSingleTextNodeContainsAssistantNameAndPID() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "Access",
             textValues: [
-                "The agent “XcodeMCPKit” at /tmp/xcode-mcp-proxy-server wants to use Xcode's tools."
-            ],
-            isModal: true,
-            defaultButtonTitle: "Allow",
-            cancelButtonTitle: "Don't Allow"
+                "The agent XcodeMCPKit, PID 6119 wants to use Xcode's tools."
+            ]
         )
 
         let decision = XcodePermissionDialogMatcher.decision(
             for: snapshot,
-            processID: 6119,
-            agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
-            assistantNameCandidates: []
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
         )
 
-        #expect(decision?.defaultButtonTitle == "allow")
         #expect(decision?.fingerprint.isEmpty == false)
+        #expect(decision?.defaultButtonTitle == "allow")
     }
 
-    @Test func matcherRecognizesDialogWhenPathContainsFormatCharactersAndCancelButtonIsUnavailable() {
-        let snapshot = XcodePermissionDialogWindowSnapshot(
-            title: "",
+    @Test func matcherMatchesWhenConfiguredAssistantNameAndPIDShareATextNode() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.ExternalViewService",
+            title: "許可",
             textValues: [
-                "Allow “XcodeMCPKit” to access Xcode?",
-                "The agent “XcodeMCPKit” at /\u{200B}tmp/\u{200B}build/\u{200B}xcode-mcp-proxy-server wants to use Xcode's tools."
-            ],
-            isModal: true,
-            defaultButtonTitle: "Allow",
-            cancelButtonTitle: nil
+                "The agent Custom MCP, PID 4317 wants to use Xcode's tools."
+            ]
         )
 
         let decision = XcodePermissionDialogMatcher.decision(
             for: snapshot,
-            processID: 4317,
-            agentPathCandidates: ["/tmp/build/xcode-mcp-proxy-server"],
-            assistantNameCandidates: []
+            processID: 500,
+            assistantNameCandidates: ["Custom MCP"],
+            serverProcessIDCandidates: [4317]
         )
 
         #expect(decision?.defaultButtonTitle == "allow")
     }
 
-    @Test func matcherRecognizesDialogFromAssistantNameWhenExecutablePathIsUnavailable() {
-        let snapshot = XcodePermissionDialogWindowSnapshot(
-            title: "Allow “XcodeMCPKit” to access Xcode?",
+    @Test func matcherRejectsLocalizedDialogThatContainsAssistantNameWithoutPID() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
             textValues: [
-                "The agent “XcodeMCPKit” wants to use Xcode's tools."
-            ],
-            isModal: true,
-            defaultButtonTitle: "Allow",
-            cancelButtonTitle: nil
+                "エージェント XcodeMCPKit が Xcode のツール使用を要求しています。"
+            ]
         )
 
         let decision = XcodePermissionDialogMatcher.decision(
             for: snapshot,
             processID: 4317,
-            agentPathCandidates: [],
-            assistantNameCandidates: ["XcodeMCPKit"]
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision == nil)
+    }
+
+    @Test func matcherRejectsDialogThatContainsPIDWithoutAssistantName() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
+            textValues: [
+                "The agent, PID 6119 wants to use Xcode's tools."
+            ]
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision == nil)
+    }
+
+    @Test func matcherMatchesDialogWhenAssistantNameAndPIDAppearInDifferentNodes() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
+            textValues: [
+                "The agent XcodeMCPKit wants to use Xcode's tools.",
+                "PID 6119"
+            ]
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
         )
 
         #expect(decision?.defaultButtonTitle == "allow")
     }
 
-    @Test func matcherIgnoresUnrelatedXcodeDialogWithoutAgentPath() {
-        let snapshot = XcodePermissionDialogWindowSnapshot(
-            title: "Xcode",
+    @Test func matcherMatchesWhenAnyPIDCandidateSharesAWindowWithAssistantName() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
             textValues: [
-                "A build destination could not be found."
-            ],
-            isModal: true,
-            defaultButtonTitle: "OK",
-            cancelButtonTitle: "Cancel"
+                "The agent XcodeMCPKit wants to use Xcode's tools.",
+                "PID 7001"
+            ]
         )
 
         let decision = XcodePermissionDialogMatcher.decision(
             for: snapshot,
-            processID: 42,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119, 7001]
+        )
+
+        #expect(decision?.defaultButtonTitle == "allow")
+    }
+
+    @Test func matcherMatchesWhenAssistantNameAndAgentPathAppearWithoutPID() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
+            textValues: [
+                "The agent XcodeMCPKit at /tmp/xcode-mcp-proxy-server wants to use Xcode's tools."
+            ]
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
             agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
-            assistantNameCandidates: []
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision?.defaultButtonTitle == "allow")
+    }
+
+    @Test func matcherMatchesWhenAgentPathAppearsAndAssistantNameCandidatesAreEmpty() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
+            textValues: [
+                "The agent at /tmp/xcode-mcp-proxy-server wants to use Xcode's tools."
+            ]
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
+            assistantNameCandidates: [],
+            serverProcessIDCandidates: []
+        )
+
+        #expect(decision?.defaultButtonTitle == "allow")
+    }
+
+    @Test func matcherRejectsEnglishCopyWithoutAssistantNameAndPID() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "Allow access",
+            textValues: [
+                "The agent wants to use Xcode's tools."
+            ]
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision == nil)
+    }
+
+    @Test func matcherRejectsNormalWorkspaceWindowEvenWhenTextContainsAssistantNameAndPID() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "Project",
+            textValues: [
+                "XcodeMCPKit PID 6119"
+            ],
+            subrole: "AXStandardWindow",
+            isMain: true,
+            document: "file:///tmp/Project.xcodeproj",
+            hasProxy: true
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
         )
 
         #expect(decision == nil)
@@ -122,6 +235,7 @@ struct XcodePermissionDialogAutoApproverTests {
                 axClient: axClient,
                 agentPathCandidates: { ["/tmp/xcode-mcp-proxy-server"] },
                 assistantNameCandidates: { ["XcodeMCPKit"] },
+                serverProcessIDCandidates: { [6119] },
                 sleep: { _ in },
                 pollInterval: .milliseconds(1),
                 logger: ProxyLogging.make("tests.permission")
@@ -136,6 +250,54 @@ struct XcodePermissionDialogAutoApproverTests {
         #expect(snapshot.promptCalls == 1)
         #expect(snapshot.windowScanCalls == 0)
     }
+}
+
+private func makeSnapshot(
+    processBundleIdentifier: String,
+    title: String,
+    textValues: [String],
+    role: String = "AXWindow",
+    subrole: String = "AXDialog",
+    windowIdentifier: String? = nil,
+    isModal: Bool = true,
+    isMain: Bool? = false,
+    isMinimized: Bool? = false,
+    document: String? = nil,
+    childCount: Int = 3,
+    hasProxy: Bool = false,
+    defaultButton: XcodePermissionDialogButtonSnapshot? = makeButton(title: "Allow"),
+    cancelButton: XcodePermissionDialogButtonSnapshot? = makeButton(title: "Cancel")
+) -> XcodePermissionDialogWindowSnapshot {
+    XcodePermissionDialogWindowSnapshot(
+        processBundleIdentifier: processBundleIdentifier,
+        title: title,
+        textValues: textValues,
+        role: role,
+        subrole: subrole,
+        windowIdentifier: windowIdentifier,
+        isModal: isModal,
+        isMain: isMain,
+        isMinimized: isMinimized,
+        document: document,
+        childCount: childCount,
+        hasProxy: hasProxy,
+        defaultButton: defaultButton,
+        cancelButton: cancelButton
+    )
+}
+
+private func makeButton(
+    title: String,
+    role: String = "AXButton",
+    subrole: String? = nil,
+    identifier: String? = nil
+) -> XcodePermissionDialogButtonSnapshot {
+    XcodePermissionDialogButtonSnapshot(
+        title: title,
+        role: role,
+        subrole: subrole,
+        identifier: identifier
+    )
 }
 
 private final class RecordingAXClient: @unchecked Sendable, XcodePermissionDialogAXAccessing {


### PR DESCRIPTION
## Summary
- add AXUIElement-based auto-approval for the Xcode MCP permission dialog during proxy startup
- make the behavior opt-in via `xcode-mcp-proxy-server --auto-approve` instead of enabling it by default
- tighten dialog matching with structural AX guards plus dynamic assistant-name, PID, and agent-path signals, including token-boundary PID checks and localized/split-node fallback coverage
- keep xcrun-based agent path resolution robust when upstream args include valueless flags such as `--log`, preserve the xcrun path candidate when tool lookup fails, and resolve tool paths with the configured xcrun executable
- surface unexpected child-channel initialization failures instead of silently swallowing them outside shutdown races

## Testing
- `swift test`

## Screenshots
- Not applicable
