### PR TITLE
feat: add configurable tool denylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,21 @@ Logs are written to stderr.
 | `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
 | `upstream_handshake.clientVersion` | string | `"dev"` |
 | `upstream_handshake.capabilities` | table | `{}` |
+| `tools.disabled` | array of strings | `[]` |
 
 If `clientVersion` is omitted, the proxy auto-resolves it from the Xcode `IDEChat*Version` entry matching `clientName` when available.
+
+Example:
+
+```toml
+[upstream_handshake]
+clientName = "XcodeMCPKit"
+
+[tools]
+disabled = ["RunAllTests", "RunSomeTests"]
+```
+
+Disabled tools are removed from `tools/list` and rejected on direct `tools/call` requests with a tool error. The config is loaded when the proxy starts; restart `xcode-mcp-proxy-server` after editing the file.
 
 ### Adapter: `xcode-mcp-proxy`
 

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -26,13 +26,21 @@ public struct ProxyConfig: Sendable {
     public var upstreamSessionID: String?
     public var maxBodyBytes: Int
     public var requestTimeout: TimeInterval
-    public var configPath: String?
+    public var configPath: String? {
+        didSet {
+            disabledToolNames = ProxyFileConfigLoader.loadDisabledToolNames(
+                configPath: configPath,
+                logger: ProxyLogging.make("config")
+            )
+        }
+    }
     public var transport: ProxyTransport
     public var stdioUpstreamURL: URL?
     public var stdioUpstreamSource: StdioUpstreamSource?
     public var prewarmToolsList: Bool
     public var autoApproveXcodeDialog: Bool
     public var refreshCodeIssuesMode: RefreshCodeIssuesMode
+    public var disabledToolNames: Set<String>
 
     public init(
         listenHost: String,
@@ -49,7 +57,8 @@ public struct ProxyConfig: Sendable {
         stdioUpstreamSource: StdioUpstreamSource? = nil,
         prewarmToolsList: Bool = true,
         autoApproveXcodeDialog: Bool = false,
-        refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy
+        refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy,
+        disabledToolNames: Set<String>? = nil
     ) {
         self.listenHost = listenHost
         self.listenPort = listenPort
@@ -66,6 +75,11 @@ public struct ProxyConfig: Sendable {
         self.prewarmToolsList = prewarmToolsList
         self.autoApproveXcodeDialog = autoApproveXcodeDialog
         self.refreshCodeIssuesMode = refreshCodeIssuesMode
+        self.disabledToolNames = disabledToolNames
+            ?? ProxyFileConfigLoader.loadDisabledToolNames(
+                configPath: configPath,
+                logger: ProxyLogging.make("config")
+            )
     }
 }
 

--- a/Sources/ProxyCore/ProxyFileConfig.swift
+++ b/Sources/ProxyCore/ProxyFileConfig.swift
@@ -7,37 +7,16 @@ package enum ProxyFileConfigLoader {
         configPath: String?,
         logger: Logger
     ) -> [String: JSONValue]? {
-        guard let rawPath = nonEmpty(configPath) else { return nil }
-        let expandedPath = NSString(string: rawPath).expandingTildeInPath
-        let url = URL(fileURLWithPath: expandedPath)
-
-        let data: Data
-        do {
-            data = try Data(contentsOf: url)
-        } catch {
-            logger.warning(
-                "Failed to read proxy config; using built-in initialize params",
-                metadata: [
-                    "path": .string(expandedPath),
-                    "error": .string(String(describing: error)),
-                ]
-            )
+        guard let loaded = loadRootTable(
+            configPath: configPath,
+            logger: logger,
+            readFailureMessage: "Failed to read proxy config; using built-in initialize params",
+            decodeFailureMessage: "Failed to decode proxy config; using built-in initialize params"
+        ) else {
             return nil
         }
-
-        let rootTable: TOMLTable
-        do {
-            rootTable = try TOMLTable(source: data)
-        } catch {
-            logger.warning(
-                "Failed to decode proxy config; using built-in initialize params",
-                metadata: [
-                    "path": .string(expandedPath),
-                    "error": .string(String(describing: error)),
-                ]
-            )
-            return nil
-        }
+        let expandedPath = loaded.path
+        let rootTable = loaded.table
 
         let handshakeTable: TOMLTable
         do {
@@ -143,6 +122,87 @@ package enum ProxyFileConfigLoader {
         return params.isEmpty ? nil : params
     }
 
+    package static func loadDisabledToolNames(
+        configPath: String?,
+        logger: Logger
+    ) -> Set<String> {
+        guard let loaded = loadRootTable(
+            configPath: configPath,
+            logger: logger,
+            readFailureMessage: "Failed to read proxy config; ignoring disabled tools",
+            decodeFailureMessage: "Failed to decode proxy config; ignoring disabled tools"
+        ) else {
+            return []
+        }
+        let expandedPath = loaded.path
+        let rootTable = loaded.table
+
+        guard rootTable.contains(key: "tools") else {
+            return []
+        }
+
+        let toolsTable: TOMLTable
+        do {
+            toolsTable = try rootTable.table(forKey: "tools")
+        } catch {
+            logger.warning(
+                "Proxy config tools is invalid; ignoring disabled tools",
+                metadata: [
+                    "path": .string(expandedPath),
+                    "error": .string(String(describing: error)),
+                ]
+            )
+            return []
+        }
+
+        guard toolsTable.contains(key: "disabled") else {
+            return []
+        }
+
+        let toolsObject: [String: Any]
+        do {
+            toolsObject = try Dictionary(toolsTable)
+        } catch {
+            logger.warning(
+                "Failed to materialize proxy config tools; ignoring disabled tools",
+                metadata: [
+                    "path": .string(expandedPath),
+                    "error": .string(String(describing: error)),
+                ]
+            )
+            return []
+        }
+
+        guard let rawDisabled = toolsObject["disabled"] else {
+            return []
+        }
+        guard let disabledArray = rawDisabled as? [Any] else {
+            logger.warning(
+                "Proxy config tools.disabled is invalid; ignoring disabled tools",
+                metadata: ["path": .string(expandedPath)]
+            )
+            return []
+        }
+
+        var disabledToolNames = Set<String>()
+        for value in disabledArray {
+            guard let rawName = value as? String else {
+                logger.warning(
+                    "Proxy config tools.disabled must contain only strings; ignoring disabled tools",
+                    metadata: ["path": .string(expandedPath)]
+                )
+                return []
+            }
+            let normalizedName = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard normalizedName.isEmpty == false else {
+                continue
+            }
+            disabledToolNames.insert(normalizedName)
+        }
+
+        return disabledToolNames
+    }
+
     package static func mergeJSONObjects(
         _ base: [String: JSONValue],
         overriding override: [String: JSONValue]
@@ -168,5 +228,46 @@ package enum ProxyFileConfigLoader {
             return nil
         }
         return raw
+    }
+
+    private static func loadRootTable(
+        configPath: String?,
+        logger: Logger,
+        readFailureMessage: String,
+        decodeFailureMessage: String
+    ) -> (path: String, table: TOMLTable)? {
+        guard let rawPath = nonEmpty(configPath) else { return nil }
+        let expandedPath = NSString(string: rawPath).expandingTildeInPath
+        let url = URL(fileURLWithPath: expandedPath)
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            logger.warning(
+                "\(readFailureMessage)",
+                metadata: [
+                    "path": .string(expandedPath),
+                    "error": .string(String(describing: error)),
+                ]
+            )
+            return nil
+        }
+
+        let rootTable: TOMLTable
+        do {
+            rootTable = try TOMLTable(source: data)
+        } catch {
+            logger.warning(
+                "\(decodeFailureMessage)",
+                metadata: [
+                    "path": .string(expandedPath),
+                    "error": .string(String(describing: error)),
+                ]
+            )
+            return nil
+        }
+
+        return (expandedPath, rootTable)
     }
 }

--- a/Sources/ProxyFeatureXcode/RefreshCodeIssuesToolsListRewriter.swift
+++ b/Sources/ProxyFeatureXcode/RefreshCodeIssuesToolsListRewriter.swift
@@ -4,7 +4,8 @@ import ProxyCore
 package enum RefreshCodeIssuesToolsListRewriter {
     package static func rewriteResult(
         _ result: JSONValue,
-        mode: RefreshCodeIssuesMode
+        mode: RefreshCodeIssuesMode,
+        hiddenToolNames: Set<String> = []
     ) -> JSONValue {
         guard case .object(var resultObject) = result,
             case .array(let tools) = resultObject["tools"]
@@ -12,11 +13,17 @@ package enum RefreshCodeIssuesToolsListRewriter {
             return result
         }
 
-        let rewrittenTools = tools.map { toolValue in
-            guard case .object(var toolObject) = toolValue,
-                case .string(let name) = toolObject["name"],
-                name == RefreshCodeIssuesRequest.toolName
-            else {
+        let rewrittenTools = tools.compactMap { toolValue -> JSONValue? in
+            guard case .object(var toolObject) = toolValue else {
+                return toolValue
+            }
+            guard case .string(let name) = toolObject["name"] else {
+                return toolValue
+            }
+            guard hiddenToolNames.contains(name) == false else {
+                return nil
+            }
+            guard name == RefreshCodeIssuesRequest.toolName else {
                 return toolValue
             }
             toolObject["description"] = .string(description(for: mode))
@@ -28,7 +35,8 @@ package enum RefreshCodeIssuesToolsListRewriter {
 
     package static func rewriteResponseDataIfNeeded(
         _ responseData: Data,
-        mode: RefreshCodeIssuesMode
+        mode: RefreshCodeIssuesMode,
+        hiddenToolNames: Set<String> = []
     ) -> Data {
         guard
             let object = try? JSONSerialization.jsonObject(with: responseData, options: [])
@@ -39,7 +47,11 @@ package enum RefreshCodeIssuesToolsListRewriter {
             return responseData
         }
 
-        let rewrittenResult = rewriteResult(resultValue, mode: mode)
+        let rewrittenResult = rewriteResult(
+            resultValue,
+            mode: mode,
+            hiddenToolNames: hiddenToolNames
+        )
         guard rewrittenResult.foundationObject as? [String: Any] != nil else {
             return responseData
         }

--- a/Sources/ProxyHTTPTransport/HTTPPostService.swift
+++ b/Sources/ProxyHTTPTransport/HTTPPostService.swift
@@ -111,10 +111,9 @@ package final class HTTPPostCancellationHandle: @unchecked Sendable {
 }
 
 package final class HTTPPostService: Sendable {
-    private struct FilteredToolCallRequest {
+    private struct FilteredToolCallRequest: Sendable {
         let bodyData: Data?
-        let requestJSON: Any?
-        let localResponseObjects: [[String: Any]]
+        let localResponseData: Data?
         let forwardedResponseIDs: [RPCID]
         let forceBatchArray: Bool
     }
@@ -258,27 +257,86 @@ package final class HTTPPostService: Sendable {
             )
         }
 
+        let filteredRequest: FilteredToolCallRequest
+        do {
+            filteredRequest = try filterDisabledToolCalls(
+                bodyData: bodyData,
+                parsedRequestJSON: parsedRequestJSON,
+                forceBatchArray: requestIsBatch
+            )
+        } catch {
+            return HTTPPostOperation(
+                future: eventLoop.makeSucceededFuture(
+                    .mcpError(
+                        id: nil,
+                        ids: [],
+                        code: -32700,
+                        message: "invalid json",
+                        forceBatchArray: false,
+                        sessionID: sessionID,
+                        prefersEventStream: prefersEventStream
+                    )
+                ),
+                cancellationHandle: nil
+            )
+        }
+
+        guard let forwardedBodyData = filteredRequest.bodyData else {
+            return HTTPPostOperation(
+                future: eventLoop.makeSucceededFuture(
+                    Self.makeLocalResponseResolution(
+                        responseData: filteredRequest.localResponseData,
+                        sessionID: sessionID,
+                        prefersEventStream: prefersEventStream,
+                        emptyStatus: .accepted
+                    )
+                ),
+                cancellationHandle: nil
+            )
+        }
+
+        let forwardedRequestJSON: Any
+        do {
+            forwardedRequestJSON = try JSONSerialization.jsonObject(with: forwardedBodyData, options: [])
+        } catch {
+            return HTTPPostOperation(
+                future: eventLoop.makeSucceededFuture(
+                    .mcpError(
+                        id: nil,
+                        ids: [],
+                        code: -32700,
+                        message: "invalid json",
+                        forceBatchArray: false,
+                        sessionID: sessionID,
+                        prefersEventStream: prefersEventStream
+                    )
+                ),
+                cancellationHandle: nil
+            )
+        }
+
+        let forwardedRequestIDs = filteredRequest.forwardedResponseIDs
+        let localResponseData = filteredRequest.localResponseData
         let descriptor = Self.topLevelRequestDescriptor(
             sessionID: sessionID,
-            parsedRequestJSON: parsedRequestJSON,
+            parsedRequestJSON: forwardedRequestJSON,
             requestIsBatch: requestIsBatch,
-            requestIDs: requestIDs
+            requestIDs: forwardedRequestIDs
         )
         let leaseID = sessionManager.createRequestLease(descriptor: descriptor)
         let cancellationHandle = HTTPPostCancellationHandle(
             leaseID: leaseID,
             sessionID: sessionID,
-            requestIDKeys: requestIDs.map(\.key)
+            requestIDKeys: forwardedRequestIDs.map(\.key)
         )
         let session = sessionManager.session(id: sessionID)
-        let refreshRequest = requestIsBatch ? nil : refreshCodeIssuesRequest(from: parsedRequestJSON)
-        if refreshRequest != nil, requestIDs.isEmpty == false {
+        let refreshRequest = requestIsBatch ? nil : refreshCodeIssuesRequest(from: forwardedRequestJSON)
+        if refreshRequest != nil, forwardedRequestIDs.isEmpty == false {
             return HTTPPostOperation(
                 future: makeTopLevelRequestFuture(
-                    bodyData: bodyData,
+                    filteredRequest: filteredRequest,
                     sessionID: sessionID,
                     headerSessionID: headerSessionID,
-                    requestIDs: requestIDs,
                     requestIsBatch: requestIsBatch,
                     prefersEventStream: prefersEventStream,
                     eventLoop: eventLoop,
@@ -304,10 +362,9 @@ package final class HTTPPostService: Sendable {
                 timeout: nil
             )
             return self.makeTopLevelRequestFuture(
-                bodyData: bodyData,
+                filteredRequest: filteredRequest,
                 sessionID: sessionID,
                 headerSessionID: headerSessionID,
-                requestIDs: requestIDs,
                 requestIsBatch: requestIsBatch,
                 prefersEventStream: prefersEventStream,
                 eventLoop: eventLoop,
@@ -326,7 +383,22 @@ package final class HTTPPostService: Sendable {
                 terminalState: .failed,
                 reason: .upstreamOverloaded
             )
-            if requestIDs.isEmpty {
+            if localResponseData != nil {
+                return eventLoop.makeSucceededFuture(
+                    Self.makePartialBatchErrorResolution(
+                        localResponseData: localResponseData,
+                        responseIDs: forwardedRequestIDs,
+                        code: -32001,
+                        message: "upstream unavailable",
+                        sessionID: sessionID,
+                        prefersEventStream: prefersEventStream,
+                        forceBatchArray: filteredRequest.forceBatchArray,
+                        fallbackStatus: .serviceUnavailable,
+                        fallbackBody: "upstream unavailable"
+                    )
+                )
+            }
+            if forwardedRequestIDs.isEmpty {
                 return eventLoop.makeSucceededFuture(
                     .plain(
                         status: .serviceUnavailable,
@@ -338,7 +410,7 @@ package final class HTTPPostService: Sendable {
             return eventLoop.makeSucceededFuture(
                 .mcpError(
                     id: nil,
-                    ids: requestIDs,
+                    ids: forwardedRequestIDs,
                     code: -32001,
                     message: "upstream unavailable",
                     forceBatchArray: requestIsBatch,
@@ -354,10 +426,9 @@ package final class HTTPPostService: Sendable {
     }
 
     private func makeTopLevelRequestFuture(
-        bodyData: Data,
+        filteredRequest: FilteredToolCallRequest,
         sessionID: String,
         headerSessionID: String?,
-        requestIDs: [RPCID],
         requestIsBatch: Bool,
         prefersEventStream: Bool,
         eventLoop: EventLoop,
@@ -366,19 +437,14 @@ package final class HTTPPostService: Sendable {
         upstreamIndex: Int,
         cancellationHandle: HTTPPostCancellationHandle?
     ) -> EventLoopFuture<HTTPPostResolution> {
-        let parsedRequestJSON: Any
-        do {
-            parsedRequestJSON = try JSONSerialization.jsonObject(with: bodyData, options: [])
-        } catch {
+        guard let forwardedBodyData = filteredRequest.bodyData
+        else {
             return makeImmediateLeaseResolution(
-                .mcpError(
-                id: nil,
-                ids: [],
-                code: -32700,
-                message: "invalid json",
-                forceBatchArray: false,
-                sessionID: sessionID,
-                prefersEventStream: prefersEventStream
+                Self.makeLocalResponseResolution(
+                    responseData: filteredRequest.localResponseData,
+                    sessionID: sessionID,
+                    prefersEventStream: prefersEventStream,
+                    emptyStatus: .accepted
                 ),
                 leaseID: leaseID,
                 eventLoop: eventLoop,
@@ -386,13 +452,9 @@ package final class HTTPPostService: Sendable {
             )
         }
 
-        let filteredRequest: FilteredToolCallRequest
+        let forwardedRequestJSON: Any
         do {
-            filteredRequest = try filterDisabledToolCalls(
-                bodyData: bodyData,
-                parsedRequestJSON: parsedRequestJSON,
-                forceBatchArray: requestIsBatch
-            )
+            forwardedRequestJSON = try JSONSerialization.jsonObject(with: forwardedBodyData, options: [])
         } catch {
             return makeImmediateLeaseResolution(
                 .mcpError(
@@ -410,35 +472,15 @@ package final class HTTPPostService: Sendable {
             )
         }
 
-        guard let forwardedRequestJSON = filteredRequest.requestJSON,
-            let forwardedBodyData = filteredRequest.bodyData
-        else {
-            return makeImmediateLeaseResolution(
-                Self.makeLocalToolResponseResolution(
-                    localResponseObjects: filteredRequest.localResponseObjects,
-                    sessionID: sessionID,
-                    prefersEventStream: prefersEventStream,
-                    forceBatchArray: filteredRequest.forceBatchArray
-                ),
-                leaseID: leaseID,
-                eventLoop: eventLoop,
-                cancellationHandle: cancellationHandle
-            )
-        }
-
-        let localResponseObjects = filteredRequest.localResponseObjects
-        let localResponseData = Self.makeToolResponseData(
-            from: localResponseObjects,
-            forceBatchArray: requestIsBatch
-        )
+        let localResponseData = filteredRequest.localResponseData
         let refreshRequest = requestIsBatch ? nil : refreshCodeIssuesRequest(from: forwardedRequestJSON)
 
-        if let refreshRequest, requestIDs.isEmpty == false {
+        if let refreshRequest, filteredRequest.forwardedResponseIDs.isEmpty == false {
             if headerSessionID == nil {
                 return makeImmediateLeaseResolution(
                     .mcpError(
                     id: nil,
-                    ids: requestIDs,
+                    ids: filteredRequest.forwardedResponseIDs,
                     code: -32000,
                     message: "expected initialize request",
                     forceBatchArray: requestIsBatch,
@@ -457,7 +499,7 @@ package final class HTTPPostService: Sendable {
                     refreshRequest,
                     bodyData: forwardedBodyData,
                     sessionID: sessionID,
-                    requestIDs: requestIDs,
+                    requestIDs: filteredRequest.forwardedResponseIDs,
                     requestIsBatch: requestIsBatch,
                     eventLoop: eventLoop,
                     leaseID: leaseID,
@@ -492,7 +534,7 @@ package final class HTTPPostService: Sendable {
                 sessionID: sessionID,
                 upstreamIndexOverride: upstreamIndex
             ) else {
-                if localResponseObjects.isEmpty == false {
+                if localResponseData != nil {
                     return makeImmediateLeaseResolution(
                         Self.makePartialBatchErrorResolution(
                             localResponseData: localResponseData,
@@ -510,7 +552,7 @@ package final class HTTPPostService: Sendable {
                         cancellationHandle: cancellationHandle
                     )
                 }
-                if requestIDs.isEmpty {
+                if filteredRequest.forwardedResponseIDs.isEmpty {
                     return makeImmediateLeaseResolution(
                         .plain(
                         status: .serviceUnavailable,
@@ -525,7 +567,7 @@ package final class HTTPPostService: Sendable {
                 return makeImmediateLeaseResolution(
                     .mcpError(
                     id: nil,
-                    ids: requestIDs,
+                    ids: filteredRequest.forwardedResponseIDs,
                     code: -32001,
                     message: "upstream unavailable",
                     forceBatchArray: requestIsBatch,
@@ -763,11 +805,11 @@ package final class HTTPPostService: Sendable {
             ensureRunning: false
         )
         return makeImmediateLeaseResolution(
-            Self.makeNotificationResolution(
-                localResponseObjects: localResponseObjects,
+            Self.makeLocalResponseResolution(
+                responseData: localResponseData,
                 sessionID: sessionID,
                 prefersEventStream: prefersEventStream,
-                forceBatchArray: filteredRequest.forceBatchArray
+                emptyStatus: .accepted
             ),
             leaseID: leaseID,
             eventLoop: eventLoop,
@@ -852,8 +894,7 @@ package final class HTTPPostService: Sendable {
         guard disabledToolNames.isEmpty == false else {
             return FilteredToolCallRequest(
                 bodyData: bodyData,
-                requestJSON: parsedRequestJSON,
-                localResponseObjects: [],
+                localResponseData: nil,
                 forwardedResponseIDs: Self.extractResponseIDs(from: parsedRequestJSON),
                 forceBatchArray: forceBatchArray
             )
@@ -863,21 +904,21 @@ package final class HTTPPostService: Sendable {
             guard let toolName = blockedToolName(from: object) else {
                 return FilteredToolCallRequest(
                     bodyData: bodyData,
-                    requestJSON: parsedRequestJSON,
-                    localResponseObjects: [],
+                    localResponseData: nil,
                     forwardedResponseIDs: Self.extractResponseIDs(from: parsedRequestJSON),
                     forceBatchArray: forceBatchArray
                 )
             }
 
-            let localResponseObjects = Self.makeBlockedToolResponseObjects(
-                requestObject: object,
-                toolName: toolName
-            )
             return FilteredToolCallRequest(
                 bodyData: nil,
-                requestJSON: nil,
-                localResponseObjects: localResponseObjects,
+                localResponseData: Self.makeToolResponseData(
+                    from: Self.makeBlockedToolResponseObjects(
+                        requestObject: object,
+                        toolName: toolName
+                    ),
+                    forceBatchArray: forceBatchArray
+                ),
                 forwardedResponseIDs: [],
                 forceBatchArray: forceBatchArray
             )
@@ -886,8 +927,7 @@ package final class HTTPPostService: Sendable {
         guard let array = parsedRequestJSON as? [Any] else {
             return FilteredToolCallRequest(
                 bodyData: bodyData,
-                requestJSON: parsedRequestJSON,
-                localResponseObjects: [],
+                localResponseData: nil,
                 forwardedResponseIDs: [],
                 forceBatchArray: forceBatchArray
             )
@@ -913,21 +953,24 @@ package final class HTTPPostService: Sendable {
             )
         }
 
+        let localResponseData = Self.makeToolResponseData(
+            from: localResponseObjects,
+            forceBatchArray: forceBatchArray
+        )
+
         guard forwardedObjects.isEmpty == false else {
             return FilteredToolCallRequest(
                 bodyData: nil,
-                requestJSON: nil,
-                localResponseObjects: localResponseObjects,
+                localResponseData: localResponseData,
                 forwardedResponseIDs: [],
                 forceBatchArray: forceBatchArray
             )
         }
 
-        if localResponseObjects.isEmpty {
+        if localResponseData == nil {
             return FilteredToolCallRequest(
                 bodyData: bodyData,
-                requestJSON: parsedRequestJSON,
-                localResponseObjects: [],
+                localResponseData: nil,
                 forwardedResponseIDs: Self.extractResponseIDs(from: parsedRequestJSON),
                 forceBatchArray: forceBatchArray
             )
@@ -939,8 +982,7 @@ package final class HTTPPostService: Sendable {
         )
         return FilteredToolCallRequest(
             bodyData: filteredBodyData,
-            requestJSON: forwardedObjects,
-            localResponseObjects: localResponseObjects,
+            localResponseData: localResponseData,
             forwardedResponseIDs: Self.extractResponseIDs(from: forwardedObjects),
             forceBatchArray: forceBatchArray
         )
@@ -1417,39 +1459,19 @@ package final class HTTPPostService: Sendable {
         return false
     }
 
-    private static func makeLocalToolResponseResolution(
-        localResponseObjects: [[String: Any]],
+    private static func makeLocalResponseResolution(
+        responseData: Data?,
         sessionID: String,
         prefersEventStream: Bool,
-        forceBatchArray: Bool
+        emptyStatus: HTTPResponseStatus
     ) -> HTTPPostResolution {
-        guard let responseData = makeToolResponseData(
-            from: localResponseObjects,
-            forceBatchArray: forceBatchArray
-        ) else {
-            return .empty(status: .accepted, sessionID: sessionID)
+        guard let responseData else {
+            return .empty(status: emptyStatus, sessionID: sessionID)
         }
         return .responseData(
             data: responseData,
             sessionID: sessionID,
             prefersEventStream: prefersEventStream
-        )
-    }
-
-    private static func makeNotificationResolution(
-        localResponseObjects: [[String: Any]],
-        sessionID: String,
-        prefersEventStream: Bool,
-        forceBatchArray: Bool
-    ) -> HTTPPostResolution {
-        guard localResponseObjects.isEmpty == false else {
-            return .empty(status: .accepted, sessionID: sessionID)
-        }
-        return makeLocalToolResponseResolution(
-            localResponseObjects: localResponseObjects,
-            sessionID: sessionID,
-            prefersEventStream: prefersEventStream,
-            forceBatchArray: forceBatchArray
         )
     }
 

--- a/Sources/ProxyHTTPTransport/HTTPPostService.swift
+++ b/Sources/ProxyHTTPTransport/HTTPPostService.swift
@@ -111,7 +111,16 @@ package final class HTTPPostCancellationHandle: @unchecked Sendable {
 }
 
 package final class HTTPPostService: Sendable {
+    private struct FilteredToolCallRequest {
+        let bodyData: Data?
+        let requestJSON: Any?
+        let localResponseObjects: [[String: Any]]
+        let forwardedResponseIDs: [RPCID]
+        let forceBatchArray: Bool
+    }
+
     private let sessionManager: any RuntimeCoordinating
+    private let disabledToolNames: Set<String>
     private let localResponder: LocalMCPResponder
     private let forwardingService: MCPForwardingService
     private let windowQueryService: XcodeWindowQueryService
@@ -129,9 +138,11 @@ package final class HTTPPostService: Sendable {
     ) {
         self.requestTimeoutSeconds = config.requestTimeout
         self.sessionManager = sessionManager
+        self.disabledToolNames = config.disabledToolNames
         self.localResponder = LocalMCPResponder(
             sessionManager: sessionManager,
             refreshCodeIssuesMode: config.refreshCodeIssuesMode,
+            disabledToolNames: config.disabledToolNames,
             logger: ProxyLogging.make("http.local")
         )
         self.forwardingService = MCPForwardingService(
@@ -228,6 +239,21 @@ package final class HTTPPostService: Sendable {
                         prefersEventStream: prefersEventStream
                     )
                 ),
+                cancellationHandle: nil
+            )
+        }
+
+        if headerSessionID == nil,
+            let initializeResolution = Self.makeMissingInitializeResolution(
+                parsedRequestJSON: parsedRequestJSON,
+                requestIDs: requestIDs,
+                requestIsBatch: requestIsBatch,
+                sessionID: sessionID,
+                prefersEventStream: prefersEventStream
+            )
+        {
+            return HTTPPostOperation(
+                future: eventLoop.makeSucceededFuture(initializeResolution),
                 cancellationHandle: nil
             )
         }
@@ -360,7 +386,52 @@ package final class HTTPPostService: Sendable {
             )
         }
 
-        let refreshRequest = requestIsBatch ? nil : refreshCodeIssuesRequest(from: parsedRequestJSON)
+        let filteredRequest: FilteredToolCallRequest
+        do {
+            filteredRequest = try filterDisabledToolCalls(
+                bodyData: bodyData,
+                parsedRequestJSON: parsedRequestJSON,
+                forceBatchArray: requestIsBatch
+            )
+        } catch {
+            return makeImmediateLeaseResolution(
+                .mcpError(
+                    id: nil,
+                    ids: [],
+                    code: -32700,
+                    message: "invalid json",
+                    forceBatchArray: false,
+                    sessionID: sessionID,
+                    prefersEventStream: prefersEventStream
+                ),
+                leaseID: leaseID,
+                eventLoop: eventLoop,
+                cancellationHandle: cancellationHandle
+            )
+        }
+
+        guard let forwardedRequestJSON = filteredRequest.requestJSON,
+            let forwardedBodyData = filteredRequest.bodyData
+        else {
+            return makeImmediateLeaseResolution(
+                Self.makeLocalToolResponseResolution(
+                    localResponseObjects: filteredRequest.localResponseObjects,
+                    sessionID: sessionID,
+                    prefersEventStream: prefersEventStream,
+                    forceBatchArray: filteredRequest.forceBatchArray
+                ),
+                leaseID: leaseID,
+                eventLoop: eventLoop,
+                cancellationHandle: cancellationHandle
+            )
+        }
+
+        let localResponseObjects = filteredRequest.localResponseObjects
+        let localResponseData = Self.makeToolResponseData(
+            from: localResponseObjects,
+            forceBatchArray: requestIsBatch
+        )
+        let refreshRequest = requestIsBatch ? nil : refreshCodeIssuesRequest(from: forwardedRequestJSON)
 
         if let refreshRequest, requestIDs.isEmpty == false {
             if headerSessionID == nil {
@@ -384,7 +455,7 @@ package final class HTTPPostService: Sendable {
             Task { [self] in
                 let execution = await forwardRefreshCodeIssuesRequest(
                     refreshRequest,
-                    bodyData: bodyData,
+                    bodyData: forwardedBodyData,
                     sessionID: sessionID,
                     requestIDs: requestIDs,
                     requestIsBatch: requestIsBatch,
@@ -416,11 +487,29 @@ package final class HTTPPostService: Sendable {
         let prepared: MCPForwardingService.PreparedRequest
         do {
             guard let candidate = try forwardingService.prepareRequest(
-                bodyData: bodyData,
-                parsedRequestJSON: parsedRequestJSON,
+                bodyData: forwardedBodyData,
+                parsedRequestJSON: forwardedRequestJSON,
                 sessionID: sessionID,
                 upstreamIndexOverride: upstreamIndex
             ) else {
+                if localResponseObjects.isEmpty == false {
+                    return makeImmediateLeaseResolution(
+                        Self.makePartialBatchErrorResolution(
+                            localResponseData: localResponseData,
+                            responseIDs: filteredRequest.forwardedResponseIDs,
+                            code: -32001,
+                            message: "upstream unavailable",
+                            sessionID: sessionID,
+                            prefersEventStream: prefersEventStream,
+                            forceBatchArray: filteredRequest.forceBatchArray,
+                            fallbackStatus: .serviceUnavailable,
+                            fallbackBody: "upstream unavailable"
+                        ),
+                        leaseID: leaseID,
+                        eventLoop: eventLoop,
+                        cancellationHandle: cancellationHandle
+                    )
+                }
                 if requestIDs.isEmpty {
                     return makeImmediateLeaseResolution(
                         .plain(
@@ -468,7 +557,7 @@ package final class HTTPPostService: Sendable {
 
         if prepared.transform.method == "tools/list" {
             let hasCache = sessionManager.cachedToolsListResult() != nil
-            let params = (parsedRequestJSON as? [String: Any])?["params"]
+            let params = (forwardedRequestJSON as? [String: Any])?["params"]
             let hasParams = params != nil && !(params is NSNull)
             logger.debug(
                 "tools/list cache miss; forwarding upstream",
@@ -526,7 +615,7 @@ package final class HTTPPostService: Sendable {
                     metadata: [
                         "lease_id": .string(leaseID.uuidString),
                         "session": .string(sessionID),
-                        "label": .string(Self.requestLabel(from: parsedRequestJSON)),
+                        "label": .string(Self.requestLabel(from: forwardedRequestJSON)),
                         "upstream": .string("\(prepared.upstreamIndex)"),
                         "timeout_ms": .string(
                             requestTimeoutOverride.map { "\($0.nanoseconds / 1_000_000)" }
@@ -592,7 +681,10 @@ package final class HTTPPostService: Sendable {
                     )
                     promise.succeed(
                         .responseData(
-                            data: responseData,
+                            data: Self.mergeLocalBatchResponses(
+                                into: responseData,
+                                localResponseData: localResponseData
+                            ),
                             sessionID: sessionID,
                             prefersEventStream: prefersEventStream
                         )
@@ -639,14 +731,16 @@ package final class HTTPPostService: Sendable {
                         ]
                     )
                     promise.succeed(
-                        .mcpError(
-                            id: nil,
-                            ids: started.transform.responseIDs,
+                        Self.makePartialBatchErrorResolution(
+                            localResponseData: localResponseData,
+                            responseIDs: started.transform.responseIDs,
                             code: -32000,
                             message: "upstream timeout",
-                            forceBatchArray: started.transform.isBatch,
                             sessionID: sessionID,
-                            prefersEventStream: prefersEventStream
+                            prefersEventStream: prefersEventStream,
+                            forceBatchArray: started.transform.isBatch,
+                            fallbackStatus: .ok,
+                            fallbackBody: ""
                         )
                     )
                 }
@@ -669,7 +763,12 @@ package final class HTTPPostService: Sendable {
             ensureRunning: false
         )
         return makeImmediateLeaseResolution(
-            .empty(status: .accepted, sessionID: sessionID),
+            Self.makeNotificationResolution(
+                localResponseObjects: localResponseObjects,
+                sessionID: sessionID,
+                prefersEventStream: prefersEventStream,
+                forceBatchArray: filteredRequest.forceBatchArray
+            ),
             leaseID: leaseID,
             eventLoop: eventLoop,
             cancellationHandle: cancellationHandle
@@ -743,6 +842,120 @@ package final class HTTPPostService: Sendable {
                 )
             )
         }
+    }
+
+    private func filterDisabledToolCalls(
+        bodyData: Data,
+        parsedRequestJSON: Any,
+        forceBatchArray: Bool
+    ) throws -> FilteredToolCallRequest {
+        guard disabledToolNames.isEmpty == false else {
+            return FilteredToolCallRequest(
+                bodyData: bodyData,
+                requestJSON: parsedRequestJSON,
+                localResponseObjects: [],
+                forwardedResponseIDs: Self.extractResponseIDs(from: parsedRequestJSON),
+                forceBatchArray: forceBatchArray
+            )
+        }
+
+        if let object = parsedRequestJSON as? [String: Any] {
+            guard let toolName = blockedToolName(from: object) else {
+                return FilteredToolCallRequest(
+                    bodyData: bodyData,
+                    requestJSON: parsedRequestJSON,
+                    localResponseObjects: [],
+                    forwardedResponseIDs: Self.extractResponseIDs(from: parsedRequestJSON),
+                    forceBatchArray: forceBatchArray
+                )
+            }
+
+            let localResponseObjects = Self.makeBlockedToolResponseObjects(
+                requestObject: object,
+                toolName: toolName
+            )
+            return FilteredToolCallRequest(
+                bodyData: nil,
+                requestJSON: nil,
+                localResponseObjects: localResponseObjects,
+                forwardedResponseIDs: [],
+                forceBatchArray: forceBatchArray
+            )
+        }
+
+        guard let array = parsedRequestJSON as? [Any] else {
+            return FilteredToolCallRequest(
+                bodyData: bodyData,
+                requestJSON: parsedRequestJSON,
+                localResponseObjects: [],
+                forwardedResponseIDs: [],
+                forceBatchArray: forceBatchArray
+            )
+        }
+
+        var forwardedObjects: [Any] = []
+        forwardedObjects.reserveCapacity(array.count)
+        var localResponseObjects: [[String: Any]] = []
+        localResponseObjects.reserveCapacity(array.count)
+
+        for item in array {
+            guard let object = item as? [String: Any],
+                let toolName = blockedToolName(from: object)
+            else {
+                forwardedObjects.append(item)
+                continue
+            }
+            localResponseObjects.append(
+                contentsOf: Self.makeBlockedToolResponseObjects(
+                    requestObject: object,
+                    toolName: toolName
+                )
+            )
+        }
+
+        guard forwardedObjects.isEmpty == false else {
+            return FilteredToolCallRequest(
+                bodyData: nil,
+                requestJSON: nil,
+                localResponseObjects: localResponseObjects,
+                forwardedResponseIDs: [],
+                forceBatchArray: forceBatchArray
+            )
+        }
+
+        if localResponseObjects.isEmpty {
+            return FilteredToolCallRequest(
+                bodyData: bodyData,
+                requestJSON: parsedRequestJSON,
+                localResponseObjects: [],
+                forwardedResponseIDs: Self.extractResponseIDs(from: parsedRequestJSON),
+                forceBatchArray: forceBatchArray
+            )
+        }
+
+        let filteredBodyData = try JSONSerialization.data(
+            withJSONObject: forwardedObjects,
+            options: []
+        )
+        return FilteredToolCallRequest(
+            bodyData: filteredBodyData,
+            requestJSON: forwardedObjects,
+            localResponseObjects: localResponseObjects,
+            forwardedResponseIDs: Self.extractResponseIDs(from: forwardedObjects),
+            forceBatchArray: forceBatchArray
+        )
+    }
+
+    private func blockedToolName(from requestObject: [String: Any]) -> String? {
+        guard let method = requestObject["method"] as? String,
+            method == "tools/call",
+            let params = requestObject["params"] as? [String: Any],
+            let toolName = params["name"] as? String,
+            disabledToolNames.contains(toolName)
+        else {
+            return nil
+        }
+        return toolName
     }
 
     private func refreshCodeIssuesRequest(from requestJSON: Any) -> RefreshCodeIssuesRequest? {
@@ -1160,5 +1373,298 @@ package final class HTTPPostService: Sendable {
         defaultSeconds: TimeInterval
     ) -> TimeAmount? {
         MCPMethodDispatcher.timeoutForMethod(method, defaultSeconds: defaultSeconds)
+    }
+
+    private static func makeMissingInitializeResolution(
+        parsedRequestJSON: Any,
+        requestIDs: [RPCID],
+        requestIsBatch: Bool,
+        sessionID: String,
+        prefersEventStream: Bool
+    ) -> HTTPPostResolution? {
+        guard requestRequiresInitialize(parsedRequestJSON) else {
+            return nil
+        }
+
+        if requestIDs.isEmpty {
+            return .plain(
+                status: .unprocessableEntity,
+                body: "expected initialize request",
+                sessionID: sessionID
+            )
+        }
+
+        return .mcpError(
+            id: nil,
+            ids: requestIDs,
+            code: -32000,
+            message: "expected initialize request",
+            forceBatchArray: requestIsBatch,
+            sessionID: sessionID,
+            prefersEventStream: prefersEventStream
+        )
+    }
+
+    private static func requestRequiresInitialize(_ parsedRequestJSON: Any) -> Bool {
+        if let object = parsedRequestJSON as? [String: Any] {
+            let method = object["method"] as? String
+            let expectsResponse = object["id"] != nil
+            return method != "initialize" || !expectsResponse
+        }
+        if parsedRequestJSON is [Any] {
+            return true
+        }
+        return false
+    }
+
+    private static func makeLocalToolResponseResolution(
+        localResponseObjects: [[String: Any]],
+        sessionID: String,
+        prefersEventStream: Bool,
+        forceBatchArray: Bool
+    ) -> HTTPPostResolution {
+        guard let responseData = makeToolResponseData(
+            from: localResponseObjects,
+            forceBatchArray: forceBatchArray
+        ) else {
+            return .empty(status: .accepted, sessionID: sessionID)
+        }
+        return .responseData(
+            data: responseData,
+            sessionID: sessionID,
+            prefersEventStream: prefersEventStream
+        )
+    }
+
+    private static func makeNotificationResolution(
+        localResponseObjects: [[String: Any]],
+        sessionID: String,
+        prefersEventStream: Bool,
+        forceBatchArray: Bool
+    ) -> HTTPPostResolution {
+        guard localResponseObjects.isEmpty == false else {
+            return .empty(status: .accepted, sessionID: sessionID)
+        }
+        return makeLocalToolResponseResolution(
+            localResponseObjects: localResponseObjects,
+            sessionID: sessionID,
+            prefersEventStream: prefersEventStream,
+            forceBatchArray: forceBatchArray
+        )
+    }
+
+    private static func makePartialBatchErrorResolution(
+        localResponseData: Data?,
+        responseIDs: [RPCID],
+        code: Int,
+        message: String,
+        sessionID: String,
+        prefersEventStream: Bool,
+        forceBatchArray: Bool,
+        fallbackStatus: HTTPResponseStatus,
+        fallbackBody: String
+    ) -> HTTPPostResolution {
+        guard let localResponseData else {
+            if responseIDs.isEmpty {
+                return .plain(
+                    status: fallbackStatus,
+                    body: fallbackBody,
+                    sessionID: sessionID
+                )
+            }
+            return .mcpError(
+                id: nil,
+                ids: responseIDs,
+                code: code,
+                message: message,
+                forceBatchArray: forceBatchArray,
+                sessionID: sessionID,
+                prefersEventStream: prefersEventStream
+            )
+        }
+
+        guard let localPayload = try? JSONSerialization.jsonObject(
+            with: localResponseData,
+            options: []
+        ) else {
+            if responseIDs.isEmpty {
+                return .plain(
+                    status: fallbackStatus,
+                    body: fallbackBody,
+                    sessionID: sessionID
+                )
+            }
+            return .mcpError(
+                id: nil,
+                ids: responseIDs,
+                code: code,
+                message: message,
+                forceBatchArray: forceBatchArray,
+                sessionID: sessionID,
+                prefersEventStream: prefersEventStream
+            )
+        }
+
+        let localResponseObjects: [Any]
+        if let array = localPayload as? [Any] {
+            localResponseObjects = array
+        } else if let object = localPayload as? [String: Any] {
+            localResponseObjects = [object]
+        } else {
+            localResponseObjects = []
+        }
+
+        let mergedObjects =
+            localResponseObjects
+            + responseIDs.map { makeJSONRPCErrorResponseObject(id: $0, code: code, message: message) }
+        guard JSONSerialization.isValidJSONObject(mergedObjects),
+            let responseData = try? JSONSerialization.data(
+                withJSONObject: mergedObjects,
+                options: []
+            )
+        else {
+            if responseIDs.isEmpty {
+                return .plain(
+                    status: fallbackStatus,
+                    body: fallbackBody,
+                    sessionID: sessionID
+                )
+            }
+            return .mcpError(
+                id: nil,
+                ids: responseIDs,
+                code: code,
+                message: message,
+                forceBatchArray: forceBatchArray,
+                sessionID: sessionID,
+                prefersEventStream: prefersEventStream
+            )
+        }
+
+        return .responseData(
+            data: responseData,
+            sessionID: sessionID,
+            prefersEventStream: prefersEventStream
+        )
+    }
+
+    private static func mergeLocalBatchResponses(
+        into responseData: Data,
+        localResponseData: Data?
+    ) -> Data {
+        guard let localResponseData,
+            let localPayload = try? JSONSerialization.jsonObject(
+                with: localResponseData,
+                options: []
+            )
+        else {
+            return responseData
+        }
+
+        guard let any = try? JSONSerialization.jsonObject(with: responseData, options: []) else {
+            return responseData
+        }
+
+        let mergedObjects: [Any]
+        let localResponseObjects: [Any]
+        if let array = localPayload as? [Any] {
+            localResponseObjects = array
+        } else if let object = localPayload as? [String: Any] {
+            localResponseObjects = [object]
+        } else {
+            localResponseObjects = []
+        }
+
+        if let array = any as? [Any] {
+            mergedObjects = array + localResponseObjects
+        } else if let object = any as? [String: Any] {
+            mergedObjects = [object] + localResponseObjects
+        } else {
+            return responseData
+        }
+
+        return (try? JSONSerialization.data(withJSONObject: mergedObjects, options: []))
+            ?? responseData
+    }
+
+    private static func makeBlockedToolResponseObjects(
+        requestObject: [String: Any],
+        toolName: String
+    ) -> [[String: Any]] {
+        guard let requestID = requestObject["id"], let rpcID = RPCID(any: requestID) else {
+            return []
+        }
+        return [makeToolResultErrorResponseObject(id: rpcID, toolName: toolName)]
+    }
+
+    private static func makeToolResultErrorResponseObject(
+        id: RPCID,
+        toolName: String
+    ) -> [String: Any] {
+        [
+            "jsonrpc": "2.0",
+            "id": id.value.foundationObject,
+            "result": [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "tool '\(toolName)' is disabled by proxy config",
+                    ]
+                ],
+                "isError": true,
+            ],
+        ]
+    }
+
+    private static func makeJSONRPCErrorResponseObject(
+        id: RPCID,
+        code: Int,
+        message: String
+    ) -> [String: Any] {
+        [
+            "jsonrpc": "2.0",
+            "id": id.value.foundationObject,
+            "error": [
+                "code": code,
+                "message": message,
+            ],
+        ]
+    }
+
+    private static func makeToolResponseData(
+        from responseObjects: [[String: Any]],
+        forceBatchArray: Bool
+    ) -> Data? {
+        guard responseObjects.isEmpty == false else {
+            return nil
+        }
+        let payload: Any = (forceBatchArray || responseObjects.count > 1)
+            ? responseObjects
+            : responseObjects[0]
+        guard JSONSerialization.isValidJSONObject(payload) else {
+            return nil
+        }
+        return try? JSONSerialization.data(withJSONObject: payload, options: [])
+    }
+
+    private static func extractResponseIDs(from requestJSON: Any) -> [RPCID] {
+        if let object = requestJSON as? [String: Any] {
+            guard let rawID = object["id"], let rpcID = RPCID(any: rawID) else {
+                return []
+            }
+            return [rpcID]
+        }
+
+        guard let array = requestJSON as? [Any] else {
+            return []
+        }
+        return array.compactMap { item in
+            guard let object = item as? [String: Any],
+                let rawID = object["id"]
+            else {
+                return nil
+            }
+            return RPCID(any: rawID)
+        }
     }
 }

--- a/Sources/ProxyHTTPTransport/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPTransport/LocalMCPResponder.swift
@@ -18,15 +18,18 @@ package enum LocalPostHandling {
 package struct LocalMCPResponder {
     private let sessionManager: any RuntimeCoordinating
     private let refreshCodeIssuesMode: RefreshCodeIssuesMode
+    private let disabledToolNames: Set<String>
     private let logger: Logger
 
     package init(
         sessionManager: any RuntimeCoordinating,
         refreshCodeIssuesMode: RefreshCodeIssuesMode,
+        disabledToolNames: Set<String>,
         logger: Logger
     ) {
         self.sessionManager = sessionManager
         self.refreshCodeIssuesMode = refreshCodeIssuesMode
+        self.disabledToolNames = disabledToolNames
         self.logger = logger
     }
 
@@ -118,7 +121,8 @@ package struct LocalMCPResponder {
             )
             let rewrittenResult = RefreshCodeIssuesToolsListRewriter.rewriteResult(
                 cachedResult,
-                mode: refreshCodeIssuesMode
+                mode: refreshCodeIssuesMode,
+                hiddenToolNames: disabledToolNames
             )
             let response: [String: Any] = [
                 "jsonrpc": "2.0",

--- a/Sources/ProxyHTTPTransport/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPTransport/MCPForwardingService.swift
@@ -25,10 +25,12 @@ package struct MCPForwardingService: Sendable {
     }
 
     private let config: ProxyConfig
+    private let disabledToolNames: Set<String>
     private let sessionManager: any RuntimeCoordinating
 
     package init(config: ProxyConfig, sessionManager: any RuntimeCoordinating) {
         self.config = config
+        self.disabledToolNames = config.disabledToolNames
         self.sessionManager = sessionManager
     }
 
@@ -136,13 +138,22 @@ package struct MCPForwardingService: Sendable {
                 originalID: started.transform.originalID,
                 upstreamData: data
             )
-            let responseData = Self.rewriteToolsListResponseIfNeeded(
+            let cacheableToolsListData = Self.rewriteToolsListResponseIfNeeded(
                 method: started.transform.method,
                 upstreamData: rewrittenResourcesData,
                 mode: config.refreshCodeIssuesMode
             )
+            let responseData = Self.rewriteToolsListResponseIfNeeded(
+                method: started.transform.method,
+                upstreamData: cacheableToolsListData,
+                mode: config.refreshCodeIssuesMode,
+                hiddenToolNames: disabledToolNames
+            )
             if started.transform.isCacheableToolsListRequest,
-                let object = try? JSONSerialization.jsonObject(with: responseData, options: [])
+                let object = try? JSONSerialization.jsonObject(
+                    with: cacheableToolsListData,
+                    options: []
+                )
                     as? [String: Any],
                 let resultAny = object["result"],
                 let result = JSONValue(any: resultAny)
@@ -437,14 +448,16 @@ package struct MCPForwardingService: Sendable {
     private static func rewriteToolsListResponseIfNeeded(
         method: String?,
         upstreamData: Data,
-        mode: RefreshCodeIssuesMode
+        mode: RefreshCodeIssuesMode,
+        hiddenToolNames: Set<String> = []
     ) -> Data {
         guard method == "tools/list" else {
             return upstreamData
         }
         return RefreshCodeIssuesToolsListRewriter.rewriteResponseDataIfNeeded(
             upstreamData,
-            mode: mode
+            mode: mode,
+            hiddenToolNames: hiddenToolNames
         )
     }
 

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -103,6 +103,57 @@ struct CLIParserTests {
         #expect(config.configPath == "/tmp/proxy-config.toml")
     }
 
+    @Test func cliLoadsDisabledToolNamesFromConfig() async throws {
+        let configPath = try makeTempConfigFile(
+            """
+            [tools]
+            disabled = ["RunAllTests", "RunSomeTests"]
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--config", configPath],
+            environment: [:]
+        )
+
+        #expect(config.disabledToolNames == ["RunAllTests", "RunSomeTests"])
+    }
+
+    @Test func cliNormalizesDisabledToolNamesFromConfig() async throws {
+        let configPath = try makeTempConfigFile(
+            """
+            [tools]
+            disabled = [" RunAllTests ", "", "RunAllTests", "RunSomeTests "]
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--config", configPath],
+            environment: [:]
+        )
+
+        #expect(config.disabledToolNames == ["RunAllTests", "RunSomeTests"])
+    }
+
+    @Test func cliIgnoresInvalidDisabledToolNamesConfig() async throws {
+        let configPath = try makeTempConfigFile(
+            """
+            [tools]
+            disabled = 123
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy", "--config", configPath],
+            environment: [:]
+        )
+
+        #expect(config.disabledToolNames.isEmpty)
+    }
+
     @Test func cliParsesUpstreamProcesses() async throws {
         let config = try CLIParser.parse(
             args: ["xcode-mcp-proxy", "--upstream-processes", "10"],
@@ -316,4 +367,12 @@ struct CLIParserTests {
         #expect(config.stdioUpstreamURL == nil)
         #expect(config.listenPort == 0)
     }
+}
+
+private func makeTempConfigFile(_ contents: String) throws -> String {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString)
+        .appendingPathExtension("toml")
+    try contents.write(to: url, atomically: true, encoding: .utf8)
+    return url.path
 }

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1264,6 +1264,114 @@ struct HTTPHandlerTests {
         #expect(description?.contains("native live diagnostics path") == true)
     }
 
+    @Test func httpToolsListHidesDisabledToolsOnForwardedMiss() async throws {
+        var config = makeConfig()
+        config.refreshCodeIssuesMode = .proxy
+        config.disabledToolNames = ["RunAllTests", "RunSomeTests"]
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config) { method, originalID in
+            #expect(method == "tools/list")
+            let response: [String: Any] = [
+                "jsonrpc": "2.0",
+                "id": originalID.value.foundationObject,
+                "result": [
+                    "tools": [
+                        [
+                            "name": "RunAllTests",
+                            "description": "blocked",
+                        ],
+                        [
+                            "name": "RunSomeTests",
+                            "description": "blocked",
+                        ],
+                        [
+                            "name": "XcodeRefreshCodeIssuesInFile",
+                            "description": "original description",
+                        ],
+                    ]
+                ],
+            ]
+            return try JSONSerialization.data(withJSONObject: response, options: [])
+        }
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let sessionID = try initializeHTTPChannel(channel)
+        try postJSON(
+            [
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+            ],
+            sessionID: sessionID,
+            to: channel
+        )
+
+        let response = try collectResponse(from: channel)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
+                as? [String: Any]
+        )
+        let result = try #require(object["result"] as? [String: Any])
+        let tools = try #require(result["tools"] as? [[String: Any]])
+        #expect(tools.map { $0["name"] as? String } == ["XcodeRefreshCodeIssuesInFile"])
+        #expect((tools.first?["description"] as? String)?.contains("avoid switching Spaces") == true)
+
+        let cachedResult = try #require(sessionManager.cachedToolsListResult())
+        let cachedObject = try #require(cachedResult.foundationObject as? [String: Any])
+        let cachedTools = try #require(cachedObject["tools"] as? [[String: Any]])
+        #expect(cachedTools.count == 3)
+    }
+
+    @Test func httpToolsListHidesDisabledToolsOnCachedResponse() async throws {
+        var config = makeConfig()
+        config.refreshCodeIssuesMode = .upstream
+        config.disabledToolNames = ["RunAllTests", "RunSomeTests"]
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        sessionManager.setCachedToolsListResult(
+            JSONValue(any: [
+                "tools": [
+                    [
+                        "name": "RunAllTests",
+                        "description": "blocked",
+                    ],
+                    [
+                        "name": "RunSomeTests",
+                        "description": "blocked",
+                    ],
+                    [
+                        "name": "XcodeRefreshCodeIssuesInFile",
+                        "description": "original description",
+                    ],
+                ]
+            ])!
+        )
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let sessionID = try initializeHTTPChannel(channel)
+        try postJSON(
+            [
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+            ],
+            sessionID: sessionID,
+            to: channel
+        )
+
+        let response = try collectResponse(from: channel)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
+                as? [String: Any]
+        )
+        let result = try #require(object["result"] as? [String: Any])
+        let tools = try #require(result["tools"] as? [[String: Any]])
+        #expect(tools.map { $0["name"] as? String } == ["XcodeRefreshCodeIssuesInFile"])
+        #expect((tools.first?["description"] as? String)?.contains("native live diagnostics path") == true)
+    }
+
     @Test func httpToolsListPrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
@@ -2597,6 +2705,323 @@ struct HTTPHandlerTests {
         await server.shutdown()
     }
 
+    @Test func httpDisabledToolCallReturnsLocalToolErrorWithoutUpstream() async throws {
+        var config = makeConfig(requestTimeout: 2)
+        config.disabledToolNames = ["RunAllTests"]
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamPlanResponder: { _, _ in
+                Issue.record("disabled tool call should not reach upstream")
+                return .immediate(Data())
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-disabled-tool",
+                payload: toolsCallPayload(
+                    id: 101,
+                    name: "RunAllTests",
+                    arguments: [:]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            #expect((result?["isError"] as? Bool) == true)
+            let content = result?["content"] as? [[String: Any]]
+            #expect(content?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
+            #expect(sessionManager.sentToolNames().isEmpty)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpDisabledToolNotificationReturnsAcceptedWithoutUpstream() async throws {
+        var config = makeConfig(requestTimeout: 2)
+        config.disabledToolNames = ["RunAllTests"]
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamPlanResponder: { _, _ in
+                Issue.record("disabled tool notification should not reach upstream")
+                return .immediate(Data())
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let rawResponse = try await postHTTPData(
+                url: server.url,
+                sessionID: "session-disabled-notification",
+                payload: [
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": [
+                        "name": "RunAllTests",
+                        "arguments": [:],
+                    ],
+                ]
+            )
+
+            #expect(rawResponse.statusCode == 202)
+            #expect(rawResponse.bodyData.isEmpty)
+            #expect(sessionManager.sentToolNames().isEmpty)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpDisabledToolBatchReturnsLocalErrorsAndForwardsAllowedRequests() async throws {
+        var config = makeConfig(requestTimeout: 2)
+        config.disabledToolNames = ["RunAllTests", "RunSomeTests"]
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "XcodeListWindows")
+                return .immediate(try makeToolSuccessResponse(id: originalID, text: "allowed"))
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-disabled-batch",
+                payload: [
+                    [
+                        "jsonrpc": "2.0",
+                        "id": 201,
+                        "method": "tools/call",
+                        "params": [
+                            "name": "RunAllTests",
+                            "arguments": [:],
+                        ],
+                    ],
+                    [
+                        "jsonrpc": "2.0",
+                        "method": "tools/call",
+                        "params": [
+                            "name": "RunSomeTests",
+                            "arguments": [:],
+                        ],
+                    ],
+                    [
+                        "jsonrpc": "2.0",
+                        "id": 202,
+                        "method": "tools/call",
+                        "params": [
+                            "name": "XcodeListWindows",
+                            "arguments": [:],
+                        ],
+                    ],
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+            let blocked = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 201 }
+            let blockedResult = blocked?["result"] as? [String: Any]
+            let blockedContent = blockedResult?["content"] as? [[String: Any]]
+            #expect((blockedResult?["isError"] as? Bool) == true)
+            #expect(blockedContent?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
+            let allowed = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 202 }
+            let allowedResult = allowed?["result"] as? [String: Any]
+            let allowedContent = allowedResult?["content"] as? [[String: Any]]
+            #expect(allowedContent?.first?["text"] as? String == "allowed")
+            #expect(sessionManager.sentToolNames() == ["XcodeListWindows"])
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpDisabledToolBatchReturnsLocalOnlyResponseWhenAllRequestsAreBlocked() async throws {
+        var config = makeConfig(requestTimeout: 2)
+        config.disabledToolNames = ["RunAllTests", "RunSomeTests"]
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamPlanResponder: { _, _ in
+                Issue.record("all-blocked batch should not reach upstream")
+                return .immediate(Data())
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-disabled-all-blocked",
+                payload: [
+                    [
+                        "jsonrpc": "2.0",
+                        "id": 301,
+                        "method": "tools/call",
+                        "params": [
+                            "name": "RunAllTests",
+                            "arguments": [:],
+                        ],
+                    ],
+                    [
+                        "jsonrpc": "2.0",
+                        "method": "tools/call",
+                        "params": [
+                            "name": "RunSomeTests",
+                            "arguments": [:],
+                        ],
+                    ],
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 1)
+            let blocked = bodyArray.first
+            let result = blocked?["result"] as? [String: Any]
+            let content = result?["content"] as? [[String: Any]]
+            #expect((blocked?["id"] as? NSNumber)?.intValue == 301)
+            #expect((result?["isError"] as? Bool) == true)
+            #expect(content?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
+            #expect(sessionManager.sentToolNames().isEmpty)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpDisabledToolNamesDoNotBlockInternalRefreshWorkflowCalls() async throws {
+        var config = makeConfig(requestTimeout: 2)
+        config.refreshCodeIssuesMode = .proxy
+        config.disabledToolNames = ["XcodeListWindows"]
+        let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
+        defer { try? FileManager.default.removeItem(atPath: temporaryRoot) }
+
+        let target = URL(fileURLWithPath: temporaryRoot)
+            .appendingPathComponent("App/Sources/App.swift")
+        try FileManager.default.createDirectory(
+            at: target.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "".write(to: target, atomically: true, encoding: .utf8)
+
+        let workspacePath = URL(fileURLWithPath: temporaryRoot)
+            .appendingPathComponent("SampleProject.xcworkspace").path
+        try FileManager.default.createDirectory(
+            atPath: workspacePath,
+            withIntermediateDirectories: true
+        )
+
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                switch toolName {
+                case "XcodeListWindows":
+                    return .immediate(
+                        try makeToolSuccessResponse(
+                            id: originalID,
+                            text:
+                                "{\"message\":\"* tabIdentifier: windowtab-disabled-internal, workspacePath: \(workspacePath)\"}"
+                        )
+                    )
+                case "XcodeListNavigatorIssues":
+                    return .immediate(
+                        try makeToolResultResponse(
+                            id: originalID,
+                            result: [
+                                "content": [
+                                    [
+                                        "type": "text",
+                                        "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
+                                    ]
+                                ],
+                                "structuredContent": [
+                                    "issues": [
+                                        [
+                                            "path": target.path,
+                                            "message": "target warning",
+                                            "line": 12,
+                                            "severity": "warning",
+                                        ]
+                                    ],
+                                    "totalFound": 1,
+                                    "truncated": false,
+                                ],
+                            ]
+                        )
+                    )
+                default:
+                    return .immediate(
+                        try makeToolErrorResponse(
+                            id: originalID,
+                            text: "unexpected tool"
+                        )
+                    )
+                }
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-disabled-internal",
+                payload: toolsCallPayload(
+                    id: 401,
+                    name: "XcodeRefreshCodeIssuesInFile",
+                    arguments: [
+                        "tabIdentifier": "windowtab-disabled-internal",
+                        "filePath": "App/Sources/App.swift",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            let structuredContent = result?["structuredContent"] as? [String: Any]
+            let issues = structuredContent?["issues"] as? [[String: Any]]
+            #expect(issues?.count == 1)
+            #expect(issues?.first?["path"] as? String == target.path)
+            #expect(sessionManager.sentToolNames() == [
+                "XcodeListWindows",
+                "XcodeListNavigatorIssues",
+            ])
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
     @Test func httpRefreshCodeIssuesReturnsBackpressureErrorWhenQueueIsFull() async throws {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .upstream
@@ -3420,10 +3845,20 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
             state.upstreamSendCount += 1
         }
 
-        guard
-            let object = try? JSONSerialization.jsonObject(with: data, options: [])
-                as? [String: Any],
-            let method = object["method"] as? String,
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            return
+        }
+        if let object = json as? [String: Any] {
+            handleSingleUpstreamRequest(object, upstreamIndex: upstreamIndex)
+            return
+        }
+        if let array = json as? [Any] {
+            handleBatchUpstreamRequest(array, upstreamIndex: upstreamIndex)
+        }
+    }
+
+    private func handleSingleUpstreamRequest(_ object: [String: Any], upstreamIndex: Int) {
+        guard let method = object["method"] as? String,
             let upstreamIDValue = object["id"]
         else {
             return
@@ -3445,23 +3880,11 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
             return
         }
 
-        let responsePlan: UpstreamResponsePlan
-        if let upstreamRequestResponder,
-            let planned = try? upstreamRequestResponder(method, toolName, mapping.originalID)
-        {
-            responsePlan = planned
-        } else if let upstreamResponder,
-            let planned = try? upstreamResponder(method, mapping.originalID)
-        {
-            responsePlan = planned
-        } else if let legacyUpstreamResponder,
-            let responseData = try? legacyUpstreamResponder(method, mapping.originalID)
-        {
-            responsePlan = .immediate(responseData)
-        } else {
-            return
-        }
-
+        let responsePlan = responsePlan(
+            method: method,
+            toolName: toolName,
+            originalID: mapping.originalID
+        )
         let deliverResponse = { [self] in
             let session = self.session(id: mapping.sessionID)
             session.router.handleIncoming(responsePlan.data)
@@ -3483,6 +3906,92 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         } else {
             deliverResponse()
         }
+    }
+
+    private func handleBatchUpstreamRequest(_ array: [Any], upstreamIndex: Int) {
+        var sessionID: String?
+        var responseObjects: [Any] = []
+
+        for item in array {
+            guard let object = item as? [String: Any],
+                let method = object["method"] as? String
+            else {
+                continue
+            }
+            let toolName = ((object["params"] as? [String: Any])?["name"] as? String)
+            state.withLockedValue { state in
+                state.sentRequests.append(
+                    SentRequest(
+                        method: method,
+                        toolName: toolName,
+                        upstreamIndex: upstreamIndex
+                    )
+                )
+            }
+
+            guard let upstreamIDValue = object["id"] else {
+                continue
+            }
+            let upstreamID =
+                (upstreamIDValue as? NSNumber)?.int64Value ?? (upstreamIDValue as? Int64)
+            guard let upstreamID,
+                let mapping = state.withLockedValue({ $0.upstreamIDMapping[upstreamID] })
+            else {
+                continue
+            }
+            sessionID = mapping.sessionID
+
+            let planned = responsePlan(
+                method: method,
+                toolName: toolName,
+                originalID: mapping.originalID
+            )
+            guard planned.deliverManually == false, planned.delayNanos == nil,
+                let responseObject = try? JSONSerialization.jsonObject(
+                    with: planned.data,
+                    options: []
+                )
+            else {
+                return
+            }
+            responseObjects.append(responseObject)
+        }
+
+        guard let sessionID,
+            responseObjects.isEmpty == false,
+            let responseData = try? JSONSerialization.data(
+                withJSONObject: responseObjects,
+                options: []
+            )
+        else {
+            return
+        }
+
+        let session = self.session(id: sessionID)
+        session.router.handleIncoming(responseData)
+    }
+
+    private func responsePlan(
+        method: String,
+        toolName: String?,
+        originalID: RPCID
+    ) -> UpstreamResponsePlan {
+        if let upstreamRequestResponder,
+            let planned = try? upstreamRequestResponder(method, toolName, originalID)
+        {
+            return planned
+        }
+        if let upstreamResponder,
+            let planned = try? upstreamResponder(method, originalID)
+        {
+            return planned
+        }
+        if let legacyUpstreamResponder,
+            let responseData = try? legacyUpstreamResponder(method, originalID)
+        {
+            return .immediate(responseData)
+        }
+        return .immediate(Data())
     }
 
     func debugSnapshot() -> ProxyDebugSnapshot {
@@ -3895,6 +4404,29 @@ private func postHTTPJSON(
     }
 }
 
+private func postHTTPAnyJSON(
+    url: URL,
+    sessionID: String,
+    payload: [Any]
+) async throws -> (HTTPURLResponse, Any) {
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = data
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+
+    return try await withTestURLSession { session in
+        let (responseData, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPTestError.missingResponseHead
+        }
+        let object = try JSONSerialization.jsonObject(with: responseData, options: [])
+        return (httpResponse, object)
+    }
+}
+
 private func postHTTPData(
     url: URL,
     sessionID: String,
@@ -3936,6 +4468,29 @@ private func makeDebugSnapshotURL(from mcpURL: URL) -> URL {
 
 private typealias AsyncSignal = TestSignal
 private typealias SyncSignal = TestSignal
+
+private func initializeHTTPChannel(_ channel: EmbeddedChannel) throws -> String {
+    let initPayload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "capabilities": [String: Any]()
+        ],
+    ]
+    let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
+    var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Content-Type", value: "application/json")
+    var initBody = channel.allocator.buffer(capacity: initData.count)
+    initBody.writeBytes(initData)
+    try channel.writeInbound(HTTPServerRequestPart.head(initHead))
+    try channel.writeInbound(HTTPServerRequestPart.body(initBody))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+    let initResponse = try collectResponse(from: channel)
+    return try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
+}
 
 private func makeToolSuccessResponse(id: RPCID, text: String) throws -> Data {
     let response: [String: Any] = [

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -2745,6 +2745,48 @@ struct HTTPHandlerTests {
         await server.shutdown()
     }
 
+    @Test func httpDisabledToolCallReturnsLocalToolErrorWhenNoUpstreamIsAvailable() async throws {
+        var config = makeConfig(requestTimeout: 2)
+        config.disabledToolNames = ["RunAllTests"]
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamPlanResponder: { _, _ in
+                Issue.record("disabled tool call should not reach upstream")
+                return .immediate(Data())
+            }
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setAvailableUpstreamIndex(nil)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-disabled-tool-no-upstream",
+                payload: toolsCallPayload(
+                    id: 111,
+                    name: "RunAllTests",
+                    arguments: [:]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            #expect((result?["isError"] as? Bool) == true)
+            let content = result?["content"] as? [[String: Any]]
+            #expect(content?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
+            #expect(sessionManager.sentToolNames().isEmpty)
+            #expect(sessionManager.chooseUpstreamIndexCallCount() == 0)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
     @Test func httpDisabledToolNotificationReturnsAcceptedWithoutUpstream() async throws {
         var config = makeConfig(requestTimeout: 2)
         config.disabledToolNames = ["RunAllTests"]
@@ -2778,6 +2820,73 @@ struct HTTPHandlerTests {
             #expect(rawResponse.statusCode == 202)
             #expect(rawResponse.bodyData.isEmpty)
             #expect(sessionManager.sentToolNames().isEmpty)
+        } catch {
+            await server.shutdown()
+            throw error
+        }
+        await server.shutdown()
+    }
+
+    @Test func httpDisabledToolBatchReturnsLocalAndQueueErrorsWhenNoUpstreamIsAvailable() async throws {
+        var config = makeConfig(requestTimeout: 2)
+        config.disabledToolNames = ["RunAllTests"]
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { _, _, _ in
+                Issue.record("batch should fail before reaching upstream")
+                return .immediate(Data())
+            }
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setAvailableUpstreamIndex(nil)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-disabled-batch-no-upstream",
+                payload: [
+                    [
+                        "jsonrpc": "2.0",
+                        "id": 211,
+                        "method": "tools/call",
+                        "params": [
+                            "name": "RunAllTests",
+                            "arguments": [:],
+                        ],
+                    ],
+                    [
+                        "jsonrpc": "2.0",
+                        "id": 212,
+                        "method": "tools/call",
+                        "params": [
+                            "name": "XcodeListWindows",
+                            "arguments": [:],
+                        ],
+                    ],
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+
+            let blocked = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 211 }
+            let blockedResult = blocked?["result"] as? [String: Any]
+            let blockedContent = blockedResult?["content"] as? [[String: Any]]
+            #expect((blockedResult?["isError"] as? Bool) == true)
+            #expect(blockedContent?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
+
+            let forwarded = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 212 }
+            let forwardedError = forwarded?["error"] as? [String: Any]
+            #expect((forwardedError?["code"] as? NSNumber)?.intValue == -32001)
+            #expect(forwardedError?["message"] as? String == "upstream unavailable")
+
+            #expect(sessionManager.sentToolNames().isEmpty)
+            #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
         } catch {
             await server.shutdown()
             throw error


### PR DESCRIPTION
Summary:
- add `tools.disabled` config loading with normalization and invalid-config fallback behavior
- hide disabled tools from `tools/list` and reject matching top-level `tools/call` requests, including mixed batch requests, while keeping internal proxy tool calls available
- document the new config key and add coverage for config parsing, tool list filtering, and local blocking behavior

Testing:
- `swift test`