### PR TITLE
fix: stabilize test server shutdown and init timeout tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     name: Test
     runs-on: macos-15
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -27,6 +28,7 @@ jobs:
   test-process-io:
     name: Test (process / pipe)
     runs-on: macos-15
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/Sources/XcodeMCPTestSupport/AsyncTestSupport.swift
+++ b/Sources/XcodeMCPTestSupport/AsyncTestSupport.swift
@@ -230,6 +230,95 @@ package func withTestURLSession<T>(
     return try await operation(session)
 }
 
+package final class HTTPTestServerChannelTracker: @unchecked Sendable {
+    private let channels = NIOLockedValueBox([ObjectIdentifier: Channel]())
+
+    package init() {}
+
+    package func register(_ channel: Channel) {
+        let id = ObjectIdentifier(channel)
+        channels.withLockedValue { $0[id] = channel }
+        channel.closeFuture.whenComplete { [weak self] _ in
+            _ = self?.channels.withLockedValue { $0.removeValue(forKey: id) }
+        }
+    }
+
+    package func snapshot() -> [Channel] {
+        channels.withLockedValue { Array($0.values) }
+    }
+}
+
+package final class HTTPTestServerAcceptedChannelHandler: ChannelInboundHandler, @unchecked Sendable {
+    package typealias InboundIn = Channel
+
+    private let tracker: HTTPTestServerChannelTracker
+
+    package init(tracker: HTTPTestServerChannelTracker) {
+        self.tracker = tracker
+    }
+
+    package func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let channel = unwrapInboundIn(data)
+        tracker.register(channel)
+        context.fireChannelRead(data)
+    }
+}
+
+package func shutdownHTTPTestServer(
+    listenChannel: Channel,
+    childChannelTracker: HTTPTestServerChannelTracker,
+    group: EventLoopGroup,
+    timeout: Duration = .seconds(5),
+    beforeClose: @escaping () -> Void = {}
+) async throws {
+    beforeClose()
+
+    var shutdownError: Error?
+
+    do {
+        let listenerCloseFuture = listenChannel.closeFuture
+        listenChannel.close(mode: .all, promise: nil)
+
+        try await waitWithTimeout(
+            "timed out waiting for HTTP test server listener to close",
+            timeout: timeout
+        ) {
+            try await listenerCloseFuture.get()
+        }
+        try await waitWithTimeout(
+            "timed out waiting for HTTP test server accept loop to drain",
+            timeout: timeout
+        ) {
+            try await listenChannel.eventLoop.submit { () }.get()
+        }
+
+        while true {
+            let childChannels = childChannelTracker.snapshot()
+            guard !childChannels.isEmpty else { break }
+
+            let childCloseFutures = childChannels.map(\.closeFuture)
+            for channel in childChannels {
+                channel.close(mode: .all, promise: nil)
+            }
+
+            try await waitWithTimeout(
+                "timed out waiting for HTTP test server channels to close",
+                timeout: timeout
+            ) {
+                try await EventLoopFuture.andAllSucceed(childCloseFutures, on: listenChannel.eventLoop).get()
+            }
+        }
+    } catch {
+        shutdownError = error
+    }
+
+    await shutdown(group)
+
+    if let shutdownError {
+        throw shutdownError
+    }
+}
+
 package final class TestSignal: @unchecked Sendable {
     private struct Waiter {
         let id: UUID

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -69,11 +69,11 @@ struct CLICommandIntegrationTests {
             let result = responseObject["result"] as? [String: Any]
             #expect(result?["transport"] as? String == "stub")
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
 
-        await server.shutdown()
+        try await server.shutdown()
     }
 }
 
@@ -81,31 +81,40 @@ private struct StubMCPHTTPServer {
     let group: MultiThreadedEventLoopGroup
     let channel: Channel
     let url: URL
+    let childChannelTracker: HTTPTestServerChannelTracker
 
     static func start() throws -> StubMCPHTTPServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let childChannelTracker = HTTPTestServerChannelTracker()
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 32)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
+                return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
                     channel.pipeline.addHandler(StubMCPHTTPHandler())
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
         let channel = try bootstrap.bind(host: "127.0.0.1", port: 0).wait()
+        try channel.pipeline.addHandler(
+            HTTPTestServerAcceptedChannelHandler(tracker: childChannelTracker)
+        ).wait()
         let port = try #require(channel.localAddress?.port)
         return StubMCPHTTPServer(
             group: group,
             channel: channel,
-            url: URL(string: "http://127.0.0.1:\(port)/mcp")!
+            url: URL(string: "http://127.0.0.1:\(port)/mcp")!,
+            childChannelTracker: childChannelTracker
         )
     }
 
