### PR TITLE
fix(proxy): handle delayed xcode readiness

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -119,7 +119,7 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 - listen: `localhost:8765`
 - request timeout: `300` seconds（`0` で無制限）
 - max body size: `1048576` bytes
-- initialization: eager at startup
+- initialization: Xcode 未起動なら起動し、利用可能になったら eager initialize / attach
 - discovery: `~/Library/Caches/XcodeMCPProxy/endpoint.json`
 
 #### オプション

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See Quick Start for how to launch.
 - request timeout: `300` seconds (`0` disables)
 - requests sharing the same MCP session are forwarded FIFO, one at a time
 - max body size: `1048576` bytes
-- initialization: eager at startup
+- initialization: launches Xcode if needed, eager when Xcode is available, and attaches after Xcode becomes ready
 - discovery: `~/Library/Caches/XcodeMCPProxy/endpoint.json`
 
 #### Options

--- a/Sources/ProxySession/ControlPlane/InitializeGate.swift
+++ b/Sources/ProxySession/ControlPlane/InitializeGate.swift
@@ -98,9 +98,17 @@ package final class InitializeManager: Sendable {
         }
     }
 
-    package func setPrimaryInitUpstreamID(_ upstreamID: Int64) {
+    package func beginPrimaryInitializeSend(upstreamID: Int64) -> Bool {
         state.withLockedValue { state in
+            guard !state.isShuttingDown,
+                  state.initResult == nil,
+                  state.initInFlight,
+                  state.primaryInitUpstreamID == nil
+            else {
+                return false
+            }
             state.primaryInitUpstreamID = upstreamID
+            return true
         }
     }
 

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
@@ -168,7 +168,16 @@ extension RuntimeCoordinator {
         return false
     }
 
-    func startUpstreamWarmInitialize(upstreamIndex: Int) {
+    func startUpstreamWarmInitialize(upstreamIndex: Int, applyBackoff: Bool = false) {
+        runWhenUpstreamReady(
+            reason: "warm_initialize_\(upstreamIndex)",
+            applyBackoff: applyBackoff
+        ) { [weak self] in
+            self?.startUpstreamWarmInitializeWhenReady(upstreamIndex: upstreamIndex)
+        }
+    }
+
+    private func startUpstreamWarmInitializeWhenReady(upstreamIndex: Int) {
         guard upstreamHealthManager.beginWarmInitialize(upstreamIndex: upstreamIndex) else { return }
 
         let upstreamID = upstreamRouter.assignInitialize(upstreamIndex: upstreamIndex)
@@ -209,7 +218,7 @@ extension RuntimeCoordinator {
         if upstreamIndex == 0 {
             let shouldRetryEagerInit = initializeManager.consumeRetryAfterWarmInitFailureIfNeeded()
             if shouldRetryEagerInit {
-                startEagerInitializePrimary()
+                startEagerInitializePrimary(applyBackoff: true)
             }
         }
         failQueuedRequestsIfNoHealthyOrRecoveringUpstream()

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -4,7 +4,18 @@ import ProxyCore
 import ProxyMCP
 
 extension RuntimeCoordinator {
-    func startEagerInitializePrimary() {
+    func startEagerInitializePrimary(applyBackoff: Bool = false) {
+        runWhenUpstreamReady(
+            reason: "primary_initialize",
+            applyBackoff: applyBackoff
+        ) { [weak self] in
+            guard let self else { return }
+            self.startAllUpstreamSlots()
+            self.startEagerInitializePrimaryWhenReady()
+        }
+    }
+
+    private func startEagerInitializePrimaryWhenReady() {
         let decision = initializeManager.beginEagerInitializePrimary()
         let shouldSend = decision.shouldSendRequest
         let shouldScheduleTimeout = decision.shouldScheduleTimeout
@@ -13,8 +24,35 @@ extension RuntimeCoordinator {
         }
         guard shouldSend else { return }
 
+        sendPrimaryInitializeRequestIfStillPending()
+    }
+
+    func startPrimaryInitializeRequestWhenReady(applyBackoff: Bool = false) {
+        let token = upstreamReadinessGate.isEnabled ? UpstreamReadinessWaiterToken() : nil
+        if let token {
+            replacePrimaryInitializeReadinessWaiter(with: token)
+        }
+        runWhenUpstreamReady(
+            reason: "primary_initialize_request",
+            applyBackoff: applyBackoff,
+            token: token
+        ) { [weak self, token] in
+            guard let self else { return }
+            if let token {
+                self.clearPrimaryInitializeReadinessWaiter(token)
+                guard !token.isCancelled else { return }
+            }
+            self.startAllUpstreamSlots()
+            self.sendPrimaryInitializeRequestIfStillPending()
+        }
+    }
+
+    private func sendPrimaryInitializeRequestIfStillPending() {
         let upstreamID = upstreamRouter.assignInitialize(upstreamIndex: 0)
-        initializeManager.setPrimaryInitUpstreamID(upstreamID)
+        guard initializeManager.beginPrimaryInitializeSend(upstreamID: upstreamID) else {
+            upstreamRouter.remove(upstreamIndex: 0, upstreamID: upstreamID)
+            return
+        }
         markUpstreamInitInFlight(upstreamIndex: 0, upstreamID: upstreamID)
 
         let request = makeInternalInitializeRequest(id: upstreamID)
@@ -156,6 +194,7 @@ extension RuntimeCoordinator {
     func completeInitPendingWithError(_ errorObject: [String: Any]) {
         let result = initializeManager.completePrimaryInitializeFailure()
         guard let result else { return }
+        cancelPrimaryInitializeReadinessWaiter()
         result.timeout?.cancel()
         if let upstreamID = result.upstreamID {
             upstreamRouter.remove(upstreamIndex: 0, upstreamID: upstreamID)
@@ -176,7 +215,7 @@ extension RuntimeCoordinator {
         }
 
         if result.shouldRetryEagerInitialize {
-            startEagerInitializePrimary()
+            startEagerInitializePrimary(applyBackoff: true)
         }
         failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
     }
@@ -262,6 +301,7 @@ extension RuntimeCoordinator {
     func failInitPending(error: Error) {
         let result = initializeManager.completePrimaryInitializeFailure()
         guard let result else { return }
+        cancelPrimaryInitializeReadinessWaiter()
         result.timeout?.cancel()
         if let upstreamID = result.upstreamID {
             upstreamRouter.remove(upstreamIndex: 0, upstreamID: upstreamID)
@@ -274,7 +314,7 @@ extension RuntimeCoordinator {
         }
 
         if result.shouldRetryEagerInitialize {
-            startEagerInitializePrimary()
+            startEagerInitializePrimary(applyBackoff: true)
         }
         failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
     }
@@ -304,6 +344,7 @@ extension RuntimeCoordinator {
     func markUpstreamInitialized(upstreamIndex: Int) {
         let timeout = upstreamHealthManager.markInitialized(upstreamIndex: upstreamIndex)
         timeout?.cancel()
+        noteUpstreamInitializationSucceeded()
     }
 
     func warmUpSecondaryUpstreams() {
@@ -328,7 +369,7 @@ extension RuntimeCoordinator {
             clearInitialize: true,
             clearToolsCatalog: true
         )
-        startEagerInitializePrimary()
+        startEagerInitializePrimary(applyBackoff: true)
     }
 
     func hasUsableInitializedSecondaryUpstreams() -> Bool {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Readiness.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Readiness.swift
@@ -122,13 +122,38 @@ extension RuntimeCoordinator {
         }
     }
 
-    private static func isDefaultXcrunMCPBridgeInvocation(config: ProxyConfig) -> Bool {
-        guard config.upstreamArgs == ["mcpbridge"] else {
+    package static func isDefaultXcrunMCPBridgeInvocation(config: ProxyConfig) -> Bool {
+        guard isXcrunCommand(config.upstreamCommand),
+              let toolName = firstXcrunToolName(from: config.upstreamArgs) else {
             return false
         }
-        if config.upstreamCommand == "xcrun" {
-            return true
+        return URL(fileURLWithPath: toolName).lastPathComponent == "mcpbridge"
+    }
+
+    private static func isXcrunCommand(_ command: String) -> Bool {
+        command == "xcrun" || URL(fileURLWithPath: command).lastPathComponent == "xcrun"
+    }
+
+    private static func firstXcrunToolName(from args: [String]) -> String? {
+        let flagsWithValues: Set<String> = [
+            "-sdk", "--sdk",
+            "-toolchain", "--toolchain",
+        ]
+
+        var index = 0
+        while index < args.count {
+            let argument = args[index]
+            if flagsWithValues.contains(argument) {
+                index += 2
+                continue
+            }
+            if argument.hasPrefix("-") {
+                index += 1
+                continue
+            }
+            return argument
         }
-        return URL(fileURLWithPath: config.upstreamCommand).lastPathComponent == "xcrun"
+
+        return nil
     }
 }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Readiness.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Readiness.swift
@@ -1,0 +1,134 @@
+import Foundation
+import ProxyCore
+
+extension RuntimeCoordinator {
+    static func defaultUpstreamReadinessGate(
+        config: ProxyConfig,
+        clock: ClockClient
+    ) -> UpstreamReadinessGate {
+        guard isDefaultXcrunMCPBridgeInvocation(config: config) else {
+            return .alwaysReady(uptimeNanoseconds: clock.uptimeNanoseconds)
+        }
+
+        let processRunner = ProcessRunner()
+        return .xcodeMCPBridge(
+            uptimeNanoseconds: clock.uptimeNanoseconds,
+            sleepNanoseconds: { nanoseconds in
+                try? await Task.sleep(nanoseconds: nanoseconds)
+            },
+            runProcess: { request in
+                try await processRunner.run(request)
+            }
+        )
+    }
+
+    func runWhenUpstreamReady(
+        reason: String,
+        applyBackoff: Bool = false,
+        token: UpstreamReadinessWaiterToken? = nil,
+        operation: @escaping @Sendable () -> Void
+    ) {
+        guard upstreamReadinessGate.isEnabled else {
+            operation()
+            return
+        }
+
+        let generation = currentUpstreamReadinessGeneration()
+        let guardedOperation: @Sendable () -> Void = { [weak self] in
+            guard let self else { return }
+            guard self.currentUpstreamReadinessGeneration() == generation else { return }
+            operation()
+        }
+        Task { [upstreamReadinessCoordinator] in
+            await upstreamReadinessCoordinator.runWhenReady(
+                reason: reason,
+                applyBackoff: applyBackoff,
+                token: token,
+                operation: guardedOperation
+            )
+        }
+    }
+
+    func cancelUpstreamReadinessWaiter(_ token: UpstreamReadinessWaiterToken) {
+        guard upstreamReadinessGate.isEnabled else { return }
+        Task { [upstreamReadinessCoordinator] in
+            await upstreamReadinessCoordinator.cancelWaiter(token)
+        }
+    }
+
+    func startAllUpstreamSlots() {
+        for upstream in upstreams {
+            Task {
+                await upstream.start()
+            }
+        }
+    }
+
+    func noteUpstreamInitializationSucceeded() {
+        guard upstreamReadinessGate.isEnabled else { return }
+        Task { [upstreamReadinessCoordinator] in
+            await upstreamReadinessCoordinator.resetBackoff()
+        }
+    }
+
+    func resetUpstreamReadinessWaiters() {
+        guard upstreamReadinessGate.isEnabled else { return }
+        Task { [upstreamReadinessCoordinator] in
+            await upstreamReadinessCoordinator.reset()
+        }
+    }
+
+    func advanceUpstreamReadinessGeneration() {
+        upstreamReadinessGenerationBox.withLockedValue { generation in
+            generation &+= 1
+        }
+    }
+
+    func currentUpstreamReadinessGeneration() -> UInt64 {
+        upstreamReadinessGenerationBox.withLockedValue { $0 }
+    }
+
+    func replacePrimaryInitializeReadinessWaiter(
+        with token: UpstreamReadinessWaiterToken
+    ) {
+        let previous = primaryInitializeReadinessTokenBox.withLockedValue { current in
+            let previous = current
+            current = token
+            return previous
+        }
+        if let previous {
+            cancelUpstreamReadinessWaiter(previous)
+        }
+    }
+
+    func clearPrimaryInitializeReadinessWaiter(
+        _ token: UpstreamReadinessWaiterToken
+    ) {
+        primaryInitializeReadinessTokenBox.withLockedValue { current in
+            if current === token {
+                current = nil
+            }
+        }
+    }
+
+    func cancelPrimaryInitializeReadinessWaiter() {
+        let token = primaryInitializeReadinessTokenBox.withLockedValue { current in
+            let token = current
+            current = nil
+            return token
+        }
+        if let token {
+            cancelUpstreamReadinessWaiter(token)
+        }
+    }
+
+    private static func isDefaultXcrunMCPBridgeInvocation(config: ProxyConfig) -> Bool {
+        guard config.upstreamArgs == ["mcpbridge"] else {
+            return false
+        }
+        if config.upstreamCommand == "xcrun" {
+            return true
+        }
+        return URL(fileURLWithPath: config.upstreamCommand).lastPathComponent == "xcrun"
+    }
+}

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import NIO
 import ProxyCore
 import ProxyMCP
@@ -185,9 +186,9 @@ extension RuntimeCoordinator {
 
         if upstreamIndex == 0 {
             if shouldResetGlobalInit || !globalInit.hadGlobalInit {
-                startEagerInitializePrimary()
+                startEagerInitializePrimary(applyBackoff: true)
             } else {
-                startUpstreamWarmInitialize(upstreamIndex: 0)
+                startUpstreamWarmInitialize(upstreamIndex: 0, applyBackoff: true)
             }
         } else if globalInit.hadGlobalInit {
             if shouldResetGlobalInit {
@@ -198,10 +199,10 @@ extension RuntimeCoordinator {
                 } else {
                     initializeManager
                         .setShouldRetryEagerInitializePrimaryAfterWarmInitFailure(false)
-                    startEagerInitializePrimary()
+                    startEagerInitializePrimary(applyBackoff: true)
                 }
             }
-            startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+            startUpstreamWarmInitialize(upstreamIndex: upstreamIndex, applyBackoff: true)
         }
     }
 
@@ -581,6 +582,35 @@ extension RuntimeCoordinator {
 
     func handleUpstreamStderr(_ message: String, upstreamIndex: Int) {
         debugRecorder.recordStderr(message, upstreamIndex: upstreamIndex)
+        let classification = UpstreamStderrClassifier.classify(message)
+        let decision = upstreamStderrLogLimiter.decision(
+            upstreamIndex: upstreamIndex,
+            message: message,
+            classification: classification,
+            nowUptimeNs: nowUptimeNanoseconds()
+        )
+        guard decision.shouldLog else { return }
+
+        var metadata: [String: Logger.MetadataValue] = [
+            "upstream": .string("\(upstreamIndex)")
+        ]
+        if decision.suppressedDuplicateCount > 0 {
+            metadata["suppressed_duplicates"] = .string("\(decision.suppressedDuplicateCount)")
+        }
+
+        switch classification {
+        case .xcodeUnavailable:
+            logger.info(
+                "mcpbridge reported that no Xcode process is running; waiting for Xcode before restarting",
+                metadata: metadata
+            )
+        case .unknown:
+            metadata["message"] = .string(message)
+            logger.error(
+                "Upstream stderr",
+                metadata: metadata
+            )
+        }
     }
 
     func handleUpstreamProtocolViolation(
@@ -630,12 +660,12 @@ extension RuntimeCoordinator {
 
         if upstreamIndex == 0 {
             if initSnapshot.hasInitResult {
-                startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+                startUpstreamWarmInitialize(upstreamIndex: upstreamIndex, applyBackoff: true)
             } else {
-                startEagerInitializePrimary()
+                startEagerInitializePrimary(applyBackoff: true)
             }
         } else if initSnapshot.hasInitResult {
-            startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+            startUpstreamWarmInitialize(upstreamIndex: upstreamIndex, applyBackoff: true)
         }
     }
 

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -172,6 +172,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let sessionRegistry: SessionRegistry
     package let initializeManager = InitializeManager()
     package let upstreamTaskBox = NIOLockedValueBox<[Task<Void, Never>]>([])
+    package let upstreamStderrLogLimiter = UpstreamStderrLogLimiter()
+    package let primaryInitializeReadinessTokenBox =
+        NIOLockedValueBox<UpstreamReadinessWaiterToken?>(nil)
+    package let upstreamReadinessGenerationBox = NIOLockedValueBox<UInt64>(0)
     package let debugRecorder: ProxyDebugRecorder
     package let leaseManager: LeaseManager
     package let eventLoop: EventLoop
@@ -185,6 +189,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     package let upstreamHealthManager: UpstreamHealthManager
     package let upstreamSlotScheduler: UpstreamSlotScheduler
+    package let upstreamReadinessGate: UpstreamReadinessGate
+    package let upstreamReadinessCoordinator: UpstreamReadinessCoordinator
     package let clock: ClockClient
     package let nowUptimeNanoseconds: @Sendable () -> UInt64
     package let scheduleRuntimeTimeout: @Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
@@ -195,7 +201,17 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         let count = max(1, min(config.upstreamProcessCount, 10))
         let upstreams = Self.makeDefaultUpstreams(
             config: config, sharedSessionID: config.upstreamSessionID, count: count)
-        self.init(config: config, eventLoop: eventLoop, upstreams: upstreams)
+        let clock = ClockClient.liveValue
+        self.init(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: upstreams,
+            clock: clock,
+            upstreamReadinessGate: Self.defaultUpstreamReadinessGate(
+                config: config,
+                clock: clock
+            )
+        )
     }
 
     package init(
@@ -203,6 +219,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         eventLoop: EventLoop,
         upstreams: [any UpstreamSlotControlling],
         clock: ClockClient = .liveValue,
+        upstreamReadinessGate: UpstreamReadinessGate? = nil,
         nowUptimeNanoseconds: (@Sendable () -> UInt64)? = nil,
         scheduleRuntimeTimeout: (@Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
             RuntimeScheduledTimeout)? = nil
@@ -236,6 +253,13 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.upstreamHealthManager = UpstreamHealthManager(upstreamCount: upstreams.count)
         self.nowUptimeNanoseconds = uptimeProvider
         self.scheduleRuntimeTimeout = timeoutScheduler
+        let resolvedReadinessGate = upstreamReadinessGate
+            ?? .alwaysReady(uptimeNanoseconds: runtimeClock.uptimeNanoseconds)
+        self.upstreamReadinessGate = resolvedReadinessGate
+        self.upstreamReadinessCoordinator = UpstreamReadinessCoordinator(
+            gate: resolvedReadinessGate,
+            logger: ProxyLogging.make("upstream.readiness")
+        )
         self.upstreamSlotScheduler = UpstreamSlotScheduler(
             upstreamCount: upstreams.count,
             defaultCapacity: 1,
@@ -351,9 +375,6 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 }
             }
             tasks.append(task)
-            Task {
-                await upstream.start()
-            }
         }
         upstreamTaskBox.withLockedValue { taskBox in
             taskBox = tasks
@@ -397,7 +418,11 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         upstreamRouter.resetAll()
         _ = leaseManager.resetAll(reason: .clientDisconnected)
         upstreamSlotScheduler.reset()
+        advanceUpstreamReadinessGeneration()
+        resetUpstreamReadinessWaiters()
+        cancelPrimaryInitializeReadinessWaiter()
         debugRecorder.resetAll()
+        upstreamStderrLogLimiter.reset()
         invalidateControlPlaneSynchronously(
             reason: "debug_reset",
             clearInitialize: true,
@@ -420,6 +445,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         for timeout in upstreamTimeouts {
             timeout?.cancel()
         }
+        await upstreamReadinessCoordinator.shutdown()
 
         invalidateControlPlaneSynchronously(
             reason: "shutdown",
@@ -622,15 +648,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
 
         if shouldSend {
-            let upstreamID = upstreamRouter.assignInitialize(upstreamIndex: 0)
-            initializeManager.setPrimaryInitUpstreamID(upstreamID)
-            markUpstreamInitInFlight(upstreamIndex: 0, upstreamID: upstreamID)
-            let initRequest = makeInternalInitializeRequest(id: upstreamID)
-            if let data = try? JSONSerialization.data(withJSONObject: initRequest, options: []) {
-                sendUpstream(data, upstreamIndex: 0, ensureRunning: true)
-            } else {
-                failInitPending(error: TimeoutError())
-            }
+            startPrimaryInitializeRequestWhenReady()
         }
 
         guard let promise = pendingPromise else {

--- a/Sources/ProxySession/Session/ResponseCorrelationStore.swift
+++ b/Sources/ProxySession/Session/ResponseCorrelationStore.swift
@@ -31,13 +31,13 @@ extension RuntimeCoordinator {
             }()
         )
         if count <= 1 {
-            return [ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig), startImmediately: true)]
+            return [ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig))]
         }
         var upstreams: [ManagedUpstreamSlot] = []
         upstreams.reserveCapacity(count)
         for _ in 0..<count {
             upstreams.append(
-                ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig), startImmediately: true)
+                ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig))
             )
         }
         return upstreams

--- a/Sources/ProxySession/Upstream/UpstreamProcess.swift
+++ b/Sources/ProxySession/Upstream/UpstreamProcess.swift
@@ -491,7 +491,6 @@ private extension ProcessBackedUpstreamSession {
             return
         }
         let message = suffix.isEmpty ? trimmed : trimmed + suffix
-        logger.error("Upstream stderr: \(message)")
         continuation.yield(.stderr(message))
     }
 

--- a/Sources/ProxySession/Upstream/UpstreamReadinessGate.swift
+++ b/Sources/ProxySession/Upstream/UpstreamReadinessGate.swift
@@ -1,0 +1,526 @@
+import Foundation
+import ApplicationServices
+import Logging
+import NIOConcurrencyHelpers
+
+package struct UpstreamReadinessGate: Sendable {
+    package let isEnabled: Bool
+    package let targetName: String
+    package let pollIntervalNanoseconds: UInt64
+    package let progressLogIntervalNanoseconds: UInt64
+    package let initialRetryBackoffNanoseconds: UInt64
+    package let maxRetryBackoffNanoseconds: UInt64
+    package let uptimeNanoseconds: @Sendable () -> UInt64
+    package let sleepNanoseconds: @Sendable (UInt64) async -> Void
+    package let isAvailable: (@Sendable () async -> Bool)?
+    package let launchIfUnavailable: (@Sendable () async -> Bool)?
+    package let isReady: @Sendable () async -> Bool
+
+    package init(
+        isEnabled: Bool,
+        targetName: String,
+        pollIntervalNanoseconds: UInt64,
+        progressLogIntervalNanoseconds: UInt64,
+        initialRetryBackoffNanoseconds: UInt64,
+        maxRetryBackoffNanoseconds: UInt64,
+        uptimeNanoseconds: @escaping @Sendable () -> UInt64,
+        sleepNanoseconds: @escaping @Sendable (UInt64) async -> Void,
+        isAvailable: (@Sendable () async -> Bool)? = nil,
+        launchIfUnavailable: (@Sendable () async -> Bool)? = nil,
+        isReady: @escaping @Sendable () async -> Bool
+    ) {
+        self.isEnabled = isEnabled
+        self.targetName = targetName
+        self.pollIntervalNanoseconds = pollIntervalNanoseconds
+        self.progressLogIntervalNanoseconds = progressLogIntervalNanoseconds
+        self.initialRetryBackoffNanoseconds = initialRetryBackoffNanoseconds
+        self.maxRetryBackoffNanoseconds = maxRetryBackoffNanoseconds
+        self.uptimeNanoseconds = uptimeNanoseconds
+        self.sleepNanoseconds = sleepNanoseconds
+        self.isAvailable = isAvailable
+        self.launchIfUnavailable = launchIfUnavailable
+        self.isReady = isReady
+    }
+
+    package static func alwaysReady(
+        uptimeNanoseconds: @escaping @Sendable () -> UInt64 = {
+            DispatchTime.now().uptimeNanoseconds
+        }
+    ) -> Self {
+        Self(
+            isEnabled: false,
+            targetName: "upstream",
+            pollIntervalNanoseconds: 0,
+            progressLogIntervalNanoseconds: 0,
+            initialRetryBackoffNanoseconds: 0,
+            maxRetryBackoffNanoseconds: 0,
+            uptimeNanoseconds: uptimeNanoseconds,
+            sleepNanoseconds: { _ in },
+            isAvailable: { true },
+            launchIfUnavailable: nil,
+            isReady: { true }
+        )
+    }
+
+    package static func xcodeMCPBridge(
+        uptimeNanoseconds: @escaping @Sendable () -> UInt64,
+        sleepNanoseconds: @escaping @Sendable (UInt64) async -> Void,
+        runProcess: @escaping @Sendable (ProcessRequest) async throws -> ProcessOutput
+    ) -> Self {
+        Self(
+            isEnabled: true,
+            targetName: "mcpbridge",
+            pollIntervalNanoseconds: 1_000_000_000,
+            progressLogIntervalNanoseconds: 5_000_000_000,
+            initialRetryBackoffNanoseconds: 1_000_000_000,
+            maxRetryBackoffNanoseconds: 8_000_000_000,
+            uptimeNanoseconds: uptimeNanoseconds,
+            sleepNanoseconds: sleepNanoseconds,
+            isAvailable: {
+                let output = try? await runProcess(
+                    ProcessRequest(
+                        label: "detect-xcode-process",
+                        executablePath: "/usr/bin/pgrep",
+                        arguments: ["-x", "Xcode"],
+                        input: nil
+                    )
+                )
+                guard let output else { return false }
+                return XcodeReadinessProbe.processIDs(fromPGrepOutput: output).isEmpty == false
+            },
+            launchIfUnavailable: {
+                let output = try? await runProcess(
+                    ProcessRequest(
+                        label: "launch-xcode",
+                        executablePath: "/usr/bin/open",
+                        arguments: ["-a", "Xcode"],
+                        input: nil
+                    )
+                )
+                return output?.terminationStatus == 0
+            },
+            isReady: {
+                let output = try? await runProcess(
+                    ProcessRequest(
+                        label: "detect-xcode-process",
+                        executablePath: "/usr/bin/pgrep",
+                        arguments: ["-x", "Xcode"],
+                        input: nil
+                    )
+                )
+                guard let output else { return false }
+                let processIDs = XcodeReadinessProbe.processIDs(fromPGrepOutput: output)
+                return XcodeReadinessProbe.isReady(
+                    xcodeProcessIDs: processIDs,
+                    windows: XcodeReadinessProbe.visibleWindowSnapshots(
+                        xcodeProcessIDs: processIDs
+                    )
+                )
+            }
+        )
+    }
+}
+
+package enum XcodeReadinessProbe {
+    package struct WindowSnapshot: Equatable, Sendable {
+        package let ownerPID: pid_t
+        package let title: String
+        package let layer: Int
+        package let alpha: Double
+
+        package init(ownerPID: pid_t, title: String, layer: Int, alpha: Double) {
+            self.ownerPID = ownerPID
+            self.title = title
+            self.layer = layer
+            self.alpha = alpha
+        }
+    }
+
+    package static func processIDs(fromPGrepOutput output: ProcessOutput) -> Set<pid_t> {
+        guard output.terminationStatus == 0 else { return [] }
+        return Set(
+            output.stdout
+                .split(whereSeparator: \.isNewline)
+                .compactMap { pid_t($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        )
+    }
+
+    package static func hasReadyWorkspaceWindow(
+        xcodeProcessIDs: Set<pid_t>,
+        windows: [WindowSnapshot]
+    ) -> Bool {
+        guard xcodeProcessIDs.isEmpty == false else { return false }
+        return windows.contains { window in
+            xcodeProcessIDs.contains(window.ownerPID)
+                && window.layer == 0
+                && window.alpha > 0
+                && isReadyWorkspaceTitle(window.title)
+        }
+    }
+
+    package static func isReady(
+        xcodeProcessIDs: Set<pid_t>,
+        windows: [WindowSnapshot]?
+    ) -> Bool {
+        guard xcodeProcessIDs.isEmpty == false else { return false }
+        guard let windows else {
+            return true
+        }
+        return hasReadyWorkspaceWindow(xcodeProcessIDs: xcodeProcessIDs, windows: windows)
+    }
+
+    package static func visibleWindowSnapshots(xcodeProcessIDs: Set<pid_t>) -> [WindowSnapshot]? {
+        guard AXIsProcessTrusted() else {
+            return nil
+        }
+        return accessibilityWindowSnapshots(xcodeProcessIDs: xcodeProcessIDs)
+    }
+
+    private static func accessibilityWindowSnapshots(
+        xcodeProcessIDs: Set<pid_t>
+    ) -> [WindowSnapshot] {
+        xcodeProcessIDs.flatMap { processID -> [WindowSnapshot] in
+            let app = AXUIElementCreateApplication(processID)
+            var rawWindows: CFTypeRef?
+            let error = unsafe AXUIElementCopyAttributeValue(
+                app,
+                kAXWindowsAttribute as CFString,
+                &rawWindows
+            )
+            guard error == .success, let windows = rawWindows as? [AXUIElement] else {
+                return []
+            }
+            return windows.map { window in
+                let minimized = accessibilityBoolAttribute(
+                    window,
+                    attribute: kAXMinimizedAttribute
+                ) ?? false
+                return WindowSnapshot(
+                    ownerPID: processID,
+                    title: accessibilityStringAttribute(window, attribute: kAXTitleAttribute) ?? "",
+                    layer: 0,
+                    alpha: minimized ? 0 : 1
+                )
+            }
+        }
+    }
+
+    private static func isReadyWorkspaceTitle(_ title: String) -> Bool {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return false }
+        guard trimmed.localizedCaseInsensitiveCompare("Welcome to Xcode") != .orderedSame else {
+            return false
+        }
+        return true
+    }
+
+    private static func accessibilityStringAttribute(
+        _ element: AXUIElement,
+        attribute: String
+    ) -> String? {
+        var value: CFTypeRef?
+        let error = unsafe AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        guard error == .success else { return nil }
+        return value as? String
+    }
+
+    private static func accessibilityBoolAttribute(
+        _ element: AXUIElement,
+        attribute: String
+    ) -> Bool? {
+        var value: CFTypeRef?
+        let error = unsafe AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        guard error == .success else { return nil }
+        return value as? Bool
+    }
+}
+
+package final class UpstreamReadinessWaiterToken: Sendable {
+    private let isCancelledBox = NIOLockedValueBox(false)
+
+    package init() {}
+
+    package func cancel() {
+        isCancelledBox.withLockedValue { isCancelled in
+            isCancelled = true
+        }
+    }
+
+    package var isCancelled: Bool {
+        isCancelledBox.withLockedValue { $0 }
+    }
+}
+
+package actor UpstreamReadinessCoordinator {
+    private struct Waiter: Sendable {
+        let reason: String
+        let applyBackoff: Bool
+        let token: UpstreamReadinessWaiterToken?
+        let operation: @Sendable () -> Void
+
+        var isCancelled: Bool {
+            token?.isCancelled ?? false
+        }
+    }
+
+    private let gate: UpstreamReadinessGate
+    private let logger: Logger
+    private var waiters: [Waiter] = []
+    private var waitTask: Task<Void, Never>?
+    private var deferredTask: Task<Void, Never>?
+    private var isShutdown = false
+    private var retryBackoffAttempt = 0
+
+    package init(gate: UpstreamReadinessGate, logger: Logger) {
+        self.gate = gate
+        self.logger = logger
+    }
+
+    package func runWhenReady(
+        reason: String,
+        applyBackoff: Bool = false,
+        token: UpstreamReadinessWaiterToken? = nil,
+        operation: @escaping @Sendable () -> Void
+    ) {
+        guard !isShutdown else { return }
+        guard token?.isCancelled != true else { return }
+        waiters.append(
+            Waiter(
+                reason: reason,
+                applyBackoff: applyBackoff,
+                token: token,
+                operation: operation
+            )
+        )
+        guard waitTask == nil, deferredTask == nil else { return }
+        startWaitTask()
+    }
+
+    package func cancelWaiter(_ token: UpstreamReadinessWaiterToken) {
+        token.cancel()
+        waiters.removeAll { waiter in
+            waiter.token === token
+        }
+    }
+
+    package func resetBackoff() {
+        retryBackoffAttempt = 0
+    }
+
+    package func reset() {
+        waitTask?.cancel()
+        deferredTask?.cancel()
+        waitTask = nil
+        deferredTask = nil
+        waiters.removeAll()
+        retryBackoffAttempt = 0
+    }
+
+    package func shutdown() {
+        isShutdown = true
+        waitTask?.cancel()
+        deferredTask?.cancel()
+        waitTask = nil
+        deferredTask = nil
+        waiters.removeAll()
+    }
+
+    private func startWaitTask() {
+        waitTask = Task { [weak self] in
+            await self?.waitUntilReady()
+        }
+    }
+
+    private func waitUntilReady() async {
+        var didLogWaiting = false
+        var didRequestLaunchWhileUnavailable = false
+        var didLogRunningWait = false
+        var lastProgressLogUptimeNs: UInt64?
+        var indicatorIndex = 0
+        let indicators = ["exploring.", "exploring..", "exploring..."]
+
+        while Task.isCancelled == false {
+            guard !isShutdown else {
+                waitTask = nil
+                return
+            }
+            waiters.removeAll { $0.isCancelled }
+            guard !waiters.isEmpty else {
+                waitTask = nil
+                return
+            }
+
+            if await gate.isReady() {
+                waitTask = nil
+                scheduleReadyWaiters(didWait: didLogWaiting)
+                return
+            }
+
+            let nowUptimeNs = gate.uptimeNanoseconds()
+            if didLogWaiting == false {
+                logger.info(
+                    "Waiting for Xcode before starting mcpbridge",
+                    metadata: [
+                        "target": .string(gate.targetName)
+                    ]
+                )
+                didLogWaiting = true
+                lastProgressLogUptimeNs = nowUptimeNs
+            } else if let lastProgress = lastProgressLogUptimeNs,
+                      nowUptimeNs &- lastProgress >= gate.progressLogIntervalNanoseconds
+            {
+                logger.info(
+                    "Still waiting for Xcode",
+                    metadata: [
+                        "target": .string(gate.targetName),
+                        "indicator": .string(indicators[indicatorIndex % indicators.count]),
+                    ]
+                )
+                indicatorIndex &+= 1
+                lastProgressLogUptimeNs = nowUptimeNs
+            }
+
+            let launchState = await updateLaunchStateIfNeeded(
+                didRequestLaunchWhileUnavailable: didRequestLaunchWhileUnavailable,
+                didLogRunningWait: didLogRunningWait
+            )
+            didRequestLaunchWhileUnavailable = launchState.didRequestLaunchWhileUnavailable
+            didLogRunningWait = launchState.didLogRunningWait
+
+            await gate.sleepNanoseconds(gate.pollIntervalNanoseconds)
+        }
+
+        waitTask = nil
+    }
+
+    private func updateLaunchStateIfNeeded(
+        didRequestLaunchWhileUnavailable: Bool,
+        didLogRunningWait: Bool
+    ) async -> (didRequestLaunchWhileUnavailable: Bool, didLogRunningWait: Bool) {
+        guard gate.launchIfUnavailable != nil else {
+            return (didRequestLaunchWhileUnavailable, didLogRunningWait)
+        }
+
+        if let isAvailable = gate.isAvailable, await isAvailable() {
+            if didLogRunningWait == false {
+                logger.info(
+                    "Xcode is running; waiting for an Xcode workspace window before starting mcpbridge",
+                    metadata: [
+                        "target": .string(gate.targetName)
+                    ]
+                )
+            }
+            return (false, true)
+        }
+
+        guard didRequestLaunchWhileUnavailable == false else {
+            return (didRequestLaunchWhileUnavailable, didLogRunningWait)
+        }
+        await launchUnavailableTarget()
+        return (true, didLogRunningWait)
+    }
+
+    private func launchUnavailableTarget() async {
+        guard let launchIfUnavailable = gate.launchIfUnavailable else { return }
+        logger.info(
+            "Xcode is not running; launching Xcode",
+            metadata: [
+                "target": .string(gate.targetName)
+            ]
+        )
+        if await launchIfUnavailable() {
+            logger.info(
+                "Launched Xcode; waiting for it to become ready",
+                metadata: [
+                    "target": .string(gate.targetName)
+                ]
+            )
+        } else {
+            logger.warning(
+                "Could not launch Xcode automatically; waiting for Xcode",
+                metadata: [
+                    "target": .string(gate.targetName)
+                ]
+            )
+        }
+    }
+
+    private func scheduleReadyWaiters(didWait: Bool) {
+        guard !isShutdown, !waiters.isEmpty else {
+            waiters.removeAll()
+            return
+        }
+
+        if didWait {
+            logger.info(
+                "Detected Xcode; starting mcpbridge",
+                metadata: [
+                    "target": .string(gate.targetName)
+                ]
+            )
+        }
+
+        let shouldBackoff = !didWait && waiters.contains { $0.applyBackoff }
+        guard shouldBackoff else {
+            fireReadyWaiters()
+            return
+        }
+
+        let delay = nextRetryBackoffNanoseconds()
+        logger.info(
+            "Backing off before restarting mcpbridge",
+            metadata: [
+                "target": .string(gate.targetName),
+                "delay_ms": .string("\(delay / 1_000_000)"),
+            ]
+        )
+        deferredTask = Task { [weak self] in
+            await self?.sleepThenFireReadyWaiters(delayNanoseconds: delay)
+        }
+    }
+
+    private func sleepThenFireReadyWaiters(delayNanoseconds: UInt64) async {
+        await gate.sleepNanoseconds(delayNanoseconds)
+        guard Task.isCancelled == false else { return }
+        deferredTask = nil
+        guard !isShutdown else {
+            waiters.removeAll()
+            return
+        }
+        waiters.removeAll { $0.isCancelled }
+        guard !waiters.isEmpty else { return }
+
+        if await gate.isReady() {
+            fireReadyWaiters()
+        } else {
+            startWaitTask()
+        }
+    }
+
+    private func fireReadyWaiters() {
+        guard !isShutdown else {
+            waiters.removeAll()
+            return
+        }
+        let readyWaiters = waiters.filter { !$0.isCancelled }
+        waiters.removeAll()
+        waitTask = nil
+        deferredTask = nil
+        for waiter in readyWaiters {
+            waiter.operation()
+        }
+    }
+
+    private func nextRetryBackoffNanoseconds() -> UInt64 {
+        let shift = min(retryBackoffAttempt, 20)
+        let base = gate.initialRetryBackoffNanoseconds
+        let delay: UInt64
+        if shift >= UInt64.bitWidth || base > UInt64.max >> UInt64(shift) {
+            delay = UInt64.max
+        } else {
+            delay = base << UInt64(shift)
+        }
+        retryBackoffAttempt &+= 1
+        return min(delay, gate.maxRetryBackoffNanoseconds)
+    }
+}

--- a/Sources/ProxySession/Upstream/UpstreamReadinessGate.swift
+++ b/Sources/ProxySession/Upstream/UpstreamReadinessGate.swift
@@ -8,6 +8,7 @@ package struct UpstreamReadinessGate: Sendable {
     package let targetName: String
     package let pollIntervalNanoseconds: UInt64
     package let progressLogIntervalNanoseconds: UInt64
+    package let launchRetryIntervalNanoseconds: UInt64
     package let initialRetryBackoffNanoseconds: UInt64
     package let maxRetryBackoffNanoseconds: UInt64
     package let uptimeNanoseconds: @Sendable () -> UInt64
@@ -21,6 +22,7 @@ package struct UpstreamReadinessGate: Sendable {
         targetName: String,
         pollIntervalNanoseconds: UInt64,
         progressLogIntervalNanoseconds: UInt64,
+        launchRetryIntervalNanoseconds: UInt64,
         initialRetryBackoffNanoseconds: UInt64,
         maxRetryBackoffNanoseconds: UInt64,
         uptimeNanoseconds: @escaping @Sendable () -> UInt64,
@@ -33,6 +35,7 @@ package struct UpstreamReadinessGate: Sendable {
         self.targetName = targetName
         self.pollIntervalNanoseconds = pollIntervalNanoseconds
         self.progressLogIntervalNanoseconds = progressLogIntervalNanoseconds
+        self.launchRetryIntervalNanoseconds = launchRetryIntervalNanoseconds
         self.initialRetryBackoffNanoseconds = initialRetryBackoffNanoseconds
         self.maxRetryBackoffNanoseconds = maxRetryBackoffNanoseconds
         self.uptimeNanoseconds = uptimeNanoseconds
@@ -52,6 +55,7 @@ package struct UpstreamReadinessGate: Sendable {
             targetName: "upstream",
             pollIntervalNanoseconds: 0,
             progressLogIntervalNanoseconds: 0,
+            launchRetryIntervalNanoseconds: 0,
             initialRetryBackoffNanoseconds: 0,
             maxRetryBackoffNanoseconds: 0,
             uptimeNanoseconds: uptimeNanoseconds,
@@ -72,6 +76,7 @@ package struct UpstreamReadinessGate: Sendable {
             targetName: "mcpbridge",
             pollIntervalNanoseconds: 1_000_000_000,
             progressLogIntervalNanoseconds: 5_000_000_000,
+            launchRetryIntervalNanoseconds: 5_000_000_000,
             initialRetryBackoffNanoseconds: 1_000_000_000,
             maxRetryBackoffNanoseconds: 8_000_000_000,
             uptimeNanoseconds: uptimeNanoseconds,
@@ -333,7 +338,7 @@ package actor UpstreamReadinessCoordinator {
 
     private func waitUntilReady() async {
         var didLogWaiting = false
-        var didRequestLaunchWhileUnavailable = false
+        var lastUnavailableLaunchUptimeNs: UInt64?
         var didLogRunningWait = false
         var lastProgressLogUptimeNs: UInt64?
         var indicatorIndex = 0
@@ -381,10 +386,11 @@ package actor UpstreamReadinessCoordinator {
             }
 
             let launchState = await updateLaunchStateIfNeeded(
-                didRequestLaunchWhileUnavailable: didRequestLaunchWhileUnavailable,
-                didLogRunningWait: didLogRunningWait
+                lastUnavailableLaunchUptimeNs: lastUnavailableLaunchUptimeNs,
+                didLogRunningWait: didLogRunningWait,
+                nowUptimeNs: nowUptimeNs
             )
-            didRequestLaunchWhileUnavailable = launchState.didRequestLaunchWhileUnavailable
+            lastUnavailableLaunchUptimeNs = launchState.lastUnavailableLaunchUptimeNs
             didLogRunningWait = launchState.didLogRunningWait
 
             await gate.sleepNanoseconds(gate.pollIntervalNanoseconds)
@@ -394,13 +400,15 @@ package actor UpstreamReadinessCoordinator {
     }
 
     private func updateLaunchStateIfNeeded(
-        didRequestLaunchWhileUnavailable: Bool,
-        didLogRunningWait: Bool
-    ) async -> (didRequestLaunchWhileUnavailable: Bool, didLogRunningWait: Bool) {
+        lastUnavailableLaunchUptimeNs: UInt64?,
+        didLogRunningWait: Bool,
+        nowUptimeNs: UInt64
+    ) async -> (lastUnavailableLaunchUptimeNs: UInt64?, didLogRunningWait: Bool) {
         guard gate.launchIfUnavailable != nil else {
-            return (didRequestLaunchWhileUnavailable, didLogRunningWait)
+            return (lastUnavailableLaunchUptimeNs, didLogRunningWait)
         }
 
+        let canObserveAvailability = gate.isAvailable != nil
         if let isAvailable = gate.isAvailable, await isAvailable() {
             if didLogRunningWait == false {
                 logger.info(
@@ -410,14 +418,16 @@ package actor UpstreamReadinessCoordinator {
                     ]
                 )
             }
-            return (false, true)
+            return (nil, true)
         }
 
-        guard didRequestLaunchWhileUnavailable == false else {
-            return (didRequestLaunchWhileUnavailable, didLogRunningWait)
+        if let lastLaunch = lastUnavailableLaunchUptimeNs,
+           (canObserveAvailability == false
+            || nowUptimeNs &- lastLaunch < gate.launchRetryIntervalNanoseconds) {
+            return (lastUnavailableLaunchUptimeNs, didLogRunningWait)
         }
         let didLaunch = await launchUnavailableTarget()
-        return (didLaunch, didLogRunningWait)
+        return (didLaunch ? gate.uptimeNanoseconds() : nil, didLogRunningWait)
     }
 
     private func launchUnavailableTarget() async -> Bool {

--- a/Sources/ProxySession/Upstream/UpstreamReadinessGate.swift
+++ b/Sources/ProxySession/Upstream/UpstreamReadinessGate.swift
@@ -416,12 +416,12 @@ package actor UpstreamReadinessCoordinator {
         guard didRequestLaunchWhileUnavailable == false else {
             return (didRequestLaunchWhileUnavailable, didLogRunningWait)
         }
-        await launchUnavailableTarget()
-        return (true, didLogRunningWait)
+        let didLaunch = await launchUnavailableTarget()
+        return (didLaunch, didLogRunningWait)
     }
 
-    private func launchUnavailableTarget() async {
-        guard let launchIfUnavailable = gate.launchIfUnavailable else { return }
+    private func launchUnavailableTarget() async -> Bool {
+        guard let launchIfUnavailable = gate.launchIfUnavailable else { return false }
         logger.info(
             "Xcode is not running; launching Xcode",
             metadata: [
@@ -435,6 +435,7 @@ package actor UpstreamReadinessCoordinator {
                     "target": .string(gate.targetName)
                 ]
             )
+            return true
         } else {
             logger.warning(
                 "Could not launch Xcode automatically; waiting for Xcode",
@@ -442,6 +443,7 @@ package actor UpstreamReadinessCoordinator {
                     "target": .string(gate.targetName)
                 ]
             )
+            return false
         }
     }
 

--- a/Sources/ProxySession/Upstream/UpstreamStderrLogFilter.swift
+++ b/Sources/ProxySession/Upstream/UpstreamStderrLogFilter.swift
@@ -1,0 +1,90 @@
+import Foundation
+import NIOConcurrencyHelpers
+
+package enum UpstreamStderrClassification: Sendable, Equatable {
+    case xcodeUnavailable
+    case unknown
+}
+
+package enum UpstreamStderrClassifier {
+    package static func classify(_ message: String) -> UpstreamStderrClassification {
+        let normalized = message.lowercased()
+        if normalized.contains("mcp_xcode_pid environment variable not set")
+            && normalized.contains("no running xcode processes found")
+        {
+            return .xcodeUnavailable
+        }
+        if normalized.contains("no running xcode processes found") {
+            return .xcodeUnavailable
+        }
+        return .unknown
+    }
+}
+
+package struct UpstreamStderrLogDecision: Sendable {
+    package let shouldLog: Bool
+    package let suppressedDuplicateCount: Int
+}
+
+package final class UpstreamStderrLogLimiter: Sendable {
+    private struct Record: Sendable {
+        var lastLoggedUptimeNs: UInt64
+        var suppressedDuplicateCount: Int
+    }
+
+    private struct State: Sendable {
+        var recordsByKey: [String: Record] = [:]
+    }
+
+    private let state = NIOLockedValueBox(State())
+    private let duplicateLogIntervalNanoseconds: UInt64
+
+    package init(duplicateLogIntervalNanoseconds: UInt64 = 5_000_000_000) {
+        self.duplicateLogIntervalNanoseconds = duplicateLogIntervalNanoseconds
+    }
+
+    package func decision(
+        upstreamIndex: Int,
+        message: String,
+        classification: UpstreamStderrClassification,
+        nowUptimeNs: UInt64
+    ) -> UpstreamStderrLogDecision {
+        let key = "\(upstreamIndex)|\(classification)|\(message)"
+        return state.withLockedValue { state in
+            guard var record = state.recordsByKey[key] else {
+                state.recordsByKey[key] = Record(
+                    lastLoggedUptimeNs: nowUptimeNs,
+                    suppressedDuplicateCount: 0
+                )
+                return UpstreamStderrLogDecision(
+                    shouldLog: true,
+                    suppressedDuplicateCount: 0
+                )
+            }
+
+            guard nowUptimeNs &- record.lastLoggedUptimeNs >= duplicateLogIntervalNanoseconds else {
+                record.suppressedDuplicateCount += 1
+                state.recordsByKey[key] = record
+                return UpstreamStderrLogDecision(
+                    shouldLog: false,
+                    suppressedDuplicateCount: record.suppressedDuplicateCount
+                )
+            }
+
+            let suppressedCount = record.suppressedDuplicateCount
+            record.lastLoggedUptimeNs = nowUptimeNs
+            record.suppressedDuplicateCount = 0
+            state.recordsByKey[key] = record
+            return UpstreamStderrLogDecision(
+                shouldLog: true,
+                suppressedDuplicateCount: suppressedCount
+            )
+        }
+    }
+
+    package func reset() {
+        state.withLockedValue { state in
+            state.recordsByKey.removeAll()
+        }
+    }
+}

--- a/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
@@ -247,6 +247,7 @@ package enum XcodePermissionDialogMatcher {
         let allowDescriptions: Set<String> = [
             "allow",
             "許可",
+            "action-button-1",
         ]
         return allowDescriptions.contains(description)
     }

--- a/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
@@ -114,18 +114,21 @@ package enum XcodePermissionDialogMatcher {
         let normalizedAgentPaths = normalizedCandidates(agentPathCandidates)
         let normalizedAssistantNames = normalizedCandidates(assistantNameCandidates)
         let pidCandidates = normalizedPIDCandidates(serverProcessIDCandidates)
+        let normalizedTextNodes = normalizedTextNodes(for: snapshot)
+        let defaultButtonDescription = normalizedButtonDescription(snapshot.defaultButton)
         guard containsAssistantNameAndPID(
-            in: normalizedTextNodes(for: snapshot),
+            in: normalizedTextNodes,
             agentPathCandidates: normalizedAgentPaths,
             assistantNameCandidates: normalizedAssistantNames,
-            serverProcessIDCandidates: pidCandidates
+            serverProcessIDCandidates: pidCandidates,
+            defaultButtonDescription: defaultButtonDescription
         ) else {
             return nil
         }
 
         return XcodePermissionDialogMatchDecision(
             fingerprint: fingerprint(for: snapshot, processID: processID),
-            defaultButtonTitle: normalizedButtonDescription(snapshot.defaultButton)
+            defaultButtonTitle: defaultButtonDescription
         )
     }
 
@@ -190,7 +193,8 @@ package enum XcodePermissionDialogMatcher {
         in normalizedTextNodes: [String],
         agentPathCandidates: Set<String>,
         assistantNameCandidates: Set<String>,
-        serverProcessIDCandidates: Set<String>
+        serverProcessIDCandidates: Set<String>,
+        defaultButtonDescription: String
     ) -> Bool {
         let containsPath = normalizedTextNodes.contains { text in
             agentPathCandidates.contains(where: { text.contains($0) })
@@ -216,6 +220,12 @@ package enum XcodePermissionDialogMatcher {
         if containsAssistantName && containsPID {
             return true
         }
+        let containsUnmatchedPIDReference = normalizedTextNodes.contains(where: containsPIDReference)
+        if containsAssistantName && !containsUnmatchedPIDReference
+            && looksLikeAllowButton(defaultButtonDescription)
+        {
+            return true
+        }
         guard containsPID == false, containsPath else {
             return false
         }
@@ -228,6 +238,14 @@ package enum XcodePermissionDialogMatcher {
             return true
         }
         return containsAssistantName
+    }
+
+    private static func looksLikeAllowButton(_ description: String) -> Bool {
+        let allowDescriptions: Set<String> = [
+            "allow",
+            "許可",
+        ]
+        return allowDescriptions.contains(description)
     }
 
     private static func normalizedButtonDescription(
@@ -267,6 +285,15 @@ package enum XcodePermissionDialogMatcher {
         }
 
         return currentDigits == candidate
+    }
+
+    private static func containsPIDReference(_ text: String) -> Bool {
+        guard text.contains("pid") else {
+            return false
+        }
+        return text.unicodeScalars.contains { scalar in
+            CharacterSet.decimalDigits.contains(scalar)
+        }
     }
 
     private static func normalizedText(_ text: String?) -> String? {
@@ -370,7 +397,7 @@ package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessi
             "com.apple.dt.Xcode",
             "com.apple.dt.ExternalViewService",
         ]
-        let processIDs = NSWorkspace.shared.runningApplications.compactMap { application -> pid_t? in
+        var processIDs = Set(NSWorkspace.shared.runningApplications.compactMap { application -> pid_t? in
             guard let bundleIdentifier = application.bundleIdentifier else {
                 return nil
             }
@@ -378,8 +405,46 @@ package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessi
                 return nil
             }
             return application.processIdentifier
+        })
+        processIDs.formUnion(Self.runningProcessIDs(named: "Xcode"))
+        return processIDs.sorted()
+    }
+
+    package static func parseProcessIDLines(_ output: String) -> [pid_t] {
+        output
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line -> pid_t? in
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let value = Int32(trimmed), value > 0 else {
+                    return nil
+                }
+                return pid_t(value)
+            }
+    }
+
+    private static func runningProcessIDs(named processName: String) -> [pid_t] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-x", processName]
+
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return []
         }
-        return Array(Set(processIDs)).sorted()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            return []
+        }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8) else {
+            return []
+        }
+        return parseProcessIDLines(output)
     }
 
     package func openWindows(for processID: pid_t) throws -> [XcodePermissionDialogAXWindow] {
@@ -397,25 +462,56 @@ package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessi
         processID: pid_t,
         window: AXUIElement
     ) throws -> XcodePermissionDialogAXWindow? {
-        guard let defaultButton = copyElement(attribute: kAXDefaultButtonAttribute as CFString, from: window) else {
+        let role = copyString(attribute: kAXRoleAttribute as CFString, from: window)
+        if let role, role != kAXWindowRole as String {
             return nil
         }
+
+        let subrole = copyString(attribute: kAXSubroleAttribute as CFString, from: window)
+        if let subrole,
+           subrole != kAXDialogSubrole as String,
+           subrole != "AXSystemDialog" {
+            return nil
+        }
+
+        let isModal = copyBool(attribute: kAXModalAttribute as CFString, from: window) ?? false
+        guard isModal else {
+            return nil
+        }
+
+        let isMinimized = copyBool(attribute: kAXMinimizedAttribute as CFString, from: window)
+        guard isMinimized != true else {
+            return nil
+        }
+
+        let isMain = copyBool(attribute: kAXMainAttribute as CFString, from: window)
+        let document = copyString(attribute: kAXDocumentAttribute as CFString, from: window)
+        let hasProxy = copyElement(attribute: kAXProxyAttribute as CFString, from: window) != nil
+        if isMain == true && (hasNonEmptyText(document) || hasProxy) {
+            return nil
+        }
+
         let children = (try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: window)) ?? []
+        guard let defaultButton = copyElement(attribute: kAXDefaultButtonAttribute as CFString, from: window)
+            ?? fallbackAllowButton(in: window)
+        else {
+            return nil
+        }
         let processBundleIdentifier = NSRunningApplication(processIdentifier: processID)?.bundleIdentifier
 
         let snapshot = XcodePermissionDialogWindowSnapshot(
             processBundleIdentifier: processBundleIdentifier,
             title: copyString(attribute: kAXTitleAttribute as CFString, from: window) ?? "",
             textValues: collectTextValues(from: window),
-            role: copyString(attribute: kAXRoleAttribute as CFString, from: window),
-            subrole: copyString(attribute: kAXSubroleAttribute as CFString, from: window),
+            role: role,
+            subrole: subrole,
             windowIdentifier: copyString(attribute: kAXIdentifierAttribute as CFString, from: window),
-            isModal: copyBool(attribute: kAXModalAttribute as CFString, from: window) ?? false,
-            isMain: copyBool(attribute: kAXMainAttribute as CFString, from: window),
-            isMinimized: copyBool(attribute: kAXMinimizedAttribute as CFString, from: window),
-            document: copyString(attribute: kAXDocumentAttribute as CFString, from: window),
+            isModal: isModal,
+            isMain: isMain,
+            isMinimized: isMinimized,
+            document: document,
             childCount: children.count,
-            hasProxy: copyElement(attribute: kAXProxyAttribute as CFString, from: window) != nil,
+            hasProxy: hasProxy,
             defaultButton: buttonSnapshot(from: defaultButton),
             cancelButton: copyElement(attribute: kAXCancelButtonAttribute as CFString, from: window)
                 .flatMap(buttonSnapshot(from:))
@@ -426,6 +522,47 @@ package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessi
             snapshot: snapshot,
             defaultButton: defaultButton
         )
+    }
+
+    private func fallbackAllowButton(in root: AXUIElement) -> AXUIElement? {
+        var queue: [AXUIElement] = [root]
+        var visited = 0
+
+        while queue.isEmpty == false, visited < maxDescendantCount {
+            let element = queue.removeFirst()
+            visited += 1
+
+            if isAllowButton(element) {
+                return element
+            }
+            let children = (try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: element)) ?? []
+            queue.append(contentsOf: children)
+        }
+
+        return nil
+    }
+
+    private func isAllowButton(_ element: AXUIElement) -> Bool {
+        let role = copyString(attribute: kAXRoleAttribute as CFString, from: element)
+        guard role == kAXButtonRole as String else { return false }
+        let title = copyString(attribute: kAXTitleAttribute as CFString, from: element)
+            .flatMap(normalizedButtonText)
+        let identifier = copyString(attribute: kAXIdentifierAttribute as CFString, from: element)
+            .flatMap(normalizedButtonText)
+        return title == "allow"
+            || title == "許可"
+            || identifier == "action-button-1"
+    }
+
+    private func normalizedButtonText(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return nil }
+        return trimmed.lowercased()
+    }
+
+    private func hasNonEmptyText(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
 
     private func collectTextValues(from root: AXUIElement) -> [String] {

--- a/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
@@ -221,6 +221,9 @@ package enum XcodePermissionDialogMatcher {
             return true
         }
         let containsUnmatchedPIDReference = normalizedTextNodes.contains(where: containsPIDReference)
+        if containsAssistantName && containsUnmatchedPIDReference {
+            return false
+        }
         if containsAssistantName && !containsUnmatchedPIDReference
             && looksLikeAllowButton(defaultButtonDescription)
         {
@@ -288,12 +291,21 @@ package enum XcodePermissionDialogMatcher {
     }
 
     private static func containsPIDReference(_ text: String) -> Bool {
-        guard text.contains("pid") else {
+        guard text.unicodeScalars.contains(where: { scalar in
+            CharacterSet.decimalDigits.contains(scalar)
+        }) else {
             return false
         }
-        return text.unicodeScalars.contains { scalar in
-            CharacterSet.decimalDigits.contains(scalar)
-        }
+        let labels = [
+            "pid",
+            "process id",
+            "process identifier",
+            "process-id",
+            "process_identifier",
+            "プロセス",
+            "識別子",
+        ]
+        return labels.contains { text.contains($0) }
     }
 
     private static func normalizedText(_ text: String?) -> String? {

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -67,6 +67,47 @@ struct XcodePermissionDialogAutoApproverTests {
         #expect(decision?.defaultButtonTitle == "許可")
     }
 
+    @Test func matcherRejectsLocalizedAllowDialogWithMismatchedProcessIdentifier() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
+            textValues: [
+                "エージェント XcodeMCPKit、プロセス識別子 7001 が Xcode のツール使用を要求しています。"
+            ],
+            defaultButton: makeButton(title: "許可")
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision == nil)
+    }
+
+    @Test func matcherRejectsPathDialogWithLocalizedMismatchedProcessIdentifier() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
+            textValues: [
+                "エージェント XcodeMCPKit at /tmp/xcode-mcp-proxy-server、プロセス ID 7001 が Xcode のツール使用を要求しています。"
+            ],
+            defaultButton: makeButton(title: "許可")
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision == nil)
+    }
+
     @Test func matcherRejectsDialogThatContainsAssistantNameWithoutPIDWhenDefaultButtonIsNotAllow() {
         let snapshot = makeSnapshot(
             processBundleIdentifier: "com.apple.dt.Xcode",

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -67,6 +67,29 @@ struct XcodePermissionDialogAutoApproverTests {
         #expect(decision?.defaultButtonTitle == "許可")
     }
 
+    @Test func matcherMatchesAssistantNameWithoutPIDWhenAllowButtonUsesFallbackIdentifier() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "Allow",
+            textValues: [
+                "The agent XcodeMCPKit wants to use Xcode's tools."
+            ],
+            defaultButton: XcodePermissionDialogButtonSnapshot(
+                role: "AXButton",
+                identifier: "action-button-1"
+            )
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision?.defaultButtonTitle == "action-button-1")
+    }
+
     @Test func matcherRejectsLocalizedAllowDialogWithMismatchedProcessIdentifier() {
         let snapshot = makeSnapshot(
             processBundleIdentifier: "com.apple.dt.Xcode",

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -47,13 +47,34 @@ struct XcodePermissionDialogAutoApproverTests {
         #expect(decision?.defaultButtonTitle == "allow")
     }
 
-    @Test func matcherRejectsLocalizedDialogThatContainsAssistantNameWithoutPID() {
+    @Test func matcherMatchesLocalizedAllowDialogThatContainsAssistantNameWithoutPID() {
         let snapshot = makeSnapshot(
             processBundleIdentifier: "com.apple.dt.Xcode",
             title: "許可",
             textValues: [
                 "エージェント XcodeMCPKit が Xcode のツール使用を要求しています。"
-            ]
+            ],
+            defaultButton: makeButton(title: "許可")
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 4317,
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [6119]
+        )
+
+        #expect(decision?.defaultButtonTitle == "許可")
+    }
+
+    @Test func matcherRejectsDialogThatContainsAssistantNameWithoutPIDWhenDefaultButtonIsNotAllow() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode",
+            title: "許可",
+            textValues: [
+                "エージェント XcodeMCPKit が Xcode のツール使用を要求しています。"
+            ],
+            defaultButton: makeButton(title: "OK")
         )
 
         let decision = XcodePermissionDialogMatcher.decision(
@@ -295,6 +316,14 @@ struct XcodePermissionDialogAutoApproverTests {
 
         #expect(candidates.contains(symlinkExecutable.path))
         #expect(candidates.contains(realExecutable.path))
+    }
+
+    @Test func parseProcessIDLinesIgnoresInvalidPGrepOutput() {
+        let processIDs = LiveXcodePermissionDialogAXClient.parseProcessIDLines(
+            "\n 4317\nnot-a-pid\n0\n-1\n 6119 \n"
+        )
+
+        #expect(processIDs == [4317, 6119])
     }
 
     @Test func autoApproverPromptsAccessibilityOnceAndRemainsInactiveWhenUntrusted() async {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -228,6 +228,39 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
     }
 
+    @Test func readinessGateRetriesLaunchWhenSuccessfulOpenDoesNotProduceXcodeProcess() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let availability = AvailabilityFlag(isAvailable: false)
+        let launchRecorder = XcodeLaunchRecorder()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                availability: availability,
+                launchRetryIntervalNanoseconds: 2_000_000,
+                launchRecorder: launchRecorder
+            )
+        )
+        defer { manager.shutdownAndWait() }
+
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            await launchRecorder.launchCount() >= 2
+        })
+        #expect(await upstream.startCount() == 0)
+
+        await availability.setAvailable(true)
+        await readiness.setReady(true)
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        #expect(await upstream.startCount() > 0)
+    }
+
     @Test func readinessGateRetriesLaunchWhenXcodeQuitsWhileWaiting() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -5437,6 +5470,7 @@ private func makeTestReadinessGate(
     readiness: ReadinessFlag,
     availability: AvailabilityFlag? = nil,
     sleepRecorder: ControlledReadinessSleep? = nil,
+    launchRetryIntervalNanoseconds: UInt64 = 5_000_000_000,
     launchRecorder: XcodeLaunchRecorder? = nil
 ) -> UpstreamReadinessGate {
     let launchIfUnavailable: (@Sendable () async -> Bool)?
@@ -5462,6 +5496,7 @@ private func makeTestReadinessGate(
         targetName: "mcpbridge",
         pollIntervalNanoseconds: 1_000_000,
         progressLogIntervalNanoseconds: 5_000_000_000,
+        launchRetryIntervalNanoseconds: launchRetryIntervalNanoseconds,
         initialRetryBackoffNanoseconds: 1_000_000_000,
         maxRetryBackoffNanoseconds: 8_000_000_000,
         uptimeNanoseconds: {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -42,6 +42,431 @@ struct RuntimeCoordinatorTests {
         #expect(environment["MCP_XCODE_SESSION_ID"] == "session-explicit")
     }
 
+    @Test func xcodeReadinessRequiresWorkspaceWindow() {
+        let pids: Set<pid_t> = [1234]
+
+        #expect(
+            XcodeReadinessProbe.hasReadyWorkspaceWindow(
+                xcodeProcessIDs: pids,
+                windows: []
+            ) == false
+        )
+        #expect(
+            XcodeReadinessProbe.hasReadyWorkspaceWindow(
+                xcodeProcessIDs: pids,
+                windows: [
+                    .init(ownerPID: 1234, title: "Welcome to Xcode", layer: 0, alpha: 1)
+                ]
+            ) == false
+        )
+        #expect(
+            XcodeReadinessProbe.hasReadyWorkspaceWindow(
+                xcodeProcessIDs: pids,
+                windows: [
+                    .init(ownerPID: 5678, title: "XcodeMCPKit — xcode", layer: 0, alpha: 1)
+                ]
+            ) == false
+        )
+        #expect(
+            XcodeReadinessProbe.hasReadyWorkspaceWindow(
+                xcodeProcessIDs: pids,
+                windows: [
+                    .init(ownerPID: 1234, title: "XcodeMCPKit — xcode", layer: 1, alpha: 1)
+                ]
+            ) == false
+        )
+        #expect(
+            XcodeReadinessProbe.hasReadyWorkspaceWindow(
+                xcodeProcessIDs: pids,
+                windows: [
+                    .init(ownerPID: 1234, title: "XcodeMCPKit — xcode", layer: 0, alpha: 1)
+                ]
+            ) == true
+        )
+    }
+
+    @Test func xcodeReadinessFallsBackToProcessWhenAccessibilityWindowsAreUnavailable() {
+        #expect(
+            XcodeReadinessProbe.isReady(
+                xcodeProcessIDs: [1234],
+                windows: nil
+            )
+        )
+        #expect(
+            XcodeReadinessProbe.isReady(
+                xcodeProcessIDs: [],
+                windows: nil
+            ) == false
+        )
+        #expect(
+            XcodeReadinessProbe.isReady(
+                xcodeProcessIDs: [1234],
+                windows: [
+                    .init(ownerPID: 1234, title: "Welcome to Xcode", layer: 0, alpha: 1)
+                ]
+            ) == false
+        )
+    }
+
+    @Test func xcodeReadinessParsesPGrepOutput() {
+        let output = ProcessOutput(terminationStatus: 0, stdout: "1234\n\n5678\n", stderr: "")
+
+        #expect(XcodeReadinessProbe.processIDs(fromPGrepOutput: output) == [1234, 5678])
+        #expect(
+            XcodeReadinessProbe.processIDs(
+                fromPGrepOutput: ProcessOutput(terminationStatus: 1, stdout: "1234\n", stderr: "")
+            ).isEmpty
+        )
+    }
+
+    @Test func readinessGateDefersStartupUntilXcodeIsAvailable() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(readiness: readiness)
+        )
+        defer { manager.shutdownAndWait() }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await upstream.startCount() == 0)
+        #expect(await upstream.sentCount() == 0)
+
+        await readiness.setReady(true)
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: sent) == "initialize")
+        #expect(await upstream.startCount() > 0)
+    }
+
+    @Test func readinessGateLaunchesXcodeWhenUnavailable() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let launchRecorder = XcodeLaunchRecorder()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                launchRecorder: launchRecorder
+            )
+        )
+        defer { manager.shutdownAndWait() }
+
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            await launchRecorder.launchCount() == 1
+        })
+        #expect(await upstream.startCount() == 0)
+        #expect(await upstream.sentCount() == 0)
+
+        await readiness.setReady(true)
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        #expect(await launchRecorder.launchCount() == 1)
+        #expect(await upstream.startCount() > 0)
+    }
+
+    @Test func readinessGateRetriesLaunchWhenXcodeQuitsWhileWaiting() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let availability = AvailabilityFlag(isAvailable: true)
+        let launchRecorder = XcodeLaunchRecorder()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                availability: availability,
+                launchRecorder: launchRecorder
+            )
+        )
+        defer { manager.shutdownAndWait() }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await launchRecorder.launchCount() == 0)
+        #expect(await upstream.startCount() == 0)
+
+        await availability.setAvailable(false)
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            await launchRecorder.launchCount() == 1
+        })
+        #expect(await upstream.startCount() == 0)
+
+        await availability.setAvailable(true)
+        await readiness.setReady(true)
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        #expect(await upstream.startCount() > 0)
+    }
+
+    @Test func readinessGateCompletesPendingInitializeAfterXcodeAppears() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(readiness: readiness)
+        )
+        defer { manager.shutdownAndWait() }
+
+        let future = manager.registerInitialize(
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await upstream.sentCount() == 0)
+
+        await readiness.setReady(true)
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: sent) == "initialize")
+        let upstreamID = try extractUpstreamID(from: sent)
+        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
+
+        let response = try decodeJSON(
+            from: try await waitWithTimeout(
+                "waiting for deferred initialize response",
+                timeout: .seconds(2)
+            ) {
+                try await future.get()
+            }
+        )
+        #expect((response["id"] as? NSNumber)?.intValue == 1)
+        let initializeRequests = await upstream.sent().filter { methodName(from: $0) == "initialize" }
+        #expect(initializeRequests.count == 1)
+    }
+
+    @Test func readinessGateDebugResetDropsWaitingEagerInitialize() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(readiness: readiness)
+        )
+        defer { manager.shutdownAndWait() }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await upstream.sentCount() == 0)
+
+        manager.debugReset()
+        await readiness.setReady(true)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(await upstream.sentCount() == 0)
+        #expect(await upstream.startCount() == 0)
+    }
+
+    @Test func readinessGateDoesNotSendTimedOutInitializeWaiterWhenXcodeAppears() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let clock = TestClock()
+        let config = makeConfig(requestTimeout: 0.05)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(readiness: readiness),
+            scheduleRuntimeTimeout: makeDeterministicRuntimeTimeoutScheduler(clock: clock)
+        )
+        defer { manager.shutdownAndWait() }
+
+        let future = manager.registerInitialize(
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        await clock.sleep(untilSuspendedBy: 1)
+        clock.advance(by: .milliseconds(60))
+        await #expect(throws: TimeoutError.self) {
+            _ = try await future.get()
+        }
+        #expect(await upstream.sentCount() == 0)
+
+        let retryFuture = manager.registerInitialize(
+            originalID: RPCID(any: NSNumber(value: 2))!,
+            requestObject: makeInitializeRequest(id: 2),
+            on: eventLoop
+        )
+        await clock.sleep(untilSuspendedBy: 1)
+        clock.advance(by: .milliseconds(60))
+        await #expect(throws: TimeoutError.self) {
+            _ = try await retryFuture.get()
+        }
+        #expect(await upstream.sentCount() == 0)
+
+        await readiness.setReady(true)
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        #expect(await upstream.sentCount() == 1)
+        #expect(await upstream.startCount() == 2)
+        let initializeRequests = await upstream.sent().filter { methodName(from: $0) == "initialize" }
+        #expect(initializeRequests.count == 1)
+    }
+
+    @Test func readinessGateWaitsInsteadOfTightRetryingWhenXcodeDisappears() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: true)
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(readiness: readiness)
+        )
+        defer { manager.shutdownAndWait() }
+
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let upstreamID = try extractUpstreamID(from: sent)
+        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            manager.isInitialized()
+        })
+
+        await readiness.setReady(false)
+        await upstream.yield(.exit(1))
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await upstream.sentCount() == 2)
+
+        await readiness.setReady(true)
+        try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
+    }
+
+    @Test func readinessGateBacksOffBeforeRetryingWhenXcodeIsStillAvailable() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: true)
+        let sleepRecorder = ControlledReadinessSleep()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                sleepRecorder: sleepRecorder
+            )
+        )
+        defer { manager.shutdownAndWait() }
+
+        let firstInit = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let firstInitID = try extractUpstreamID(from: firstInit)
+        await upstream.yield(.message(try makeInitializeResponse(id: firstInitID)))
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            manager.isInitialized()
+        })
+
+        await upstream.yield(.exit(1))
+        _ = try await waitWithTimeout(
+            "waiting for readiness retry backoff",
+            timeout: .seconds(2)
+        ) {
+            try await sleepRecorder.nextSleep(at: 0)
+        }
+        #expect(await upstream.sentCount() == 2)
+
+        await sleepRecorder.resumeNext()
+        try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
+        let secondInit = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        let secondInitID = try extractUpstreamID(from: secondInit)
+        await upstream.yield(.message(try makeInitializeResponse(id: secondInitID)))
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            manager.isInitialized()
+        })
+
+        await upstream.yield(.exit(1))
+        let secondDelay = try await waitWithTimeout(
+            "waiting for second readiness retry backoff",
+            timeout: .seconds(2)
+        ) {
+            try await sleepRecorder.nextSleep(at: 1)
+        }
+        #expect(secondDelay == 1_000_000_000)
+        await sleepRecorder.resumeNext()
+    }
+
+    @Test func upstreamStderrClassifierTreatsNoXcodeFatalAsAvailabilityWait() {
+        let message =
+            "mcpbridge/MCPBridge.swift:125: Fatal error: MCP_XCODE_PID environment variable not set and no running Xcode processes found"
+
+        #expect(UpstreamStderrClassifier.classify(message) == .xcodeUnavailable)
+    }
+
+    @Test func upstreamStderrLogLimiterSuppressesRepeatedMessages() {
+        let limiter = UpstreamStderrLogLimiter(duplicateLogIntervalNanoseconds: 1_000_000_000)
+        let message = "some upstream stderr"
+        let first = limiter.decision(
+            upstreamIndex: 0,
+            message: message,
+            classification: .unknown,
+            nowUptimeNs: 0
+        )
+        let second = limiter.decision(
+            upstreamIndex: 0,
+            message: message,
+            classification: .unknown,
+            nowUptimeNs: 100_000_000
+        )
+        let third = limiter.decision(
+            upstreamIndex: 0,
+            message: message,
+            classification: .unknown,
+            nowUptimeNs: 1_100_000_000
+        )
+
+        #expect(first.shouldLog)
+        #expect(!second.shouldLog)
+        #expect(third.shouldLog)
+        #expect(third.suppressedDuplicateCount == 1)
+    }
+
+    @Test func upstreamStderrStillRecordsInDebugSnapshotWhenRateLimited() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        manager.handleUpstreamStderr("repeated stderr", upstreamIndex: 0)
+        manager.handleUpstreamStderr("repeated stderr", upstreamIndex: 0)
+
+        let snapshot = manager.debugSnapshot()
+        #expect(snapshot.upstreams[0].recentStderr.count == 2)
+    }
+
     @Test func sessionManagerQueuesInitializeRequests() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -4861,6 +5286,140 @@ private actor ToggleableOverloadUpstreamClient: UpstreamSlotControlling {
     func nextSent(at index: Int) async throws -> Data {
         try await sentMessages.nextValue(at: index)
     }
+}
+
+private actor ReadinessFlag {
+    private var ready: Bool
+
+    init(isReady: Bool) {
+        self.ready = isReady
+    }
+
+    func setReady(_ value: Bool) {
+        ready = value
+    }
+
+    func isReady() -> Bool {
+        ready
+    }
+}
+
+private actor AvailabilityFlag {
+    private var available: Bool
+
+    init(isAvailable: Bool) {
+        self.available = isAvailable
+    }
+
+    func setAvailable(_ value: Bool) {
+        available = value
+    }
+
+    func isAvailable() -> Bool {
+        available
+    }
+}
+
+private actor ControlledReadinessSleep {
+    private var sleeps: [UInt64] = []
+    private var sleepContinuations: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [(index: Int, continuation: CheckedContinuation<UInt64, Error>)] = []
+
+    func sleep(nanoseconds: UInt64) async {
+        sleeps.append(nanoseconds)
+        resumeReadyWaiters()
+        await withCheckedContinuation { continuation in
+            sleepContinuations.append(continuation)
+        }
+    }
+
+    func nextSleep(at index: Int) async throws -> UInt64 {
+        if index < sleeps.count {
+            return sleeps[index]
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            waiters.append((index, continuation))
+        }
+    }
+
+    func resumeNext() {
+        guard !sleepContinuations.isEmpty else { return }
+        sleepContinuations.removeFirst().resume()
+    }
+
+    private func resumeReadyWaiters() {
+        var remaining: [(index: Int, continuation: CheckedContinuation<UInt64, Error>)] = []
+        for waiter in waiters {
+            if waiter.index < sleeps.count {
+                waiter.continuation.resume(returning: sleeps[waiter.index])
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        waiters = remaining
+    }
+}
+
+private actor XcodeLaunchRecorder {
+    private var count = 0
+
+    func launch() -> Bool {
+        count += 1
+        return true
+    }
+
+    func launchCount() -> Int {
+        count
+    }
+}
+
+private func makeTestReadinessGate(
+    readiness: ReadinessFlag,
+    availability: AvailabilityFlag? = nil,
+    sleepRecorder: ControlledReadinessSleep? = nil,
+    launchRecorder: XcodeLaunchRecorder? = nil
+) -> UpstreamReadinessGate {
+    let launchIfUnavailable: (@Sendable () async -> Bool)?
+    if let launchRecorder {
+        launchIfUnavailable = {
+            await launchRecorder.launch()
+        }
+    } else {
+        launchIfUnavailable = nil
+    }
+
+    let isAvailable: (@Sendable () async -> Bool)?
+    if let availability {
+        isAvailable = {
+            await availability.isAvailable()
+        }
+    } else {
+        isAvailable = nil
+    }
+
+    return UpstreamReadinessGate(
+        isEnabled: true,
+        targetName: "mcpbridge",
+        pollIntervalNanoseconds: 1_000_000,
+        progressLogIntervalNanoseconds: 5_000_000_000,
+        initialRetryBackoffNanoseconds: 1_000_000_000,
+        maxRetryBackoffNanoseconds: 8_000_000_000,
+        uptimeNanoseconds: {
+            DispatchTime.now().uptimeNanoseconds
+        },
+        sleepNanoseconds: { nanoseconds in
+            if let sleepRecorder, nanoseconds >= 1_000_000_000 {
+                await sleepRecorder.sleep(nanoseconds: nanoseconds)
+            } else {
+                try? await Task.sleep(nanoseconds: nanoseconds)
+            }
+        },
+        isAvailable: isAvailable,
+        launchIfUnavailable: launchIfUnavailable,
+        isReady: {
+            await readiness.isReady()
+        }
+    )
 }
 
 private func makeInitializeRequest(id: Int) -> [String: Any] {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -176,6 +176,34 @@ struct RuntimeCoordinatorTests {
         #expect(await upstream.startCount() > 0)
     }
 
+    @Test func readinessGateRetriesLaunchAfterFailedAutoLaunch() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let launchRecorder = XcodeLaunchRecorder(outcomes: [false, true])
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                launchRecorder: launchRecorder
+            )
+        )
+        defer { manager.shutdownAndWait() }
+
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            await launchRecorder.launchCount() == 2
+        })
+        #expect(await upstream.startCount() == 0)
+
+        await readiness.setReady(true)
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+    }
+
     @Test func readinessGateRetriesLaunchWhenXcodeQuitsWhileWaiting() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -5362,10 +5390,18 @@ private actor ControlledReadinessSleep {
 
 private actor XcodeLaunchRecorder {
     private var count = 0
+    private var outcomes: [Bool]
+
+    init(outcomes: [Bool] = []) {
+        self.outcomes = outcomes
+    }
 
     func launch() -> Bool {
         count += 1
-        return true
+        guard outcomes.isEmpty == false else {
+            return true
+        }
+        return outcomes.removeFirst()
     }
 
     func launchCount() -> Int {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -119,6 +119,30 @@ struct RuntimeCoordinatorTests {
         )
     }
 
+    @Test func defaultReadinessGateRecognizesFlaggedXcrunMCPBridgeInvocation() {
+        var config = makeConfig(requestTimeout: 5)
+        config.upstreamArgs = ["--sdk", "macosx", "mcpbridge"]
+        #expect(RuntimeCoordinator.isDefaultXcrunMCPBridgeInvocation(config: config))
+
+        config.upstreamCommand = "/usr/bin/xcrun"
+        config.upstreamArgs = ["--sdk=macosx", "--toolchain", "default", "mcpbridge"]
+        #expect(RuntimeCoordinator.isDefaultXcrunMCPBridgeInvocation(config: config))
+    }
+
+    @Test func defaultReadinessGateIgnoresNonMCPBridgeAndCustomWrapperInvocations() {
+        var config = makeConfig(requestTimeout: 5)
+        config.upstreamArgs = ["--sdk", "macosx", "swift"]
+        #expect(RuntimeCoordinator.isDefaultXcrunMCPBridgeInvocation(config: config) == false)
+
+        config.upstreamCommand = "/bin/echo"
+        config.upstreamArgs = ["xcrun", "mcpbridge"]
+        #expect(RuntimeCoordinator.isDefaultXcrunMCPBridgeInvocation(config: config) == false)
+
+        config.upstreamCommand = "xcrun"
+        config.upstreamArgs = ["--sdk", "mcpbridge"]
+        #expect(RuntimeCoordinator.isDefaultXcrunMCPBridgeInvocation(config: config) == false)
+    }
+
     @Test func readinessGateDefersStartupUntilXcodeIsAvailable() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }


### PR DESCRIPTION
Summary:
- Add an upstream readiness gate for the default `xcrun mcpbridge` path so the proxy can wait for, launch, and attach to Xcode after startup.
- Improve Xcode waiting, retry, stderr classification, and debug reset behavior to avoid tight restart loops and stale readiness waiters.
- Update permission dialog auto-approval for delayed Xcode launches and document the new initialization behavior.

Testing:
- `swift test --filter 'xcodeReadiness|readinessGate' -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `codex-review`