### PR TITLE
refactor(test): make timing-sensitive tests deterministic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,6 +80,7 @@ let package = Package(
                 "ProxyCore",
                 "ProxyRuntime",
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIO", package: "swift-nio"),
             ],
             path: "Sources/ProxyFeatureXcode",

--- a/Package.swift
+++ b/Package.swift
@@ -138,7 +138,8 @@ let package = Package(
         .target(
             name: "XcodeMCPTestSupport",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio")
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
             ],
             swiftSettings: strictSwiftSettings
         ),

--- a/Sources/ProxyFeatureXcode/RefreshCodeIssuesCoordinator.swift
+++ b/Sources/ProxyFeatureXcode/RefreshCodeIssuesCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NIOConcurrencyHelpers
 
 package actor RefreshCodeIssuesCoordinator {
     package struct Permit: Sendable {
@@ -20,7 +21,8 @@ package actor RefreshCodeIssuesCoordinator {
 
     package nonisolated let maxPendingPerKey: Int
     package nonisolated let maxPendingTotal: Int
-    package nonisolated let queueWaitTimeoutNanoseconds: UInt64
+    package nonisolated let queueWaitTimeout: Duration
+    package nonisolated let queueWaitClock: any Clock<Duration> & Sendable
     private var nextWaiterID: UInt64 = 0
     private var busyKeys: Set<String> = []
     private var pendingWaiterCount = 0
@@ -41,13 +43,28 @@ package actor RefreshCodeIssuesCoordinator {
         maxPendingTotal: Int = 32,
         queueWaitTimeout: TimeInterval = 30
     ) {
+        self.init(
+            maxPendingPerKey: maxPendingPerKey,
+            maxPendingTotal: maxPendingTotal,
+            queueWaitTimeout: Self.duration(from: queueWaitTimeout),
+            queueWaitClock: ContinuousClock()
+        )
+    }
+
+    package init(
+        maxPendingPerKey: Int = 4,
+        maxPendingTotal: Int = 32,
+        queueWaitTimeout: Duration,
+        queueWaitClock: any Clock<Duration> & Sendable = ContinuousClock()
+    ) {
         self.maxPendingPerKey = max(0, maxPendingPerKey)
         self.maxPendingTotal = max(0, maxPendingTotal)
-        self.queueWaitTimeoutNanoseconds = Self.nanoseconds(from: queueWaitTimeout)
+        self.queueWaitTimeout = queueWaitTimeout
+        self.queueWaitClock = queueWaitClock
     }
 
     package nonisolated var queueWaitTimeoutSeconds: Double {
-        Double(queueWaitTimeoutNanoseconds) / 1_000_000_000
+        Self.seconds(from: queueWaitTimeout)
     }
 
     package func withPermit<T: Sendable>(
@@ -88,18 +105,16 @@ package actor RefreshCodeIssuesCoordinator {
             pendingTotal: pendingWaiterCount + 1
         )
 
-        let timeoutTask = Task { [queueWaitTimeoutNanoseconds] in
-            do {
-                try await Task.sleep(nanoseconds: queueWaitTimeoutNanoseconds)
-                self.timeoutWaiter(key: key, waiterID: waiterID)
-            } catch {
-                return
-            }
-        }
+        let timeoutTaskBox = NIOLockedValueBox<Task<Void, Never>?>(nil)
 
         return try await withTaskCancellationHandler(
             operation: {
-                defer { timeoutTask.cancel() }
+                defer {
+                    timeoutTaskBox.withLockedValue { task in
+                        task?.cancel()
+                        task = nil
+                    }
+                }
 
                 return try await withCheckedThrowingContinuation { continuation in
                     waitersByKey[key, default: []].append(
@@ -111,6 +126,18 @@ package actor RefreshCodeIssuesCoordinator {
                     )
                     pendingWaiterCount += 1
 
+                    let timeoutTask = Task { [queueWaitClock, queueWaitTimeout] in
+                        do {
+                            try await queueWaitClock.sleep(for: queueWaitTimeout)
+                            self.timeoutWaiter(key: key, waiterID: waiterID)
+                        } catch {
+                            return
+                        }
+                    }
+                    timeoutTaskBox.withLockedValue { task in
+                        task = timeoutTask
+                    }
+
                     if Task.isCancelled {
                         failWaiter(
                             key: key,
@@ -121,7 +148,10 @@ package actor RefreshCodeIssuesCoordinator {
                 }
             },
             onCancel: {
-                timeoutTask.cancel()
+                timeoutTaskBox.withLockedValue { task in
+                    task?.cancel()
+                    task = nil
+                }
                 Task {
                     await self.cancelWaiter(key: key, waiterID: waiterID)
                 }
@@ -182,5 +212,16 @@ package actor RefreshCodeIssuesCoordinator {
             return UInt64.max
         }
         return UInt64(nanoseconds.rounded(.up))
+    }
+
+    private static func seconds(from duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds)
+            + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
+    }
+
+    private static func duration(from interval: TimeInterval) -> Duration {
+        let clampedNanoseconds = min(nanoseconds(from: interval), UInt64(Int64.max))
+        return .nanoseconds(Int64(clampedNanoseconds))
     }
 }

--- a/Sources/ProxyRuntime/InitializeGate.swift
+++ b/Sources/ProxyRuntime/InitializeGate.swift
@@ -21,21 +21,21 @@ package final class InitializeGate: Sendable {
     }
 
     package struct SuccessPreparation: Sendable {
-        package let timeout: Scheduled<Void>?
+        package let timeout: RuntimeScheduledTimeout?
         package let shouldWarmSecondary: Bool
         package let cachedResult: JSONValue?
     }
 
     package struct FailureResult: Sendable {
         package let pending: [PendingInitialize]
-        package let timeout: Scheduled<Void>?
+        package let timeout: RuntimeScheduledTimeout?
         package let upstreamID: Int64?
         package let shouldRetryEagerInitialize: Bool
     }
 
     package struct ExitResult: Sendable {
         package let pending: [PendingInitialize]
-        package let timeout: Scheduled<Void>?
+        package let timeout: RuntimeScheduledTimeout?
         package let hadGlobalInit: Bool
         package let wasInFlight: Bool
         package let primaryInitUpstreamID: Int64?
@@ -53,7 +53,7 @@ package final class InitializeGate: Sendable {
         var initResult: JSONValue?
         var initPending: [PendingInitialize] = []
         var initInFlight = false
-        var initTimeout: Scheduled<Void>?
+        var initTimeout: RuntimeScheduledTimeout?
         var isShuttingDown = false
         var didWarmSecondary = false
         var primaryInitUpstreamID: Int64?
@@ -64,7 +64,7 @@ package final class InitializeGate: Sendable {
 
     package init() {}
 
-    package func beginShutdown() -> (pending: [PendingInitialize], timeout: Scheduled<Void>?) {
+    package func beginShutdown() -> (pending: [PendingInitialize], timeout: RuntimeScheduledTimeout?) {
         state.withLockedValue { state in
             state.isShuttingDown = true
             state.initInFlight = false
@@ -253,7 +253,7 @@ package final class InitializeGate: Sendable {
         }
     }
 
-    package func replaceInitTimeout(_ timeout: Scheduled<Void>) -> Scheduled<Void>? {
+    package func replaceInitTimeout(_ timeout: RuntimeScheduledTimeout) -> RuntimeScheduledTimeout? {
         state.withLockedValue { state in
             let existing = state.initTimeout
             state.initTimeout = timeout
@@ -296,7 +296,7 @@ package final class InitializeGate: Sendable {
         }
     }
 
-    package func resetForDebug() -> (pending: [PendingInitialize], timeout: Scheduled<Void>?) {
+    package func resetForDebug() -> (pending: [PendingInitialize], timeout: RuntimeScheduledTimeout?) {
         state.withLockedValue { state in
             let result = (pending: state.initPending, timeout: state.initTimeout)
             state.initResult = nil

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Health.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Health.swift
@@ -13,7 +13,7 @@ extension RuntimeCoordinator {
     }
 
     func markRequestTimedOut(upstreamIndex: Int) {
-        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        let nowUptimeNs = nowUptimeNanoseconds()
         let result = upstreamSelectionPolicy.markRequestTimedOut(
             upstreamIndex: upstreamIndex,
             nowUptimeNs: nowUptimeNs
@@ -111,7 +111,7 @@ extension RuntimeCoordinator {
         success: Bool,
         reason: String
     ) {
-        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        let nowUptimeNs = nowUptimeNanoseconds()
         upstreamSelectionPolicy.finishHealthProbe(
             upstreamIndex: upstreamIndex,
             probeGeneration: probeGeneration,
@@ -164,7 +164,7 @@ extension RuntimeCoordinator {
         }
 
         let refreshTimeout: TimeAmount = .seconds(5)
-        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        let nowUptimeNs = nowUptimeNanoseconds()
         let internalSessionID = toolsListInternalSessionID()
         _ = session(id: internalSessionID)
 
@@ -277,7 +277,7 @@ extension RuntimeCoordinator {
         else {
             return
         }
-        let timeout = eventLoop.scheduleTask(in: timeoutAmount) { [weak self] in
+        let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
             guard let self else { return }
             self.handleUpstreamInitTimeout(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
         }

--- a/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+Initialization.swift
@@ -226,7 +226,7 @@ extension RuntimeCoordinator {
         else {
             return
         }
-        let timeout = eventLoop.scheduleTask(in: timeoutAmount) { [weak self] in
+        let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
             guard let self else { return }
             self.failInitPending(error: TimeoutError())
         }

--- a/Sources/ProxyRuntime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator+UpstreamRouting.swift
@@ -576,7 +576,7 @@ extension RuntimeCoordinator {
         upstreamIndex: Int
     ) {
         debugRecorder.recordProtocolViolation(protocolViolation, upstreamIndex: upstreamIndex)
-        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        let nowUptimeNs = nowUptimeNanoseconds()
         let initSnapshot = initializeGate.snapshot()
         let transition = upstreamSelectionPolicy.markProtocolViolation(
             upstreamIndex: upstreamIndex,

--- a/Sources/ProxyRuntime/RuntimeCoordinator.swift
+++ b/Sources/ProxyRuntime/RuntimeCoordinator.swift
@@ -149,6 +149,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     package let upstreamSelectionPolicy: UpstreamSelectionPolicy
     package let upstreamSlotScheduler: UpstreamSlotScheduler
+    package let nowUptimeNanoseconds: @Sendable () -> UInt64
+    package let scheduleRuntimeTimeout: @Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
+        RuntimeScheduledTimeout
 
     package convenience init(config: ProxyConfig, eventLoop: EventLoop) {
         let count = max(1, min(config.upstreamProcessCount, 10))
@@ -157,9 +160,27 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.init(config: config, eventLoop: eventLoop, upstreams: upstreams)
     }
 
-    package init(config: ProxyConfig, eventLoop: EventLoop, upstreams: [any UpstreamSlotControlling]) {
+    package init(
+        config: ProxyConfig,
+        eventLoop: EventLoop,
+        upstreams: [any UpstreamSlotControlling],
+        nowUptimeNanoseconds: @escaping @Sendable () -> UInt64 = {
+            DispatchTime.now().uptimeNanoseconds
+        },
+        scheduleRuntimeTimeout: (@Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
+            RuntimeScheduledTimeout)? = nil
+    ) {
         precondition(!upstreams.isEmpty, "upstreams must not be empty")
         let schedulerProbeStarter = NIOLockedValueBox<(@Sendable ([HealthProbeRequest]) -> Void)?>(nil)
+        let uptimeProvider = nowUptimeNanoseconds
+        let timeoutScheduler = scheduleRuntimeTimeout
+            ?? { delay, operation in
+                RuntimeScheduledTimeout.schedule(
+                    on: eventLoop,
+                    in: delay,
+                    operation: operation
+                )
+            }
         self.config = config
         self.eventLoop = eventLoop
         self.upstreams = upstreams
@@ -168,11 +189,13 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.requestLeaseRegistry = RequestLeaseRegistry()
         self.responseCorrelationStore = ResponseCorrelationStore(upstreamCount: upstreams.count)
         self.upstreamSelectionPolicy = UpstreamSelectionPolicy(upstreamCount: upstreams.count)
+        self.nowUptimeNanoseconds = nowUptimeNanoseconds
+        self.scheduleRuntimeTimeout = timeoutScheduler
         self.upstreamSlotScheduler = UpstreamSlotScheduler(
             upstreamCount: upstreams.count,
             defaultCapacity: 1,
             canUseUpstream: { [weak upstreamSelectionPolicy = self.upstreamSelectionPolicy] upstreamIndex in
-                let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+                let nowUptimeNs = uptimeProvider()
                 guard let upstreamSelectionPolicy else { return false }
                 let evaluation = upstreamSelectionPolicy.evaluateUsableInitialized(
                     index: upstreamIndex,
@@ -186,7 +209,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 return evaluation.0
             },
             selectUpstream: { [weak upstreamSelectionPolicy = self.upstreamSelectionPolicy] occupied in
-                let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+                let nowUptimeNs = uptimeProvider()
                 let chooseResult = upstreamSelectionPolicy?.chooseBestInitializedUpstream(
                     nowUptimeNs: nowUptimeNs,
                     occupiedUpstreams: occupied
@@ -340,7 +363,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     }
 
     package func chooseUpstreamIndex() -> Int? {
-        let nowUptimeNs = DispatchTime.now().uptimeNanoseconds
+        let nowUptimeNs = nowUptimeNanoseconds()
         let occupiedUpstreams = upstreamSlotScheduler.occupiedUpstreamIndices()
 
         let chooseResult = upstreamSelectionPolicy.chooseBestInitializedUpstream(

--- a/Sources/ProxyRuntime/RuntimeScheduledTimeout.swift
+++ b/Sources/ProxyRuntime/RuntimeScheduledTimeout.swift
@@ -1,0 +1,26 @@
+import NIO
+
+package final class RuntimeScheduledTimeout: @unchecked Sendable {
+    private let cancelImpl: @Sendable () -> Void
+
+    package init(cancel: @escaping @Sendable () -> Void) {
+        self.cancelImpl = cancel
+    }
+
+    package func cancel() {
+        cancelImpl()
+    }
+
+    package static func schedule(
+        on eventLoop: EventLoop,
+        in delay: TimeAmount,
+        operation: @escaping @Sendable () -> Void
+    ) -> RuntimeScheduledTimeout {
+        let task = eventLoop.scheduleTask(in: delay) {
+            operation()
+        }
+        return RuntimeScheduledTimeout {
+            task.cancel()
+        }
+    }
+}

--- a/Sources/ProxyRuntime/UpstreamSelectionPolicy.swift
+++ b/Sources/ProxyRuntime/UpstreamSelectionPolicy.swift
@@ -9,14 +9,14 @@ package struct HealthProbeRequest: Sendable {
 
 package struct ProtocolViolationTransition: Sendable {
     package let quarantineUntil: UInt64
-    package let cancelledInitTimeout: Scheduled<Void>?
+    package let cancelledInitTimeout: RuntimeScheduledTimeout?
 }
 
 package final class UpstreamSelectionPolicy: Sendable {
     package struct UpstreamState: Sendable {
         package var isInitialized = false
         package var initInFlight = false
-        package var initTimeout: Scheduled<Void>?
+        package var initTimeout: RuntimeScheduledTimeout?
         package var didSendInitialized = false
         package var initUpstreamID: Int64?
         package var healthState: UpstreamHealthState = .healthy
@@ -50,9 +50,9 @@ package final class UpstreamSelectionPolicy: Sendable {
         state.withLockedValue { $0.upstreamStates.count }
     }
 
-    package func clearInitTimeoutsForShutdown() -> [Scheduled<Void>?] {
-        state.withLockedValue { state -> [Scheduled<Void>?] in
-            var timeouts: [Scheduled<Void>?] = []
+    package func clearInitTimeoutsForShutdown() -> [RuntimeScheduledTimeout?] {
+        state.withLockedValue { state -> [RuntimeScheduledTimeout?] in
+            var timeouts: [RuntimeScheduledTimeout?] = []
             timeouts.reserveCapacity(state.upstreamStates.count)
             for index in 0..<state.upstreamStates.count {
                 timeouts.append(state.upstreamStates[index].initTimeout)
@@ -299,7 +299,7 @@ package final class UpstreamSelectionPolicy: Sendable {
         }
     }
 
-    package func resetForDebug() -> [Scheduled<Void>?] {
+    package func resetForDebug() -> [RuntimeScheduledTimeout?] {
         state.withLockedValue { state in
             let timeouts = state.upstreamStates.map(\.initTimeout)
             state.upstreamStates = Array(repeating: UpstreamState(), count: state.upstreamStates.count)
@@ -326,7 +326,10 @@ package final class UpstreamSelectionPolicy: Sendable {
         }
     }
 
-    package func replaceInitTimeout(_ timeout: Scheduled<Void>, upstreamIndex: Int) -> Scheduled<Void>? {
+    package func replaceInitTimeout(
+        _ timeout: RuntimeScheduledTimeout,
+        upstreamIndex: Int
+    ) -> RuntimeScheduledTimeout? {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
             let existing = state.upstreamStates[upstreamIndex].initTimeout
@@ -366,7 +369,7 @@ package final class UpstreamSelectionPolicy: Sendable {
     }
 
     package func clearUpstreamState(upstreamIndex: Int) -> (
-        timeout: Scheduled<Void>?,
+        timeout: RuntimeScheduledTimeout?,
         initUpstreamID: Int64?
     )? {
         state.withLockedValue { state in
@@ -389,7 +392,7 @@ package final class UpstreamSelectionPolicy: Sendable {
         }
     }
 
-    package func markInitialized(upstreamIndex: Int) -> Scheduled<Void>? {
+    package func markInitialized(upstreamIndex: Int) -> RuntimeScheduledTimeout? {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
             state.upstreamStates[upstreamIndex].isInitialized = true

--- a/Sources/XcodeMCPTestSupport/AsyncTestSupport.swift
+++ b/Sources/XcodeMCPTestSupport/AsyncTestSupport.swift
@@ -1,6 +1,7 @@
 import Dispatch
 import Foundation
 import NIO
+import NIOConcurrencyHelpers
 
 package struct AsyncTestTimeoutError: Error, CustomStringConvertible {
     package let description: String
@@ -125,6 +126,20 @@ package func waitUntil(
     return await condition()
 }
 
+package func spinUntil(
+    _ description: String = "condition was not satisfied",
+    maxIterations: Int = 200,
+    _ condition: @escaping @Sendable () async -> Bool
+) async throws {
+    for _ in 0..<maxIterations {
+        if await condition() {
+            return
+        }
+        await Task.yield()
+    }
+    throw AsyncTestTimeoutError(description: description)
+}
+
 package func waitUntilCount(
     _ expectedCount: Int,
     count: @escaping @Sendable () async -> Int,
@@ -186,4 +201,265 @@ package func shutdownAndWait(_ group: EventLoopGroup) {
         semaphore.signal()
     }
     semaphore.wait()
+}
+
+package func makeTestURLSession(
+    timeout: TimeInterval = 5,
+    waitsForConnectivity: Bool = false
+) -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.waitsForConnectivity = waitsForConnectivity
+    configuration.timeoutIntervalForRequest = timeout
+    configuration.timeoutIntervalForResource = timeout
+    return URLSession(configuration: configuration)
+}
+
+package func withTestURLSession<T>(
+    timeout: TimeInterval = 5,
+    waitsForConnectivity: Bool = false,
+    operation: (URLSession) async throws -> T
+) async throws -> T {
+    let session = makeTestURLSession(
+        timeout: timeout,
+        waitsForConnectivity: waitsForConnectivity
+    )
+
+    do {
+        let result = try await operation(session)
+        session.finishTasksAndInvalidate()
+        return result
+    } catch {
+        session.invalidateAndCancel()
+        throw error
+    }
+}
+
+package final class TestSignal: @unchecked Sendable {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private struct State {
+        var signaled = false
+        var waiters: [Waiter] = []
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    package init() {}
+
+    package func wait(
+        timeout: Duration = .seconds(2),
+        description: String
+    ) async throws {
+        if state.withLockedValue({ $0.signaled }) {
+            return
+        }
+
+        let waiterID = UUID()
+        try await waitWithTimeout(description, timeout: timeout) {
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<Void, Error>) in
+                    let shouldResume = self.state.withLockedValue { state in
+                        if state.signaled {
+                            return true
+                        }
+                        state.waiters.append(Waiter(id: waiterID, continuation: continuation))
+                        return false
+                    }
+                    if shouldResume {
+                        continuation.resume(returning: ())
+                    }
+                }
+            } onCancel: {
+                self.cancelWaiter(id: waiterID)
+            }
+        }
+    }
+
+    package func signal() {
+        let waiters = state.withLockedValue { state -> [Waiter] in
+            guard state.signaled == false else {
+                return []
+            }
+            state.signaled = true
+            let waiters = state.waiters
+            state.waiters.removeAll()
+            return waiters
+        }
+
+        for waiter in waiters {
+            waiter.continuation.resume(returning: ())
+        }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        let waiter = state.withLockedValue { state -> Waiter? in
+            guard let index = state.waiters.firstIndex(where: { $0.id == id }) else {
+                return nil
+            }
+            return state.waiters.remove(at: index)
+        }
+        waiter?.continuation.resume(throwing: CancellationError())
+    }
+}
+
+package final class TestClock: Clock, @unchecked Sendable {
+    package typealias Instant = ContinuousClock.Instant
+    package typealias Duration = Swift.Duration
+
+    private struct SleepWaiter {
+        let deadline: Instant
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private struct SuspensionWaiter {
+        let minimumSleepers: Int
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private struct State {
+        var now: Instant
+        var sleepers: [UInt64: SleepWaiter] = [:]
+        var nextSleepToken: UInt64 = 0
+        var suspensionWaiters: [UInt64: SuspensionWaiter] = [:]
+        var nextSuspensionToken: UInt64 = 0
+    }
+
+    private let state: NIOLockedValueBox<State>
+
+    package init(now: Instant = ContinuousClock().now) {
+        self.state = NIOLockedValueBox(State(now: now))
+    }
+
+    package var now: Instant {
+        state.withLockedValue { $0.now }
+    }
+
+    package var minimumResolution: Duration {
+        .zero
+    }
+
+    package func sleep(until deadline: Instant, tolerance: Duration?) async throws {
+        _ = tolerance
+        let token = state.withLockedValue { state -> UInt64? in
+            guard deadline > state.now else {
+                return nil
+            }
+            let token = state.nextSleepToken
+            state.nextSleepToken &+= 1
+            return token
+        }
+
+        guard let token else {
+            return
+        }
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let continuations = state.withLockedValue { state -> [CheckedContinuation<Void, Never>] in
+                    state.sleepers[token] = SleepWaiter(deadline: deadline, continuation: continuation)
+                    return Self.resumeReadySuspensionWaiters(state: &state)
+                }
+                for continuation in continuations {
+                    continuation.resume()
+                }
+            }
+        } onCancel: {
+            let waiter = state.withLockedValue { state in
+                state.sleepers.removeValue(forKey: token)
+            }
+            waiter?.continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    package func advance(by duration: Duration) {
+        let continuations = state.withLockedValue { state -> [CheckedContinuation<Void, Error>] in
+            state.now = state.now.advanced(by: duration)
+            let readyTokens = state.sleepers.compactMap { token, waiter in
+                waiter.deadline <= state.now ? token : nil
+            }
+            let readyWaiters = readyTokens.compactMap { state.sleepers.removeValue(forKey: $0) }
+            return readyWaiters.map(\.continuation)
+        }
+
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+
+    package func sleep(untilSuspendedBy minimumSleepers: Int) async {
+        let token = state.withLockedValue { state -> UInt64? in
+            guard state.sleepers.count < minimumSleepers else {
+                return nil
+            }
+            let token = state.nextSuspensionToken
+            state.nextSuspensionToken &+= 1
+            return token
+        }
+
+        guard let token else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            let shouldResume = state.withLockedValue { state in
+                if state.sleepers.count >= minimumSleepers {
+                    return true
+                }
+                state.suspensionWaiters[token] = SuspensionWaiter(
+                    minimumSleepers: minimumSleepers,
+                    continuation: continuation
+                )
+                return false
+            }
+            if shouldResume {
+                continuation.resume()
+            }
+        }
+    }
+
+    private static func resumeReadySuspensionWaiters(
+        state: inout State
+    ) -> [CheckedContinuation<Void, Never>] {
+        let readyTokens = state.suspensionWaiters.compactMap { token, waiter in
+            state.sleepers.count >= waiter.minimumSleepers ? token : nil
+        }
+        return readyTokens.compactMap { state.suspensionWaiters.removeValue(forKey: $0)?.continuation }
+    }
+}
+
+package final class TestUptimeClock: @unchecked Sendable {
+    private let value: NIOLockedValueBox<UInt64>
+
+    package init(nowUptimeNanoseconds: UInt64 = 0) {
+        self.value = NIOLockedValueBox(nowUptimeNanoseconds)
+    }
+
+    package func now() -> UInt64 {
+        value.withLockedValue { $0 }
+    }
+
+    package func advance(by duration: Duration) {
+        let delta = durationToNanoseconds(duration)
+        value.withLockedValue { current in
+            current &+= delta
+        }
+    }
+}
+
+private func durationToNanoseconds(_ duration: Duration) -> UInt64 {
+    let components = duration.components
+    let seconds = max(0, components.seconds)
+    let attoseconds = max(0, components.attoseconds)
+    let secondsComponent = UInt64(seconds).multipliedReportingOverflow(by: 1_000_000_000)
+    if secondsComponent.overflow {
+        return UInt64.max
+    }
+
+    let attosecondsComponent = UInt64(attoseconds / 1_000_000_000)
+    let total = secondsComponent.partialValue.addingReportingOverflow(attosecondsComponent)
+    return total.overflow ? UInt64.max : total.partialValue
 }

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -41,14 +41,19 @@ struct CLICommandIntegrationTests {
             inputPipe.fileHandleForWriting.write(request)
             inputPipe.fileHandleForWriting.closeFile()
 
-            let exitCode = await command.run(
-                args: [
-                    "xcode-mcp-proxy",
-                    "--url",
-                    server.url.absoluteString,
-                ],
-                environment: [:]
-            )
+            let exitCode = try await waitWithTimeout(
+                "CLI command should finish after stdin closes",
+                timeout: .seconds(5)
+            ) {
+                await command.run(
+                    args: [
+                        "xcode-mcp-proxy",
+                        "--url",
+                        server.url.absoluteString,
+                    ],
+                    environment: [:]
+                )
+            }
             outputPipe.fileHandleForWriting.closeFile()
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
 
@@ -178,3 +183,5 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
         }
     }
 }
+
+extension XcodeMCPProxyCLICommand: @unchecked Sendable {}

--- a/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
@@ -316,12 +316,14 @@ struct HTTPConcurrencyTests {
             async let first = postJSON(
                 url: url,
                 sessionID: sessionID,
-                payload: toolListPayload(id: 400)
+                payload: toolListPayload(id: 400),
+                timeout: 10
             )
             async let notification = postStatusOnly(
                 url: url,
                 sessionID: sessionID,
-                payload: notificationPayload(method: "notifications/test-progress")
+                payload: notificationPayload(method: "notifications/test-progress"),
+                timeout: 10
             )
 
             #expect(
@@ -361,12 +363,14 @@ struct HTTPConcurrencyTests {
             async let first = postJSON(
                 url: url,
                 sessionID: sessionID,
-                payload: toolListPayload(id: 600)
+                payload: toolListPayload(id: 600),
+                timeout: 10
             )
             async let second = postJSON(
                 url: url,
                 sessionID: sessionID,
-                payload: toolListPayload(id: 601)
+                payload: toolListPayload(id: 601),
+                timeout: 10
             )
 
             #expect(
@@ -645,19 +649,21 @@ struct HTTPConcurrencyTests {
             request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
 
             let sseTask = Task<(HTTPURLResponse, String), Error> {
-                let (bytes, response) = try await URLSession.shared.bytes(for: request)
-                guard let httpResponse = response as? HTTPURLResponse else {
+                try await withTestURLSession { session in
+                    let (bytes, response) = try await session.bytes(for: request)
+                    guard let httpResponse = response as? HTTPURLResponse else {
+                        throw ConcurrencyTestError.invalidResponse
+                    }
+
+                    var iterator = bytes.lines.makeAsyncIterator()
+                    while let line = try await iterator.next() {
+                        if line.hasPrefix("data: ") {
+                            return (httpResponse, String(line.dropFirst(6)))
+                        }
+                    }
+
                     throw ConcurrencyTestError.invalidResponse
                 }
-
-                var iterator = bytes.lines.makeAsyncIterator()
-                while let line = try await iterator.next() {
-                    if line.hasPrefix("data: ") {
-                        return (httpResponse, String(line.dropFirst(6)))
-                    }
-                }
-
-                throw ConcurrencyTestError.invalidResponse
             }
             defer { sseTask.cancel() }
 
@@ -1362,36 +1368,23 @@ private func postJSON(
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
     }
 
-    let session: URLSession
-    if let timeout {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = timeout
-        configuration.timeoutIntervalForResource = timeout
-        session = URLSession(configuration: configuration)
-    } else {
-        session = URLSession.shared
-    }
-
-    defer {
-        if session !== URLSession.shared {
-            session.finishTasksAndInvalidate()
+    return try await withTestURLSession(timeout: timeout ?? 5) { session in
+        let (responseData, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ConcurrencyTestError.invalidResponse
         }
+        let object =
+            (try? JSONSerialization.jsonObject(with: responseData, options: [])) as? [String: Any]
+            ?? [:]
+        return (httpResponse, object)
     }
-
-    let (responseData, response) = try await session.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse else {
-        throw ConcurrencyTestError.invalidResponse
-    }
-    let object =
-        (try? JSONSerialization.jsonObject(with: responseData, options: [])) as? [String: Any]
-        ?? [:]
-    return (httpResponse, object)
 }
 
 private func postStatusOnly(
     url: URL,
     sessionID: String?,
-    payload: [String: Any]
+    payload: [String: Any],
+    timeout: TimeInterval? = nil
 ) async throws -> HTTPURLResponse {
     let data = try JSONSerialization.data(withJSONObject: payload, options: [])
     var request = URLRequest(url: url)
@@ -1399,15 +1392,20 @@ private func postStatusOnly(
     request.httpBody = data
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("application/json", forHTTPHeaderField: "Accept")
+    if let timeout {
+        request.timeoutInterval = timeout
+    }
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
     }
 
-    let (_, response) = try await URLSession.shared.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse else {
-        throw ConcurrencyTestError.invalidResponse
+    return try await withTestURLSession(timeout: timeout ?? 5) { session in
+        let (_, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ConcurrencyTestError.invalidResponse
+        }
+        return httpResponse
     }
-    return httpResponse
 }
 
 private func makeEmbeddedConfig(requestTimeout: TimeInterval) -> ProxyConfig {

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -11,7 +11,7 @@ import XcodeMCPTestSupport
 
 @testable import ProxyHTTPTransport
 
-@Suite
+@Suite(.serialized)
 struct HTTPHandlerTests {
     @Test func httpHealthCheck() async throws {
         let config = makeConfig()
@@ -215,7 +215,7 @@ struct HTTPHandlerTests {
                 )
             }
 
-            await firstSent.wait()
+            try await firstSent.wait(description: "waiting for navigator issues request to start")
 
             let (httpResponse, data) = try await getHTTPData(url: makeDebugSnapshotURL(from: server.url))
             #expect(httpResponse.statusCode == 200)
@@ -1771,223 +1771,6 @@ struct HTTPHandlerTests {
         #expect(result?["resources"] == nil)
     }
 
-    @Test func httpRefreshCodeIssuesSerializesRequestsForSameTabIdentifier() async throws {
-        let coordinator = RefreshCodeIssuesCoordinator()
-        let firstEntered = AsyncSignal()
-        let releaseFirst = AsyncSignal()
-        let secondEntered = NIOLockedValueBox(false)
-
-        let firstTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
-                await firstEntered.signal()
-                await releaseFirst.wait()
-            }
-        }
-        await firstEntered.wait()
-
-        let secondTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
-                secondEntered.withLockedValue { value in
-                    value = true
-                }
-            }
-        }
-
-        await Task.yield()
-        await Task.yield()
-        #expect(secondEntered.withLockedValue { $0 } == false)
-
-        await releaseFirst.signal()
-        _ = await firstTask.value
-        _ = await secondTask.value
-        #expect(secondEntered.withLockedValue { $0 } == true)
-    }
-
-    @Test func httpRefreshCodeIssuesKeepsDifferentTabIdentifiersConcurrent() async throws {
-        let coordinator = RefreshCodeIssuesCoordinator()
-        let firstEntered = AsyncSignal()
-        let secondEntered = AsyncSignal()
-        let releaseFirst = AsyncSignal()
-
-        let firstTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-a") { _ in
-                await firstEntered.signal()
-                await releaseFirst.wait()
-            }
-        }
-        await firstEntered.wait()
-
-        let secondTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-b") { _ in
-                await secondEntered.signal()
-            }
-        }
-
-        await secondEntered.wait()
-        await releaseFirst.signal()
-        _ = await firstTask.value
-        _ = await secondTask.value
-        #expect(Bool(true))
-    }
-
-    @Test func httpRefreshCodeIssuesRejectsWhenPerKeyQueueLimitIsExceeded() async throws {
-        let coordinator = RefreshCodeIssuesCoordinator(
-            maxPendingPerKey: 1,
-            maxPendingTotal: 8,
-            queueWaitTimeout: 5
-        )
-        let firstEntered = AsyncSignal()
-        let releaseFirst = AsyncSignal()
-        let secondEntered = AsyncSignal()
-
-        let firstTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
-                await firstEntered.signal()
-                await releaseFirst.wait()
-            }
-        }
-        await firstEntered.wait()
-
-        let secondTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
-                await secondEntered.signal()
-            }
-        }
-
-        await Task.yield()
-        await Task.yield()
-
-        do {
-            _ = try await coordinator.withPermit(key: "windowtab-same") { _ in
-                ()
-            }
-            #expect(Bool(false))
-        } catch RefreshCodeIssuesCoordinator.AcquireError.queueLimitExceeded {
-            #expect(Bool(true))
-        }
-
-        await releaseFirst.signal()
-        await secondEntered.wait()
-        _ = await firstTask.value
-        _ = await secondTask.value
-    }
-
-    @Test func httpRefreshCodeIssuesRejectsWhenGlobalQueueLimitIsExceeded() async throws {
-        let coordinator = RefreshCodeIssuesCoordinator(
-            maxPendingPerKey: 4,
-            maxPendingTotal: 0,
-            queueWaitTimeout: 5
-        )
-        let firstEntered = AsyncSignal()
-        let releaseFirst = AsyncSignal()
-
-        let firstTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-a") { _ in
-                await firstEntered.signal()
-                await releaseFirst.wait()
-            }
-        }
-        await firstEntered.wait()
-
-        do {
-            _ = try await coordinator.withPermit(key: "windowtab-a") { _ in
-                ()
-            }
-            #expect(Bool(false))
-        } catch RefreshCodeIssuesCoordinator.AcquireError.queueLimitExceeded {
-            #expect(Bool(true))
-        }
-
-        await releaseFirst.signal()
-        _ = await firstTask.value
-    }
-
-    @Test func httpRefreshCodeIssuesTimeoutRemovesQueuedWaiter() async throws {
-        let coordinator = RefreshCodeIssuesCoordinator(
-            maxPendingPerKey: 1,
-            maxPendingTotal: 4,
-            queueWaitTimeout: 0.05
-        )
-        let firstEntered = AsyncSignal()
-        let releaseFirst = AsyncSignal()
-        let thirdEntered = AsyncSignal()
-
-        let firstTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-timeout") { _ in
-                await firstEntered.signal()
-                await releaseFirst.wait()
-            }
-        }
-        await firstEntered.wait()
-
-        do {
-            _ = try await coordinator.withPermit(key: "windowtab-timeout") { _ in
-                ()
-            }
-            #expect(Bool(false))
-        } catch RefreshCodeIssuesCoordinator.AcquireError.queueWaitTimedOut {
-            #expect(Bool(true))
-        }
-
-        let thirdTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-timeout") { _ in
-                await thirdEntered.signal()
-            }
-        }
-
-        await Task.yield()
-        await releaseFirst.signal()
-        await thirdEntered.wait()
-        _ = await firstTask.value
-        _ = await thirdTask.value
-    }
-
-    @Test func httpRefreshCodeIssuesCancellationRemovesQueuedWaiter() async throws {
-        let coordinator = RefreshCodeIssuesCoordinator(
-            maxPendingPerKey: 1,
-            maxPendingTotal: 4,
-            queueWaitTimeout: 5
-        )
-        let firstEntered = AsyncSignal()
-        let releaseFirst = AsyncSignal()
-        let thirdEntered = AsyncSignal()
-
-        let firstTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-cancel") { _ in
-                await firstEntered.signal()
-                await releaseFirst.wait()
-            }
-        }
-        await firstEntered.wait()
-
-        let cancelledTask = Task<Void, Error> {
-            _ = try await coordinator.withPermit(key: "windowtab-cancel") { _ in
-                ()
-            }
-        }
-        await Task.yield()
-        cancelledTask.cancel()
-        let cancelledResult = await cancelledTask.result
-        switch cancelledResult {
-        case .failure(let error):
-            #expect(error is CancellationError)
-        case .success:
-            #expect(Bool(false))
-        }
-
-        let thirdTask = Task<Void, Never> {
-            _ = try? await coordinator.withPermit(key: "windowtab-cancel") { _ in
-                await thirdEntered.signal()
-            }
-        }
-
-        await Task.yield()
-        await releaseFirst.signal()
-        await thirdEntered.wait()
-        _ = await firstTask.value
-        _ = await thirdTask.value
-    }
-
     @Test func httpRefreshCodeIssuesUsesNavigatorIssuesProxyByDefault() async throws {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .proxy
@@ -2855,7 +2638,7 @@ struct HTTPHandlerTests {
                 return response.statusCode
             }
 
-            await firstSent.wait()
+            try await firstSent.wait(description: "waiting for first upstream refresh request")
 
             let (secondResponse, secondBody) = try await postHTTPJSON(
                 url: server.url,
@@ -2966,7 +2749,7 @@ struct HTTPHandlerTests {
                 return response.statusCode
             }
 
-            await firstSent.wait()
+            try await firstSent.wait(description: "waiting for first proxy refresh request")
 
             let (secondResponse, secondBody) = try await postHTTPJSON(
                 url: server.url,
@@ -3037,7 +2820,7 @@ struct HTTPHandlerTests {
                 return response.statusCode
             }
 
-            await firstSent.wait()
+            try await firstSent.wait(description: "waiting for first upstream timeout refresh request")
 
             let (secondResponse, secondBody) = try await postHTTPJSON(
                 url: server.url,
@@ -3148,7 +2931,7 @@ struct HTTPHandlerTests {
                 return response.statusCode
             }
 
-            await firstSent.wait()
+            try await firstSent.wait(description: "waiting for first proxy timeout refresh request")
 
             let (secondResponse, secondBody) = try await postHTTPJSON(
                 url: server.url,
@@ -4100,14 +3883,16 @@ private func postHTTPJSON(
     request.setValue("application/json", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
 
-    let (responseData, response) = try await URLSession.shared.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse else {
-        throw HTTPTestError.missingResponseHead
+    return try await withTestURLSession { session in
+        let (responseData, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPTestError.missingResponseHead
+        }
+        let object =
+            (try? JSONSerialization.jsonObject(with: responseData, options: [])) as? [String: Any]
+            ?? [:]
+        return (httpResponse, object)
     }
-    let object =
-        (try? JSONSerialization.jsonObject(with: responseData, options: [])) as? [String: Any]
-        ?? [:]
-    return (httpResponse, object)
 }
 
 private func postHTTPData(
@@ -4123,19 +3908,23 @@ private func postHTTPData(
     request.setValue("application/json", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
 
-    let (responseData, response) = try await URLSession.shared.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse else {
-        throw HTTPTestError.missingResponseHead
+    return try await withTestURLSession { session in
+        let (responseData, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPTestError.missingResponseHead
+        }
+        return RawHTTPResponse(statusCode: httpResponse.statusCode, bodyData: responseData)
     }
-    return RawHTTPResponse(statusCode: httpResponse.statusCode, bodyData: responseData)
 }
 
 private func getHTTPData(url: URL) async throws -> (HTTPURLResponse, Data) {
-    let (data, response) = try await URLSession.shared.data(from: url)
-    guard let httpResponse = response as? HTTPURLResponse else {
-        throw HTTPTestError.missingResponseHead
+    try await withTestURLSession { session in
+        let (data, response) = try await session.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPTestError.missingResponseHead
+        }
+        return (httpResponse, data)
     }
-    return (httpResponse, data)
 }
 
 private func makeDebugSnapshotURL(from mcpURL: URL) -> URL {
@@ -4145,71 +3934,8 @@ private func makeDebugSnapshotURL(from mcpURL: URL) -> URL {
     return components.url!
 }
 
-private actor AsyncSignal {
-    private var signaled = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func wait() async {
-        if signaled {
-            return
-        }
-        await withCheckedContinuation { continuation in
-            waiters.append(continuation)
-        }
-    }
-
-    func signal() {
-        guard signaled == false else { return }
-        signaled = true
-        let continuations = waiters
-        waiters.removeAll()
-        for continuation in continuations {
-            continuation.resume()
-        }
-    }
-}
-
-private final class SyncSignal: @unchecked Sendable {
-    private struct State {
-        var signaled = false
-        var waiters: [CheckedContinuation<Void, Never>] = []
-    }
-
-    private let state = NIOLockedValueBox(State())
-
-    func wait() async {
-        if state.withLockedValue({ $0.signaled }) {
-            return
-        }
-
-        await withCheckedContinuation { continuation in
-            let shouldResume = state.withLockedValue { state in
-                if state.signaled {
-                    return true
-                }
-                state.waiters.append(continuation)
-                return false
-            }
-            if shouldResume {
-                continuation.resume()
-            }
-        }
-    }
-
-    func signal() {
-        let continuations = state.withLockedValue { state -> [CheckedContinuation<Void, Never>] in
-            guard state.signaled == false else { return [] }
-            state.signaled = true
-            let waiters = state.waiters
-            state.waiters.removeAll()
-            return waiters
-        }
-
-        for continuation in continuations {
-            continuation.resume()
-        }
-    }
-}
+private typealias AsyncSignal = TestSignal
+private typealias SyncSignal = TestSignal
 
 private func makeToolSuccessResponse(id: RPCID, text: String) throws -> Data {
     let response: [String: Any] = [

--- a/Tests/ProxyHTTPTransportTests/RefreshCodeIssuesCoordinatorTests.swift
+++ b/Tests/ProxyHTTPTransportTests/RefreshCodeIssuesCoordinatorTests.swift
@@ -1,0 +1,275 @@
+import Testing
+import XcodeMCPTestSupport
+
+@testable import ProxyFeatureXcode
+
+@Suite(.serialized)
+struct RefreshCodeIssuesCoordinatorTests {
+    @Test func refreshCoordinatorSerializesRequestsForSameKey() async throws {
+        let clock = TestClock()
+        let coordinator = RefreshCodeIssuesCoordinator(
+            queueWaitTimeout: .seconds(5),
+            queueWaitClock: clock
+        )
+        let releaseFirst = AsyncGate()
+        let acquisitions = RecordedValues<String>()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
+                await acquisitions.append("first")
+                await releaseFirst.wait()
+            }
+        }
+        try await spinUntil("waiting for first acquisition") {
+            await acquisitions.count() == 1
+        }
+
+        let secondTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
+                await acquisitions.append("second")
+            }
+        }
+
+        await clock.sleep(untilSuspendedBy: 1)
+        #expect(await acquisitions.snapshot() == ["first"])
+        await releaseFirst.signal()
+
+        _ = await firstTask.value
+        _ = await secondTask.value
+        #expect(await acquisitions.snapshot() == ["first", "second"])
+    }
+
+    @Test func refreshCoordinatorAllowsDifferentKeysToAcquireConcurrently() async throws {
+        let coordinator = RefreshCodeIssuesCoordinator()
+        let releaseFirst = AsyncGate()
+        let acquisitions = RecordedValues<String>()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-a") { _ in
+                await acquisitions.append("first")
+                await releaseFirst.wait()
+            }
+        }
+        try await spinUntil("waiting for first acquisition") {
+            await acquisitions.count() == 1
+        }
+
+        let secondTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-b") { _ in
+                await acquisitions.append("second")
+            }
+        }
+
+        try await spinUntil("waiting for second acquisition") {
+            await acquisitions.count() == 2
+        }
+
+        await releaseFirst.signal()
+        _ = await firstTask.value
+        _ = await secondTask.value
+        #expect(await acquisitions.snapshot() == ["first", "second"])
+    }
+
+    @Test func refreshCoordinatorRejectsWhenPerKeyQueueLimitIsExceeded() async throws {
+        let clock = TestClock()
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 1,
+            maxPendingTotal: 8,
+            queueWaitTimeout: .seconds(5),
+            queueWaitClock: clock
+        )
+        let releaseFirst = AsyncGate()
+        let acquisitions = RecordedValues<String>()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
+                await acquisitions.append("first")
+                await releaseFirst.wait()
+            }
+        }
+        try await spinUntil("waiting for first acquisition") {
+            await acquisitions.count() == 1
+        }
+
+        let secondTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-same") { _ in
+                await acquisitions.append("second")
+            }
+        }
+
+        await clock.sleep(untilSuspendedBy: 1)
+
+        do {
+            _ = try await coordinator.withPermit(key: "windowtab-same") { _ in () }
+            #expect(Bool(false))
+        } catch RefreshCodeIssuesCoordinator.AcquireError.queueLimitExceeded {
+            #expect(Bool(true))
+        }
+
+        await releaseFirst.signal()
+        _ = await firstTask.value
+        _ = await secondTask.value
+        #expect(await acquisitions.snapshot() == ["first", "second"])
+    }
+
+    @Test func refreshCoordinatorRejectsWhenGlobalQueueLimitIsExceeded() async throws {
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 4,
+            maxPendingTotal: 0
+        )
+        let releaseFirst = AsyncGate()
+        let acquisitions = RecordedValues<String>()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-a") { _ in
+                await acquisitions.append("first")
+                await releaseFirst.wait()
+            }
+        }
+        try await spinUntil("waiting for first acquisition") {
+            await acquisitions.count() == 1
+        }
+
+        do {
+            _ = try await coordinator.withPermit(key: "windowtab-a") { _ in () }
+            #expect(Bool(false))
+        } catch RefreshCodeIssuesCoordinator.AcquireError.queueLimitExceeded {
+            #expect(Bool(true))
+        }
+
+        await releaseFirst.signal()
+        _ = await firstTask.value
+    }
+
+    @Test func refreshCoordinatorTimeoutRemovesQueuedWaiterDeterministically() async throws {
+        let clock = TestClock()
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 1,
+            maxPendingTotal: 4,
+            queueWaitTimeout: .milliseconds(50),
+            queueWaitClock: clock
+        )
+        let releaseFirst = AsyncGate()
+        let acquisitions = RecordedValues<String>()
+        let outcomes = RecordedValues<String>()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-timeout") { _ in
+                await acquisitions.append("first")
+                await releaseFirst.wait()
+            }
+        }
+        try await spinUntil("waiting for first acquisition") {
+            await acquisitions.count() == 1
+        }
+
+        let secondTask = Task<Void, Never> {
+            do {
+                _ = try await coordinator.withPermit(key: "windowtab-timeout") { _ in () }
+                await outcomes.append("success")
+            } catch RefreshCodeIssuesCoordinator.AcquireError.queueWaitTimedOut {
+                await outcomes.append("timed-out")
+            } catch {
+                await outcomes.append("unexpected")
+            }
+        }
+
+        await clock.sleep(untilSuspendedBy: 1)
+        clock.advance(by: .milliseconds(50))
+        try await spinUntil("waiting for timed-out waiter to finish") {
+            await outcomes.count() == 1
+        }
+        #expect(await outcomes.snapshot() == ["timed-out"])
+
+        let thirdTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-timeout") { _ in
+                await acquisitions.append("third")
+            }
+        }
+
+        await releaseFirst.signal()
+        _ = await firstTask.value
+        _ = await secondTask.value
+        _ = await thirdTask.value
+        #expect(await acquisitions.snapshot() == ["first", "third"])
+    }
+
+    @Test func refreshCoordinatorCancellationRemovesQueuedWaiterDeterministically() async throws {
+        let clock = TestClock()
+        let coordinator = RefreshCodeIssuesCoordinator(
+            maxPendingPerKey: 1,
+            maxPendingTotal: 4,
+            queueWaitTimeout: .seconds(5),
+            queueWaitClock: clock
+        )
+        let releaseFirst = AsyncGate()
+        let acquisitions = RecordedValues<String>()
+        let outcomes = RecordedValues<String>()
+
+        let firstTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-cancel") { _ in
+                await acquisitions.append("first")
+                await releaseFirst.wait()
+            }
+        }
+        try await spinUntil("waiting for first acquisition") {
+            await acquisitions.count() == 1
+        }
+
+        let cancelledTask = Task<Void, Never> {
+            do {
+                _ = try await coordinator.withPermit(key: "windowtab-cancel") { _ in () }
+                await outcomes.append("success")
+            } catch is CancellationError {
+                await outcomes.append("cancelled")
+            } catch {
+                await outcomes.append("unexpected")
+            }
+        }
+
+        await clock.sleep(untilSuspendedBy: 1)
+        cancelledTask.cancel()
+        try await spinUntil("waiting for cancelled waiter to finish") {
+            await outcomes.count() == 1
+        }
+        #expect(await outcomes.snapshot() == ["cancelled"])
+
+        let thirdTask = Task<Void, Never> {
+            _ = try? await coordinator.withPermit(key: "windowtab-cancel") { _ in
+                await acquisitions.append("third")
+            }
+        }
+
+        await releaseFirst.signal()
+        _ = await firstTask.value
+        _ = await cancelledTask.value
+        _ = await thirdTask.value
+        #expect(await acquisitions.snapshot() == ["first", "third"])
+    }
+}
+
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func signal() {
+        guard isOpen == false else {
+            return
+        }
+        isOpen = true
+        let waiters = waiters
+        self.waiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+}

--- a/Tests/ProxyRuntimeTests/ProcessRunnerTests.swift
+++ b/Tests/ProxyRuntimeTests/ProcessRunnerTests.swift
@@ -1,9 +1,10 @@
 import Foundation
 import Testing
+import XcodeMCPTestSupport
 
 @testable import ProxyRuntime
 
-@Suite
+@Suite(.serialized)
 struct ProcessRunnerTests {
     @Test func dispatchGroupLeaveGuardLeavesOnlyOnce() {
         let group = DispatchGroup()
@@ -17,14 +18,19 @@ struct ProcessRunnerTests {
 
     @Test func processRunnerDrainsLargeStdoutWithoutHanging() async throws {
         let runner = ProcessRunner()
-        let output = try await runner.run(
-            ProcessRequest(
-                label: "large-stdout",
-                executablePath: "/bin/sh",
-                arguments: ["-c", "yes x | head -c 200000"],
-                input: nil
+        let output = try await waitWithTimeout(
+            "ProcessRunner should finish draining large stdout",
+            timeout: .seconds(5)
+        ) {
+            try await runner.run(
+                ProcessRequest(
+                    label: "large-stdout",
+                    executablePath: "/bin/sh",
+                    arguments: ["-c", "yes x | head -c 200000"],
+                    input: nil
+                )
             )
-        )
+        }
 
         #expect(output.terminationStatus == 0)
         #expect(output.stdout.utf8.count == 200000)
@@ -38,14 +44,19 @@ struct ProcessRunnerTests {
             return prefix + String(repeating: Character(scalar), count: 2048)
         }
         let expected = segments.joined()
-        let output = try await runner.run(
-            ProcessRequest(
-                label: "ordered-large-stdout",
-                executablePath: "/usr/bin/python3",
-                arguments: makePythonSegmentEmitterArgs(segments: segments, pauseSeconds: 0.0005),
-                input: nil
+        let output = try await waitWithTimeout(
+            "ProcessRunner should preserve large chunk ordering",
+            timeout: .seconds(5)
+        ) {
+            try await runner.run(
+                ProcessRequest(
+                    label: "ordered-large-stdout",
+                    executablePath: "/usr/bin/python3",
+                    arguments: makePythonSegmentEmitterArgs(segments: segments, pauseSeconds: 0.0005),
+                    input: nil
+                )
             )
-        )
+        }
 
         #expect(output.terminationStatus == 0)
         #expect(output.stdout == expected)

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -72,8 +72,22 @@ struct RuntimeCoordinatorTests {
         let response = try makeInitializeResponse(id: upstreamID)
         await upstream.yield(.message(response))
 
-        let response1 = try decodeJSON(from: try await future1.get())
-        let response2 = try decodeJSON(from: try await future2.get())
+        let response1 = try decodeJSON(
+            from: try await waitWithTimeout(
+                "waiting for first queued initialize response",
+                timeout: .seconds(2)
+            ) {
+                try await future1.get()
+            }
+        )
+        let response2 = try decodeJSON(
+            from: try await waitWithTimeout(
+                "waiting for second queued initialize response",
+                timeout: .seconds(2)
+            ) {
+                try await future2.get()
+            }
+        )
         let id1 = (response1["id"] as? NSNumber)?.intValue
         let id2 = (response2["id"] as? NSNumber)?.intValue
         #expect(id1 == 1)
@@ -140,8 +154,14 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = ToggleableOverloadUpstreamClient()
+        let timeoutClock = TestClock()
         let config = makeConfig(requestTimeout: 0.3)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            scheduleRuntimeTimeout: makeDeterministicRuntimeTimeoutScheduler(clock: timeoutClock)
+        )
         defer { manager.shutdown() }
 
         let future = manager.registerInitialize(
@@ -149,26 +169,44 @@ struct RuntimeCoordinatorTests {
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
-        let initialInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+
+        try await spinUntilSentCount(
+            upstream,
+            count: 1,
+            description: "waiting for initial initialize request"
+        )
+        let initialInitialize = try #require(await upstream.sentValue(at: 0))
         let initialUpstreamID = try extractUpstreamID(from: initialInitialize)
 
         await upstream.overloadNextInitializedNotificationSend()
-        try await Task.sleep(for: .milliseconds(150))
+        await timeoutClock.sleep(untilSuspendedBy: 1)
+        timeoutClock.advance(by: .milliseconds(150))
         await upstream.yield(.message(try makeInitializeResponse(id: initialUpstreamID)))
 
-        try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
-        let retriedInitialize = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream,
+            count: 2,
+            description: "waiting for overloaded initialized notification send"
+        )
+        try await spinUntilSentCount(
+            upstream,
+            count: 3,
+            description: "waiting for retried initialize request"
+        )
+        let retriedInitialize = try #require(await upstream.sentValue(at: 2))
         let retriedUpstreamID = try extractUpstreamID(from: retriedInitialize)
 
-        try await Task.sleep(for: .milliseconds(180))
+        await timeoutClock.sleep(untilSuspendedBy: 1)
+        timeoutClock.advance(by: .milliseconds(180))
         await upstream.yield(.message(try makeInitializeResponse(id: retriedUpstreamID)))
+        try await spinUntilSentCount(
+            upstream,
+            count: 4,
+            description: "waiting for retried initialized notification send"
+        )
 
-        _ = try await waitWithTimeout(
-            "retry initialize should still succeed after original timeout window passes",
-            timeout: .seconds(2)
-        ) {
-            try await future.get()
-        }
+        let response = try decodeJSON(from: try await future.get())
+        #expect(response["result"] != nil, "initializeResponse=\(response)")
     }
 
     @Test func sessionManagerRunsSecondaryWarmupAfterRecoveredInitializedNotification()
@@ -521,8 +559,14 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let timeoutClock = TestClock()
         let config = makeConfig(requestTimeout: 1)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            scheduleRuntimeTimeout: makeDeterministicRuntimeTimeoutScheduler(clock: timeoutClock)
+        )
         defer { manager.shutdown() }
 
         let request = makeInitializeRequest(id: 1)
@@ -531,19 +575,21 @@ struct RuntimeCoordinatorTests {
             requestObject: request,
             on: eventLoop
         )
-        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+
+        try await spinUntilSentCount(
+            upstream,
+            count: 1,
+            description: "waiting for initial initialize request"
+        )
         #expect((await upstream.sent()).count == 1)
 
-        do {
-            _ = try await waitWithTimeout(
-                "initialize request should fail with TimeoutError",
-                timeout: .seconds(2)
-            ) {
-                try await future.get()
-            }
-            #expect(Bool(false))
-        } catch {
-            #expect(error is TimeoutError)
+        await timeoutClock.sleep(untilSuspendedBy: 1)
+        timeoutClock.advance(by: .seconds(1))
+        try await spinUntil("waiting for initialize timeout state reset") {
+            manager.testStateSnapshot().initInFlight == false
+        }
+        await #expect(throws: TimeoutError.self) {
+            try await future.get()
         }
 
         _ = manager.registerInitialize(
@@ -551,7 +597,11 @@ struct RuntimeCoordinatorTests {
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
-        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
+        try await spinUntilSentCount(
+            upstream,
+            count: 2,
+            description: "waiting for second initialize request after timeout reset"
+        )
         #expect((await upstream.sent()).count == 2)
     }
 
@@ -854,18 +904,31 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let timeoutClock = TestClock()
         var config = makeConfig(requestTimeout: 0.1)
         config.configPath = configPath
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            scheduleRuntimeTimeout: makeDeterministicRuntimeTimeoutScheduler(clock: timeoutClock)
+        )
         defer { manager.shutdown() }
 
-        _ = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                let snapshot = manager.testStateSnapshot()
-                return snapshot.initInFlight == false && snapshot.hasInitResult == false
-            }
+        try await spinUntilSentCount(
+            upstream,
+            count: 1,
+            description: "waiting for eager initialize request"
         )
+        await timeoutClock.sleep(untilSuspendedBy: 1)
+        timeoutClock.advance(by: .milliseconds(100))
+        try await spinUntil("waiting for eager initialize timeout") {
+            let snapshot = manager.testStateSnapshot()
+            return snapshot.initInFlight == false && snapshot.hasInitResult == false
+        }
+        let snapshot = manager.testStateSnapshot()
+        #expect(snapshot.initInFlight == false)
+        #expect(snapshot.hasInitResult == false)
 
         _ = manager.registerInitialize(
             originalID: RPCID(any: NSNumber(value: 1))!,
@@ -885,7 +948,12 @@ struct RuntimeCoordinatorTests {
             on: eventLoop
         )
 
-        let resent = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream,
+            count: 2,
+            description: "waiting for resent initialize request"
+        )
+        let resent = try #require(await upstream.sentValue(at: 1))
         let object = try JSONSerialization.jsonObject(with: resent, options: []) as? [String: Any]
         let params = try #require(object?["params"] as? [String: Any])
         let clientInfo = try #require(params["clientInfo"] as? [String: Any])
@@ -1747,8 +1815,14 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let uptimeClock = TestUptimeClock(nowUptimeNanoseconds: 20_000_000_000)
         let config = makeConfig(requestTimeout: 2)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            nowUptimeNanoseconds: { uptimeClock.now() }
+        )
         defer { manager.shutdown() }
 
         let initFuture = manager.registerInitialize(
@@ -1756,11 +1830,20 @@ struct RuntimeCoordinatorTests {
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
-        let initRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream,
+            count: 1,
+            description: "waiting for eager initialize request"
+        )
+        let initRequest = try #require(await upstream.sentValue(at: 0))
         let initUpstreamID = try extractUpstreamID(from: initRequest)
         await upstream.yield(.message(try makeInitializeResponse(id: initUpstreamID)))
         _ = try await initFuture.get()
-        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
+        try await spinUntilSentCount(
+            upstream,
+            count: 2,
+            description: "waiting for initialized notification"
+        )
 
         _ = manager.upstreamSelectionPolicy.markRequestTimedOut(upstreamIndex: 0, nowUptimeNs: 0)
         _ = manager.upstreamSelectionPolicy.markRequestTimedOut(upstreamIndex: 0, nowUptimeNs: 0)
@@ -1786,7 +1869,12 @@ struct RuntimeCoordinatorTests {
             try await future.get()
         }
 
-        let probe = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream,
+            count: 3,
+            description: "waiting for recovery probe request"
+        )
+        let probe = try #require(await upstream.sentValue(at: 2))
         #expect(methodName(from: probe) == "tools/list")
     }
 
@@ -1796,11 +1884,13 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let uptimeClock = TestUptimeClock(nowUptimeNanoseconds: 20_000_000_000)
         let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
             config: config,
             eventLoop: eventLoop,
-            upstreams: [upstream0, upstream1]
+            upstreams: [upstream0, upstream1],
+            nowUptimeNanoseconds: { uptimeClock.now() }
         )
         defer { manager.shutdown() }
 
@@ -1809,13 +1899,27 @@ struct RuntimeCoordinatorTests {
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
-        let init0 = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream0,
+            count: 1,
+            description: "waiting for primary initialize request"
+        )
+        let init0 = try #require(await upstream0.sentValue(at: 0))
         let init0ID = try extractUpstreamID(from: init0)
         await upstream0.yield(.message(try makeInitializeResponse(id: init0ID)))
         _ = try await initFuture.get()
-        try await waitForSentCount(upstream0, count: 2, timeoutSeconds: 2)
+        try await spinUntilSentCount(
+            upstream0,
+            count: 2,
+            description: "waiting for primary initialized notification"
+        )
 
-        let warmInitialize = try await sentValue(from: upstream1, at: 0, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream1,
+            count: 1,
+            description: "waiting for secondary warm initialize request"
+        )
+        let warmInitialize = try #require(await upstream1.sentValue(at: 0))
         let warmInitID = try extractUpstreamID(from: warmInitialize)
 
         let activeDescriptor = SessionPipelineRequestDescriptor(
@@ -1843,8 +1947,12 @@ struct RuntimeCoordinatorTests {
         _ = activeFuture
 
         await upstream1.yield(.message(try makeInitializeResponse(id: warmInitID)))
-        try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
-        let initializedNotification = try await sentValue(from: upstream1, at: 1, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream1,
+            count: 2,
+            description: "waiting for secondary initialized notification"
+        )
+        let initializedNotification = try #require(await upstream1.sentValue(at: 1))
         #expect(methodName(from: initializedNotification) == "notifications/initialized")
 
         _ = manager.upstreamSelectionPolicy.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
@@ -1882,11 +1990,16 @@ struct RuntimeCoordinatorTests {
             return eventLoop.makeSucceededFuture(())
         }
 
-        try await waitForCondition(timeoutSeconds: 2) {
+        try await spinUntil("waiting for queued request to be visible") {
             manager.debugSnapshot().queuedRequestCount == 1
         }
 
-        let probeRequest = try await sentValue(from: upstream1, at: 2, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream1,
+            count: 3,
+            description: "waiting for recovery probe request"
+        )
+        let probeRequest = try #require(await upstream1.sentValue(at: 2))
         #expect(methodName(from: probeRequest) == "tools/list")
         let probeID = try extractUpstreamID(from: probeRequest)
         let probeResponse: [String: Any] = [
@@ -1901,7 +2014,12 @@ struct RuntimeCoordinatorTests {
         )
 
         _ = try await queuedFuture.get()
-        let queuedRequest = try await sentValue(from: upstream1, at: 3, timeout: .seconds(2))
+        try await spinUntilSentCount(
+            upstream1,
+            count: 4,
+            description: "waiting for queued request dispatch after probe recovery"
+        )
+        let queuedRequest = try #require(await upstream1.sentValue(at: 3))
         #expect(methodName(from: queuedRequest) == "tools/list")
         #expect(try extractUpstreamID(from: queuedRequest) == 99)
 
@@ -3975,6 +4093,44 @@ private func waitForSentCount(
     } catch {
         let actual = await upstream.sentCount()
         throw WaitForSentCountError.timeout(expected: count, actual: actual)
+    }
+}
+
+private func makeDeterministicRuntimeTimeoutScheduler(
+    clock: TestClock
+) -> @Sendable (TimeAmount, @escaping @Sendable () -> Void) -> RuntimeScheduledTimeout {
+    { amount, operation in
+        let task = Task {
+            do {
+                try await clock.sleep(for: .nanoseconds(amount.nanoseconds))
+                operation()
+            } catch {
+                return
+            }
+        }
+        return RuntimeScheduledTimeout {
+            task.cancel()
+        }
+    }
+}
+
+private func spinUntilSentCount(
+    _ upstream: TestUpstreamClient,
+    count: Int,
+    description: String
+) async throws {
+    try await spinUntil(description, maxIterations: 1_000) {
+        await upstream.sentCount() >= count
+    }
+}
+
+private func spinUntilSentCount(
+    _ upstream: ToggleableOverloadUpstreamClient,
+    count: Int,
+    description: String
+) async throws {
+    try await spinUntil(description, maxIterations: 1_000) {
+        await upstream.sentCount() >= count
     }
 }
 


### PR DESCRIPTION
Summary:
- add deterministic test support utilities for manual clocks, isolated HTTP sessions, and runtime timeout scheduling
- move `RefreshCodeIssuesCoordinator` queue/timeout/cancellation coverage into direct deterministic tests and remove that logic from the HTTP handler integration suite
- refactor `RuntimeCoordinator` timeout, retry, quarantine, and recovery tests to use injected manual scheduling while keeping process/stdio/real HTTP integration tests timeout-backed
- declare the direct `NIOConcurrencyHelpers` dependency for `ProxyFeatureXcode` so explicit target-dependency builds keep compiling

Testing:
- `swift test --filter 'RefreshCodeIssuesCoordinatorTests|RuntimeCoordinatorTests/sessionManagerTimeoutResetsInitState|RuntimeCoordinatorTests/sessionManagerCancelsOriginalInitTimeoutBeforeRetryingInitializedNotificationOverload|RuntimeCoordinatorTests/sessionManagerUsesConfiguredInitializeParamsAfterEagerInitTimesOut|RuntimeCoordinatorTests/sessionManagerEnqueueOnUpstreamSlotStartsRecoveryProbeWhenAllUpstreamsAreQuarantined|RuntimeCoordinatorTests/sessionManagerQueuedRequestStartsProbeForExpiredQuarantinedUpstream' -Xswiftc -strict-concurrency=minimal`
- `swift test --filter 'HTTPHandlerTests|HTTPConcurrencyTests|CLICommandIntegrationTests|StdioAdapterIntegrationTests|ProcessRunnerTests|RefreshCodeIssuesCoordinatorTests|RuntimeCoordinatorTests/sessionManagerTimeoutResetsInitState|RuntimeCoordinatorTests/sessionManagerCancelsOriginalInitTimeoutBeforeRetryingInitializedNotificationOverload|RuntimeCoordinatorTests/sessionManagerUsesConfiguredInitializeParamsAfterEagerInitTimesOut|RuntimeCoordinatorTests/sessionManagerEnqueueOnUpstreamSlotStartsRecoveryProbeWhenAllUpstreamsAreQuarantined|RuntimeCoordinatorTests/sessionManagerQueuedRequestStartsProbeForExpiredQuarantinedUpstream' -Xswiftc -strict-concurrency=minimal`
- `swift test --parallel --num-workers 24 --filter 'CLICommandIntegrationTests/cliCommandRoundTripsJSONOverStubHTTPServer|HTTPConcurrencyTests/httpConcurrentInitializeRequests|HTTPHandlerTests/httpDebugUpstreamsIncludesActiveRefreshCodeIssuesState|HTTPHandlerTests/httpNonTargetToolsCallDoesNotUseRefreshRetryPath|HTTPHandlerTests/httpRefreshCodeIssuesDoesNotRetryNonRetryableToolError|HTTPHandlerTests/httpRefreshCodeIssuesFallsBackToUpstreamWhenNavigatorIssuesFails|HTTPHandlerTests/httpRefreshCodeIssuesFallsBackToUpstreamWhenResolverCannotFindTarget|HTTPHandlerTests/httpRefreshCodeIssuesFallsBackToUpstreamWhenWindowLookupFailsAfterPreviousSuccess|HTTPHandlerTests/httpRefreshCodeIssuesFallsBackToUpstreamWithUnlimitedTimeout|HTTPHandlerTests/httpRefreshCodeIssuesRequeuesLeaseAcrossRetryAttempts|HTTPHandlerTests/httpRefreshCodeIssuesRetriesShortSourceEditorErrorFiveText|HTTPHandlerTests/httpRefreshCodeIssuesRetriesSourceEditorErrorFive|HTTPHandlerTests/httpRefreshCodeIssuesReturnsBackpressureErrorAfterQueueWaitTimeout|HTTPHandlerTests/httpRefreshCodeIssuesReturnsBackpressureErrorWhenQueueIsFull|HTTPHandlerTests/httpRefreshCodeIssuesUsesNavigatorIssuesProxyByDefault|HTTPHandlerTests/httpRefreshProxyInternalToolCallsDoNotResetUpstreamSuccessState|HTTPHandlerTests/httpRefreshProxyReturnsBackpressureErrorAfterQueueWaitTimeout|HTTPHandlerTests/httpRefreshProxyReturnsBackpressureErrorWhenQueueIsFull|HTTPHandlerTests/refreshWorkflowFallsBackToUpstreamWhenNavigatorIssuesTimesOut|ProcessRunnerTests/processRunnerDrainsLargeStdoutWithoutHanging|ProcessRunnerTests/processRunnerPreservesLargeChunkedStdoutOrder|RuntimeCoordinatorTests/sessionManagerQueuesInitializeRequests|StdioAdapterIntegrationTests/stdioAdapterDoesNotHangOnEOFWithStalledRequest' -Xswiftc -strict-concurrency=minimal` (run twice)
- `swift test -Xswiftc -strict-concurrency=minimal`
