### PR TITLE
fix(proxy): suppress benign ExternalViewService AX warning

### DIFF
--- a/Sources/ProxyFeatureXcode/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyFeatureXcode/XcodePermissionDialogAutoApprover.swift
@@ -329,6 +329,27 @@ package enum XcodePermissionDialogAXError: Error, CustomStringConvertible {
     }
 }
 
+package enum XcodePermissionDialogAXFailureClassifier {
+    private static let externalViewServiceBundleIdentifier = "com.apple.dt.ExternalViewService"
+    private static let windowsAttribute = kAXWindowsAttribute as String
+
+    package static func isBenignOpenWindowsFailure(
+        _ error: Error,
+        processBundleIdentifier: String?
+    ) -> Bool {
+        guard processBundleIdentifier == externalViewServiceBundleIdentifier else {
+            return false
+        }
+        guard let error = error as? XcodePermissionDialogAXError else {
+            return false
+        }
+        guard case .copyAttributeFailed(let attribute, let axError) = error else {
+            return false
+        }
+        return attribute == windowsAttribute && axError == .cannotComplete
+    }
+}
+
 package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessing {
     private let maxDescendantCount = 128
 
@@ -728,10 +749,24 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
         let nowUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
 
         for processID in processIDs {
+            let processBundleIdentifier = NSRunningApplication(processIdentifier: processID)?.bundleIdentifier
             let windows: [XcodePermissionDialogAXWindow]
             do {
                 windows = try dependencies.axClient.openWindows(for: processID)
             } catch {
+                if XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
+                    error,
+                    processBundleIdentifier: processBundleIdentifier
+                ) {
+                    dependencies.logger.debug(
+                        "Ignoring benign AX window inspection failure for ExternalViewService.",
+                        metadata: [
+                            "pid": "\(processID)",
+                            "error": "\(error)",
+                        ]
+                    )
+                    continue
+                }
                 dependencies.logger.warning(
                     "Failed to inspect AX windows for a running Xcode-related process.",
                     metadata: [

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import Foundation
 import Testing
 
@@ -222,6 +223,54 @@ struct XcodePermissionDialogAutoApproverTests {
         )
 
         #expect(decision == nil)
+    }
+
+    @Test func openWindowsFailureClassifierTreatsExternalViewServiceAXWindowsCannotCompleteAsBenign() {
+        let isBenign = XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
+            XcodePermissionDialogAXError.copyAttributeFailed(
+                attribute: kAXWindowsAttribute as String,
+                error: .cannotComplete
+            ),
+            processBundleIdentifier: "com.apple.dt.ExternalViewService"
+        )
+
+        #expect(isBenign)
+    }
+
+    @Test func openWindowsFailureClassifierRejectsXcodeAXWindowsCannotComplete() {
+        let isBenign = XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
+            XcodePermissionDialogAXError.copyAttributeFailed(
+                attribute: kAXWindowsAttribute as String,
+                error: .cannotComplete
+            ),
+            processBundleIdentifier: "com.apple.dt.Xcode"
+        )
+
+        #expect(isBenign == false)
+    }
+
+    @Test func openWindowsFailureClassifierRejectsExternalViewServiceForDifferentAttribute() {
+        let isBenign = XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
+            XcodePermissionDialogAXError.copyAttributeFailed(
+                attribute: kAXTitleAttribute as String,
+                error: .cannotComplete
+            ),
+            processBundleIdentifier: "com.apple.dt.ExternalViewService"
+        )
+
+        #expect(isBenign == false)
+    }
+
+    @Test func openWindowsFailureClassifierRejectsExternalViewServiceForDifferentAXError() {
+        let isBenign = XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
+            XcodePermissionDialogAXError.copyAttributeFailed(
+                attribute: kAXWindowsAttribute as String,
+                error: .attributeUnsupported
+            ),
+            processBundleIdentifier: "com.apple.dt.ExternalViewService"
+        )
+
+        #expect(isBenign == false)
     }
 
     @Test func defaultAgentPathCandidatesIncludeRawAndResolvedExecutablePaths() throws {


### PR DESCRIPTION
Summary:
- Suppress the known benign `ExternalViewService` `AXWindows` / `.cannotComplete` inspection failure during auto-approve polling.
- Keep all other AX inspection failures on the existing warning path.
- Add focused classifier tests so the suppression stays narrowly scoped.

Testing:
- `swift test --filter XcodePermissionDialogAutoApproverTests`