-    func shutdown() async {
-        channel.close(promise: nil)
-        await XcodeMCPTestSupport.shutdown(group)
+    func shutdown() async throws {
+        try await shutdownHTTPTestServer(
+            listenChannel: channel,
+            childChannelTracker: childChannelTracker,
+            group: group
+        )
     }
 }
 

--- a/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPConcurrencyTests.swift
@@ -21,10 +21,10 @@ struct HTTPConcurrencyTests {
             #expect(Set(results.0).count == count)
             #expect(Set(results.1).count == count)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpConcurrentInitializeStress() async throws {
@@ -38,10 +38,10 @@ struct HTTPConcurrencyTests {
             #expect(Set(results.0).count == count)
             #expect(Set(results.1).count == count)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpConcurrentRequestsShareSession() async throws {
@@ -95,10 +95,10 @@ struct HTTPConcurrencyTests {
             #expect((secondResult.1["id"] as? NSNumber)?.intValue == 101)
             #expect(await upstream.nonInitializeLabels() == ["tools/list", "tools/list"])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpConcurrentRequestsCanOverlapAcrossSessions() async throws {
@@ -154,10 +154,10 @@ struct HTTPConcurrencyTests {
             #expect(firstResult.0.statusCode == 200)
             #expect(secondResult.0.statusCode == 200)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpQueuedWaitDoesNotConsumeRequestTimeout() async throws {
@@ -210,10 +210,10 @@ struct HTTPConcurrencyTests {
             #expect(secondResult.0.statusCode == 200)
             #expect((secondResult.1["id"] as? NSNumber)?.intValue == 301)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpTimedOutExecuteSnippetReleasesSessionAndStartsNextQueuedRequest() async throws {
@@ -289,10 +289,10 @@ struct HTTPConcurrencyTests {
                 }
             )
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpQueuedNotificationDoesNotOvertakeEarlierSessionRequest() async throws {
@@ -336,10 +336,10 @@ struct HTTPConcurrencyTests {
             let firstResult = try await first
             #expect(firstResult.0.statusCode == 200)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDebugSnapshotReportsSessionPipelineState() async throws {
@@ -395,10 +395,10 @@ struct HTTPConcurrencyTests {
                 }
             )
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDocumentationSearchRequestsSerializeWithinSession() async throws {
@@ -464,10 +464,10 @@ struct HTTPConcurrencyTests {
             #expect(firstResult.0.statusCode == 200)
             #expect(secondResult.0.statusCode == 200)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpConcurrentRefreshCodeIssuesRequestsDoNotSurfaceErrorFiveOrDeadlockInternalCalls() async throws {
@@ -520,10 +520,10 @@ struct HTTPConcurrencyTests {
                 #expect(isError == false)
             }
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpConcurrentRefreshCodeIssuesRequestsRespectSingleFlightPerUpstream() async throws {
@@ -576,10 +576,10 @@ struct HTTPConcurrencyTests {
                 #expect(isError == false)
             }
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesNotificationForwardsWithoutInvalidUpstreamOverride()
@@ -620,10 +620,10 @@ struct HTTPConcurrencyTests {
                 }
             )
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpServerNotificationsReachActiveSSESessions() async throws {
@@ -692,10 +692,10 @@ struct HTTPConcurrencyTests {
             #expect(response.statusCode == 200)
             #expect(line == String(decoding: notificationData, as: UTF8.self))
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 }
 
@@ -738,6 +738,7 @@ private struct TestHTTPServer {
     let url: URL
     let sessionManager: RuntimeCoordinator
     let upstream: any UpstreamSlotControlling
+    let childChannelTracker: HTTPTestServerChannelTracker
 
     static func start(
         upstream providedUpstream: (any UpstreamSlotControlling)? = nil,
@@ -745,6 +746,7 @@ private struct TestHTTPServer {
     ) throws -> TestHTTPServer {
         ProxyLogging.bootstrap(environment: ["MCP_LOG_LEVEL": "critical"])
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        let childChannelTracker = HTTPTestServerChannelTracker()
         let config = ProxyConfig(
             listenHost: "127.0.0.1",
             listenPort: 0,
@@ -762,7 +764,7 @@ private struct TestHTTPServer {
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
+                return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
                     channel.pipeline.addHandler(
                         HTTPHandler(
                             config: config,
@@ -774,6 +776,9 @@ private struct TestHTTPServer {
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
         let channel = try bootstrap.bind(host: config.listenHost, port: config.listenPort).wait()
+        try channel.pipeline.addHandler(
+            HTTPTestServerAcceptedChannelHandler(tracker: childChannelTracker)
+        ).wait()
         let port = channel.localAddress?.port ?? config.listenPort
         let url = URL(string: "http://\(config.listenHost):\(port)/mcp")!
         return TestHTTPServer(
@@ -781,18 +786,20 @@ private struct TestHTTPServer {
             channel: channel,
             url: url,
             sessionManager: sessionManager,
-            upstream: upstream
+            upstream: upstream,
+            childChannelTracker: childChannelTracker
         )
     }
 
-    func shutdown() async {
-        sessionManager.shutdown()
-        channel.close(promise: nil)
-        await withCheckedContinuation { continuation in
-            group.shutdownGracefully { _ in
-                continuation.resume()
+    func shutdown() async throws {
+        try await shutdownHTTPTestServer(
+            listenChannel: channel,
+            childChannelTracker: childChannelTracker,
+            group: group,
+            beforeClose: {
+                sessionManager.shutdown()
             }
-        }
+        )
     }
 }
 

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -125,11 +125,11 @@ struct HTTPHandlerTests {
             #expect(sessionManager.hasSession(id: "debug-reset-session") == false)
             #expect(sessionManager.cachedToolsListResult() == nil)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
 
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDebugResetReturnsNotFoundWhenListenerIsNotLoopback() async throws {
@@ -270,10 +270,10 @@ struct HTTPHandlerTests {
             #expect(completedRefreshSnapshot.recentCompletedRequests.first?.finalState == "completed")
             #expect(completedRefreshSnapshot.recentCompletedRequests.first?.outcome == "success")
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpSSERequiresAcceptHeader() async throws {
@@ -2370,10 +2370,10 @@ struct HTTPHandlerTests {
                 "XcodeListNavigatorIssues@1",
             ]))
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpSingleElementBatchRefreshCodeIssuesUsesNavigatorIssuesProxyByDefault() async throws {
@@ -2492,10 +2492,10 @@ struct HTTPHandlerTests {
                 "XcodeListNavigatorIssues",
             ])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpMixedBatchKeepsRefreshProxyAndAllowedResponses() async throws {
@@ -2618,10 +2618,10 @@ struct HTTPHandlerTests {
             let otherContent = otherResult["content"] as? [[String: Any]]
             #expect(otherContent?.first?["text"] as? String == "other-tool-result")
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpMixedBatchReturnsInvalidRequestForScalarLeftoverAfterRefreshSplit() async throws {
@@ -2740,10 +2740,10 @@ struct HTTPHandlerTests {
                 "XcodeListNavigatorIssues",
             ])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpMixedBatchPreservesNotificationLeftoverWhenScalarIsStripped() async throws {
@@ -2868,10 +2868,10 @@ struct HTTPHandlerTests {
             #expect((error["code"] as? NSNumber)?.intValue == -32600)
             #expect(error["message"] as? String == "invalid request")
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpMixedBatchRefreshRetryDoesNotReplayAllowedCalls() async throws {
@@ -2968,10 +2968,10 @@ struct HTTPHandlerTests {
             #expect(refreshAttempts.withLockedValue { $0 } == 2)
             #expect(otherAttempts.withLockedValue { $0 } == 1)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesFallsBackToUpstreamWhenWindowLookupFailsAfterPreviousSuccess() async throws {
@@ -3113,10 +3113,10 @@ struct HTTPHandlerTests {
                 "XcodeRefreshCodeIssuesInFile",
             ])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesFallsBackToUpstreamWhenNavigatorIssuesAreTruncated() async throws {
@@ -3219,10 +3219,10 @@ struct HTTPHandlerTests {
                 "XcodeRefreshCodeIssuesInFile",
             ])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesFallsBackToUpstreamWhenResolverCannotFindTarget() async throws {
@@ -3295,10 +3295,10 @@ struct HTTPHandlerTests {
             ])
             #expect(sessionManager.chooseUpstreamShouldPinValues().isEmpty)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesFallsBackToUpstreamWhenNavigatorIssuesFails() async throws {
@@ -3387,10 +3387,10 @@ struct HTTPHandlerTests {
             ])
             #expect(sessionManager.chooseUpstreamShouldPinValues().isEmpty)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func refreshWorkflowFallsBackToUpstreamWhenNavigatorIssuesTimesOut() async throws {
@@ -3884,10 +3884,10 @@ struct HTTPHandlerTests {
                 "XcodeRefreshCodeIssuesInFile",
             ])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesRetriesSourceEditorErrorFive() async throws {
@@ -3939,10 +3939,10 @@ struct HTTPHandlerTests {
             #expect((result?["isError"] as? Bool) != true)
             #expect(sessionManager.sentUpstreamCount() == 2)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpSingleElementBatchRefreshCodeIssuesRetriesSourceEditorErrorFive() async throws {
@@ -4007,10 +4007,10 @@ struct HTTPHandlerTests {
             #expect((result?["isError"] as? Bool) != true)
             #expect(sessionManager.sentUpstreamCount() == 2)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesRetriesShortSourceEditorErrorFiveText() async throws {
@@ -4062,10 +4062,10 @@ struct HTTPHandlerTests {
             #expect((result?["isError"] as? Bool) != true)
             #expect(sessionManager.sentUpstreamCount() == 2)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesDoesNotRetryNonRetryableToolError() async throws {
@@ -4108,10 +4108,10 @@ struct HTTPHandlerTests {
             #expect((result?["isError"] as? Bool) == true)
             #expect(sessionManager.sentUpstreamCount() == 1)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpNonTargetToolsCallDoesNotUseRefreshRetryPath() async throws {
@@ -4151,10 +4151,10 @@ struct HTTPHandlerTests {
             #expect((result?["isError"] as? Bool) == true)
             #expect(sessionManager.sentUpstreamCount() == 1)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDisabledToolCallReturnsLocalToolErrorWithoutUpstream() async throws {
@@ -4191,10 +4191,10 @@ struct HTTPHandlerTests {
             #expect(content?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
             #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDisabledToolCallReturnsLocalToolErrorWhenNoUpstreamIsAvailable() async throws {
@@ -4233,10 +4233,10 @@ struct HTTPHandlerTests {
             #expect(sessionManager.sentToolNames().isEmpty)
             #expect(sessionManager.chooseUpstreamIndexCallCount() == 0)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDisabledToolNotificationReturnsAcceptedWithoutUpstream() async throws {
@@ -4273,10 +4273,10 @@ struct HTTPHandlerTests {
             #expect(rawResponse.bodyData.isEmpty)
             #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpMixedBatchDropsDisabledNotificationBeforeForwardingAllowedCalls() async throws {
@@ -4339,10 +4339,10 @@ struct HTTPHandlerTests {
             #expect(content?.first?["text"] as? String == "other-tool-result")
             #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDisabledToolBatchReturnsLocalAndQueueErrorsWhenNoUpstreamIsAvailable() async throws {
@@ -4406,10 +4406,10 @@ struct HTTPHandlerTests {
             #expect(sessionManager.sentToolNames().isEmpty)
             #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDisabledToolBatchReturnsLocalErrorsAndForwardsAllowedRequests() async throws {
@@ -4477,10 +4477,10 @@ struct HTTPHandlerTests {
             #expect(allowedContent?.first?["text"] as? String == "allowed")
             #expect(sessionManager.sentToolNames() == ["XcodeListWindows"])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDisabledToolBatchReturnsLocalOnlyResponseWhenAllRequestsAreBlocked() async throws {
@@ -4535,10 +4535,10 @@ struct HTTPHandlerTests {
             #expect(content?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
             #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDisabledToolNamesDoNotBlockInternalRefreshWorkflowCalls() async throws {
@@ -4643,10 +4643,10 @@ struct HTTPHandlerTests {
                 "XcodeListNavigatorIssues",
             ])
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesReturnsBackpressureErrorWhenQueueIsFull() async throws {
@@ -4715,10 +4715,10 @@ struct HTTPHandlerTests {
             #expect(firstStatusCode == 200)
             #expect(sessionManager.sentUpstreamCount() == 1)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshProxyReturnsBackpressureErrorWhenQueueIsFull() async throws {
@@ -4825,10 +4825,10 @@ struct HTTPHandlerTests {
             let firstStatusCode = try await firstTask.value
             #expect(firstStatusCode == 200)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesReturnsBackpressureErrorAfterQueueWaitTimeout() async throws {
@@ -4897,10 +4897,10 @@ struct HTTPHandlerTests {
             #expect(firstStatusCode == 200)
             #expect(sessionManager.sentUpstreamCount() == 1)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshProxyReturnsBackpressureErrorAfterQueueWaitTimeout() async throws {
@@ -5007,10 +5007,10 @@ struct HTTPHandlerTests {
             let firstStatusCode = try await firstTask.value
             #expect(firstStatusCode == 200)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshProxyInternalToolCallsUpdateUpstreamHealthState() async throws {
@@ -5090,10 +5090,10 @@ struct HTTPHandlerTests {
             #expect(sessionManager.requestTimeoutNotificationCount() == 1)
             #expect(sessionManager.chooseUpstreamShouldPinValues().isEmpty)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func forwardingServiceInternalToolRespectsRequestedOverride()
@@ -5212,11 +5212,11 @@ struct HTTPHandlerTests {
             #expect(completedLease.state == .completed)
         } catch {
             requestTask.cancel()
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
 
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpRefreshCodeIssuesCompletesLeaseWhenRetryBudgetExpires() async throws {
@@ -5265,11 +5265,11 @@ struct HTTPHandlerTests {
             let lease = try #require(sessionManager.leaseDebugSnapshots().first)
             #expect(lease.state == .completed)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
 
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDirectRefreshSuccessDoesNotRecordLateLeaseResponse() async throws {
@@ -5317,11 +5317,11 @@ struct HTTPHandlerTests {
             #expect(lease.state == .completed)
             #expect(lease.lateResponseCount == 0)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
 
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func httpDirectRefreshCancellationAbandonsActiveLease() async throws {
@@ -5359,11 +5359,11 @@ struct HTTPHandlerTests {
             #expect(abandonedLease.state == .abandoned)
             #expect(abandonedLease.releaseReason == "clientDisconnected")
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
 
-        await server.shutdown()
+        try await server.shutdown()
     }
 }
 
@@ -6111,6 +6111,7 @@ private struct TestHTTPHandlerServer {
     let channel: Channel
     let url: URL
     let sessionManager: any RuntimeCoordinating
+    let childChannelTracker: HTTPTestServerChannelTracker
 
     static func start(
         config: ProxyConfig,
@@ -6119,6 +6120,7 @@ private struct TestHTTPHandlerServer {
         refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver()
     ) throws -> TestHTTPHandlerServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let childChannelTracker = HTTPTestServerChannelTracker()
         let refreshCoordinator =
             refreshCodeIssuesCoordinator
             ?? RefreshCodeIssuesCoordinator.makeDefault(
@@ -6133,7 +6135,7 @@ private struct TestHTTPHandlerServer {
             .serverChannelOption(ChannelOptions.backlog, value: 256)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
+                return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
                     channel.pipeline.addHandler(
                         HTTPHandler(
                             config: config,
@@ -6148,24 +6150,29 @@ private struct TestHTTPHandlerServer {
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
         let channel = try bootstrap.bind(host: config.listenHost, port: 0).wait()
+        try channel.pipeline.addHandler(
+            HTTPTestServerAcceptedChannelHandler(tracker: childChannelTracker)
+        ).wait()
         let port = channel.localAddress?.port ?? 0
         let url = URL(string: "http://\(config.listenHost):\(port)/mcp")!
         return TestHTTPHandlerServer(
             group: group,
             channel: channel,
             url: url,
-            sessionManager: sessionManager
+            sessionManager: sessionManager,
+            childChannelTracker: childChannelTracker
         )
     }
 
-    func shutdown() async {
-        sessionManager.shutdown()
-        channel.close(promise: nil)
-        await withCheckedContinuation { continuation in
-            group.shutdownGracefully { _ in
-                continuation.resume()
+    func shutdown() async throws {
+        try await shutdownHTTPTestServer(
+            listenChannel: channel,
+            childChannelTracker: childChannelTracker,
+            group: group,
+            beforeClose: {
+                sessionManager.shutdown()
             }
-        }
+        )
     }
 }
 

--- a/Tests/ProxyIntegrationTests/StdioAdapterIntegrationTests.swift
+++ b/Tests/ProxyIntegrationTests/StdioAdapterIntegrationTests.swift
@@ -39,12 +39,12 @@ struct StdioAdapterIntegrationTests {
 
             #expect(completed)
         } catch {
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
 
         outputPipe.fileHandleForWriting.closeFile()
-        await server.shutdown()
+        try await server.shutdown()
     }
 
     @Test func stdioAdapterStopsReadLoopAfterFatalInputProtocolViolation() async throws {
@@ -78,13 +78,13 @@ struct StdioAdapterIntegrationTests {
         } catch {
             inputPipe.fileHandleForWriting.closeFile()
             outputPipe.fileHandleForWriting.closeFile()
-            await server.shutdown()
+            try? await server.shutdown()
             throw error
         }
 
         inputPipe.fileHandleForWriting.closeFile()
         outputPipe.fileHandleForWriting.closeFile()
-        await server.shutdown()
+        try await server.shutdown()
     }
 }
 
@@ -92,31 +92,40 @@ private struct HangingHTTPServer {
     let group: MultiThreadedEventLoopGroup
     let channel: Channel
     let url: URL
+    let childChannelTracker: HTTPTestServerChannelTracker
 
     static func start() throws -> HangingHTTPServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let childChannelTracker = HTTPTestServerChannelTracker()
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 32)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
-                channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
+                return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
                     channel.pipeline.addHandler(HangingHTTPHandler())
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
 
         let channel = try bootstrap.bind(host: "127.0.0.1", port: 0).wait()
+        try channel.pipeline.addHandler(
+            HTTPTestServerAcceptedChannelHandler(tracker: childChannelTracker)
+        ).wait()
         let port = try #require(channel.localAddress?.port)
         return HangingHTTPServer(
             group: group,
             channel: channel,
-            url: URL(string: "http://127.0.0.1:\(port)/mcp")!
+            url: URL(string: "http://127.0.0.1:\(port)/mcp")!,
+            childChannelTracker: childChannelTracker
         )
     }
 
-    func shutdown() async {
-        channel.close(promise: nil)
-        await XcodeMCPTestSupport.shutdown(group)
+    func shutdown() async throws {
+        try await shutdownHTTPTestServer(
+            listenChannel: channel,
+            childChannelTracker: childChannelTracker,
+            group: group
+        )
     }
 }
 

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -170,11 +170,7 @@ struct RuntimeCoordinatorTests {
             on: eventLoop
         )
 
-        try await spinUntilSentCount(
-            upstream,
-            count: 1,
-            description: "waiting for initial initialize request"
-        )
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
         let initialInitialize = try #require(await upstream.sentValue(at: 0))
         let initialUpstreamID = try extractUpstreamID(from: initialInitialize)
 
@@ -183,27 +179,15 @@ struct RuntimeCoordinatorTests {
         timeoutClock.advance(by: .milliseconds(150))
         await upstream.yield(.message(try makeInitializeResponse(id: initialUpstreamID)))
 
-        try await spinUntilSentCount(
-            upstream,
-            count: 2,
-            description: "waiting for overloaded initialized notification send"
-        )
-        try await spinUntilSentCount(
-            upstream,
-            count: 3,
-            description: "waiting for retried initialize request"
-        )
+        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
+        try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
         let retriedInitialize = try #require(await upstream.sentValue(at: 2))
         let retriedUpstreamID = try extractUpstreamID(from: retriedInitialize)
 
         await timeoutClock.sleep(untilSuspendedBy: 1)
         timeoutClock.advance(by: .milliseconds(180))
         await upstream.yield(.message(try makeInitializeResponse(id: retriedUpstreamID)))
-        try await spinUntilSentCount(
-            upstream,
-            count: 4,
-            description: "waiting for retried initialized notification send"
-        )
+        try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
 
         let response = try decodeJSON(from: try await future.get())
         #expect(response["result"] != nil, "initializeResponse=\(response)")
@@ -585,12 +569,10 @@ struct RuntimeCoordinatorTests {
 
         await timeoutClock.sleep(untilSuspendedBy: 1)
         timeoutClock.advance(by: .seconds(1))
-        try await spinUntil("waiting for initialize timeout state reset") {
-            manager.testStateSnapshot().initInFlight == false
-        }
         await #expect(throws: TimeoutError.self) {
             try await future.get()
         }
+        #expect(manager.testStateSnapshot().initInFlight == false)
 
         _ = manager.registerInitialize(
             originalID: RPCID(any: NSNumber(value: 2))!,
@@ -922,13 +904,10 @@ struct RuntimeCoordinatorTests {
         )
         await timeoutClock.sleep(untilSuspendedBy: 1)
         timeoutClock.advance(by: .milliseconds(100))
-        try await spinUntil("waiting for eager initialize timeout") {
+        try await spinUntil("waiting for eager initialize timeout", maxIterations: 1_000) {
             let snapshot = manager.testStateSnapshot()
             return snapshot.initInFlight == false && snapshot.hasInitResult == false
         }
-        let snapshot = manager.testStateSnapshot()
-        #expect(snapshot.initInFlight == false)
-        #expect(snapshot.hasInitResult == false)
 
         _ = manager.registerInitialize(
             originalID: RPCID(any: NSNumber(value: 1))!,
@@ -948,16 +927,14 @@ struct RuntimeCoordinatorTests {
             on: eventLoop
         )
 
-        try await spinUntilSentCount(
-            upstream,
-            count: 2,
-            description: "waiting for resent initialize request"
-        )
+        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
         let resent = try #require(await upstream.sentValue(at: 1))
         let object = try JSONSerialization.jsonObject(with: resent, options: []) as? [String: Any]
         let params = try #require(object?["params"] as? [String: Any])
         let clientInfo = try #require(params["clientInfo"] as? [String: Any])
 
+        let snapshot = manager.testStateSnapshot()
+        #expect(snapshot.hasInitResult == false)
         #expect(params["protocolVersion"] as? String == "2025-03-26")
         #expect(clientInfo["name"] as? String == "configured-proxy")
         #expect(clientInfo["version"] as? String == manager.defaultProxyClientVersion())


### PR DESCRIPTION
## Summary
- stabilize the HTTP test-server shutdown path by tracking accepted child channels and draining listener teardown before shutting down the event loop group
- update runtime timeout tests to wait on deterministic post-timeout state transitions instead of flaky intermediate polling
- add release workflow job timeouts so a stuck CI test job cannot block the release pipeline indefinitely

## Testing
- `swift test --filter 'RuntimeCoordinatorTests/sessionManagerCancelsOriginalInitTimeoutBeforeRetryingInitializedNotificationOverload|RuntimeCoordinatorTests/sessionManagerTimeoutResetsInitState|RuntimeCoordinatorTests/sessionManagerUsesConfiguredInitializeParamsAfterEagerInitTimesOut' -Xswiftc -strict-concurrency=minimal`
- `swift test --skip 'ProcessRunnerTests|UpstreamProcessTests|StdioAdapterIntegrationTests' -Xswiftc -strict-concurrency=minimal`
- `swift test --no-parallel --filter 'ProcessRunnerTests|UpstreamProcessTests|StdioAdapterIntegrationTests' -Xswiftc -strict-concurrency=minimal`

## UI Changes
- None

## Related Issues
- None