### PR TITLE
Fix DocumentationSearch provider selection

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -343,6 +343,7 @@ let package = Package(
             dependencies: [
                 "XcodeMCPProxy",
                 "ProxyCore",
+                "ProxyXcodeSupport",
                 .product(name: "NIO", package: "swift-nio"),
             ],
             path: "Tests/ProxyLiveMCPBridgeTests",

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -213,85 +213,6 @@ package struct LocalMCPResponder {
             let originalID = RPCID(any: originalIDValue),
             let params = object["params"] as? [String: Any],
             let toolName = params["name"] as? String,
-            toolName == DocumentationToolCatalog.toolName,
-            sessionManager.hasDocumentationProvider(),
-            disabledToolNames.contains(toolName) == false
-        {
-            if headerSessionExists == false {
-                _ = sessionManager.session(id: headerSessionID)
-            }
-            guard JSONSerialization.isValidJSONObject(object),
-                  let requestData = try? JSONSerialization.data(withJSONObject: object, options: [])
-            else {
-                return Self.fallbackLocalError(
-                    id: originalID,
-                    sessionID: headerSessionID
-                )
-            }
-            if shouldUseEmbeddedTestSynchronousResolution(on: eventLoop) {
-                do {
-                    let responseData = try Self.waitForAsyncResult {
-                        try await sessionManager.callDocumentationSearch(
-                            requestData: requestData,
-                            requestTimeoutOverride: requestTimeoutOverride
-                        )
-                    }
-                    return .immediateResponse(
-                        data: normalizeDocumentationSearchResponseData(responseData),
-                        sessionID: headerSessionID
-                    )
-                } catch {
-                    let data = try? Self.encodeErrorData(id: originalID, error: error)
-                    if let data {
-                        return .immediateResponse(data: data, sessionID: headerSessionID)
-                    }
-                    return Self.fallbackLocalError(
-                        id: originalID,
-                        sessionID: headerSessionID
-                    )
-                }
-            }
-            let promise = eventLoop.makePromise(of: ByteBuffer.self)
-            Task {
-                do {
-                    let responseData = try await sessionManager.callDocumentationSearch(
-                        requestData: requestData,
-                        requestTimeoutOverride: requestTimeoutOverride
-                    )
-                    let normalizedData = normalizeDocumentationSearchResponseData(responseData)
-                    var responseBuffer = ByteBufferAllocator().buffer(capacity: normalizedData.count)
-                    responseBuffer.writeBytes(normalizedData)
-                    let buffer = responseBuffer
-                    eventLoop.execute {
-                        promise.succeed(buffer)
-                    }
-                } catch {
-                    do {
-                        let buffer = try Self.encodeErrorBuffer(id: originalID, error: error)
-                        eventLoop.execute {
-                            promise.succeed(buffer)
-                        }
-                    } catch {
-                        eventLoop.execute {
-                            promise.fail(error)
-                        }
-                    }
-                }
-            }
-            return .pendingResponse(
-                future: promise.futureResult,
-                sessionID: headerSessionID,
-                originalID: originalID
-            )
-        }
-
-        if method == "tools/call",
-            let headerSessionID,
-            sessionManager.isInitialized(),
-            let originalIDValue = object["id"],
-            let originalID = RPCID(any: originalIDValue),
-            let params = object["params"] as? [String: Any],
-            let toolName = params["name"] as? String,
             toolName == "XcodeListWindows",
             disabledToolNames.contains(toolName) == false
         {
@@ -358,14 +279,6 @@ package struct LocalMCPResponder {
         }
 
         return nil
-    }
-
-    private func normalizeDocumentationSearchResponseData(_ data: Data) -> Data {
-        ToolCallNormalizer(sessionManager: sessionManager).normalizeResponseDataIfNeeded(
-            method: "tools/call",
-            toolName: DocumentationToolCatalog.toolName,
-            upstreamData: data
-        )
     }
 
     private static func encodeResultBuffer(

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -214,6 +214,7 @@ package struct LocalMCPResponder {
             let params = object["params"] as? [String: Any],
             let toolName = params["name"] as? String,
             toolName == DocumentationToolCatalog.toolName,
+            sessionManager.hasDocumentationProvider(),
             disabledToolNames.contains(toolName) == false
         {
             if headerSessionExists == false {

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -188,6 +188,84 @@ package struct LocalMCPResponder {
             let originalID = RPCID(any: originalIDValue),
             let params = object["params"] as? [String: Any],
             let toolName = params["name"] as? String,
+            toolName == DocumentationToolCatalog.toolName,
+            disabledToolNames.contains(toolName) == false
+        {
+            if headerSessionExists == false {
+                _ = sessionManager.session(id: headerSessionID)
+            }
+            guard JSONSerialization.isValidJSONObject(object),
+                  let requestData = try? JSONSerialization.data(withJSONObject: object, options: [])
+            else {
+                return Self.fallbackLocalError(
+                    id: originalID,
+                    sessionID: headerSessionID
+                )
+            }
+            if shouldUseEmbeddedTestSynchronousResolution(on: eventLoop) {
+                do {
+                    let responseData = try Self.waitForAsyncResult {
+                        try await sessionManager.callDocumentationSearch(
+                            requestData: requestData,
+                            requestTimeoutOverride: requestTimeoutOverride
+                        )
+                    }
+                    return .immediateResponse(
+                        data: normalizeDocumentationSearchResponseData(responseData),
+                        sessionID: headerSessionID
+                    )
+                } catch {
+                    let data = try? Self.encodeErrorData(id: originalID, error: error)
+                    if let data {
+                        return .immediateResponse(data: data, sessionID: headerSessionID)
+                    }
+                    return Self.fallbackLocalError(
+                        id: originalID,
+                        sessionID: headerSessionID
+                    )
+                }
+            }
+            let promise = eventLoop.makePromise(of: ByteBuffer.self)
+            Task {
+                do {
+                    let responseData = try await sessionManager.callDocumentationSearch(
+                        requestData: requestData,
+                        requestTimeoutOverride: requestTimeoutOverride
+                    )
+                    let normalizedData = normalizeDocumentationSearchResponseData(responseData)
+                    var responseBuffer = ByteBufferAllocator().buffer(capacity: normalizedData.count)
+                    responseBuffer.writeBytes(normalizedData)
+                    let buffer = responseBuffer
+                    eventLoop.execute {
+                        promise.succeed(buffer)
+                    }
+                } catch {
+                    do {
+                        let buffer = try Self.encodeErrorBuffer(id: originalID, error: error)
+                        eventLoop.execute {
+                            promise.succeed(buffer)
+                        }
+                    } catch {
+                        eventLoop.execute {
+                            promise.fail(error)
+                        }
+                    }
+                }
+            }
+            return .pendingResponse(
+                future: promise.futureResult,
+                sessionID: headerSessionID,
+                originalID: originalID
+            )
+        }
+
+        if method == "tools/call",
+            let headerSessionID,
+            sessionManager.isInitialized(),
+            let originalIDValue = object["id"],
+            let originalID = RPCID(any: originalIDValue),
+            let params = object["params"] as? [String: Any],
+            let toolName = params["name"] as? String,
             toolName == "XcodeListWindows",
             disabledToolNames.contains(toolName) == false
         {
@@ -254,6 +332,14 @@ package struct LocalMCPResponder {
         }
 
         return nil
+    }
+
+    private func normalizeDocumentationSearchResponseData(_ data: Data) -> Data {
+        ToolCallNormalizer(sessionManager: sessionManager).normalizeResponseDataIfNeeded(
+            method: "tools/call",
+            toolName: DocumentationToolCatalog.toolName,
+            upstreamData: data
+        )
     }
 
     private static func encodeResultBuffer(

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -37,6 +37,31 @@ package struct LocalMCPResponder {
         self.logger = logger
     }
 
+    package func toolsListResponseData(
+        object: [String: Any],
+        sessionID: String,
+        requestTimeoutOverride: TimeAmount?
+    ) async throws -> Data {
+        guard let originalIDValue = object["id"],
+              let originalID = RPCID(any: originalIDValue) else {
+            throw ControlPlaneError.invalidResponse("missing id")
+        }
+        let result = try await sessionManager.sharedToolsList(
+            sessionID: sessionID,
+            requestTimeoutOverride: requestTimeoutOverride
+        )
+        let rewrittenResult = RefreshCodeIssuesToolsListRewriter.rewriteResult(
+            result,
+            mode: refreshCodeIssuesMode,
+            hiddenToolNames: disabledToolNames
+        )
+        var buffer = try Self.encodeResultBuffer(
+            id: originalID,
+            result: rewrittenResult
+        )
+        return buffer.readData(length: buffer.readableBytes) ?? Data()
+    }
+
     package func handle(
         object: [String: Any],
         headerSessionID: String?,

--- a/Sources/ProxyHTTPGateway/MCP/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPGateway/MCP/MCPForwardingService.swift
@@ -86,6 +86,7 @@ package struct MCPForwardingService: Sendable {
             registration = session.router.registerBatchPending(
                 on: eventLoop,
                 timeout: requestTimeout,
+                responseIDKeys: prepared.transform.responseIDs.map(\.key),
                 onTimeout: onTimeout
             )
         } else if let idKey = prepared.transform.idKey {

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -213,15 +213,18 @@ extension HTTPPostService {
         )
     }
 
-    package func filterDocumentationSearchToolCalls(
+    package func filterLocalToolCalls(
         filteredRequest: FilteredToolCallRequest,
         sessionID: String,
         eventLoop: EventLoop,
         requestTimeoutOverride: TimeAmount?
-    ) -> DocumentationSearchFilterOperation? {
+    ) -> LocalToolFilterOperation? {
         guard let bodyData = filteredRequest.bodyData,
               let parsedRequestJSON = try? JSONSerialization.jsonObject(with: bodyData, options: [])
         else {
+            return nil
+        }
+        guard !Self.shouldUseEmbeddedTestSynchronousResolution(on: eventLoop) else {
             return nil
         }
 
@@ -234,21 +237,28 @@ extension HTTPPostService {
             return nil
         }
 
+        var toolsListRequests: [[String: Any]] = []
+        toolsListRequests.reserveCapacity(requestItems.count)
         var documentationRequests: [[String: Any]] = []
         documentationRequests.reserveCapacity(requestItems.count)
         var forwardedObjects: [Any] = []
         forwardedObjects.reserveCapacity(requestItems.count)
 
         for item in requestItems {
-            guard let object = item as? [String: Any],
-                  isDocumentationSearchRequest(object) else {
+            guard let object = item as? [String: Any] else {
                 forwardedObjects.append(item)
                 continue
             }
-            documentationRequests.append(object)
+            if isToolsListRequest(object) {
+                toolsListRequests.append(object)
+            } else if isDocumentationSearchRequest(object) {
+                documentationRequests.append(object)
+            } else {
+                forwardedObjects.append(item)
+            }
         }
 
-        guard documentationRequests.isEmpty == false else {
+        guard toolsListRequests.isEmpty == false || documentationRequests.isEmpty == false else {
             return nil
         }
 
@@ -268,7 +278,7 @@ extension HTTPPostService {
         let deadline = Self.timeoutDeadline(
             for: requestTimeoutOverride
                 ?? Self.topLevelRequestTimeoutOverride(
-                    method: "tools/call",
+                    method: nil,
                     defaultSeconds: requestTimeoutSeconds
                 )
         )
@@ -280,38 +290,13 @@ extension HTTPPostService {
                 }
                 return
             }
-            let documentationResponseData = await makeDocumentationSearchBatchResponseData(
-                requests: documentationRequests,
+            let rewritten = await makeFilteredLocalToolRequest(
+                filteredRequest: filteredRequest,
+                toolsListRequests: toolsListRequests,
+                documentationRequests: documentationRequests,
+                forwardedObjects: forwardedObjects,
+                sessionID: sessionID,
                 deadline: deadline
-            )
-            let localResponseData = Self.mergeBatchResponsePayloads(
-                [
-                    filteredRequest.localResponseData,
-                    documentationResponseData,
-                ],
-                forceBatchArray: true
-            )
-
-            let forwardedPayload: Any?
-            if forwardedObjects.isEmpty {
-                forwardedPayload = nil
-            } else if filteredRequest.forceBatchArray || forwardedObjects.count > 1 {
-                forwardedPayload = forwardedObjects
-            } else {
-                forwardedPayload = forwardedObjects[0]
-            }
-            let forwardedBodyData = forwardedPayload.flatMap {
-                try? JSONSerialization.data(withJSONObject: $0, options: [])
-            }
-            let forwardedResponseIDs = forwardedPayload.map {
-                Self.extractResponseIDs(from: $0)
-            } ?? []
-
-            let rewritten = FilteredToolCallRequest(
-                bodyData: forwardedBodyData,
-                localResponseData: localResponseData,
-                forwardedResponseIDs: forwardedResponseIDs,
-                forceBatchArray: filteredRequest.forceBatchArray
             )
             let wasCancelled = Task.isCancelled
             eventLoop.execute {
@@ -323,10 +308,125 @@ extension HTTPPostService {
             }
         }
         cancellationHandle.bindRefreshTask(task)
-        return DocumentationSearchFilterOperation(
+        return LocalToolFilterOperation(
             future: promise.futureResult,
             cancellationHandle: cancellationHandle,
             deadline: deadline
+        )
+    }
+
+    private func makeFilteredLocalToolRequest(
+        filteredRequest: FilteredToolCallRequest,
+        toolsListRequests: [[String: Any]],
+        documentationRequests: [[String: Any]],
+        forwardedObjects: [Any],
+        sessionID: String,
+        deadline: Date?
+    ) async -> FilteredToolCallRequest {
+        let toolsListResponseData = await makeToolsListBatchResponseData(
+            requests: toolsListRequests,
+            sessionID: sessionID,
+            deadline: deadline
+        )
+        let documentationResponseData = await makeDocumentationSearchBatchResponseData(
+            requests: documentationRequests,
+            deadline: deadline
+        )
+        let localResponseData = Self.mergeBatchResponsePayloads(
+            [
+                filteredRequest.localResponseData,
+                toolsListResponseData,
+                documentationResponseData,
+            ],
+            forceBatchArray: true
+        )
+
+        let forwardedPayload: Any?
+        if forwardedObjects.isEmpty {
+            forwardedPayload = nil
+        } else if filteredRequest.forceBatchArray || forwardedObjects.count > 1 {
+            forwardedPayload = forwardedObjects
+        } else {
+            forwardedPayload = forwardedObjects[0]
+        }
+        let forwardedBodyData = forwardedPayload.flatMap {
+            try? JSONSerialization.data(withJSONObject: $0, options: [])
+        }
+        let forwardedResponseIDs = forwardedPayload.map {
+            Self.extractResponseIDs(from: $0)
+        } ?? []
+
+        return FilteredToolCallRequest(
+            bodyData: forwardedBodyData,
+            localResponseData: localResponseData,
+            forwardedResponseIDs: forwardedResponseIDs,
+            forceBatchArray: filteredRequest.forceBatchArray
+        )
+    }
+
+    private func makeToolsListBatchResponseData(
+        requests: [[String: Any]],
+        sessionID: String,
+        deadline: Date?
+    ) async -> Data? {
+        var responseObjects: [[String: Any]] = []
+        responseObjects.reserveCapacity(requests.count)
+
+        for request in requests {
+            guard !Task.isCancelled else {
+                break
+            }
+            guard let idValue = request["id"],
+                  let originalID = RPCID(any: idValue) else {
+                continue
+            }
+            let requestTimeout = Self.remainingRequestTimeout(until: deadline)
+            if deadline != nil,
+                requestTimeout == nil
+            {
+                responseObjects.append(
+                    Self.makeJSONRPCErrorResponseObject(
+                        id: originalID,
+                        code: -32000,
+                        message: "upstream timeout"
+                    )
+                )
+                continue
+            }
+            do {
+                let responseData = try await localResponder.toolsListResponseData(
+                    object: request,
+                    sessionID: sessionID,
+                    requestTimeoutOverride: requestTimeout
+                )
+                responseObjects.append(
+                    contentsOf: Self.responseObjects(from: responseData)
+                )
+            } catch {
+                let mapped = Self.mapDocumentationSearchError(error)
+                if let responseData = Self.responseDataForBatchResolution(
+                    .mcpError(
+                        id: originalID,
+                        ids: [originalID],
+                        code: mapped.code,
+                        message: mapped.message,
+                        forceBatchArray: false,
+                        sessionID: sessionID,
+                        prefersEventStream: false
+                    ),
+                    fallbackRequestIDs: [originalID],
+                    forceBatchArray: false
+                ) {
+                    responseObjects.append(
+                        contentsOf: Self.responseObjects(from: responseData)
+                    )
+                }
+            }
+        }
+
+        return Self.makeToolResponseData(
+            from: responseObjects,
+            forceBatchArray: true
         )
     }
 
@@ -409,6 +509,16 @@ extension HTTPPostService {
             return false
         }
         return true
+    }
+
+    private func isToolsListRequest(_ object: [String: Any]) -> Bool {
+        object["method"] as? String == "tools/list"
+            && object["id"] != nil
+            && sessionManager.isInitialized()
+    }
+
+    private static func shouldUseEmbeddedTestSynchronousResolution(on eventLoop: EventLoop) -> Bool {
+        String(describing: type(of: eventLoop)).contains("EmbeddedEventLoop")
     }
 
     package func blockedToolName(from requestObject: [String: Any]) -> String? {

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -237,18 +237,10 @@ extension HTTPPostService {
             return nil
         }
 
-        let hasLocalToolsListRequest = requestItems.contains { item in
-            guard let object = item as? [String: Any] else {
-                return false
-            }
-            return isToolsListRequest(object)
-        }
         var toolsListRequests: [[String: Any]] = []
         toolsListRequests.reserveCapacity(requestItems.count)
         var documentationRequests: [[String: Any]] = []
         documentationRequests.reserveCapacity(requestItems.count)
-        var deferredDocumentationRequests: [[String: Any]] = []
-        deferredDocumentationRequests.reserveCapacity(requestItems.count)
         var forwardedObjects: [Any] = []
         forwardedObjects.reserveCapacity(requestItems.count)
 
@@ -259,11 +251,8 @@ extension HTTPPostService {
             }
             if isToolsListRequest(object) {
                 toolsListRequests.append(object)
-            } else if isDocumentationSearchRequest(object) {
+            } else if isDocumentationSearchRequest(object, allowInactiveProvider: true) {
                 documentationRequests.append(object)
-            } else if hasLocalToolsListRequest,
-                      isDocumentationSearchRequest(object, allowInactiveProvider: true) {
-                deferredDocumentationRequests.append(object)
             } else {
                 forwardedObjects.append(item)
             }
@@ -309,8 +298,8 @@ extension HTTPPostService {
                 initialLocalResponseData: filteredRequest.localResponseData,
                 toolsListRequests: toolsListRequests,
                 documentationRequests: documentationRequests,
-                deferredDocumentationRequests: deferredDocumentationRequests,
                 sessionID: sessionID,
+                forceBatchArray: filteredRequest.forceBatchArray,
                 deadline: deadline
             )
             let wasCancelled = Task.isCancelled
@@ -362,8 +351,8 @@ extension HTTPPostService {
         initialLocalResponseData: Data?,
         toolsListRequests: [[String: Any]],
         documentationRequests: [[String: Any]],
-        deferredDocumentationRequests: [[String: Any]],
         sessionID: String,
+        forceBatchArray: Bool,
         deadline: Date?
     ) async -> LocalToolBatchResult {
         let toolsListResponseData = await makeToolsListBatchResponseData(
@@ -371,33 +360,23 @@ extension HTTPPostService {
             sessionID: sessionID,
             deadline: deadline
         )
-        var localDocumentationRequests = documentationRequests
-        let fallbackDocumentationRequests: [[String: Any]]
-        if deferredDocumentationRequests.isEmpty {
-            fallbackDocumentationRequests = []
-        } else if sessionManager.hasActiveDocumentationProvider() {
-            localDocumentationRequests.append(contentsOf: deferredDocumentationRequests)
-            fallbackDocumentationRequests = []
-        } else {
-            fallbackDocumentationRequests = deferredDocumentationRequests
-        }
-        let documentationResponseData = await makeDocumentationSearchBatchResponseData(
-            requests: localDocumentationRequests,
+        let documentationResult = await makeDocumentationSearchBatchResult(
+            requests: documentationRequests,
             deadline: deadline
         )
         let localResponseData = Self.mergeBatchResponsePayloads(
             [
                 initialLocalResponseData,
                 toolsListResponseData,
-                documentationResponseData,
+                documentationResult.responseData,
             ],
             forceBatchArray: true
         )
-        let fallbackForwardedRequest = fallbackDocumentationRequests.isEmpty
+        let fallbackForwardedRequest = documentationResult.fallbackRequests.isEmpty
             ? nil
             : makeForwardedLocalToolRequest(
-                forwardedObjects: fallbackDocumentationRequests,
-                forceBatchArray: true
+                forwardedObjects: documentationResult.fallbackRequests,
+                forceBatchArray: forceBatchArray
             )
         return LocalToolBatchResult(
             responseData: localResponseData,
@@ -471,12 +450,14 @@ extension HTTPPostService {
         )
     }
 
-    private func makeDocumentationSearchBatchResponseData(
+    private func makeDocumentationSearchBatchResult(
         requests: [[String: Any]],
         deadline: Date?
-    ) async -> Data? {
+    ) async -> (responseData: Data?, fallbackRequests: [[String: Any]]) {
         var responseObjects: [[String: Any]] = []
         responseObjects.reserveCapacity(requests.count)
+        var fallbackRequests: [[String: Any]] = []
+        fallbackRequests.reserveCapacity(requests.count)
         let normalizer = ToolCallNormalizer(sessionManager: sessionManager)
 
         for request in requests {
@@ -525,6 +506,10 @@ extension HTTPPostService {
                     contentsOf: Self.responseObjects(from: normalizedData)
                 )
             } catch {
+                if Self.shouldFallbackDocumentationSearchToUpstream(error) {
+                    fallbackRequests.append(request)
+                    continue
+                }
                 let mapped = Self.mapDocumentationSearchError(error)
                 responseObjects.append(
                     Self.makeJSONRPCErrorResponseObject(
@@ -536,10 +521,23 @@ extension HTTPPostService {
             }
         }
 
-        return Self.makeToolResponseData(
-            from: responseObjects,
-            forceBatchArray: true
+        return (
+            Self.makeToolResponseData(
+                from: responseObjects,
+                forceBatchArray: true
+            ),
+            fallbackRequests
         )
+    }
+
+    private static func shouldFallbackDocumentationSearchToUpstream(_ error: Error) -> Bool {
+        if error is UpstreamSlotAcquisitionError {
+            return true
+        }
+        if let error = error as? ControlPlaneRequestError {
+            return shouldFallbackDocumentationSearchToUpstream(error.underlying)
+        }
+        return false
     }
 
     private func isDocumentationSearchRequest(

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -237,6 +237,12 @@ extension HTTPPostService {
             return nil
         }
 
+        let hasLocalToolsListRequest = requestItems.contains { item in
+            guard let object = item as? [String: Any] else {
+                return false
+            }
+            return isToolsListRequest(object)
+        }
         var toolsListRequests: [[String: Any]] = []
         toolsListRequests.reserveCapacity(requestItems.count)
         var documentationRequests: [[String: Any]] = []
@@ -251,7 +257,10 @@ extension HTTPPostService {
             }
             if isToolsListRequest(object) {
                 toolsListRequests.append(object)
-            } else if isDocumentationSearchRequest(object) {
+            } else if isDocumentationSearchRequest(
+                object,
+                allowInactiveProvider: hasLocalToolsListRequest
+            ) {
                 documentationRequests.append(object)
             } else {
                 forwardedObjects.append(item)
@@ -510,8 +519,15 @@ extension HTTPPostService {
         )
     }
 
-    private func isDocumentationSearchRequest(_ object: [String: Any]) -> Bool {
-        guard sessionManager.hasActiveDocumentationProvider() else {
+    private func isDocumentationSearchRequest(
+        _ object: [String: Any],
+        allowInactiveProvider: Bool = false
+    ) -> Bool {
+        let hasRoute =
+            allowInactiveProvider
+            ? sessionManager.hasDocumentationProvider()
+            : sessionManager.hasActiveDocumentationProvider()
+        guard hasRoute else {
             return false
         }
         guard object["method"] as? String == "tools/call",

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -213,6 +213,152 @@ extension HTTPPostService {
         )
     }
 
+    package func filterDocumentationSearchToolCalls(
+        filteredRequest: FilteredToolCallRequest,
+        sessionID: String,
+        eventLoop: EventLoop,
+        requestTimeoutOverride: TimeAmount?
+    ) -> EventLoopFuture<FilteredToolCallRequest>? {
+        guard let bodyData = filteredRequest.bodyData,
+              let parsedRequestJSON = try? JSONSerialization.jsonObject(with: bodyData, options: [])
+        else {
+            return nil
+        }
+
+        let requestItems: [Any]
+        if let object = parsedRequestJSON as? [String: Any] {
+            requestItems = [object]
+        } else if let array = parsedRequestJSON as? [Any] {
+            requestItems = array
+        } else {
+            return nil
+        }
+
+        var documentationRequests: [[String: Any]] = []
+        documentationRequests.reserveCapacity(requestItems.count)
+        var forwardedObjects: [Any] = []
+        forwardedObjects.reserveCapacity(requestItems.count)
+
+        for item in requestItems {
+            guard let object = item as? [String: Any],
+                  isDocumentationSearchRequest(object) else {
+                forwardedObjects.append(item)
+                continue
+            }
+            documentationRequests.append(object)
+        }
+
+        guard documentationRequests.isEmpty == false else {
+            return nil
+        }
+
+        let promise = eventLoop.makePromise(of: FilteredToolCallRequest.self)
+        Task {
+            let documentationResponseData = await makeDocumentationSearchBatchResponseData(
+                requests: documentationRequests,
+                requestTimeoutOverride: requestTimeoutOverride
+            )
+            let localResponseData = Self.mergeBatchResponsePayloads(
+                [
+                    filteredRequest.localResponseData,
+                    documentationResponseData,
+                ],
+                forceBatchArray: true
+            )
+
+            let forwardedPayload: Any?
+            if forwardedObjects.isEmpty {
+                forwardedPayload = nil
+            } else if filteredRequest.forceBatchArray || forwardedObjects.count > 1 {
+                forwardedPayload = forwardedObjects
+            } else {
+                forwardedPayload = forwardedObjects[0]
+            }
+            let forwardedBodyData = forwardedPayload.flatMap {
+                try? JSONSerialization.data(withJSONObject: $0, options: [])
+            }
+            let forwardedResponseIDs = forwardedPayload.map {
+                Self.extractResponseIDs(from: $0)
+            } ?? []
+
+            let rewritten = FilteredToolCallRequest(
+                bodyData: forwardedBodyData,
+                localResponseData: localResponseData,
+                forwardedResponseIDs: forwardedResponseIDs,
+                forceBatchArray: filteredRequest.forceBatchArray
+            )
+            eventLoop.execute {
+                promise.succeed(rewritten)
+            }
+        }
+        return promise.futureResult
+    }
+
+    private func makeDocumentationSearchBatchResponseData(
+        requests: [[String: Any]],
+        requestTimeoutOverride: TimeAmount?
+    ) async -> Data? {
+        var responseObjects: [[String: Any]] = []
+        responseObjects.reserveCapacity(requests.count)
+        let normalizer = ToolCallNormalizer(sessionManager: sessionManager)
+
+        for request in requests {
+            guard let idValue = request["id"],
+                  let originalID = RPCID(any: idValue) else {
+                continue
+            }
+            guard JSONSerialization.isValidJSONObject(request),
+                  let requestData = try? JSONSerialization.data(withJSONObject: request, options: []) else {
+                responseObjects.append(
+                    Self.makeJSONRPCErrorResponseObject(
+                        id: originalID,
+                        code: -32600,
+                        message: "invalid request"
+                    )
+                )
+                continue
+            }
+            do {
+                let responseData = try await sessionManager.callDocumentationSearch(
+                    requestData: requestData,
+                    requestTimeoutOverride: requestTimeoutOverride
+                )
+                let normalizedData = normalizer.normalizeResponseDataIfNeeded(
+                    method: "tools/call",
+                    toolName: DocumentationToolCatalog.toolName,
+                    upstreamData: responseData
+                )
+                responseObjects.append(
+                    contentsOf: Self.responseObjects(from: normalizedData)
+                )
+            } catch {
+                let mapped = Self.mapDocumentationSearchError(error)
+                responseObjects.append(
+                    Self.makeJSONRPCErrorResponseObject(
+                        id: originalID,
+                        code: mapped.code,
+                        message: mapped.message
+                    )
+                )
+            }
+        }
+
+        return Self.makeToolResponseData(
+            from: responseObjects,
+            forceBatchArray: true
+        )
+    }
+
+    private func isDocumentationSearchRequest(_ object: [String: Any]) -> Bool {
+        guard object["method"] as? String == "tools/call",
+              let params = object["params"] as? [String: Any],
+              params["name"] as? String == DocumentationToolCatalog.toolName,
+              disabledToolNames.contains(DocumentationToolCatalog.toolName) == false else {
+            return false
+        }
+        return true
+    }
+
     package func blockedToolName(from requestObject: [String: Any]) -> String? {
         guard let method = requestObject["method"] as? String,
             method == "tools/call",

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -511,7 +511,7 @@ extension HTTPPostService {
     }
 
     private func isDocumentationSearchRequest(_ object: [String: Any]) -> Bool {
-        guard sessionManager.hasDocumentationProvider() else {
+        guard sessionManager.hasActiveDocumentationProvider() else {
             return false
         }
         guard object["method"] as? String == "tools/call",

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -247,6 +247,8 @@ extension HTTPPostService {
         toolsListRequests.reserveCapacity(requestItems.count)
         var documentationRequests: [[String: Any]] = []
         documentationRequests.reserveCapacity(requestItems.count)
+        var deferredDocumentationRequests: [[String: Any]] = []
+        deferredDocumentationRequests.reserveCapacity(requestItems.count)
         var forwardedObjects: [Any] = []
         forwardedObjects.reserveCapacity(requestItems.count)
 
@@ -257,11 +259,11 @@ extension HTTPPostService {
             }
             if isToolsListRequest(object) {
                 toolsListRequests.append(object)
-            } else if isDocumentationSearchRequest(
-                object,
-                allowInactiveProvider: hasLocalToolsListRequest
-            ) {
+            } else if isDocumentationSearchRequest(object) {
                 documentationRequests.append(object)
+            } else if hasLocalToolsListRequest,
+                      isDocumentationSearchRequest(object, allowInactiveProvider: true) {
+                deferredDocumentationRequests.append(object)
             } else {
                 forwardedObjects.append(item)
             }
@@ -295,7 +297,7 @@ extension HTTPPostService {
             forwardedObjects: forwardedObjects,
             forceBatchArray: filteredRequest.forceBatchArray
         )
-        let promise = eventLoop.makePromise(of: Data?.self)
+        let promise = eventLoop.makePromise(of: LocalToolBatchResult.self)
         let task = Task { [self] in
             guard !Task.isCancelled else {
                 eventLoop.execute {
@@ -303,10 +305,11 @@ extension HTTPPostService {
                 }
                 return
             }
-            let localResponseData = await makeLocalToolBatchResponseData(
+            let localBatchResult = await makeLocalToolBatchResult(
                 initialLocalResponseData: filteredRequest.localResponseData,
                 toolsListRequests: toolsListRequests,
                 documentationRequests: documentationRequests,
+                deferredDocumentationRequests: deferredDocumentationRequests,
                 sessionID: sessionID,
                 deadline: deadline
             )
@@ -316,7 +319,7 @@ extension HTTPPostService {
                     promise.fail(CancellationError())
                     return
                 }
-                promise.succeed(localResponseData)
+                promise.succeed(localBatchResult)
             }
         }
         cancellationHandle.bindRefreshTask(task)
@@ -355,20 +358,31 @@ extension HTTPPostService {
         )
     }
 
-    private func makeLocalToolBatchResponseData(
+    private func makeLocalToolBatchResult(
         initialLocalResponseData: Data?,
         toolsListRequests: [[String: Any]],
         documentationRequests: [[String: Any]],
+        deferredDocumentationRequests: [[String: Any]],
         sessionID: String,
         deadline: Date?
-    ) async -> Data? {
+    ) async -> LocalToolBatchResult {
         let toolsListResponseData = await makeToolsListBatchResponseData(
             requests: toolsListRequests,
             sessionID: sessionID,
             deadline: deadline
         )
+        var localDocumentationRequests = documentationRequests
+        let fallbackDocumentationRequests: [[String: Any]]
+        if deferredDocumentationRequests.isEmpty {
+            fallbackDocumentationRequests = []
+        } else if sessionManager.hasActiveDocumentationProvider() {
+            localDocumentationRequests.append(contentsOf: deferredDocumentationRequests)
+            fallbackDocumentationRequests = []
+        } else {
+            fallbackDocumentationRequests = deferredDocumentationRequests
+        }
         let documentationResponseData = await makeDocumentationSearchBatchResponseData(
-            requests: documentationRequests,
+            requests: localDocumentationRequests,
             deadline: deadline
         )
         let localResponseData = Self.mergeBatchResponsePayloads(
@@ -379,7 +393,16 @@ extension HTTPPostService {
             ],
             forceBatchArray: true
         )
-        return localResponseData
+        let fallbackForwardedRequest = fallbackDocumentationRequests.isEmpty
+            ? nil
+            : makeForwardedLocalToolRequest(
+                forwardedObjects: fallbackDocumentationRequests,
+                forceBatchArray: true
+            )
+        return LocalToolBatchResult(
+            responseData: localResponseData,
+            fallbackForwardedRequest: fallbackForwardedRequest
+        )
     }
 
     private func makeToolsListBatchResponseData(

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -511,6 +511,9 @@ extension HTTPPostService {
     }
 
     private func isDocumentationSearchRequest(_ object: [String: Any]) -> Bool {
+        guard sessionManager.hasDocumentationProvider() else {
+            return false
+        }
         guard object["method"] as? String == "tools/call",
               let params = object["params"] as? [String: Any],
               params["name"] as? String == DocumentationToolCatalog.toolName,

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -218,7 +218,7 @@ extension HTTPPostService {
         sessionID: String,
         eventLoop: EventLoop,
         requestTimeoutOverride: TimeAmount?
-    ) -> EventLoopFuture<FilteredToolCallRequest>? {
+    ) -> DocumentationSearchFilterOperation? {
         guard let bodyData = filteredRequest.bodyData,
               let parsedRequestJSON = try? JSONSerialization.jsonObject(with: bodyData, options: [])
         else {
@@ -252,11 +252,37 @@ extension HTTPPostService {
             return nil
         }
 
+        let requestIDs = Self.extractResponseIDs(from: parsedRequestJSON)
+        let descriptor = Self.topLevelRequestDescriptor(
+            sessionID: sessionID,
+            parsedRequestJSON: parsedRequestJSON,
+            requestIsBatch: filteredRequest.forceBatchArray,
+            requestIDs: requestIDs
+        )
+        let leaseID = sessionManager.createRequestLease(descriptor: descriptor)
+        let cancellationHandle = HTTPPostCancellationHandle(
+            leaseID: leaseID,
+            sessionID: sessionID,
+            requestIDKeys: requestIDs.map(\.key)
+        )
+        let deadline = Self.timeoutDeadline(
+            for: requestTimeoutOverride
+                ?? Self.topLevelRequestTimeoutOverride(
+                    method: "tools/call",
+                    defaultSeconds: requestTimeoutSeconds
+                )
+        )
         let promise = eventLoop.makePromise(of: FilteredToolCallRequest.self)
-        Task {
+        let task = Task { [self] in
+            guard !Task.isCancelled else {
+                eventLoop.execute {
+                    promise.fail(CancellationError())
+                }
+                return
+            }
             let documentationResponseData = await makeDocumentationSearchBatchResponseData(
                 requests: documentationRequests,
-                requestTimeoutOverride: requestTimeoutOverride
+                deadline: deadline
             )
             let localResponseData = Self.mergeBatchResponsePayloads(
                 [
@@ -287,22 +313,35 @@ extension HTTPPostService {
                 forwardedResponseIDs: forwardedResponseIDs,
                 forceBatchArray: filteredRequest.forceBatchArray
             )
+            let wasCancelled = Task.isCancelled
             eventLoop.execute {
+                if wasCancelled {
+                    promise.fail(CancellationError())
+                    return
+                }
                 promise.succeed(rewritten)
             }
         }
-        return promise.futureResult
+        cancellationHandle.bindRefreshTask(task)
+        return DocumentationSearchFilterOperation(
+            future: promise.futureResult,
+            cancellationHandle: cancellationHandle,
+            deadline: deadline
+        )
     }
 
     private func makeDocumentationSearchBatchResponseData(
         requests: [[String: Any]],
-        requestTimeoutOverride: TimeAmount?
+        deadline: Date?
     ) async -> Data? {
         var responseObjects: [[String: Any]] = []
         responseObjects.reserveCapacity(requests.count)
         let normalizer = ToolCallNormalizer(sessionManager: sessionManager)
 
         for request in requests {
+            guard !Task.isCancelled else {
+                break
+            }
             guard let idValue = request["id"],
                   let originalID = RPCID(any: idValue) else {
                 continue
@@ -318,10 +357,23 @@ extension HTTPPostService {
                 )
                 continue
             }
+            let requestTimeout = Self.remainingRequestTimeout(until: deadline)
+            if deadline != nil,
+                requestTimeout == nil
+            {
+                responseObjects.append(
+                    Self.makeJSONRPCErrorResponseObject(
+                        id: originalID,
+                        code: -32000,
+                        message: "upstream timeout"
+                    )
+                )
+                continue
+            }
             do {
                 let responseData = try await sessionManager.callDocumentationSearch(
                     requestData: requestData,
-                    requestTimeoutOverride: requestTimeoutOverride
+                    requestTimeoutOverride: requestTimeout
                 )
                 let normalizedData = normalizer.normalizeResponseDataIfNeeded(
                     method: "tools/call",

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -282,7 +282,11 @@ extension HTTPPostService {
                     defaultSeconds: requestTimeoutSeconds
                 )
         )
-        let promise = eventLoop.makePromise(of: FilteredToolCallRequest.self)
+        let forwardedRequest = makeForwardedLocalToolRequest(
+            forwardedObjects: forwardedObjects,
+            forceBatchArray: filteredRequest.forceBatchArray
+        )
+        let promise = eventLoop.makePromise(of: Data?.self)
         let task = Task { [self] in
             guard !Task.isCancelled else {
                 eventLoop.execute {
@@ -290,11 +294,10 @@ extension HTTPPostService {
                 }
                 return
             }
-            let rewritten = await makeFilteredLocalToolRequest(
-                filteredRequest: filteredRequest,
+            let localResponseData = await makeLocalToolBatchResponseData(
+                initialLocalResponseData: filteredRequest.localResponseData,
                 toolsListRequests: toolsListRequests,
                 documentationRequests: documentationRequests,
-                forwardedObjects: forwardedObjects,
                 sessionID: sessionID,
                 deadline: deadline
             )
@@ -304,47 +307,26 @@ extension HTTPPostService {
                     promise.fail(CancellationError())
                     return
                 }
-                promise.succeed(rewritten)
+                promise.succeed(localResponseData)
             }
         }
         cancellationHandle.bindRefreshTask(task)
         return LocalToolFilterOperation(
-            future: promise.futureResult,
+            localResponseFuture: promise.futureResult,
+            forwardedRequest: forwardedRequest,
             cancellationHandle: cancellationHandle,
             deadline: deadline
         )
     }
 
-    private func makeFilteredLocalToolRequest(
-        filteredRequest: FilteredToolCallRequest,
-        toolsListRequests: [[String: Any]],
-        documentationRequests: [[String: Any]],
+    private func makeForwardedLocalToolRequest(
         forwardedObjects: [Any],
-        sessionID: String,
-        deadline: Date?
-    ) async -> FilteredToolCallRequest {
-        let toolsListResponseData = await makeToolsListBatchResponseData(
-            requests: toolsListRequests,
-            sessionID: sessionID,
-            deadline: deadline
-        )
-        let documentationResponseData = await makeDocumentationSearchBatchResponseData(
-            requests: documentationRequests,
-            deadline: deadline
-        )
-        let localResponseData = Self.mergeBatchResponsePayloads(
-            [
-                filteredRequest.localResponseData,
-                toolsListResponseData,
-                documentationResponseData,
-            ],
-            forceBatchArray: true
-        )
-
+        forceBatchArray: Bool
+    ) -> FilteredToolCallRequest {
         let forwardedPayload: Any?
         if forwardedObjects.isEmpty {
             forwardedPayload = nil
-        } else if filteredRequest.forceBatchArray || forwardedObjects.count > 1 {
+        } else if forceBatchArray || forwardedObjects.count > 1 {
             forwardedPayload = forwardedObjects
         } else {
             forwardedPayload = forwardedObjects[0]
@@ -358,10 +340,37 @@ extension HTTPPostService {
 
         return FilteredToolCallRequest(
             bodyData: forwardedBodyData,
-            localResponseData: localResponseData,
+            localResponseData: nil,
             forwardedResponseIDs: forwardedResponseIDs,
-            forceBatchArray: filteredRequest.forceBatchArray
+            forceBatchArray: forceBatchArray
         )
+    }
+
+    private func makeLocalToolBatchResponseData(
+        initialLocalResponseData: Data?,
+        toolsListRequests: [[String: Any]],
+        documentationRequests: [[String: Any]],
+        sessionID: String,
+        deadline: Date?
+    ) async -> Data? {
+        let toolsListResponseData = await makeToolsListBatchResponseData(
+            requests: toolsListRequests,
+            sessionID: sessionID,
+            deadline: deadline
+        )
+        let documentationResponseData = await makeDocumentationSearchBatchResponseData(
+            requests: documentationRequests,
+            deadline: deadline
+        )
+        let localResponseData = Self.mergeBatchResponsePayloads(
+            [
+                initialLocalResponseData,
+                toolsListResponseData,
+                documentationResponseData,
+            ],
+            forceBatchArray: true
+        )
+        return localResponseData
     }
 
     private func makeToolsListBatchResponseData(

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -515,6 +515,7 @@ extension HTTPPostService {
             return false
         }
         guard object["method"] as? String == "tools/call",
+              object["id"] != nil,
               let params = object["params"] as? [String: Any],
               params["name"] as? String == DocumentationToolCatalog.toolName,
               disabledToolNames.contains(DocumentationToolCatalog.toolName) == false else {

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
@@ -395,6 +395,37 @@ extension HTTPPostService {
         return try? JSONSerialization.data(withJSONObject: payload, options: [])
     }
 
+    package static func responseObjects(from responseData: Data) -> [[String: Any]] {
+        guard let payload = try? JSONSerialization.jsonObject(with: responseData, options: []) else {
+            return []
+        }
+        if let array = payload as? [[String: Any]] {
+            return array
+        }
+        if let object = payload as? [String: Any] {
+            return [object]
+        }
+        return []
+    }
+
+    package static func mapDocumentationSearchError(_ error: Error) -> (code: Int, message: String) {
+        if error is UpstreamSlotAcquisitionError {
+            return (-32001, "upstream unavailable")
+        }
+        if let error = error as? ControlPlaneRequestError {
+            return mapDocumentationSearchError(error.underlying)
+        }
+        if let error = error as? ControlPlaneError {
+            switch error {
+            case .invalidResponse:
+                return (-32000, "upstream timeout")
+            case .upstreamRPC(let code, let message):
+                return (code, message)
+            }
+        }
+        return (-32000, "upstream timeout")
+    }
+
     package static func extractResponseIDs(from requestJSON: Any) -> [RPCID] {
         if let object = requestJSON as? [String: Any] {
             guard let rawID = object["id"], let rpcID = RPCID(any: rawID) else {

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
@@ -250,6 +250,37 @@ extension HTTPPostService {
             ?? responseData
     }
 
+    package static func mergeLocalToolResponseData(
+        _ localResponseData: Data?,
+        into resolution: HTTPPostResolution,
+        fallbackRequestIDs: [RPCID],
+        forceBatchArray: Bool,
+        sessionID: String,
+        prefersEventStream: Bool
+    ) -> HTTPPostResolution {
+        guard localResponseData != nil else {
+            return resolution
+        }
+        let forwardedResponseData = responseDataForBatchResolution(
+            resolution,
+            fallbackRequestIDs: fallbackRequestIDs,
+            forceBatchArray: forceBatchArray
+        )
+        let mergedData = mergeBatchResponsePayloads(
+            [
+                forwardedResponseData,
+                localResponseData,
+            ],
+            forceBatchArray: forceBatchArray
+        )
+        return makeLocalResponseResolution(
+            responseData: mergedData,
+            sessionID: sessionID,
+            prefersEventStream: prefersEventStream,
+            emptyStatus: .accepted
+        )
+    }
+
     package static func mergeBatchResponsePayloads(
         _ payloads: [Data?],
         forceBatchArray: Bool

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -15,7 +15,7 @@ package final class HTTPPostService: Sendable {
         let forceBatchArray: Bool
     }
 
-    package struct DocumentationSearchFilterOperation {
+    package struct LocalToolFilterOperation {
         let future: EventLoopFuture<FilteredToolCallRequest>
         let cancellationHandle: HTTPPostCancellationHandle
         let deadline: Date?
@@ -186,16 +186,16 @@ package final class HTTPPostService: Sendable {
             )
         }
 
-        if let documentationFilter = filterDocumentationSearchToolCalls(
+        if let localToolFilter = filterLocalToolCalls(
             filteredRequest: filteredRequest,
             sessionID: sessionID,
             eventLoop: eventLoop,
             requestTimeoutOverride: requestTimeoutOverride
         ) {
             if let parentCancellationHandle,
-                parentCancellationHandle.bindChildHandle(documentationFilter.cancellationHandle) == false
+                parentCancellationHandle.bindChildHandle(localToolFilter.cancellationHandle) == false
             {
-                documentationFilter.cancellationHandle.cancel(using: sessionManager)
+                localToolFilter.cancellationHandle.cancel(using: sessionManager)
                 return HTTPPostOperation(
                     future: eventLoop.makeSucceededFuture(
                         .empty(status: .accepted, sessionID: sessionID)
@@ -204,9 +204,9 @@ package final class HTTPPostService: Sendable {
                 )
             }
 
-            let future = documentationFilter.future.flatMap { rewrittenRequest in
-                let forwardingTimeout = Self.remainingRequestTimeout(until: documentationFilter.deadline)
-                if documentationFilter.deadline != nil,
+            let future = localToolFilter.future.flatMap { rewrittenRequest in
+                let forwardingTimeout = Self.remainingRequestTimeout(until: localToolFilter.deadline)
+                if localToolFilter.deadline != nil,
                     forwardingTimeout == nil,
                     rewrittenRequest.bodyData != nil
                 {
@@ -232,17 +232,17 @@ package final class HTTPPostService: Sendable {
                     prefersEventStream: prefersEventStream,
                     eventLoop: eventLoop,
                     requestTimeoutOverride: forwardingTimeout,
-                    parentCancellationHandle: documentationFilter.cancellationHandle
+                    parentCancellationHandle: localToolFilter.cancellationHandle
                 ).future
             }
             future.whenComplete { result in
                 guard (try? result.get()) != nil else { return }
-                documentationFilter.cancellationHandle.markCompleted()
-                self.sessionManager.completeRequestLease(documentationFilter.cancellationHandle.leaseID)
+                localToolFilter.cancellationHandle.markCompleted()
+                self.sessionManager.completeRequestLease(localToolFilter.cancellationHandle.leaseID)
             }
             return HTTPPostOperation(
                 future: future,
-                cancellationHandle: documentationFilter.cancellationHandle
+                cancellationHandle: localToolFilter.cancellationHandle
             )
         }
 

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -16,7 +16,8 @@ package final class HTTPPostService: Sendable {
     }
 
     package struct LocalToolFilterOperation {
-        let future: EventLoopFuture<FilteredToolCallRequest>
+        let localResponseFuture: EventLoopFuture<Data?>
+        let forwardedRequest: FilteredToolCallRequest
         let cancellationHandle: HTTPPostCancellationHandle
         let deadline: Date?
     }
@@ -204,28 +205,26 @@ package final class HTTPPostService: Sendable {
                 )
             }
 
-            let future = localToolFilter.future.flatMap { rewrittenRequest in
-                let forwardingTimeout = Self.remainingRequestTimeout(until: localToolFilter.deadline)
-                if localToolFilter.deadline != nil,
-                    forwardingTimeout == nil,
-                    rewrittenRequest.bodyData != nil
-                {
-                    return eventLoop.makeSucceededFuture(
-                        Self.makePartialBatchErrorResolution(
-                            localResponseData: rewrittenRequest.localResponseData,
-                            responseIDs: rewrittenRequest.forwardedResponseIDs,
-                            code: -32000,
-                            message: "upstream timeout",
-                            sessionID: sessionID,
-                            prefersEventStream: prefersEventStream,
-                            forceBatchArray: rewrittenRequest.forceBatchArray,
-                            fallbackStatus: .gatewayTimeout,
-                            fallbackBody: "upstream timeout"
-                        )
+            let forwardingTimeout = Self.remainingRequestTimeout(until: localToolFilter.deadline)
+            let forwardingFuture: EventLoopFuture<HTTPPostResolution>
+            if localToolFilter.deadline != nil,
+                forwardingTimeout == nil,
+                localToolFilter.forwardedRequest.bodyData != nil
+            {
+                forwardingFuture = eventLoop.makeSucceededFuture(
+                    .mcpError(
+                        id: nil,
+                        ids: localToolFilter.forwardedRequest.forwardedResponseIDs,
+                        code: -32000,
+                        message: "upstream timeout",
+                        forceBatchArray: localToolFilter.forwardedRequest.forceBatchArray,
+                        sessionID: sessionID,
+                        prefersEventStream: prefersEventStream
                     )
-                }
-                return self.makeForwardingOperation(
-                    filteredRequest: rewrittenRequest,
+                )
+            } else {
+                forwardingFuture = self.makeForwardingOperation(
+                    filteredRequest: localToolFilter.forwardedRequest,
                     sessionID: sessionID,
                     headerSessionID: headerSessionID,
                     requestIsBatch: requestIsBatch,
@@ -234,6 +233,18 @@ package final class HTTPPostService: Sendable {
                     requestTimeoutOverride: forwardingTimeout,
                     parentCancellationHandle: localToolFilter.cancellationHandle
                 ).future
+            }
+            let future = forwardingFuture.and(localToolFilter.localResponseFuture).map {
+                forwardingResolution,
+                localResponseData in
+                Self.mergeLocalToolResponseData(
+                    localResponseData,
+                    into: forwardingResolution,
+                    fallbackRequestIDs: localToolFilter.forwardedRequest.forwardedResponseIDs,
+                    forceBatchArray: localToolFilter.forwardedRequest.forceBatchArray,
+                    sessionID: sessionID,
+                    prefersEventStream: prefersEventStream
+                )
             }
             future.whenComplete { result in
                 guard (try? result.get()) != nil else { return }

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -180,6 +180,51 @@ package final class HTTPPostService: Sendable {
             )
         }
 
+        if let documentationFilterFuture = filterDocumentationSearchToolCalls(
+            filteredRequest: filteredRequest,
+            sessionID: sessionID,
+            eventLoop: eventLoop,
+            requestTimeoutOverride: requestTimeoutOverride
+        ) {
+            return HTTPPostOperation(
+                future: documentationFilterFuture.flatMap { rewrittenRequest in
+                    self.makeForwardingOperation(
+                        filteredRequest: rewrittenRequest,
+                        sessionID: sessionID,
+                        headerSessionID: headerSessionID,
+                        requestIsBatch: requestIsBatch,
+                        prefersEventStream: prefersEventStream,
+                        eventLoop: eventLoop,
+                        requestTimeoutOverride: requestTimeoutOverride,
+                        parentCancellationHandle: parentCancellationHandle
+                    ).future
+                },
+                cancellationHandle: nil
+            )
+        }
+
+        return makeForwardingOperation(
+            filteredRequest: filteredRequest,
+            sessionID: sessionID,
+            headerSessionID: headerSessionID,
+            requestIsBatch: requestIsBatch,
+            prefersEventStream: prefersEventStream,
+            eventLoop: eventLoop,
+            requestTimeoutOverride: requestTimeoutOverride,
+            parentCancellationHandle: parentCancellationHandle
+        )
+    }
+
+    package func makeForwardingOperation(
+        filteredRequest: FilteredToolCallRequest,
+        sessionID: String,
+        headerSessionID: String?,
+        requestIsBatch: Bool,
+        prefersEventStream: Bool,
+        eventLoop: EventLoop,
+        requestTimeoutOverride: TimeAmount?,
+        parentCancellationHandle: HTTPPostCancellationHandle?
+    ) -> HTTPPostOperation {
         guard let forwardedBodyData = filteredRequest.bodyData else {
             return HTTPPostOperation(
                 future: eventLoop.makeSucceededFuture(

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -20,6 +20,11 @@ package final class HTTPPostService: Sendable {
         let fallbackForwardedRequest: FilteredToolCallRequest?
     }
 
+    private struct LocalToolFallbackForwardingResult {
+        let request: FilteredToolCallRequest
+        let resolution: HTTPPostResolution
+    }
+
     package struct LocalToolFilterOperation {
         let localResponseFuture: EventLoopFuture<LocalToolBatchResult>
         let forwardedRequest: FilteredToolCallRequest
@@ -210,38 +215,47 @@ package final class HTTPPostService: Sendable {
                 )
             }
 
-            let forwardingTimeout = Self.remainingRequestTimeout(until: localToolFilter.deadline)
-            let forwardingFuture: EventLoopFuture<HTTPPostResolution>
-            if localToolFilter.deadline != nil,
-                forwardingTimeout == nil,
-                localToolFilter.forwardedRequest.bodyData != nil
-            {
-                forwardingFuture = eventLoop.makeSucceededFuture(
-                    .mcpError(
-                        id: nil,
-                        ids: localToolFilter.forwardedRequest.forwardedResponseIDs,
-                        code: -32000,
-                        message: "upstream timeout",
-                        forceBatchArray: localToolFilter.forwardedRequest.forceBatchArray,
-                        sessionID: sessionID,
-                        prefersEventStream: prefersEventStream
-                    )
-                )
-            } else {
-                forwardingFuture = self.makeForwardingOperation(
-                    filteredRequest: localToolFilter.forwardedRequest,
+            let forwardingFuture = makeLocalToolForwardingFuture(
+                request: localToolFilter.forwardedRequest,
+                sessionID: sessionID,
+                headerSessionID: headerSessionID,
+                requestIsBatch: requestIsBatch,
+                prefersEventStream: prefersEventStream,
+                eventLoop: eventLoop,
+                deadline: localToolFilter.deadline,
+                cancellationHandle: localToolFilter.cancellationHandle
+            )
+            let localAndFallbackFuture = localToolFilter.localResponseFuture.flatMap {
+                localBatchResult -> EventLoopFuture<(
+                    LocalToolBatchResult,
+                    LocalToolFallbackForwardingResult?
+                )> in
+                guard let fallbackRequest = localBatchResult.fallbackForwardedRequest else {
+                    return eventLoop.makeSucceededFuture((localBatchResult, nil))
+                }
+                return self.makeLocalToolForwardingFuture(
+                    request: fallbackRequest,
                     sessionID: sessionID,
                     headerSessionID: headerSessionID,
                     requestIsBatch: requestIsBatch,
                     prefersEventStream: prefersEventStream,
                     eventLoop: eventLoop,
-                    requestTimeoutOverride: forwardingTimeout,
-                    parentCancellationHandle: localToolFilter.cancellationHandle
-                ).future
+                    deadline: localToolFilter.deadline,
+                    cancellationHandle: localToolFilter.cancellationHandle
+                ).map { fallbackResolution in
+                    (
+                        localBatchResult,
+                        LocalToolFallbackForwardingResult(
+                            request: fallbackRequest,
+                            resolution: fallbackResolution
+                        )
+                    )
+                }
             }
-            let future = forwardingFuture.and(localToolFilter.localResponseFuture).flatMap {
+            let future = forwardingFuture.and(localAndFallbackFuture).map {
                 forwardingResolution,
-                localBatchResult in
+                localAndFallback in
+                let (localBatchResult, fallbackForwarding) = localAndFallback
                 let initialResolution = Self.mergeLocalToolResponseData(
                     localBatchResult.responseData,
                     into: forwardingResolution,
@@ -250,53 +264,22 @@ package final class HTTPPostService: Sendable {
                     sessionID: sessionID,
                     prefersEventStream: prefersEventStream
                 )
-                guard let fallbackRequest = localBatchResult.fallbackForwardedRequest else {
-                    return eventLoop.makeSucceededFuture(initialResolution)
+                guard let fallbackForwarding else {
+                    return initialResolution
                 }
-                let fallbackTimeout = Self.remainingRequestTimeout(until: localToolFilter.deadline)
-                let fallbackForwardingFuture: EventLoopFuture<HTTPPostResolution>
-                if localToolFilter.deadline != nil,
-                    fallbackTimeout == nil,
-                    fallbackRequest.bodyData != nil
-                {
-                    fallbackForwardingFuture = eventLoop.makeSucceededFuture(
-                        .mcpError(
-                            id: nil,
-                            ids: fallbackRequest.forwardedResponseIDs,
-                            code: -32000,
-                            message: "upstream timeout",
-                            forceBatchArray: fallbackRequest.forceBatchArray,
-                            sessionID: sessionID,
-                            prefersEventStream: prefersEventStream
-                        )
-                    )
-                } else {
-                    fallbackForwardingFuture = self.makeForwardingOperation(
-                        filteredRequest: fallbackRequest,
-                        sessionID: sessionID,
-                        headerSessionID: headerSessionID,
-                        requestIsBatch: requestIsBatch,
-                        prefersEventStream: prefersEventStream,
-                        eventLoop: eventLoop,
-                        requestTimeoutOverride: fallbackTimeout,
-                        parentCancellationHandle: localToolFilter.cancellationHandle
-                    ).future
-                }
-                return fallbackForwardingFuture.map { fallbackResolution in
-                    let initialData = Self.responseDataForBatchResolution(
-                        initialResolution,
-                        fallbackRequestIDs: localToolFilter.forwardedRequest.forwardedResponseIDs,
-                        forceBatchArray: localToolFilter.forwardedRequest.forceBatchArray
-                    )
-                    return Self.mergeLocalToolResponseData(
-                        initialData,
-                        into: fallbackResolution,
-                        fallbackRequestIDs: fallbackRequest.forwardedResponseIDs,
-                        forceBatchArray: fallbackRequest.forceBatchArray,
-                        sessionID: sessionID,
-                        prefersEventStream: prefersEventStream
-                    )
-                }
+                let initialData = Self.responseDataForBatchResolution(
+                    initialResolution,
+                    fallbackRequestIDs: localToolFilter.forwardedRequest.forwardedResponseIDs,
+                    forceBatchArray: localToolFilter.forwardedRequest.forceBatchArray
+                )
+                return Self.mergeLocalToolResponseData(
+                    initialData,
+                    into: fallbackForwarding.resolution,
+                    fallbackRequestIDs: fallbackForwarding.request.forwardedResponseIDs,
+                    forceBatchArray: fallbackForwarding.request.forceBatchArray,
+                    sessionID: sessionID,
+                    prefersEventStream: prefersEventStream
+                )
             }
             future.whenComplete { result in
                 guard (try? result.get()) != nil else { return }
@@ -319,6 +302,45 @@ package final class HTTPPostService: Sendable {
             requestTimeoutOverride: requestTimeoutOverride,
             parentCancellationHandle: parentCancellationHandle
         )
+    }
+
+    private func makeLocalToolForwardingFuture(
+        request: FilteredToolCallRequest,
+        sessionID: String,
+        headerSessionID: String?,
+        requestIsBatch: Bool,
+        prefersEventStream: Bool,
+        eventLoop: EventLoop,
+        deadline: Date?,
+        cancellationHandle: HTTPPostCancellationHandle
+    ) -> EventLoopFuture<HTTPPostResolution> {
+        let forwardingTimeout = Self.remainingRequestTimeout(until: deadline)
+        if deadline != nil,
+            forwardingTimeout == nil,
+            request.bodyData != nil
+        {
+            return eventLoop.makeSucceededFuture(
+                .mcpError(
+                    id: nil,
+                    ids: request.forwardedResponseIDs,
+                    code: -32000,
+                    message: "upstream timeout",
+                    forceBatchArray: request.forceBatchArray,
+                    sessionID: sessionID,
+                    prefersEventStream: prefersEventStream
+                )
+            )
+        }
+        return makeForwardingOperation(
+            filteredRequest: request,
+            sessionID: sessionID,
+            headerSessionID: headerSessionID,
+            requestIsBatch: requestIsBatch,
+            prefersEventStream: prefersEventStream,
+            eventLoop: eventLoop,
+            requestTimeoutOverride: forwardingTimeout,
+            parentCancellationHandle: cancellationHandle
+        ).future
     }
 
     package func makeForwardingOperation(

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -15,6 +15,12 @@ package final class HTTPPostService: Sendable {
         let forceBatchArray: Bool
     }
 
+    package struct DocumentationSearchFilterOperation {
+        let future: EventLoopFuture<FilteredToolCallRequest>
+        let cancellationHandle: HTTPPostCancellationHandle
+        let deadline: Date?
+    }
+
     package let sessionManager: any RuntimeCoordinating
     package let disabledToolNames: Set<String>
     package let localResponder: LocalMCPResponder
@@ -180,26 +186,63 @@ package final class HTTPPostService: Sendable {
             )
         }
 
-        if let documentationFilterFuture = filterDocumentationSearchToolCalls(
+        if let documentationFilter = filterDocumentationSearchToolCalls(
             filteredRequest: filteredRequest,
             sessionID: sessionID,
             eventLoop: eventLoop,
             requestTimeoutOverride: requestTimeoutOverride
         ) {
+            if let parentCancellationHandle,
+                parentCancellationHandle.bindChildHandle(documentationFilter.cancellationHandle) == false
+            {
+                documentationFilter.cancellationHandle.cancel(using: sessionManager)
+                return HTTPPostOperation(
+                    future: eventLoop.makeSucceededFuture(
+                        .empty(status: .accepted, sessionID: sessionID)
+                    ),
+                    cancellationHandle: nil
+                )
+            }
+
+            let future = documentationFilter.future.flatMap { rewrittenRequest in
+                let forwardingTimeout = Self.remainingRequestTimeout(until: documentationFilter.deadline)
+                if documentationFilter.deadline != nil,
+                    forwardingTimeout == nil,
+                    rewrittenRequest.bodyData != nil
+                {
+                    return eventLoop.makeSucceededFuture(
+                        Self.makePartialBatchErrorResolution(
+                            localResponseData: rewrittenRequest.localResponseData,
+                            responseIDs: rewrittenRequest.forwardedResponseIDs,
+                            code: -32000,
+                            message: "upstream timeout",
+                            sessionID: sessionID,
+                            prefersEventStream: prefersEventStream,
+                            forceBatchArray: rewrittenRequest.forceBatchArray,
+                            fallbackStatus: .gatewayTimeout,
+                            fallbackBody: "upstream timeout"
+                        )
+                    )
+                }
+                return self.makeForwardingOperation(
+                    filteredRequest: rewrittenRequest,
+                    sessionID: sessionID,
+                    headerSessionID: headerSessionID,
+                    requestIsBatch: requestIsBatch,
+                    prefersEventStream: prefersEventStream,
+                    eventLoop: eventLoop,
+                    requestTimeoutOverride: forwardingTimeout,
+                    parentCancellationHandle: documentationFilter.cancellationHandle
+                ).future
+            }
+            future.whenComplete { result in
+                guard (try? result.get()) != nil else { return }
+                documentationFilter.cancellationHandle.markCompleted()
+                self.sessionManager.completeRequestLease(documentationFilter.cancellationHandle.leaseID)
+            }
             return HTTPPostOperation(
-                future: documentationFilterFuture.flatMap { rewrittenRequest in
-                    self.makeForwardingOperation(
-                        filteredRequest: rewrittenRequest,
-                        sessionID: sessionID,
-                        headerSessionID: headerSessionID,
-                        requestIsBatch: requestIsBatch,
-                        prefersEventStream: prefersEventStream,
-                        eventLoop: eventLoop,
-                        requestTimeoutOverride: requestTimeoutOverride,
-                        parentCancellationHandle: parentCancellationHandle
-                    ).future
-                },
-                cancellationHandle: nil
+                future: future,
+                cancellationHandle: documentationFilter.cancellationHandle
             )
         }
 

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -15,8 +15,13 @@ package final class HTTPPostService: Sendable {
         let forceBatchArray: Bool
     }
 
+    package struct LocalToolBatchResult: Sendable {
+        let responseData: Data?
+        let fallbackForwardedRequest: FilteredToolCallRequest?
+    }
+
     package struct LocalToolFilterOperation {
-        let localResponseFuture: EventLoopFuture<Data?>
+        let localResponseFuture: EventLoopFuture<LocalToolBatchResult>
         let forwardedRequest: FilteredToolCallRequest
         let cancellationHandle: HTTPPostCancellationHandle
         let deadline: Date?
@@ -234,17 +239,64 @@ package final class HTTPPostService: Sendable {
                     parentCancellationHandle: localToolFilter.cancellationHandle
                 ).future
             }
-            let future = forwardingFuture.and(localToolFilter.localResponseFuture).map {
+            let future = forwardingFuture.and(localToolFilter.localResponseFuture).flatMap {
                 forwardingResolution,
-                localResponseData in
-                Self.mergeLocalToolResponseData(
-                    localResponseData,
+                localBatchResult in
+                let initialResolution = Self.mergeLocalToolResponseData(
+                    localBatchResult.responseData,
                     into: forwardingResolution,
                     fallbackRequestIDs: localToolFilter.forwardedRequest.forwardedResponseIDs,
                     forceBatchArray: localToolFilter.forwardedRequest.forceBatchArray,
                     sessionID: sessionID,
                     prefersEventStream: prefersEventStream
                 )
+                guard let fallbackRequest = localBatchResult.fallbackForwardedRequest else {
+                    return eventLoop.makeSucceededFuture(initialResolution)
+                }
+                let fallbackTimeout = Self.remainingRequestTimeout(until: localToolFilter.deadline)
+                let fallbackForwardingFuture: EventLoopFuture<HTTPPostResolution>
+                if localToolFilter.deadline != nil,
+                    fallbackTimeout == nil,
+                    fallbackRequest.bodyData != nil
+                {
+                    fallbackForwardingFuture = eventLoop.makeSucceededFuture(
+                        .mcpError(
+                            id: nil,
+                            ids: fallbackRequest.forwardedResponseIDs,
+                            code: -32000,
+                            message: "upstream timeout",
+                            forceBatchArray: fallbackRequest.forceBatchArray,
+                            sessionID: sessionID,
+                            prefersEventStream: prefersEventStream
+                        )
+                    )
+                } else {
+                    fallbackForwardingFuture = self.makeForwardingOperation(
+                        filteredRequest: fallbackRequest,
+                        sessionID: sessionID,
+                        headerSessionID: headerSessionID,
+                        requestIsBatch: requestIsBatch,
+                        prefersEventStream: prefersEventStream,
+                        eventLoop: eventLoop,
+                        requestTimeoutOverride: fallbackTimeout,
+                        parentCancellationHandle: localToolFilter.cancellationHandle
+                    ).future
+                }
+                return fallbackForwardingFuture.map { fallbackResolution in
+                    let initialData = Self.responseDataForBatchResolution(
+                        initialResolution,
+                        fallbackRequestIDs: localToolFilter.forwardedRequest.forwardedResponseIDs,
+                        forceBatchArray: localToolFilter.forwardedRequest.forceBatchArray
+                    )
+                    return Self.mergeLocalToolResponseData(
+                        initialData,
+                        into: fallbackResolution,
+                        fallbackRequestIDs: fallbackRequest.forwardedResponseIDs,
+                        forceBatchArray: fallbackRequest.forceBatchArray,
+                        sessionID: sessionID,
+                        prefersEventStream: prefersEventStream
+                    )
+                }
             }
             future.whenComplete { result in
                 guard (try? result.get()) != nil else { return }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -662,6 +662,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 requestData,
                 timeout: retryCallTimeout
             )
+            if DocumentationToolCatalog.responseIsDocumentationNotEnabled(retryResponse) {
+                await invalidate(replacement, reason: "documentation_search_retry_not_enabled")
+            }
             return DocumentationProviderCallResult(
                 data: retryResponse,
                 didInvalidateProvider: true

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -23,7 +23,7 @@ package struct DocumentationProviderCallResult: Sendable {
 }
 
 package protocol DocumentationProviderManaging: Sendable {
-    func prewarm(requestTimeout: TimeAmount?) async
+    func prewarm(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate
     func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate
     func callDocumentationSearch(
         requestData: Data,
@@ -36,7 +36,9 @@ package protocol DocumentationProviderManaging: Sendable {
 package struct DisabledDocumentationProviderManager: DocumentationProviderManaging {
     package init() {}
 
-    package func prewarm(requestTimeout _: TimeAmount?) async {}
+    package func prewarm(requestTimeout _: TimeAmount?) async -> DocumentationToolListUpdate {
+        .unchanged
+    }
 
     package func toolListUpdate(requestTimeout _: TimeAmount?) async -> DocumentationToolListUpdate {
         .unchanged
@@ -336,10 +338,14 @@ package protocol DocumentationProviderSessionMaking: Sendable {
 }
 
 package struct LiveDocumentationProviderSessionFactory: DocumentationProviderSessionMaking {
-    package init() {}
+    private let baseEnvironment: [String: String]
+
+    package init(baseEnvironment: [String: String] = ProcessInfo.processInfo.environment) {
+        self.baseEnvironment = baseEnvironment
+    }
 
     package func startSession(for target: DocumentationProviderTarget) async throws -> any UpstreamSession {
-        var environment = ProcessInfo.processInfo.environment
+        var environment = baseEnvironment
         environment.removeValue(forKey: "XCODE_PID")
         environment["MCP_XCODE_PID"] = String(target.processID)
         environment["DEVELOPER_DIR"] = target.developerDir
@@ -563,6 +569,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     private let discovery: any XcodeTargetDiscovering
     private let sessionFactory: any DocumentationProviderSessionMaking
     private let providerSelectionTimeout: TimeAmount?
+    private let pinnedProcessID: pid_t?
+    private let initializeParams: [String: JSONValue]
     private let logger: Logger
     private var activeProvider: ActiveProvider?
     private var providerSelection: ProviderSelection?
@@ -572,17 +580,21 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         discovery: any XcodeTargetDiscovering = LiveXcodeTargetDiscovery(),
         sessionFactory: any DocumentationProviderSessionMaking = LiveDocumentationProviderSessionFactory(),
         providerSelectionTimeout: TimeAmount? = .seconds(30),
+        pinnedProcessID: pid_t? = nil,
+        initializeParams: [String: JSONValue] = DocumentationProviderManager.defaultInitializeParams(),
         logger: Logger = ProxyLogging.make("documentation.provider")
     ) {
         self.discovery = discovery
         self.sessionFactory = sessionFactory
         self.providerSelectionTimeout = providerSelectionTimeout
+        self.pinnedProcessID = pinnedProcessID
+        self.initializeParams = initializeParams
         self.logger = logger
     }
 
-    package func prewarm(requestTimeout: TimeAmount?) async {
-        guard !isShutdown else { return }
-        _ = await toolListUpdate(requestTimeout: requestTimeout)
+    package func prewarm(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
+        guard !isShutdown else { return .unavailable }
+        return await toolListUpdate(requestTimeout: requestTimeout)
     }
 
     package func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
@@ -820,11 +832,19 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             return nil
         }
         let selectionDeadline = Self.requestDeadline(for: requestTimeout)
-        let targets = discovery.runningXcodeTargets()
+        let discoveredTargets = discovery.runningXcodeTargets()
+        let targets: [DocumentationProviderTarget]
+        if let pinnedProcessID {
+            targets = discoveredTargets.filter { $0.processID == pinnedProcessID }
+        } else {
+            targets = discoveredTargets
+        }
         logger.debug(
             "Selecting documentation provider from running Xcode processes",
             metadata: [
                 "candidate_count": .string("\(targets.count)"),
+                "discovered_candidate_count": .string("\(discoveredTargets.count)"),
+                "pinned_pid": .string(pinnedProcessID.map(String.init) ?? ""),
                 "candidates": .string(targets.map { "\($0.processID):\($0.appPath)" }.joined(separator: ",")),
             ]
         )
@@ -906,7 +926,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 throw TimeoutError()
             }
             let initialize = try await connection.call(
-                try Self.makeInitializeRequestData(),
+                try makeInitializeRequestData(),
                 timeout: initializeTimeout
             )
             let serverVersion = Self.serverVersion(fromInitializeResponse: initialize) ?? ""
@@ -953,20 +973,24 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
     }
 
-    private static func makeInitializeRequestData() throws -> Data {
+    package static func defaultInitializeParams() -> [String: JSONValue] {
+        [
+            "protocolVersion": .string("2025-03-26"),
+            "capabilities": .object([:]),
+            "clientInfo": .object([
+                "name": .string("XcodeMCPKit"),
+                "version": .string("dev"),
+            ]),
+        ]
+    }
+
+    private func makeInitializeRequestData() throws -> Data {
         try JSONSerialization.data(
             withJSONObject: [
                 "jsonrpc": "2.0",
                 "id": "initialize",
                 "method": "initialize",
-                "params": [
-                    "protocolVersion": "2025-03-26",
-                    "capabilities": [:],
-                    "clientInfo": [
-                        "name": "XcodeMCPKitDocumentationProvider",
-                        "version": "dev",
-                    ],
-                ],
+                "params": initializeParams.mapValues(\.foundationObject),
             ],
             options: []
         )

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -508,6 +508,7 @@ package actor DocumentationProviderConnection {
 
 package actor DocumentationProviderManager: DocumentationProviderManaging {
     private struct CandidateProfile: Sendable {
+        let id: UUID
         let target: DocumentationProviderTarget
         let connection: DocumentationProviderConnection
         let descriptor: JSONValue
@@ -519,10 +520,16 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let profile: CandidateProfile
     }
 
+    private struct ProviderSelection: Sendable {
+        let id: UUID
+        let task: Task<CandidateProfile?, Never>
+    }
+
     private let discovery: any XcodeTargetDiscovering
     private let sessionFactory: any DocumentationProviderSessionMaking
     private let logger: Logger
     private var activeProvider: ActiveProvider?
+    private var providerSelection: ProviderSelection?
 
     package init(
         discovery: any XcodeTargetDiscovering = LiveXcodeTargetDiscovery(),
@@ -576,7 +583,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 timeout: callTimeout
             )
         } catch {
-            await invalidate(reason: "documentation_provider_call_failed")
+            await invalidate(provider, reason: "documentation_provider_call_failed")
             let replacementSelectionTimeout = Self.requestTimeout(until: requestDeadline)
             guard replacementSelectionTimeout?.nanoseconds != 0 else {
                 throw error
@@ -601,7 +608,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             return DocumentationProviderCallResult(data: response, didInvalidateProvider: false)
         }
 
-        await invalidate(reason: "documentation_search_not_enabled")
+        await invalidate(provider, reason: "documentation_search_not_enabled")
         let replacementSelectionTimeout = Self.requestTimeout(until: requestDeadline)
         guard replacementSelectionTimeout?.nanoseconds != 0,
               let replacement = await providerIfAvailable(requestTimeout: replacementSelectionTimeout) else {
@@ -617,7 +624,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 timeout: retryCallTimeout
             )
             if DocumentationToolCatalog.responseIsDocumentationNotEnabled(retryResponse) {
-                await invalidate(reason: "documentation_search_retry_not_enabled")
+                await invalidate(replacement, reason: "documentation_search_retry_not_enabled")
             }
             return DocumentationProviderCallResult(
                 data: retryResponse,
@@ -629,6 +636,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     }
 
     package func invalidate(reason _: String) async {
+        providerSelection?.task.cancel()
+        providerSelection = nil
         guard let provider = activeProvider else {
             return
         }
@@ -644,12 +653,51 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         if let activeProvider {
             return activeProvider
         }
-        guard let selected = await selectProvider(requestTimeout: requestTimeout) else {
+        let selection: ProviderSelection
+        if let providerSelection {
+            selection = providerSelection
+        } else {
+            selection = ProviderSelection(
+                id: UUID(),
+                task: Task { await self.selectProvider(requestTimeout: requestTimeout) }
+            )
+            providerSelection = selection
+        }
+
+        let selected = await selection.task.value
+        let selectionIsCurrent = providerSelection?.id == selection.id
+        if selectionIsCurrent {
+            providerSelection = nil
+        }
+
+        if let activeProvider {
+            if let selected, selected.id != activeProvider.profile.id {
+                await selected.connection.stop()
+            }
+            return activeProvider
+        }
+
+        guard selectionIsCurrent else {
+            if let selected {
+                await selected.connection.stop()
+            }
+            return nil
+        }
+        guard let selected else {
             return nil
         }
         let provider = ActiveProvider(profile: selected)
         activeProvider = provider
         return provider
+    }
+
+    private func invalidate(_ provider: ActiveProvider, reason _: String) async {
+        guard let activeProvider, activeProvider.profile.id == provider.profile.id else {
+            await provider.profile.connection.stop()
+            return
+        }
+        self.activeProvider = nil
+        await provider.profile.connection.stop()
     }
 
     private func selectProvider(requestTimeout: TimeAmount?) async -> CandidateProfile? {
@@ -687,6 +735,13 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 )
                 continue
             }
+        }
+
+        if Task.isCancelled {
+            for profile in profiles {
+                await profile.connection.stop()
+            }
+            return nil
         }
 
         guard let selected = profiles.max(by: { lhs, rhs in
@@ -761,6 +816,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 throw UpstreamSlotAcquisitionError.unavailable
             }
             return CandidateProfile(
+                id: UUID(),
                 target: target,
                 connection: connection,
                 descriptor: descriptor,

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -22,6 +22,16 @@ package struct DocumentationProviderCallResult: Sendable {
     }
 }
 
+package struct DocumentationProviderCallFailure: Error {
+    package let underlying: any Error
+    package let providerIsActive: Bool
+
+    package init(underlying: any Error, providerIsActive: Bool) {
+        self.underlying = underlying
+        self.providerIsActive = providerIsActive
+    }
+}
+
 package protocol DocumentationProviderManaging: Sendable {
     func prewarm(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate
     func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate
@@ -648,20 +658,28 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             await invalidate(provider, reason: "documentation_provider_call_failed")
             let replacementSelectionTimeout = Self.requestTimeout(until: requestDeadline)
             guard replacementSelectionTimeout?.nanoseconds != 0 else {
-                throw error
+                throw DocumentationProviderCallFailure(underlying: error, providerIsActive: false)
             }
             guard let replacement = await providerIfAvailable(requestTimeout: replacementSelectionTimeout) else {
                 try Task.checkCancellation()
-                throw error
+                throw DocumentationProviderCallFailure(underlying: error, providerIsActive: false)
             }
             let retryCallTimeout = Self.requestTimeout(until: requestDeadline)
             guard retryCallTimeout?.nanoseconds != 0 else {
-                throw error
+                throw DocumentationProviderCallFailure(underlying: error, providerIsActive: true)
             }
-            let retryResponse = try await replacement.profile.connection.call(
-                requestData,
-                timeout: retryCallTimeout
-            )
+            let retryResponse: Data
+            do {
+                retryResponse = try await replacement.profile.connection.call(
+                    requestData,
+                    timeout: retryCallTimeout
+                )
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try Task.checkCancellation()
+                throw DocumentationProviderCallFailure(underlying: error, providerIsActive: true)
+            }
             if DocumentationToolCatalog.responseIsDocumentationNotEnabled(retryResponse) {
                 await invalidate(replacement, reason: "documentation_search_retry_not_enabled")
             }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -532,19 +532,31 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
 
     private final class ProviderSelectionWaitState: @unchecked Sendable {
         private let lock = NSLock()
-        private var didResume = false
+        private var continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>?
+        private var resolvedResult: ProviderSelectionWaitResult?
 
-        func resume(
-            _ result: ProviderSelectionWaitResult,
-            continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>
-        ) {
+        func setContinuation(_ continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>) {
             lock.lock()
-            defer { lock.unlock() }
-            guard !didResume else {
+            if let resolvedResult {
+                lock.unlock()
+                continuation.resume(returning: resolvedResult)
                 return
             }
-            didResume = true
-            continuation.resume(returning: result)
+            self.continuation = continuation
+            lock.unlock()
+        }
+
+        func resume(_ result: ProviderSelectionWaitResult) {
+            lock.lock()
+            guard resolvedResult == nil else {
+                lock.unlock()
+                return
+            }
+            resolvedResult = result
+            let continuation = continuation
+            self.continuation = nil
+            lock.unlock()
+            continuation?.resume(returning: result)
         }
     }
 
@@ -602,6 +614,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             throw TimeoutError()
         }
         guard let provider = await providerIfAvailable(requestTimeout: initialTimeout) else {
+            try Task.checkCancellation()
             throw UpstreamSlotAcquisitionError.unavailable
         }
 
@@ -626,6 +639,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 throw error
             }
             guard let replacement = await providerIfAvailable(requestTimeout: replacementSelectionTimeout) else {
+                try Task.checkCancellation()
                 throw error
             }
             let retryCallTimeout = Self.requestTimeout(until: requestDeadline)
@@ -648,8 +662,11 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         await invalidate(provider, reason: "documentation_search_not_enabled")
         try Task.checkCancellation()
         let replacementSelectionTimeout = Self.requestTimeout(until: requestDeadline)
-        guard replacementSelectionTimeout?.nanoseconds != 0,
-              let replacement = await providerIfAvailable(requestTimeout: replacementSelectionTimeout) else {
+        guard replacementSelectionTimeout?.nanoseconds != 0 else {
+            return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
+        }
+        guard let replacement = await providerIfAvailable(requestTimeout: replacementSelectionTimeout) else {
+            try Task.checkCancellation()
             return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
         }
         let retryCallTimeout = Self.requestTimeout(until: requestDeadline)
@@ -758,24 +775,35 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         _ selection: ProviderSelection,
         requestTimeout: TimeAmount?
     ) async -> ProviderSelectionWaitResult {
-        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
-            return .completed(await selection.task.value)
+        guard !Task.isCancelled else {
+            return .timedOut
         }
 
-        return await withCheckedContinuation { continuation in
-            let state = ProviderSelectionWaitState()
-            Task.detached {
-                let profile = await selection.task.value
-                state.resume(
-                    .completed(profile),
-                    continuation: continuation
-                )
-            }
-            Task.detached {
-                try? await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
-                state.resume(.timedOut, continuation: continuation)
-            }
+        let state = ProviderSelectionWaitState()
+        let selectionWaitTask = Task {
+            let profile = await selection.task.value
+            state.resume(.completed(profile))
         }
+        let timeoutTask: Task<Void, Never>?
+        if let requestTimeout, requestTimeout.nanoseconds > 0 {
+            timeoutTask = Task {
+                try? await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
+                state.resume(.timedOut)
+            }
+        } else {
+            timeoutTask = nil
+        }
+
+        let result = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                state.setContinuation(continuation)
+            }
+        } onCancel: {
+            state.resume(.timedOut)
+        }
+        selectionWaitTask.cancel()
+        timeoutTask?.cancel()
+        return result
     }
 
     private func invalidate(_ provider: ActiveProvider, reason _: String) async {

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -550,25 +550,33 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
 
     private let discovery: any XcodeTargetDiscovering
     private let sessionFactory: any DocumentationProviderSessionMaking
+    private let providerSelectionTimeout: TimeAmount?
     private let logger: Logger
     private var activeProvider: ActiveProvider?
     private var providerSelection: ProviderSelection?
+    private var isShutdown = false
 
     package init(
         discovery: any XcodeTargetDiscovering = LiveXcodeTargetDiscovery(),
         sessionFactory: any DocumentationProviderSessionMaking = LiveDocumentationProviderSessionFactory(),
+        providerSelectionTimeout: TimeAmount? = .seconds(30),
         logger: Logger = ProxyLogging.make("documentation.provider")
     ) {
         self.discovery = discovery
         self.sessionFactory = sessionFactory
+        self.providerSelectionTimeout = providerSelectionTimeout
         self.logger = logger
     }
 
     package func prewarm(requestTimeout: TimeAmount?) async {
+        guard !isShutdown else { return }
         _ = await toolListUpdate(requestTimeout: requestTimeout)
     }
 
     package func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
+        guard !isShutdown else {
+            return .unavailable
+        }
         guard requestTimeout?.nanoseconds != 0 else {
             return .unavailable
         }
@@ -585,6 +593,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         requestData: Data,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> DocumentationProviderCallResult {
+        guard !isShutdown else {
+            throw UpstreamSlotAcquisitionError.unavailable
+        }
         let requestDeadline = Self.requestDeadline(for: requestTimeoutOverride)
         let initialTimeout = Self.requestTimeout(until: requestDeadline)
         guard initialTimeout?.nanoseconds != 0 else {
@@ -659,35 +670,40 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     }
 
     package func invalidate(reason _: String) async {
-        providerSelection?.task.cancel()
+        let selection = providerSelection
         providerSelection = nil
-        guard let provider = activeProvider else {
-            return
-        }
+        selection?.task.cancel()
+        let provider = activeProvider
         activeProvider = nil
-        await provider.profile.connection.stop()
+        if let selected = await selection?.task.value,
+           selected.id != provider?.profile.id {
+            await selected.connection.stop()
+        }
+        await provider?.profile.connection.stop()
     }
 
     package func shutdown() async {
+        isShutdown = true
         await invalidate(reason: "shutdown")
     }
 
     private func providerIfAvailable(requestTimeout: TimeAmount?) async -> ActiveProvider? {
+        guard !isShutdown else {
+            return nil
+        }
         if let activeProvider {
             return activeProvider
         }
         let selection: ProviderSelection
-        let didStartSelection: Bool
         if let providerSelection {
             selection = providerSelection
-            didStartSelection = false
         } else {
+            let selectionTimeout = providerSelectionTimeout
             selection = ProviderSelection(
                 id: UUID(),
-                task: Task { await self.selectProvider(requestTimeout: requestTimeout) }
+                task: Task { await self.selectProvider(requestTimeout: selectionTimeout) }
             )
             providerSelection = selection
-            didStartSelection = true
         }
 
         let waitResult = await waitForSelection(selection, requestTimeout: requestTimeout)
@@ -696,17 +712,18 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         case .completed(let profile):
             selected = profile
         case .timedOut:
-            if didStartSelection,
-                providerSelection?.id == selection.id
-            {
-                providerSelection = nil
-                selection.task.cancel()
-            }
             return nil
         }
         let selectionIsCurrent = providerSelection?.id == selection.id
         if selectionIsCurrent {
             providerSelection = nil
+        }
+
+        if isShutdown {
+            if let selected {
+                await selected.connection.stop()
+            }
+            return nil
         }
 
         if let activeProvider {
@@ -764,6 +781,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     }
 
     private func selectProvider(requestTimeout: TimeAmount?) async -> CandidateProfile? {
+        guard !isShutdown else {
+            return nil
+        }
         let selectionDeadline = Self.requestDeadline(for: requestTimeout)
         let targets = discovery.runningXcodeTargets()
         logger.debug(
@@ -775,7 +795,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         )
         var profiles: [CandidateProfile] = []
         for target in targets {
-            guard !Task.isCancelled else {
+            guard !Task.isCancelled, !isShutdown else {
                 break
             }
             let candidateTimeout = Self.requestTimeout(until: selectionDeadline)
@@ -784,6 +804,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             }
             do {
                 let profile = try await probe(target: target, requestTimeout: candidateTimeout)
+                guard !Task.isCancelled, !isShutdown else {
+                    await profile.connection.stop()
+                    break
+                }
                 profiles.append(profile)
             } catch is CancellationError {
                 break
@@ -800,7 +824,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             }
         }
 
-        if Task.isCancelled {
+        if Task.isCancelled || isShutdown {
             for profile in profiles {
                 await profile.connection.stop()
             }
@@ -836,10 +860,12 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         requestTimeout: TimeAmount?
     ) async throws -> CandidateProfile {
         let probeDeadline = Self.requestDeadline(for: requestTimeout ?? .seconds(30))
+        try Task.checkCancellation()
         let session = try await sessionFactory.startSession(for: target)
         let connection = DocumentationProviderConnection(session: session)
-        await connection.start()
         do {
+            try Task.checkCancellation()
+            await connection.start()
             let initializeTimeout = Self.requestTimeout(until: probeDeadline)
             guard initializeTimeout?.nanoseconds != 0 else {
                 throw TimeoutError()

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -407,7 +407,8 @@ package actor DocumentationProviderConnection {
             throw ControlPlaneError.invalidResponse("missing DocumentationSearch request id")
         }
 
-        let upstreamID = "__documentation-provider-\(nextID)"
+        let upstreamID = nextID
+        let upstreamIDKey = String(upstreamID)
         nextID += 1
         object["id"] = upstreamID
         guard JSONSerialization.isValidJSONObject(object) else {
@@ -421,20 +422,20 @@ package actor DocumentationProviderConnection {
                     originalID: originalID,
                     continuation: continuation
                 )
-                pendingResponses[upstreamID] = pending
-                scheduleTimeoutIfNeeded(id: upstreamID, timeout: timeout, pending: pending)
+                pendingResponses[upstreamIDKey] = pending
+                scheduleTimeoutIfNeeded(id: upstreamIDKey, timeout: timeout, pending: pending)
 
                 Task { [weak self, session] in
                     let sendResult = await session.send(upstreamData)
                     guard sendResult == .accepted else {
-                        await self?.failPending(id: upstreamID, error: UpstreamSlotAcquisitionError.unavailable)
+                        await self?.failPending(id: upstreamIDKey, error: UpstreamSlotAcquisitionError.unavailable)
                         return
                     }
                 }
             }
         } onCancel: {
             Task { [weak self] in
-                await self?.failPending(id: upstreamID, error: CancellationError())
+                await self?.failPending(id: upstreamIDKey, error: CancellationError())
             }
         }
     }
@@ -530,6 +531,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         guard requestTimeout?.nanoseconds != 0 else {
             return .unavailable
         }
+        guard !Task.isCancelled else {
+            return .unavailable
+        }
         guard let provider = await providerIfAvailable(requestTimeout: requestTimeout) else {
             return .unavailable
         }
@@ -549,11 +553,16 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             throw UpstreamSlotAcquisitionError.unavailable
         }
 
+        let callTimeout = Self.requestTimeout(until: requestDeadline)
+        guard callTimeout?.nanoseconds != 0 else {
+            throw TimeoutError()
+        }
+
         let response: Data
         do {
             response = try await provider.profile.connection.call(
                 requestData,
-                timeout: initialTimeout
+                timeout: callTimeout
             )
         } catch {
             await invalidate(reason: "documentation_provider_call_failed")
@@ -625,14 +634,21 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     }
 
     private func selectProvider(requestTimeout: TimeAmount?) async -> CandidateProfile? {
+        let selectionDeadline = Self.requestDeadline(for: requestTimeout)
         var profiles: [CandidateProfile] = []
         for target in discovery.runningXcodeTargets() {
-            if requestTimeout?.nanoseconds == 0 {
+            guard !Task.isCancelled else {
+                break
+            }
+            let candidateTimeout = Self.requestTimeout(until: selectionDeadline)
+            if candidateTimeout?.nanoseconds == 0 {
                 break
             }
             do {
-                let profile = try await probe(target: target, requestTimeout: requestTimeout)
+                let profile = try await probe(target: target, requestTimeout: candidateTimeout)
                 profiles.append(profile)
+            } catch is CancellationError {
+                break
             } catch {
                 continue
             }
@@ -657,31 +673,44 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         target: DocumentationProviderTarget,
         requestTimeout: TimeAmount?
     ) async throws -> CandidateProfile {
-        let probeTimeout = requestTimeout ?? .seconds(30)
+        let probeDeadline = Self.requestDeadline(for: requestTimeout ?? .seconds(30))
         let session = try await sessionFactory.startSession(for: target)
         let connection = DocumentationProviderConnection(session: session)
         await connection.start()
         do {
+            let initializeTimeout = Self.requestTimeout(until: probeDeadline)
+            guard initializeTimeout?.nanoseconds != 0 else {
+                throw TimeoutError()
+            }
             let initialize = try await connection.call(
                 try Self.makeInitializeRequestData(),
-                timeout: probeTimeout
+                timeout: initializeTimeout
             )
             let serverVersion = Self.serverVersion(fromInitializeResponse: initialize) ?? ""
+            try Task.checkCancellation()
             try await connection.sendNotification([
                 "jsonrpc": "2.0",
                 "method": "notifications/initialized",
             ])
+            let toolsListTimeout = Self.requestTimeout(until: probeDeadline)
+            guard toolsListTimeout?.nanoseconds != 0 else {
+                throw TimeoutError()
+            }
             let toolsList = try await connection.call(
                 try Self.makeToolsListRequestData(),
-                timeout: probeTimeout
+                timeout: toolsListTimeout
             )
             let toolsResult = try Self.resultValue(from: toolsList)
             guard let descriptor = DocumentationToolCatalog.descriptor(in: toolsResult) else {
                 throw UpstreamSlotAcquisitionError.unavailable
             }
+            let documentationProbeTimeout = Self.requestTimeout(until: probeDeadline)
+            guard documentationProbeTimeout?.nanoseconds != 0 else {
+                throw TimeoutError()
+            }
             let probeResponse = try await connection.call(
                 try Self.makeDocumentationProbeRequestData(),
-                timeout: probeTimeout
+                timeout: documentationProbeTimeout
             )
             guard !DocumentationToolCatalog.responseIsDocumentationNotEnabled(probeResponse),
                   !DocumentationToolCatalog.responseIsToolError(probeResponse) else {

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -540,10 +540,12 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         requestData: Data,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> DocumentationProviderCallResult {
-        guard requestTimeoutOverride?.nanoseconds != 0 else {
+        let requestDeadline = Self.requestDeadline(for: requestTimeoutOverride)
+        let initialTimeout = Self.requestTimeout(until: requestDeadline)
+        guard initialTimeout?.nanoseconds != 0 else {
             throw TimeoutError()
         }
-        guard let provider = await providerIfAvailable(requestTimeout: requestTimeoutOverride) else {
+        guard let provider = await providerIfAvailable(requestTimeout: initialTimeout) else {
             throw UpstreamSlotAcquisitionError.unavailable
         }
 
@@ -551,16 +553,20 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         do {
             response = try await provider.profile.connection.call(
                 requestData,
-                timeout: requestTimeoutOverride
+                timeout: initialTimeout
             )
         } catch {
             await invalidate(reason: "documentation_provider_call_failed")
-            guard let replacement = await providerIfAvailable(requestTimeout: requestTimeoutOverride) else {
+            let retryTimeout = Self.requestTimeout(until: requestDeadline)
+            guard retryTimeout?.nanoseconds != 0 else {
+                throw error
+            }
+            guard let replacement = await providerIfAvailable(requestTimeout: retryTimeout) else {
                 throw error
             }
             let retryResponse = try await replacement.profile.connection.call(
                 requestData,
-                timeout: requestTimeoutOverride
+                timeout: retryTimeout
             )
             return DocumentationProviderCallResult(
                 data: retryResponse,
@@ -572,13 +578,15 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
 
         await invalidate(reason: "documentation_search_not_enabled")
-        guard let replacement = await providerIfAvailable(requestTimeout: requestTimeoutOverride) else {
+        let retryTimeout = Self.requestTimeout(until: requestDeadline)
+        guard retryTimeout?.nanoseconds != 0,
+              let replacement = await providerIfAvailable(requestTimeout: retryTimeout) else {
             return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
         }
         do {
             let retryResponse = try await replacement.profile.connection.call(
                 requestData,
-                timeout: requestTimeoutOverride
+                timeout: retryTimeout
             )
             if DocumentationToolCatalog.responseIsDocumentationNotEnabled(retryResponse) {
                 await invalidate(reason: "documentation_search_retry_not_enabled")
@@ -790,5 +798,27 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 !character.isNumber
             }
             .compactMap { Int($0) }
+    }
+
+    private static func requestDeadline(for requestTimeout: TimeAmount?) -> UInt64? {
+        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
+            return nil
+        }
+        let now = DispatchTime.now().uptimeNanoseconds
+        let remainingToMax = UInt64.max &- now
+        let clamped = min(UInt64(requestTimeout.nanoseconds), remainingToMax)
+        return now &+ clamped
+    }
+
+    private static func requestTimeout(until deadlineUptimeNs: UInt64?) -> TimeAmount? {
+        guard let deadlineUptimeNs else {
+            return nil
+        }
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard deadlineUptimeNs > now else {
+            return .nanoseconds(0)
+        }
+        let remaining = deadlineUptimeNs - now
+        return .nanoseconds(Int64(min(remaining, UInt64(Int64.max))))
     }
 }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Darwin
 import Foundation
+import Logging
 import NIO
 import ProxyCore
 import ProxyMCP
@@ -22,6 +23,7 @@ package struct DocumentationProviderCallResult: Sendable {
 }
 
 package protocol DocumentationProviderManaging: Sendable {
+    func prewarm(requestTimeout: TimeAmount?) async
     func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate
     func callDocumentationSearch(
         requestData: Data,
@@ -33,6 +35,8 @@ package protocol DocumentationProviderManaging: Sendable {
 
 package struct DisabledDocumentationProviderManager: DocumentationProviderManaging {
     package init() {}
+
+    package func prewarm(requestTimeout _: TimeAmount?) async {}
 
     package func toolListUpdate(requestTimeout _: TimeAmount?) async -> DocumentationToolListUpdate {
         .unchanged
@@ -517,14 +521,21 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
 
     private let discovery: any XcodeTargetDiscovering
     private let sessionFactory: any DocumentationProviderSessionMaking
+    private let logger: Logger
     private var activeProvider: ActiveProvider?
 
     package init(
         discovery: any XcodeTargetDiscovering = LiveXcodeTargetDiscovery(),
-        sessionFactory: any DocumentationProviderSessionMaking = LiveDocumentationProviderSessionFactory()
+        sessionFactory: any DocumentationProviderSessionMaking = LiveDocumentationProviderSessionFactory(),
+        logger: Logger = ProxyLogging.make("documentation.provider")
     ) {
         self.discovery = discovery
         self.sessionFactory = sessionFactory
+        self.logger = logger
+    }
+
+    package func prewarm(requestTimeout: TimeAmount?) async {
+        _ = await toolListUpdate(requestTimeout: requestTimeout)
     }
 
     package func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
@@ -635,8 +646,16 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
 
     private func selectProvider(requestTimeout: TimeAmount?) async -> CandidateProfile? {
         let selectionDeadline = Self.requestDeadline(for: requestTimeout)
+        let targets = discovery.runningXcodeTargets()
+        logger.debug(
+            "Selecting documentation provider from running Xcode processes",
+            metadata: [
+                "candidate_count": .string("\(targets.count)"),
+                "candidates": .string(targets.map { "\($0.processID):\($0.appPath)" }.joined(separator: ",")),
+            ]
+        )
         var profiles: [CandidateProfile] = []
-        for target in discovery.runningXcodeTargets() {
+        for target in targets {
             guard !Task.isCancelled else {
                 break
             }
@@ -650,6 +669,14 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             } catch is CancellationError {
                 break
             } catch {
+                logger.debug(
+                    "Documentation provider candidate rejected",
+                    metadata: [
+                        "pid": .string("\(target.processID)"),
+                        "app_path": .string(target.appPath),
+                        "error": .string(String(describing: error)),
+                    ]
+                )
                 continue
             }
         }
@@ -666,6 +693,15 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         for profile in profiles where profile.target != selected.target {
             await profile.connection.stop()
         }
+        logger.info(
+            "Selected documentation provider",
+            metadata: [
+                "pid": .string("\(selected.target.processID)"),
+                "app_path": .string(selected.target.appPath),
+                "server_version": .string(selected.serverVersion),
+                "tool_count": .string("\(selected.toolCount)"),
+            ]
+        )
         return selected
     }
 

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -22,7 +22,7 @@ package struct DocumentationProviderCallResult: Sendable {
 }
 
 package protocol DocumentationProviderManaging: Sendable {
-    func toolListUpdate() async -> DocumentationToolListUpdate
+    func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate
     func callDocumentationSearch(
         requestData: Data,
         requestTimeoutOverride: TimeAmount?
@@ -34,7 +34,7 @@ package protocol DocumentationProviderManaging: Sendable {
 package struct DisabledDocumentationProviderManager: DocumentationProviderManaging {
     package init() {}
 
-    package func toolListUpdate() async -> DocumentationToolListUpdate {
+    package func toolListUpdate(requestTimeout _: TimeAmount?) async -> DocumentationToolListUpdate {
         .unchanged
     }
 
@@ -526,8 +526,11 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         self.sessionFactory = sessionFactory
     }
 
-    package func toolListUpdate() async -> DocumentationToolListUpdate {
-        guard let provider = await providerIfAvailable() else {
+    package func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
+        guard requestTimeout?.nanoseconds != 0 else {
+            return .unavailable
+        }
+        guard let provider = await providerIfAvailable(requestTimeout: requestTimeout) else {
             return .unavailable
         }
         return .available(provider.profile.descriptor)
@@ -537,7 +540,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         requestData: Data,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> DocumentationProviderCallResult {
-        guard let provider = await providerIfAvailable() else {
+        guard requestTimeoutOverride?.nanoseconds != 0 else {
+            throw TimeoutError()
+        }
+        guard let provider = await providerIfAvailable(requestTimeout: requestTimeoutOverride) else {
             throw UpstreamSlotAcquisitionError.unavailable
         }
 
@@ -549,7 +555,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             )
         } catch {
             await invalidate(reason: "documentation_provider_call_failed")
-            guard let replacement = await providerIfAvailable() else {
+            guard let replacement = await providerIfAvailable(requestTimeout: requestTimeoutOverride) else {
                 throw error
             }
             let retryResponse = try await replacement.profile.connection.call(
@@ -566,7 +572,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
 
         await invalidate(reason: "documentation_search_not_enabled")
-        guard let replacement = await providerIfAvailable() else {
+        guard let replacement = await providerIfAvailable(requestTimeout: requestTimeoutOverride) else {
             return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
         }
         do {
@@ -598,11 +604,11 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         await invalidate(reason: "shutdown")
     }
 
-    private func providerIfAvailable() async -> ActiveProvider? {
+    private func providerIfAvailable(requestTimeout: TimeAmount?) async -> ActiveProvider? {
         if let activeProvider {
             return activeProvider
         }
-        guard let selected = await selectProvider() else {
+        guard let selected = await selectProvider(requestTimeout: requestTimeout) else {
             return nil
         }
         let provider = ActiveProvider(profile: selected)
@@ -610,11 +616,14 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         return provider
     }
 
-    private func selectProvider() async -> CandidateProfile? {
+    private func selectProvider(requestTimeout: TimeAmount?) async -> CandidateProfile? {
         var profiles: [CandidateProfile] = []
         for target in discovery.runningXcodeTargets() {
+            if requestTimeout?.nanoseconds == 0 {
+                break
+            }
             do {
-                let profile = try await probe(target: target)
+                let profile = try await probe(target: target, requestTimeout: requestTimeout)
                 profiles.append(profile)
             } catch {
                 continue
@@ -636,14 +645,18 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         return selected
     }
 
-    private func probe(target: DocumentationProviderTarget) async throws -> CandidateProfile {
+    private func probe(
+        target: DocumentationProviderTarget,
+        requestTimeout: TimeAmount?
+    ) async throws -> CandidateProfile {
+        let probeTimeout = requestTimeout ?? .seconds(30)
         let session = try await sessionFactory.startSession(for: target)
         let connection = DocumentationProviderConnection(session: session)
         await connection.start()
         do {
             let initialize = try await connection.call(
                 try Self.makeInitializeRequestData(),
-                timeout: .seconds(30)
+                timeout: probeTimeout
             )
             let serverVersion = Self.serverVersion(fromInitializeResponse: initialize) ?? ""
             try await connection.sendNotification([
@@ -652,7 +665,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             ])
             let toolsList = try await connection.call(
                 try Self.makeToolsListRequestData(),
-                timeout: .seconds(30)
+                timeout: probeTimeout
             )
             let toolsResult = try Self.resultValue(from: toolsList)
             guard let descriptor = DocumentationToolCatalog.descriptor(in: toolsResult) else {
@@ -660,7 +673,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             }
             let probeResponse = try await connection.call(
                 try Self.makeDocumentationProbeRequestData(),
-                timeout: .seconds(30)
+                timeout: probeTimeout
             )
             guard !DocumentationToolCatalog.responseIsDocumentationNotEnabled(probeResponse),
                   !DocumentationToolCatalog.responseIsToolError(probeResponse) else {

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -525,6 +525,29 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let task: Task<CandidateProfile?, Never>
     }
 
+    private enum ProviderSelectionWaitResult: Sendable {
+        case completed(CandidateProfile?)
+        case timedOut
+    }
+
+    private final class ProviderSelectionWaitState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var didResume = false
+
+        func resume(
+            _ result: ProviderSelectionWaitResult,
+            continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>
+        ) {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !didResume else {
+                return
+            }
+            didResume = true
+            continuation.resume(returning: result)
+        }
+    }
+
     private let discovery: any XcodeTargetDiscovering
     private let sessionFactory: any DocumentationProviderSessionMaking
     private let logger: Logger
@@ -654,17 +677,33 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             return activeProvider
         }
         let selection: ProviderSelection
+        let didStartSelection: Bool
         if let providerSelection {
             selection = providerSelection
+            didStartSelection = false
         } else {
             selection = ProviderSelection(
                 id: UUID(),
                 task: Task { await self.selectProvider(requestTimeout: requestTimeout) }
             )
             providerSelection = selection
+            didStartSelection = true
         }
 
-        let selected = await selection.task.value
+        let waitResult = await waitForSelection(selection, requestTimeout: requestTimeout)
+        let selected: CandidateProfile?
+        switch waitResult {
+        case .completed(let profile):
+            selected = profile
+        case .timedOut:
+            if didStartSelection,
+                providerSelection?.id == selection.id
+            {
+                providerSelection = nil
+                selection.task.cancel()
+            }
+            return nil
+        }
         let selectionIsCurrent = providerSelection?.id == selection.id
         if selectionIsCurrent {
             providerSelection = nil
@@ -689,6 +728,30 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let provider = ActiveProvider(profile: selected)
         activeProvider = provider
         return provider
+    }
+
+    private func waitForSelection(
+        _ selection: ProviderSelection,
+        requestTimeout: TimeAmount?
+    ) async -> ProviderSelectionWaitResult {
+        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
+            return .completed(await selection.task.value)
+        }
+
+        return await withCheckedContinuation { continuation in
+            let state = ProviderSelectionWaitState()
+            Task.detached {
+                let profile = await selection.task.value
+                state.resume(
+                    .completed(profile),
+                    continuation: continuation
+                )
+            }
+            Task.detached {
+                try? await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
+                state.resume(.timedOut, continuation: continuation)
+            }
+        }
     }
 
     private func invalidate(_ provider: ActiveProvider, reason _: String) async {

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -616,7 +616,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 requestData,
                 timeout: callTimeout
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
+            try Task.checkCancellation()
             await invalidate(provider, reason: "documentation_provider_call_failed")
             let replacementSelectionTimeout = Self.requestTimeout(until: requestDeadline)
             guard replacementSelectionTimeout?.nanoseconds != 0 else {
@@ -643,6 +646,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
 
         await invalidate(provider, reason: "documentation_search_not_enabled")
+        try Task.checkCancellation()
         let replacementSelectionTimeout = Self.requestTimeout(until: requestDeadline)
         guard replacementSelectionTimeout?.nanoseconds != 0,
               let replacement = await providerIfAvailable(requestTimeout: replacementSelectionTimeout) else {
@@ -664,7 +668,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 data: retryResponse,
                 didInvalidateProvider: true
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
+            try Task.checkCancellation()
             return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
         }
     }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -678,7 +678,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 throw CancellationError()
             } catch {
                 try Task.checkCancellation()
-                throw DocumentationProviderCallFailure(underlying: error, providerIsActive: true)
+                await invalidate(replacement, reason: "documentation_provider_retry_call_failed")
+                throw DocumentationProviderCallFailure(underlying: error, providerIsActive: false)
             }
             if DocumentationToolCatalog.responseIsDocumentationNotEnabled(retryResponse) {
                 await invalidate(replacement, reason: "documentation_search_retry_not_enabled")
@@ -722,7 +723,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             throw CancellationError()
         } catch {
             try Task.checkCancellation()
-            return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
+            await invalidate(replacement, reason: "documentation_search_retry_call_failed")
+            throw DocumentationProviderCallFailure(underlying: error, providerIsActive: false)
         }
     }
 
@@ -870,16 +872,19 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             ]
         )
         var profiles: [CandidateProfile] = []
-        for target in targets {
+        for (index, target) in targets.enumerated() {
             guard !Task.isCancelled, !isShutdown else {
                 break
             }
-            let candidateTimeout = Self.requestTimeout(until: selectionDeadline)
+            let candidateTimeout = Self.candidateProbeTimeout(
+                until: selectionDeadline,
+                remainingCandidateCount: targets.count - index
+            )
             if candidateTimeout?.nanoseconds == 0 {
                 break
             }
             do {
-                let profile = try await probe(target: target, requestTimeout: candidateTimeout)
+                let profile = try await boundedProbe(target: target, requestTimeout: candidateTimeout)
                 guard !Task.isCancelled, !isShutdown else {
                     await profile.connection.stop()
                     break
@@ -929,6 +934,34 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             ]
         )
         return selected
+    }
+
+    private func boundedProbe(
+        target: DocumentationProviderTarget,
+        requestTimeout: TimeAmount?
+    ) async throws -> CandidateProfile {
+        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
+            return try await probe(target: target, requestTimeout: requestTimeout)
+        }
+        return try await withThrowingTaskGroup(of: CandidateProfile.self) { group in
+            group.addTask {
+                try await self.probe(target: target, requestTimeout: requestTimeout)
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
+                throw TimeoutError()
+            }
+            do {
+                guard let result = try await group.next() else {
+                    throw UpstreamSlotAcquisitionError.unavailable
+                }
+                group.cancelAll()
+                return result
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+        }
     }
 
     private func probe(
@@ -1118,5 +1151,19 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
         let remaining = deadlineUptimeNs - now
         return .nanoseconds(Int64(min(remaining, UInt64(Int64.max))))
+    }
+
+    private static func candidateProbeTimeout(
+        until deadlineUptimeNs: UInt64?,
+        remainingCandidateCount: Int
+    ) -> TimeAmount? {
+        guard let remaining = requestTimeout(until: deadlineUptimeNs) else {
+            return nil
+        }
+        guard remaining.nanoseconds > 0 else {
+            return .nanoseconds(0)
+        }
+        let divisor = max(Int64(remainingCandidateCount), 1)
+        return .nanoseconds(max(remaining.nanoseconds / divisor, 1))
     }
 }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -160,6 +160,9 @@ package enum DocumentationToolCatalog {
             object["message"] as? String
         }
         texts += responseResultObjects(in: data).flatMap { object -> [String] in
+            guard object["isError"] as? Bool == true else {
+                return []
+            }
             guard let content = object["content"] as? [[String: Any]] else {
                 return []
             }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1,0 +1,781 @@
+import AppKit
+import Darwin
+import Foundation
+import NIO
+import ProxyCore
+import ProxyMCP
+
+package enum DocumentationToolListUpdate: Sendable {
+    case unchanged
+    case unavailable
+    case available(JSONValue)
+}
+
+package struct DocumentationProviderCallResult: Sendable {
+    package let data: Data
+    package let didInvalidateProvider: Bool
+
+    package init(data: Data, didInvalidateProvider: Bool) {
+        self.data = data
+        self.didInvalidateProvider = didInvalidateProvider
+    }
+}
+
+package protocol DocumentationProviderManaging: Sendable {
+    func toolListUpdate() async -> DocumentationToolListUpdate
+    func callDocumentationSearch(
+        requestData: Data,
+        requestTimeoutOverride: TimeAmount?
+    ) async throws -> DocumentationProviderCallResult
+    func invalidate(reason: String) async
+    func shutdown() async
+}
+
+package struct DisabledDocumentationProviderManager: DocumentationProviderManaging {
+    package init() {}
+
+    package func toolListUpdate() async -> DocumentationToolListUpdate {
+        .unchanged
+    }
+
+    package func callDocumentationSearch(
+        requestData _: Data,
+        requestTimeoutOverride _: TimeAmount?
+    ) async throws -> DocumentationProviderCallResult {
+        throw UpstreamSlotAcquisitionError.unavailable
+    }
+
+    package func invalidate(reason _: String) async {}
+    package func shutdown() async {}
+}
+
+package enum DocumentationToolCatalog {
+    package static let toolName = "DocumentationSearch"
+
+    package static func applying(
+        _ update: DocumentationToolListUpdate,
+        to result: JSONValue
+    ) -> JSONValue {
+        switch update {
+        case .unchanged:
+            return result
+        case .unavailable:
+            return removingDocumentationSearch(from: result)
+        case .available(let descriptor):
+            return replacingDocumentationSearch(in: result, with: descriptor)
+        }
+    }
+
+    package static func descriptor(in result: JSONValue) -> JSONValue? {
+        guard case .object(let object) = result,
+              case .array(let tools)? = object["tools"] else {
+            return nil
+        }
+        return tools.first { value in
+            guard case .object(let toolObject) = value,
+                  case .string(let name)? = toolObject["name"] else {
+                return false
+            }
+            return name == toolName
+        }
+    }
+
+    package static func responseIsDocumentationNotEnabled(_ data: Data) -> Bool {
+        responseErrorTexts(in: data).contains { text in
+            let normalized = text.lowercased()
+            return normalized.contains("documentationsearch")
+                && normalized.contains("not enabled")
+        }
+    }
+
+    package static func responseIsToolError(_ data: Data) -> Bool {
+        responseErrorObjects(in: data).isEmpty == false || responseResultObjects(in: data).contains { object in
+            object["isError"] as? Bool == true
+        }
+    }
+
+    private static func replacingDocumentationSearch(
+        in result: JSONValue,
+        with descriptor: JSONValue
+    ) -> JSONValue {
+        guard case .object(var object) = result,
+              case .array(let tools)? = object["tools"] else {
+            return result
+        }
+        var replaced = false
+        var rewritten: [JSONValue] = []
+        rewritten.reserveCapacity(tools.count + 1)
+        for tool in tools {
+            guard case .object(let toolObject) = tool,
+                  case .string(let name)? = toolObject["name"],
+                  name == toolName else {
+                rewritten.append(tool)
+                continue
+            }
+            if !replaced {
+                rewritten.append(descriptor)
+                replaced = true
+            }
+        }
+        if !replaced {
+            rewritten.append(descriptor)
+        }
+        object["tools"] = .array(rewritten)
+        return .object(object)
+    }
+
+    private static func removingDocumentationSearch(from result: JSONValue) -> JSONValue {
+        guard case .object(var object) = result,
+              case .array(let tools)? = object["tools"] else {
+            return result
+        }
+        object["tools"] = .array(tools.filter { tool in
+            guard case .object(let toolObject) = tool,
+                  case .string(let name)? = toolObject["name"] else {
+                return true
+            }
+            return name != toolName
+        })
+        return .object(object)
+    }
+
+    private static func responseErrorTexts(in data: Data) -> [String] {
+        var texts = responseErrorObjects(in: data).compactMap { object in
+            object["message"] as? String
+        }
+        texts += responseResultObjects(in: data).flatMap { object -> [String] in
+            guard let content = object["content"] as? [[String: Any]] else {
+                return []
+            }
+            return content.compactMap { $0["text"] as? String }
+        }
+        return texts
+    }
+
+    private static func responseErrorObjects(in data: Data) -> [[String: Any]] {
+        guard let payload = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            return []
+        }
+        if let object = payload as? [String: Any],
+           let error = object["error"] as? [String: Any] {
+            return [error]
+        }
+        guard let array = payload as? [Any] else {
+            return []
+        }
+        return array.compactMap { item in
+            guard let object = item as? [String: Any] else { return nil }
+            return object["error"] as? [String: Any]
+        }
+    }
+
+    private static func responseResultObjects(in data: Data) -> [[String: Any]] {
+        guard let payload = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            return []
+        }
+        if let object = payload as? [String: Any],
+           let result = object["result"] as? [String: Any] {
+            return [result]
+        }
+        guard let array = payload as? [Any] else {
+            return []
+        }
+        return array.compactMap { item in
+            guard let object = item as? [String: Any] else { return nil }
+            return object["result"] as? [String: Any]
+        }
+    }
+}
+
+package struct DocumentationProviderTarget: Sendable, Equatable {
+    package let processID: pid_t
+    package let appPath: String
+    package let developerDir: String
+    package let mcpbridgePath: String
+
+    package init(
+        processID: pid_t,
+        appPath: String,
+        developerDir: String,
+        mcpbridgePath: String
+    ) {
+        self.processID = processID
+        self.appPath = appPath
+        self.developerDir = developerDir
+        self.mcpbridgePath = mcpbridgePath
+    }
+}
+
+package protocol XcodeTargetDiscovering: Sendable {
+    func runningXcodeTargets() -> [DocumentationProviderTarget]
+}
+
+package struct LiveXcodeTargetDiscovery: XcodeTargetDiscovering {
+    package init() {}
+
+    package func runningXcodeTargets() -> [DocumentationProviderTarget] {
+        var targetsByPID: [pid_t: DocumentationProviderTarget] = [:]
+
+        for application in NSWorkspace.shared.runningApplications {
+            guard application.bundleIdentifier == "com.apple.dt.Xcode",
+                  application.isTerminated == false,
+                  let bundlePath = application.bundleURL?.path else {
+                continue
+            }
+            if let target = Self.target(processID: application.processIdentifier, appPath: bundlePath) {
+                targetsByPID[target.processID] = target
+            }
+        }
+
+        for processID in Self.runningProcessIDs(named: "Xcode") {
+            if targetsByPID[processID] != nil {
+                continue
+            }
+            guard let processPath = Self.processPath(processID: processID),
+                  let appPath = Self.appPath(fromExecutablePath: processPath),
+                  let target = Self.target(processID: processID, appPath: appPath) else {
+                continue
+            }
+            targetsByPID[target.processID] = target
+        }
+
+        return targetsByPID.values.sorted { lhs, rhs in
+            if lhs.appPath == rhs.appPath {
+                return lhs.processID < rhs.processID
+            }
+            return lhs.appPath < rhs.appPath
+        }
+    }
+
+    private static func target(processID: pid_t, appPath: String) -> DocumentationProviderTarget? {
+        let developerDir = URL(fileURLWithPath: appPath)
+            .appendingPathComponent("Contents/Developer")
+            .path
+        let mcpbridgePath = URL(fileURLWithPath: developerDir)
+            .appendingPathComponent("usr/bin/mcpbridge")
+            .path
+        guard FileManager.default.isExecutableFile(atPath: mcpbridgePath) else {
+            return nil
+        }
+        return DocumentationProviderTarget(
+            processID: processID,
+            appPath: appPath,
+            developerDir: developerDir,
+            mcpbridgePath: mcpbridgePath
+        )
+    }
+
+    private static func appPath(fromExecutablePath path: String) -> String? {
+        guard let range = path.range(of: "/Contents/MacOS/Xcode") else {
+            return nil
+        }
+        return String(path[..<range.lowerBound])
+    }
+
+    private static func processPath(processID: pid_t) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-p", String(processID), "-o", "comm="]
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+        let output = String(
+            data: stdout.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        )?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let output, output.isEmpty == false else {
+            return nil
+        }
+        return output
+    }
+
+    private static func runningProcessIDs(named processName: String) -> [pid_t] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        process.arguments = ["-x", processName]
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            return []
+        }
+        let output = String(
+            data: stdout.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        return output
+            .split(whereSeparator: \.isNewline)
+            .compactMap { pid_t($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+    }
+}
+
+package protocol DocumentationProviderSessionMaking: Sendable {
+    func startSession(for target: DocumentationProviderTarget) async throws -> any UpstreamSession
+}
+
+package struct LiveDocumentationProviderSessionFactory: DocumentationProviderSessionMaking {
+    package init() {}
+
+    package func startSession(for target: DocumentationProviderTarget) async throws -> any UpstreamSession {
+        var environment = ProcessInfo.processInfo.environment
+        environment.removeValue(forKey: "XCODE_PID")
+        environment["MCP_XCODE_PID"] = String(target.processID)
+        environment["DEVELOPER_DIR"] = target.developerDir
+        let config = UpstreamProcess.Config(
+            command: target.mcpbridgePath,
+            args: [],
+            environment: environment,
+            maxQueuedWriteBytes: 4 * 1_048_576
+        )
+        return try await UpstreamProcess(config: config).startSession()
+    }
+}
+
+private final class DocumentationPendingResponse: @unchecked Sendable {
+    let originalID: RPCID
+    let continuation: CheckedContinuation<Data, Error>
+    var timeoutTask: Task<Void, Never>?
+
+    init(originalID: RPCID, continuation: CheckedContinuation<Data, Error>) {
+        self.originalID = originalID
+        self.continuation = continuation
+    }
+}
+
+package actor DocumentationProviderConnection {
+    private let session: any UpstreamSession
+    private var eventTask: Task<Void, Never>?
+    private var pendingResponses: [String: DocumentationPendingResponse] = [:]
+    private var nextID: Int64 = 1
+
+    package init(session: any UpstreamSession) {
+        self.session = session
+    }
+
+    package func start() {
+        guard eventTask == nil else { return }
+        let session = session
+        eventTask = Task { [weak self, session] in
+            for await event in session.events {
+                await self?.handle(event)
+            }
+            await self?.failAll(UpstreamSlotAcquisitionError.unavailable)
+        }
+    }
+
+    package func stop() async {
+        eventTask?.cancel()
+        eventTask = nil
+        failAll(CancellationError())
+        await session.stop()
+    }
+
+    package func sendNotification(_ object: [String: Any]) async throws {
+        guard JSONSerialization.isValidJSONObject(object) else {
+            throw ControlPlaneError.invalidResponse("invalid notification")
+        }
+        let data = try JSONSerialization.data(withJSONObject: object, options: [])
+        let result = await session.send(data)
+        guard result == .accepted else {
+            throw UpstreamSlotAcquisitionError.unavailable
+        }
+    }
+
+    package func call(_ requestData: Data, timeout: TimeAmount?) async throws -> Data {
+        guard var object = try JSONSerialization.jsonObject(with: requestData, options: [])
+            as? [String: Any],
+            let originalIDValue = object["id"],
+            let originalID = RPCID(any: originalIDValue) else {
+            throw ControlPlaneError.invalidResponse("missing DocumentationSearch request id")
+        }
+
+        let upstreamID = "__documentation-provider-\(nextID)"
+        nextID += 1
+        object["id"] = upstreamID
+        guard JSONSerialization.isValidJSONObject(object) else {
+            throw ControlPlaneError.invalidResponse("invalid DocumentationSearch request")
+        }
+        let upstreamData = try JSONSerialization.data(withJSONObject: object, options: [])
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let pending = DocumentationPendingResponse(
+                    originalID: originalID,
+                    continuation: continuation
+                )
+                pendingResponses[upstreamID] = pending
+                scheduleTimeoutIfNeeded(id: upstreamID, timeout: timeout, pending: pending)
+
+                Task { [weak self, session] in
+                    let sendResult = await session.send(upstreamData)
+                    guard sendResult == .accepted else {
+                        await self?.failPending(id: upstreamID, error: UpstreamSlotAcquisitionError.unavailable)
+                        return
+                    }
+                }
+            }
+        } onCancel: {
+            Task { [weak self] in
+                await self?.failPending(id: upstreamID, error: CancellationError())
+            }
+        }
+    }
+
+    private func scheduleTimeoutIfNeeded(
+        id: String,
+        timeout: TimeAmount?,
+        pending: DocumentationPendingResponse
+    ) {
+        guard let timeout, timeout.nanoseconds > 0 else {
+            return
+        }
+        let nanoseconds = UInt64(timeout.nanoseconds)
+        pending.timeoutTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            await self?.failPending(id: id, error: TimeoutError())
+        }
+    }
+
+    private func handle(_ event: UpstreamEvent) {
+        switch event {
+        case .message(let data):
+            handleMessage(data)
+        case .exit, .stdoutProtocolViolation:
+            failAll(UpstreamSlotAcquisitionError.unavailable)
+        case .stderr, .stdoutBufferSize:
+            break
+        }
+    }
+
+    private func handleMessage(_ data: Data) {
+        guard var object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+              let responseIDValue = object["id"],
+              let responseID = RPCID(any: responseIDValue),
+              let pending = pendingResponses.removeValue(forKey: responseID.key) else {
+            return
+        }
+
+        pending.timeoutTask?.cancel()
+        object["id"] = pending.originalID.value.foundationObject
+        guard JSONSerialization.isValidJSONObject(object),
+              let rewrittenData = try? JSONSerialization.data(withJSONObject: object, options: []) else {
+            pending.continuation.resume(throwing: ControlPlaneError.invalidResponse("invalid DocumentationSearch response"))
+            return
+        }
+        pending.continuation.resume(returning: rewrittenData)
+    }
+
+    private func failPending(id: String, error: Error) {
+        guard let pending = pendingResponses.removeValue(forKey: id) else {
+            return
+        }
+        pending.timeoutTask?.cancel()
+        pending.continuation.resume(throwing: error)
+    }
+
+    private func failAll(_ error: Error) {
+        let pending = pendingResponses
+        pendingResponses.removeAll()
+        for item in pending.values {
+            item.timeoutTask?.cancel()
+            item.continuation.resume(throwing: error)
+        }
+    }
+}
+
+package actor DocumentationProviderManager: DocumentationProviderManaging {
+    private struct CandidateProfile: Sendable {
+        let target: DocumentationProviderTarget
+        let connection: DocumentationProviderConnection
+        let descriptor: JSONValue
+        let toolCount: Int
+        let serverVersion: String
+    }
+
+    private struct ActiveProvider: Sendable {
+        let profile: CandidateProfile
+    }
+
+    private let discovery: any XcodeTargetDiscovering
+    private let sessionFactory: any DocumentationProviderSessionMaking
+    private var activeProvider: ActiveProvider?
+
+    package init(
+        discovery: any XcodeTargetDiscovering = LiveXcodeTargetDiscovery(),
+        sessionFactory: any DocumentationProviderSessionMaking = LiveDocumentationProviderSessionFactory()
+    ) {
+        self.discovery = discovery
+        self.sessionFactory = sessionFactory
+    }
+
+    package func toolListUpdate() async -> DocumentationToolListUpdate {
+        guard let provider = await providerIfAvailable() else {
+            return .unavailable
+        }
+        return .available(provider.profile.descriptor)
+    }
+
+    package func callDocumentationSearch(
+        requestData: Data,
+        requestTimeoutOverride: TimeAmount?
+    ) async throws -> DocumentationProviderCallResult {
+        guard let provider = await providerIfAvailable() else {
+            throw UpstreamSlotAcquisitionError.unavailable
+        }
+
+        let response: Data
+        do {
+            response = try await provider.profile.connection.call(
+                requestData,
+                timeout: requestTimeoutOverride
+            )
+        } catch {
+            await invalidate(reason: "documentation_provider_call_failed")
+            guard let replacement = await providerIfAvailable() else {
+                throw error
+            }
+            let retryResponse = try await replacement.profile.connection.call(
+                requestData,
+                timeout: requestTimeoutOverride
+            )
+            return DocumentationProviderCallResult(
+                data: retryResponse,
+                didInvalidateProvider: true
+            )
+        }
+        guard DocumentationToolCatalog.responseIsDocumentationNotEnabled(response) else {
+            return DocumentationProviderCallResult(data: response, didInvalidateProvider: false)
+        }
+
+        await invalidate(reason: "documentation_search_not_enabled")
+        guard let replacement = await providerIfAvailable() else {
+            return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
+        }
+        do {
+            let retryResponse = try await replacement.profile.connection.call(
+                requestData,
+                timeout: requestTimeoutOverride
+            )
+            if DocumentationToolCatalog.responseIsDocumentationNotEnabled(retryResponse) {
+                await invalidate(reason: "documentation_search_retry_not_enabled")
+            }
+            return DocumentationProviderCallResult(
+                data: retryResponse,
+                didInvalidateProvider: true
+            )
+        } catch {
+            return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
+        }
+    }
+
+    package func invalidate(reason _: String) async {
+        guard let provider = activeProvider else {
+            return
+        }
+        activeProvider = nil
+        await provider.profile.connection.stop()
+    }
+
+    package func shutdown() async {
+        await invalidate(reason: "shutdown")
+    }
+
+    private func providerIfAvailable() async -> ActiveProvider? {
+        if let activeProvider {
+            return activeProvider
+        }
+        guard let selected = await selectProvider() else {
+            return nil
+        }
+        let provider = ActiveProvider(profile: selected)
+        activeProvider = provider
+        return provider
+    }
+
+    private func selectProvider() async -> CandidateProfile? {
+        var profiles: [CandidateProfile] = []
+        for target in discovery.runningXcodeTargets() {
+            do {
+                let profile = try await probe(target: target)
+                profiles.append(profile)
+            } catch {
+                continue
+            }
+        }
+
+        guard let selected = profiles.max(by: { lhs, rhs in
+            if lhs.toolCount != rhs.toolCount {
+                return lhs.toolCount < rhs.toolCount
+            }
+            return Self.compareVersion(lhs.serverVersion, rhs.serverVersion) == .orderedAscending
+        }) else {
+            return nil
+        }
+
+        for profile in profiles where profile.target != selected.target {
+            await profile.connection.stop()
+        }
+        return selected
+    }
+
+    private func probe(target: DocumentationProviderTarget) async throws -> CandidateProfile {
+        let session = try await sessionFactory.startSession(for: target)
+        let connection = DocumentationProviderConnection(session: session)
+        await connection.start()
+        do {
+            let initialize = try await connection.call(
+                try Self.makeInitializeRequestData(),
+                timeout: .seconds(30)
+            )
+            let serverVersion = Self.serverVersion(fromInitializeResponse: initialize) ?? ""
+            try await connection.sendNotification([
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            ])
+            let toolsList = try await connection.call(
+                try Self.makeToolsListRequestData(),
+                timeout: .seconds(30)
+            )
+            let toolsResult = try Self.resultValue(from: toolsList)
+            guard let descriptor = DocumentationToolCatalog.descriptor(in: toolsResult) else {
+                throw UpstreamSlotAcquisitionError.unavailable
+            }
+            let probeResponse = try await connection.call(
+                try Self.makeDocumentationProbeRequestData(),
+                timeout: .seconds(30)
+            )
+            guard !DocumentationToolCatalog.responseIsDocumentationNotEnabled(probeResponse),
+                  !DocumentationToolCatalog.responseIsToolError(probeResponse) else {
+                throw UpstreamSlotAcquisitionError.unavailable
+            }
+            return CandidateProfile(
+                target: target,
+                connection: connection,
+                descriptor: descriptor,
+                toolCount: Self.toolCount(in: toolsResult),
+                serverVersion: serverVersion
+            )
+        } catch {
+            await connection.stop()
+            throw error
+        }
+    }
+
+    private static func makeInitializeRequestData() throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": "initialize",
+                "method": "initialize",
+                "params": [
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": [:],
+                    "clientInfo": [
+                        "name": "XcodeMCPKitDocumentationProvider",
+                        "version": "dev",
+                    ],
+                ],
+            ],
+            options: []
+        )
+    }
+
+    private static func makeToolsListRequestData() throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": "tools-list",
+                "method": "tools/list",
+            ],
+            options: []
+        )
+    }
+
+    private static func makeDocumentationProbeRequestData() throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": "documentation-probe",
+                "method": "tools/call",
+                "params": [
+                    "name": DocumentationToolCatalog.toolName,
+                    "arguments": [
+                        "query": "UIView animate withDuration animations completion",
+                    ],
+                ],
+            ],
+            options: []
+        )
+    }
+
+    private static func resultValue(from responseData: Data) throws -> JSONValue {
+        guard let object = try JSONSerialization.jsonObject(with: responseData, options: [])
+            as? [String: Any],
+            let result = object["result"],
+            let value = JSONValue(any: result) else {
+            throw ControlPlaneError.invalidResponse("invalid documentation provider response")
+        }
+        return value
+    }
+
+    private static func toolCount(in result: JSONValue) -> Int {
+        guard case .object(let object) = result,
+              case .array(let tools)? = object["tools"] else {
+            return 0
+        }
+        return tools.count
+    }
+
+    private static func serverVersion(fromInitializeResponse data: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [])
+            as? [String: Any],
+            let result = object["result"] as? [String: Any],
+            let serverInfo = result["serverInfo"] as? [String: Any] else {
+            return nil
+        }
+        return serverInfo["version"] as? String
+    }
+
+    private static func compareVersion(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let lhsParts = numericVersionParts(lhs)
+        let rhsParts = numericVersionParts(rhs)
+        let count = max(lhsParts.count, rhsParts.count)
+        for index in 0..<count {
+            let lhsValue = index < lhsParts.count ? lhsParts[index] : 0
+            let rhsValue = index < rhsParts.count ? rhsParts[index] : 0
+            if lhsValue < rhsValue {
+                return .orderedAscending
+            }
+            if lhsValue > rhsValue {
+                return .orderedDescending
+            }
+        }
+        return lhs.localizedStandardCompare(rhs)
+    }
+
+    private static func numericVersionParts(_ version: String) -> [Int] {
+        version
+            .split { character in
+                !character.isNumber
+            }
+            .compactMap { Int($0) }
+    }
+}

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -577,16 +577,20 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             )
         } catch {
             await invalidate(reason: "documentation_provider_call_failed")
-            let retryTimeout = Self.requestTimeout(until: requestDeadline)
-            guard retryTimeout?.nanoseconds != 0 else {
+            let replacementSelectionTimeout = Self.requestTimeout(until: requestDeadline)
+            guard replacementSelectionTimeout?.nanoseconds != 0 else {
                 throw error
             }
-            guard let replacement = await providerIfAvailable(requestTimeout: retryTimeout) else {
+            guard let replacement = await providerIfAvailable(requestTimeout: replacementSelectionTimeout) else {
+                throw error
+            }
+            let retryCallTimeout = Self.requestTimeout(until: requestDeadline)
+            guard retryCallTimeout?.nanoseconds != 0 else {
                 throw error
             }
             let retryResponse = try await replacement.profile.connection.call(
                 requestData,
-                timeout: retryTimeout
+                timeout: retryCallTimeout
             )
             return DocumentationProviderCallResult(
                 data: retryResponse,
@@ -598,15 +602,19 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
 
         await invalidate(reason: "documentation_search_not_enabled")
-        let retryTimeout = Self.requestTimeout(until: requestDeadline)
-        guard retryTimeout?.nanoseconds != 0,
-              let replacement = await providerIfAvailable(requestTimeout: retryTimeout) else {
+        let replacementSelectionTimeout = Self.requestTimeout(until: requestDeadline)
+        guard replacementSelectionTimeout?.nanoseconds != 0,
+              let replacement = await providerIfAvailable(requestTimeout: replacementSelectionTimeout) else {
+            return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
+        }
+        let retryCallTimeout = Self.requestTimeout(until: requestDeadline)
+        guard retryCallTimeout?.nanoseconds != 0 else {
             return DocumentationProviderCallResult(data: response, didInvalidateProvider: true)
         }
         do {
             let retryResponse = try await replacement.profile.connection.call(
                 requestData,
-                timeout: retryTimeout
+                timeout: retryCallTimeout
             )
             if DocumentationToolCatalog.responseIsDocumentationNotEnabled(retryResponse) {
                 await invalidate(reason: "documentation_search_retry_not_enabled")

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -395,17 +395,35 @@ extension RuntimeCoordinator {
     }
 
     func resolvedInitializeParams() -> [String: JSONValue] {
+        Self.resolvedInitializeParams(initializeParamsOverride: initializeParamsOverride)
+    }
+
+    package static func resolvedInitializeParams(config: ProxyConfig) -> [String: JSONValue] {
+        let override = ProxyFileConfigLoader.loadInitializeParamsOverride(
+            configPath: config.configPath,
+            logger: ProxyLogging.make("config")
+        )
+        return resolvedInitializeParams(initializeParamsOverride: override)
+    }
+
+    package static func resolvedInitializeParams(
+        initializeParamsOverride: [String: JSONValue]?
+    ) -> [String: JSONValue] {
         let mergedParams = ProxyFileConfigLoader.mergeJSONObjects(
             defaultInitializeParams(),
             overriding: initializeParamsOverride ?? [:]
         )
-        guard hasExplicitClientVersionOverride() == false else {
+        guard hasExplicitClientVersionOverride(initializeParamsOverride: initializeParamsOverride) == false else {
             return mergedParams
         }
         return applyingAutomaticClientVersion(to: mergedParams)
     }
 
     func defaultInitializeParams() -> [String: JSONValue] {
+        Self.defaultInitializeParams()
+    }
+
+    package static func defaultInitializeParams() -> [String: JSONValue] {
         [
             "protocolVersion": .string("2025-03-26"),
             "capabilities": .object([:]),
@@ -417,6 +435,12 @@ extension RuntimeCoordinator {
     }
 
     func hasExplicitClientVersionOverride() -> Bool {
+        Self.hasExplicitClientVersionOverride(initializeParamsOverride: initializeParamsOverride)
+    }
+
+    package static func hasExplicitClientVersionOverride(
+        initializeParamsOverride: [String: JSONValue]?
+    ) -> Bool {
         guard case .object(let clientInfo)? = initializeParamsOverride?["clientInfo"] else {
             return false
         }
@@ -424,6 +448,10 @@ extension RuntimeCoordinator {
     }
 
     func applyingAutomaticClientVersion(to params: [String: JSONValue]) -> [String: JSONValue] {
+        Self.applyingAutomaticClientVersion(to: params)
+    }
+
+    package static func applyingAutomaticClientVersion(to params: [String: JSONValue]) -> [String: JSONValue] {
         guard case .object(var clientInfo)? = params["clientInfo"],
               case .string(let clientName)? = clientInfo["name"] else {
             return params
@@ -440,23 +468,43 @@ extension RuntimeCoordinator {
     }
 
     func defaultClientVersion(for clientName: String) -> String {
+        Self.defaultClientVersion(for: clientName)
+    }
+
+    package static func defaultClientVersion(for clientName: String) -> String {
         xcodeChatClientVersion(for: clientName) ?? defaultProxyClientVersion()
     }
 
     func defaultProxyClientName() -> String {
+        Self.defaultProxyClientName()
+    }
+
+    package static func defaultProxyClientName() -> String {
         "XcodeMCPKit"
     }
 
     func defaultProxyClientVersion() -> String {
+        Self.defaultProxyClientVersion()
+    }
+
+    package static func defaultProxyClientVersion() -> String {
         "dev"
     }
 
     func xcodeChatClientVersion(for clientName: String) -> String? {
+        Self.xcodeChatClientVersion(for: clientName)
+    }
+
+    package static func xcodeChatClientVersion(for clientName: String) -> String? {
         let defaults = UserDefaults(suiteName: "com.apple.dt.Xcode")?.dictionaryRepresentation() ?? [:]
         return xcodeChatClientVersion(for: clientName, defaults: defaults)
     }
 
     func xcodeChatClientVersion(for clientName: String, defaults: [String: Any]) -> String? {
+        Self.xcodeChatClientVersion(for: clientName, defaults: defaults)
+    }
+
+    package static func xcodeChatClientVersion(for clientName: String, defaults: [String: Any]) -> String? {
         let normalizedName = normalizedChatClientName(clientName)
         guard !normalizedName.isEmpty else { return nil }
 
@@ -500,6 +548,10 @@ extension RuntimeCoordinator {
     }
 
     func xcodeChatVersionValue(forDefaultsKey defaultsKey: String) -> String? {
+        Self.xcodeChatVersionValue(forDefaultsKey: defaultsKey)
+    }
+
+    package static func xcodeChatVersionValue(forDefaultsKey defaultsKey: String) -> String? {
         guard let raw = UserDefaults(suiteName: "com.apple.dt.Xcode")?.string(forKey: defaultsKey) else {
             return nil
         }
@@ -507,6 +559,10 @@ extension RuntimeCoordinator {
     }
 
     func xcodeChatVersionValue(from raw: String) -> String? {
+        Self.xcodeChatVersionValue(from: raw)
+    }
+
+    package static func xcodeChatVersionValue(from raw: String) -> String? {
         guard
             let data = raw.data(using: .utf8),
             let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
@@ -519,6 +575,10 @@ extension RuntimeCoordinator {
     }
 
     func chatClientAliases(forVersionStem stem: String) -> Set<String> {
+        Self.chatClientAliases(forVersionStem: stem)
+    }
+
+    package static func chatClientAliases(forVersionStem stem: String) -> Set<String> {
         var aliases: Set<String> = []
         let normalizedStem = normalizedChatClientName(stem)
         if !normalizedStem.isEmpty {
@@ -537,6 +597,10 @@ extension RuntimeCoordinator {
     }
 
     func normalizedChatClientName(_ name: String) -> String {
+        Self.normalizedChatClientName(name)
+    }
+
+    package static func normalizedChatClientName(_ name: String) -> String {
         let scalars = name.unicodeScalars.filter(CharacterSet.alphanumerics.contains)
         return String(String.UnicodeScalarView(scalars)).lowercased()
     }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -10,7 +10,7 @@ extension RuntimeCoordinator {
             applyBackoff: applyBackoff
         ) { [weak self] in
             guard let self else { return }
-            self.startAllUpstreamSlots()
+            self.startPrimaryUpstreamSlot()
             self.startEagerInitializePrimaryWhenReady()
         }
     }
@@ -42,7 +42,7 @@ extension RuntimeCoordinator {
                 self.clearPrimaryInitializeReadinessWaiter(token)
                 guard !token.isCancelled else { return }
             }
-            self.startAllUpstreamSlots()
+            self.startPrimaryUpstreamSlot()
             self.sendPrimaryInitializeRequestIfStillPending()
         }
     }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Readiness.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Readiness.swift
@@ -64,6 +64,13 @@ extension RuntimeCoordinator {
         }
     }
 
+    func startPrimaryUpstreamSlot() {
+        guard let primary = upstreams.first else { return }
+        Task {
+            await primary.start()
+        }
+    }
+
     func noteUpstreamInitializationSucceeded() {
         guard upstreamReadinessGate.isEnabled else { return }
         Task { [upstreamReadinessCoordinator] in

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -60,6 +60,11 @@ package protocol RuntimeCoordinating: Sendable {
         route: ControlPlaneRoute,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> JSONValue
+    func callDocumentationSearch(
+        requestData: Data,
+        requestTimeoutOverride: TimeAmount?
+    ) async throws -> Data
+    func invalidateDocumentationProvider(reason: String) async
     func chooseUpstreamIndex() -> Int?
     func enqueueOnUpstreamSlot<Output: Sendable>(
         leaseID: RequestLeaseID,
@@ -137,6 +142,15 @@ extension RuntimeCoordinating {
             requestTimeoutOverride: requestTimeoutOverride
         )
     }
+
+    package func callDocumentationSearch(
+        requestData _: Data,
+        requestTimeoutOverride _: TimeAmount?
+    ) async throws -> Data {
+        throw UpstreamSlotAcquisitionError.unavailable
+    }
+
+    package func invalidateDocumentationProvider(reason _: String) async {}
 }
 
 extension RuntimeCoordinator {
@@ -196,6 +210,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let scheduleRuntimeTimeout: @Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
         RuntimeScheduledTimeout
     package let controlPlaneCoordinator: ControlPlaneCoordinator
+    package let documentationProviderManager: (any DocumentationProviderManaging)?
 
     package convenience init(config: ProxyConfig, eventLoop: EventLoop) {
         let count = max(1, min(config.upstreamProcessCount, 10))
@@ -210,7 +225,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             upstreamReadinessGate: Self.defaultUpstreamReadinessGate(
                 config: config,
                 clock: clock
-            )
+            ),
+            documentationProviderManager: DocumentationProviderManager()
         )
     }
 
@@ -222,7 +238,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         upstreamReadinessGate: UpstreamReadinessGate? = nil,
         nowUptimeNanoseconds: (@Sendable () -> UInt64)? = nil,
         scheduleRuntimeTimeout: (@Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
-            RuntimeScheduledTimeout)? = nil
+            RuntimeScheduledTimeout)? = nil,
+        documentationProviderManager: (any DocumentationProviderManaging)? = nil
     ) {
         precondition(!upstreams.isEmpty, "upstreams must not be empty")
         let schedulerProbeStarter = NIOLockedValueBox<(@Sendable ([HealthProbeRequest]) -> Void)?>(nil)
@@ -253,6 +270,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.upstreamHealthManager = UpstreamHealthManager(upstreamCount: upstreams.count)
         self.nowUptimeNanoseconds = uptimeProvider
         self.scheduleRuntimeTimeout = timeoutScheduler
+        self.documentationProviderManager = documentationProviderManager
         let resolvedReadinessGate = upstreamReadinessGate
             ?? .alwaysReady(uptimeNanoseconds: runtimeClock.uptimeNanoseconds)
         self.upstreamReadinessGate = resolvedReadinessGate
@@ -466,6 +484,11 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             for upstream in upstreams {
                 group.addTask {
                     await upstream.stop()
+                }
+            }
+            if let documentationProviderManager {
+                group.addTask {
+                    await documentationProviderManager.shutdown()
                 }
             }
         }
@@ -682,11 +705,16 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 defaultSeconds: config.requestTimeout
             )
         let deadline = timeoutDeadline(for: timeout)
-        return try await awaitControlPlaneOperation {
+        let baseResult = try await awaitControlPlaneOperation {
             try await self.controlPlaneCoordinator.toolsCatalog(
                 deadlineUptimeNs: deadline
             )
         }
+        guard let documentationProviderManager else {
+            return baseResult
+        }
+        let update = await documentationProviderManager.toolListUpdate()
+        return DocumentationToolCatalog.applying(update, to: baseResult)
     }
 
     package func sharedXcodeListWindowsResult(
@@ -719,6 +747,38 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 deadlineUptimeNs: deadline
             )
         }
+    }
+
+    package func callDocumentationSearch(
+        requestData: Data,
+        requestTimeoutOverride: TimeAmount?
+    ) async throws -> Data {
+        guard let documentationProviderManager else {
+            throw UpstreamSlotAcquisitionError.unavailable
+        }
+        let result = try await documentationProviderManager.callDocumentationSearch(
+            requestData: requestData,
+            requestTimeoutOverride: requestTimeoutOverride
+        )
+        if result.didInvalidateProvider
+            || DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data)
+        {
+            invalidateControlPlaneSynchronously(
+                reason: "documentation_provider_invalidated",
+                clearInitialize: false,
+                clearToolsCatalog: true
+            )
+        }
+        return result.data
+    }
+
+    package func invalidateDocumentationProvider(reason: String) async {
+        await documentationProviderManager?.invalidate(reason: reason)
+        invalidateControlPlaneSynchronously(
+            reason: "documentation_provider_\(reason)",
+            clearInitialize: false,
+            clearToolsCatalog: true
+        )
     }
 
     func encodeJSONRPCResultBuffer(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -241,6 +241,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package static func makeDefaultDocumentationProviderManager(
         config: ProxyConfig
     ) -> (any DocumentationProviderManaging)? {
+        guard config.disabledToolNames.contains(DocumentationToolCatalog.toolName) == false else {
+            return nil
+        }
         guard isDefaultXcrunMCPBridgeInvocation(config: config) else {
             return nil
         }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -218,6 +218,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         let upstreams = Self.makeDefaultUpstreams(
             config: config, sharedSessionID: config.upstreamSessionID, count: count)
         let clock = ClockClient.liveValue
+        let documentationProviderManager = Self.makeDefaultDocumentationProviderManager(config: config)
         self.init(
             config: config,
             eventLoop: eventLoop,
@@ -227,9 +228,18 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 config: config,
                 clock: clock
             ),
-            documentationProviderManager: DocumentationProviderManager(),
-            prewarmDocumentationProviderOnStartup: true
+            documentationProviderManager: documentationProviderManager,
+            prewarmDocumentationProviderOnStartup: documentationProviderManager != nil
         )
+    }
+
+    package static func makeDefaultDocumentationProviderManager(
+        config: ProxyConfig
+    ) -> (any DocumentationProviderManaging)? {
+        guard isDefaultXcrunMCPBridgeInvocation(config: config) else {
+            return nil
+        }
+        return DocumentationProviderManager()
     }
 
     package init(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -189,6 +189,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let upstreamStderrLogLimiter = UpstreamStderrLogLimiter()
     package let primaryInitializeReadinessTokenBox =
         NIOLockedValueBox<UpstreamReadinessWaiterToken?>(nil)
+    package let documentationPrewarmTaskBox = NIOLockedValueBox<Task<Void, Never>?>(nil)
     package let upstreamReadinessGenerationBox = NIOLockedValueBox<UInt64>(0)
     package let debugRecorder: ProxyDebugRecorder
     package let leaseManager: LeaseManager
@@ -468,6 +469,12 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         for timeout in upstreamTimeouts {
             timeout?.cancel()
         }
+        let documentationPrewarmTask = documentationPrewarmTaskBox.withLockedValue { taskBox in
+            let task = taskBox
+            taskBox = nil
+            return task
+        }
+        documentationPrewarmTask?.cancel()
         await upstreamReadinessCoordinator.shutdown()
 
         invalidateControlPlaneSynchronously(
@@ -494,6 +501,11 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             if let documentationProviderManager {
                 group.addTask {
                     await documentationProviderManager.shutdown()
+                }
+            }
+            if let documentationPrewarmTask {
+                group.addTask {
+                    await documentationPrewarmTask.value
                 }
             }
         }
@@ -547,7 +559,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             ? min(config.requestTimeout, 30)
             : 30
         let timeout = MCPMethodDispatcher.timeoutForControlPlane(defaultSeconds: timeoutSeconds)
-        Task { [documentationProviderManager, logger] in
+        let task = Task { [documentationProviderManager, logger] in
+            guard !Task.isCancelled else { return }
             logger.debug(
                 "Prewarming documentation provider",
                 metadata: [
@@ -555,8 +568,15 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 ]
             )
             await documentationProviderManager.prewarm(requestTimeout: timeout)
+            guard !Task.isCancelled else { return }
             logger.debug("Documentation provider prewarm completed")
         }
+        let previous = documentationPrewarmTaskBox.withLockedValue { taskBox in
+            let previous = taskBox
+            taskBox = task
+            return previous
+        }
+        previous?.cancel()
     }
 
     package func chooseUpstreamIndex() -> Int? {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -879,7 +879,6 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                     "timeout_ns": .string("\(requestTimeout.nanoseconds)"),
                 ]
             )
-            await manager.invalidate(reason: "tools_list_timeout")
             return .unavailable
         }
     }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -840,10 +840,21 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 "tools/call",
                 defaultSeconds: config.requestTimeout
             )
-        let result = try await documentationProviderManager.callDocumentationSearch(
-            requestData: requestData,
-            requestTimeoutOverride: timeout
-        )
+        let result: DocumentationProviderCallResult
+        do {
+            result = try await documentationProviderManager.callDocumentationSearch(
+                requestData: requestData,
+                requestTimeoutOverride: timeout
+            )
+        } catch let failure as DocumentationProviderCallFailure {
+            setDocumentationProviderActive(failure.providerIsActive)
+            invalidateControlPlaneSynchronously(
+                reason: "documentation_provider_invalidated",
+                clearInitialize: false,
+                clearToolsCatalog: true
+            )
+            throw failure.underlying
+        }
         let responseIsDocumentationNotEnabled =
             DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data)
         setDocumentationProviderActive(responseIsDocumentationNotEnabled == false)

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -64,6 +64,7 @@ package protocol RuntimeCoordinating: Sendable {
         requestData: Data,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> Data
+    func hasDocumentationProvider() -> Bool
     func invalidateDocumentationProvider(reason: String) async
     func chooseUpstreamIndex() -> Int?
     func enqueueOnUpstreamSlot<Output: Sendable>(
@@ -109,6 +110,10 @@ package protocol RuntimeCoordinating: Sendable {
 }
 
 extension RuntimeCoordinating {
+    package func hasDocumentationProvider() -> Bool {
+        false
+    }
+
     func sendUpstream(_ data: Data, upstreamIndex: Int) {
         sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: false)
     }
@@ -832,6 +837,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             )
         }
         return result.data
+    }
+
+    package func hasDocumentationProvider() -> Bool {
+        documentationProviderManager != nil
     }
 
     private func documentationToolListUpdate(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -226,7 +226,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 config: config,
                 clock: clock
             ),
-            documentationProviderManager: DocumentationProviderManager()
+            documentationProviderManager: DocumentationProviderManager(),
+            prewarmDocumentationProviderOnStartup: true
         )
     }
 
@@ -239,7 +240,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         nowUptimeNanoseconds: (@Sendable () -> UInt64)? = nil,
         scheduleRuntimeTimeout: (@Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
             RuntimeScheduledTimeout)? = nil,
-        documentationProviderManager: (any DocumentationProviderManaging)? = nil
+        documentationProviderManager: (any DocumentationProviderManaging)? = nil,
+        prewarmDocumentationProviderOnStartup: Bool = false
     ) {
         precondition(!upstreams.isEmpty, "upstreams must not be empty")
         let schedulerProbeStarter = NIOLockedValueBox<(@Sendable ([HealthProbeRequest]) -> Void)?>(nil)
@@ -399,6 +401,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
 
         startEagerInitializePrimary()
+        if prewarmDocumentationProviderOnStartup {
+            prewarmDocumentationProvider()
+        }
     }
 
     package func session(id: String) -> SessionContext {
@@ -533,6 +538,24 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             await self?.controlPlaneCoordinator.prewarmToolsCatalogIfNeeded(
                 deadlineUptimeNs: deadline
             )
+        }
+    }
+
+    package func prewarmDocumentationProvider() {
+        guard let documentationProviderManager else { return }
+        let timeoutSeconds = config.requestTimeout > 0
+            ? min(config.requestTimeout, 30)
+            : 30
+        let timeout = MCPMethodDispatcher.timeoutForControlPlane(defaultSeconds: timeoutSeconds)
+        Task { [documentationProviderManager, logger] in
+            logger.debug(
+                "Prewarming documentation provider",
+                metadata: [
+                    "timeout_seconds": .string("\(timeoutSeconds)"),
+                ]
+            )
+            await documentationProviderManager.prewarm(requestTimeout: timeout)
+            logger.debug("Documentation provider prewarm completed")
         }
     }
 

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -65,6 +65,7 @@ package protocol RuntimeCoordinating: Sendable {
         requestTimeoutOverride: TimeAmount?
     ) async throws -> Data
     func hasDocumentationProvider() -> Bool
+    func hasActiveDocumentationProvider() -> Bool
     func invalidateDocumentationProvider(reason: String) async
     func chooseUpstreamIndex() -> Int?
     func enqueueOnUpstreamSlot<Output: Sendable>(
@@ -111,6 +112,10 @@ package protocol RuntimeCoordinating: Sendable {
 
 extension RuntimeCoordinating {
     package func hasDocumentationProvider() -> Bool {
+        false
+    }
+
+    package func hasActiveDocumentationProvider() -> Bool {
         false
     }
 
@@ -217,6 +222,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         RuntimeScheduledTimeout
     package let controlPlaneCoordinator: ControlPlaneCoordinator
     package let documentationProviderManager: (any DocumentationProviderManaging)?
+    private let documentationProviderActiveBox = NIOLockedValueBox(false)
 
     package convenience init(config: ProxyConfig, eventLoop: EventLoop) {
         let count = max(1, min(config.upstreamProcessCount, 10))
@@ -247,7 +253,13 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         guard isDefaultXcrunMCPBridgeInvocation(config: config) else {
             return nil
         }
-        return DocumentationProviderManager()
+        let environment = ProcessInfo.processInfo.environment
+        let pinnedProcessID = environment["MCP_XCODE_PID"].flatMap(pid_t.init)
+        return DocumentationProviderManager(
+            sessionFactory: LiveDocumentationProviderSessionFactory(baseEnvironment: environment),
+            pinnedProcessID: pinnedProcessID,
+            initializeParams: Self.resolvedInitializeParams(config: config)
+        )
     }
 
     package init(
@@ -577,7 +589,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             ? min(config.requestTimeout, 30)
             : 30
         let timeout = MCPMethodDispatcher.timeoutForControlPlane(defaultSeconds: timeoutSeconds)
-        let task = Task { [documentationProviderManager, logger] in
+        let task = Task { [weak self, documentationProviderManager, logger] in
             guard !Task.isCancelled else { return }
             logger.debug(
                 "Prewarming documentation provider",
@@ -585,7 +597,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                     "timeout_seconds": .string("\(timeoutSeconds)"),
                 ]
             )
-            await documentationProviderManager.prewarm(requestTimeout: timeout)
+            let update = await documentationProviderManager.prewarm(requestTimeout: timeout)
+            self?.recordDocumentationToolListUpdate(update)
             guard !Task.isCancelled else { return }
             logger.debug("Documentation provider prewarm completed")
         }
@@ -778,6 +791,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             manager: documentationProviderManager,
             requestTimeout: timeAmount(until: deadline)
         )
+        recordDocumentationToolListUpdate(update)
         return DocumentationToolCatalog.applying(update, to: baseResult)
     }
 
@@ -833,17 +847,39 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         if result.didInvalidateProvider
             || DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data)
         {
+            setDocumentationProviderActive(false)
             invalidateControlPlaneSynchronously(
                 reason: "documentation_provider_invalidated",
                 clearInitialize: false,
                 clearToolsCatalog: true
             )
+        } else {
+            setDocumentationProviderActive(true)
         }
         return result.data
     }
 
     package func hasDocumentationProvider() -> Bool {
         documentationProviderManager != nil
+    }
+
+    package func hasActiveDocumentationProvider() -> Bool {
+        documentationProviderActiveBox.withLockedValue { $0 }
+    }
+
+    private func recordDocumentationToolListUpdate(_ update: DocumentationToolListUpdate) {
+        switch update {
+        case .available:
+            setDocumentationProviderActive(true)
+        case .unavailable:
+            setDocumentationProviderActive(false)
+        case .unchanged:
+            break
+        }
+    }
+
+    private func setDocumentationProviderActive(_ isActive: Bool) {
+        documentationProviderActiveBox.withLockedValue { $0 = isActive }
     }
 
     private func documentationToolListUpdate(
@@ -885,6 +921,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     package func invalidateDocumentationProvider(reason: String) async {
         await documentationProviderManager?.invalidate(reason: reason)
+        setDocumentationProviderActive(false)
         invalidateControlPlaneSynchronously(
             reason: "documentation_provider_\(reason)",
             clearInitialize: false,

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -713,7 +713,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         guard let documentationProviderManager else {
             return baseResult
         }
-        let update = await documentationProviderManager.toolListUpdate()
+        let update = await documentationToolListUpdate(
+            manager: documentationProviderManager,
+            requestTimeout: timeAmount(until: deadline)
+        )
         return DocumentationToolCatalog.applying(update, to: baseResult)
     }
 
@@ -756,9 +759,15 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         guard let documentationProviderManager else {
             throw UpstreamSlotAcquisitionError.unavailable
         }
+        let timeout =
+            requestTimeoutOverride
+            ?? MCPMethodDispatcher.timeoutForMethod(
+                "tools/call",
+                defaultSeconds: config.requestTimeout
+            )
         let result = try await documentationProviderManager.callDocumentationSearch(
             requestData: requestData,
-            requestTimeoutOverride: requestTimeoutOverride
+            requestTimeoutOverride: timeout
         )
         if result.didInvalidateProvider
             || DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data)
@@ -770,6 +779,37 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             )
         }
         return result.data
+    }
+
+    private func documentationToolListUpdate(
+        manager: any DocumentationProviderManaging,
+        requestTimeout: TimeAmount?
+    ) async -> DocumentationToolListUpdate {
+        guard requestTimeout?.nanoseconds != 0 else {
+            return .unavailable
+        }
+        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
+            return await manager.toolListUpdate(requestTimeout: requestTimeout)
+        }
+        do {
+            return try await withThrowingTaskGroup(of: DocumentationToolListUpdate.self) { group in
+                group.addTask {
+                    await manager.toolListUpdate(requestTimeout: requestTimeout)
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
+                    throw TimeoutError()
+                }
+                guard let update = try await group.next() else {
+                    throw TimeoutError()
+                }
+                group.cancelAll()
+                return update
+            }
+        } catch {
+            await manager.invalidate(reason: "tools_list_timeout")
+            return .unavailable
+        }
     }
 
     package func invalidateDocumentationProvider(reason: String) async {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -844,17 +844,15 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             requestData: requestData,
             requestTimeoutOverride: timeout
         )
-        if result.didInvalidateProvider
-            || DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data)
-        {
-            setDocumentationProviderActive(false)
+        let responseIsDocumentationNotEnabled =
+            DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data)
+        setDocumentationProviderActive(responseIsDocumentationNotEnabled == false)
+        if result.didInvalidateProvider || responseIsDocumentationNotEnabled {
             invalidateControlPlaneSynchronously(
                 reason: "documentation_provider_invalidated",
                 clearInitialize: false,
                 clearToolsCatalog: true
             )
-        } else {
-            setDocumentationProviderActive(true)
         }
         return result.data
     }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -807,6 +807,13 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 return update
             }
         } catch {
+            logger.debug(
+                "documentation provider tools/list update failed",
+                metadata: [
+                    "error": .string(String(describing: error)),
+                    "timeout_ns": .string("\(requestTimeout.nanoseconds)"),
+                ]
+            )
             await manager.invalidate(reason: "tools_list_timeout")
             return .unavailable
         }

--- a/Sources/ProxySession/Session/ProxyRouter.swift
+++ b/Sources/ProxySession/Session/ProxyRouter.swift
@@ -13,6 +13,7 @@ package final class ProxyRouter: Sendable {
         var promise: EventLoopPromise<ByteBuffer>
         var timeout: Scheduled<Void>?
         var onTimeout: (@Sendable () -> Void)?
+        var responseIDKeys: Set<String>?
     }
 
     private struct State: Sendable {
@@ -73,7 +74,8 @@ package final class ProxyRouter: Sendable {
                 token: token,
                 promise: promise,
                 timeout: timeout,
-                onTimeout: onTimeout
+                onTimeout: onTimeout,
+                responseIDKeys: nil
             )
         }
         return PendingRegistration(token: token, future: promise.futureResult)
@@ -94,6 +96,7 @@ package final class ProxyRouter: Sendable {
     package func registerBatchPending(
         on eventLoop: EventLoop,
         timeout: TimeAmount? = nil,
+        responseIDKeys: [String] = [],
         onTimeout: (@Sendable () -> Void)? = nil
     ) -> PendingRegistration {
         let promise = eventLoop.makePromise(of: ByteBuffer.self)
@@ -102,16 +105,18 @@ package final class ProxyRouter: Sendable {
         let timeout = effectiveTimeout.map { timeout in
             eventLoop.scheduleTask(in: timeout) { [weak self] in
                 guard let self else { return }
-                self.failBatchTimeout()
+                self.failBatchTimeout(token: token)
             }
         }
+        let responseIDKeySet = Set(responseIDKeys)
         state.withLockedValue { state in
             state.pendingBatches.append(
                 Pending(
                     token: token,
                     promise: promise,
                     timeout: timeout,
-                    onTimeout: onTimeout
+                    onTimeout: onTimeout,
+                    responseIDKeys: responseIDKeySet.isEmpty ? nil : responseIDKeySet
                 )
             )
         }
@@ -140,8 +145,9 @@ package final class ProxyRouter: Sendable {
             return
         }
 
-        if (json as? [Any]) != nil {
-            if let pending = popBatch() {
+        if let array = json as? [Any] {
+            let responseIDKeys = Self.idKeys(from: array)
+            if let pending = popBatch(matching: responseIDKeys) {
                 complete(pending: pending, data: data)
             } else {
                 notify(data)
@@ -177,23 +183,40 @@ package final class ProxyRouter: Sendable {
         pending?.promise.fail(TimeoutError())
     }
 
-    private func failBatchTimeout() {
-        let pending = state.withLockedValue { state in
-            state.pendingBatches.isEmpty ? nil : state.pendingBatches.removeFirst()
+    private func failBatchTimeout(token: UUID) {
+        let pending = state.withLockedValue { state -> Pending? in
+            guard let index = state.pendingBatches.firstIndex(where: { $0.token == token }) else {
+                return nil
+            }
+            return state.pendingBatches.remove(at: index)
         }
         pending?.onTimeout?()
         pending?.promise.fail(TimeoutError())
     }
 
     private func pop(idKey: String) -> Pending? {
-        state.withLockedValue { state in
+        state.withLockedValue { state -> Pending? in
             state.pendingByID.removeValue(forKey: idKey)
         }
     }
 
-    private func popBatch() -> Pending? {
+    private func popBatch(matching responseIDKeys: Set<String>) -> Pending? {
         state.withLockedValue { state in
-            state.pendingBatches.isEmpty ? nil : state.pendingBatches.removeFirst()
+            if responseIDKeys.isEmpty == false {
+                if let index = state.pendingBatches.firstIndex(where: { pending in
+                    guard let expected = pending.responseIDKeys else {
+                        return false
+                    }
+                    return expected.isDisjoint(with: responseIDKeys) == false
+                }) {
+                    return state.pendingBatches.remove(at: index)
+                }
+                if let index = state.pendingBatches.firstIndex(where: { $0.responseIDKeys == nil }) {
+                    return state.pendingBatches.remove(at: index)
+                }
+                return nil
+            }
+            return state.pendingBatches.isEmpty ? nil : state.pendingBatches.removeFirst()
         }
     }
 
@@ -230,6 +253,17 @@ package final class ProxyRouter: Sendable {
             return numberID.stringValue
         }
         return String(describing: id)
+    }
+
+    private static func idKeys(from array: [Any]) -> Set<String> {
+        Set(
+            array.compactMap { item -> String? in
+                guard let object = item as? [String: Any] else {
+                    return nil
+                }
+                return idKey(from: object)
+            }
+        )
     }
 }
 

--- a/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
@@ -91,6 +91,7 @@ package enum XcodePermissionDialogMatcher {
     private static let allowedProcessBundleIdentifiers = normalizedCandidates([
         "com.apple.dt.Xcode",
         "com.apple.dt.ExternalViewService",
+        "com.apple.dt.Xcode.DeveloperSystemPolicyService",
     ])
     private static let allowedWindowRoles = normalizedCandidates([
         "AXWindow"
@@ -409,6 +410,7 @@ package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessi
         let bundleIdentifiers: Set<String> = [
             "com.apple.dt.Xcode",
             "com.apple.dt.ExternalViewService",
+            "com.apple.dt.Xcode.DeveloperSystemPolicyService",
         ]
         var processIDs = Set(NSWorkspace.shared.runningApplications.compactMap { application -> pid_t? in
             guard let bundleIdentifier = application.bundleIdentifier else {

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1709,7 +1709,71 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
-    @Test func httpDocumentationSearchFallsThroughWhenDocumentationProviderIsInactive() async throws {
+    @Test func httpDocumentationSearchRoutesThroughInactiveDocumentationProvider() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let documentationRequests = NIOLockedValueBox<[String]>([])
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { _, _, originalID in
+                Issue.record("DocumentationSearch should not be forwarded upstream")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "{\"answer\":\"upstream-docs\"}"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let params = try #require(object["params"] as? [String: Any])
+                let arguments = try #require(params["arguments"] as? [String: Any])
+                documentationRequests.withLockedValue { requests in
+                    requests.append(arguments["query"] as? String ?? "")
+                }
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"cold-docs\"}"
+                )
+            },
+            documentationProviderIsActive: false
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-docs-inactive-local",
+                payload: toolsCallPayload(
+                    id: 65,
+                    name: "DocumentationSearch",
+                    arguments: [
+                        "query": "hello",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            let structuredContent = result?["structuredContent"] as? [String: Any]
+            #expect(structuredContent?["answer"] as? String == "cold-docs")
+            #expect(sessionManager.sentToolNames() == [])
+            #expect(documentationRequests.withLockedValue { $0 } == ["hello"])
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
+    @Test func httpDocumentationSearchFallsBackWhenInactiveProviderIsUnavailable() async throws {
         let config = makeConfig(requestTimeout: 2)
         let localDocumentationRequests = NIOLockedValueBox(0)
         let sessionManager = TestRuntimeCoordinator(
@@ -1740,9 +1804,9 @@ struct HTTPHandlerTests {
         do {
             let (response, body) = try await postHTTPJSON(
                 url: server.url,
-                sessionID: "session-docs-inactive-fallthrough",
+                sessionID: "session-docs-inactive-fallback",
                 payload: toolsCallPayload(
-                    id: 65,
+                    id: 66,
                     name: "DocumentationSearch",
                     arguments: [
                         "query": "hello",
@@ -1755,7 +1819,7 @@ struct HTTPHandlerTests {
             let content = result?["content"] as? [[String: Any]]
             #expect(content?.first?["text"] as? String == "{\"answer\":\"upstream-docs\"}")
             #expect(sessionManager.sentToolNames() == ["DocumentationSearch"])
-            #expect(localDocumentationRequests.withLockedValue { $0 } == 0)
+            #expect(localDocumentationRequests.withLockedValue { $0 } == 1)
         } catch {
             try? await server.shutdown()
             throw error
@@ -2339,7 +2403,7 @@ struct HTTPHandlerTests {
             #expect(docsContent?.first?["text"] as? String == "{\"answer\":\"upstream-docs\"}")
 
             #expect(sessionManager.sentToolNames() == ["DocumentationSearch"])
-            #expect(localDocumentationRequests.withLockedValue { $0 } == 0)
+            #expect(localDocumentationRequests.withLockedValue { $0 } == 1)
         } catch {
             try? await server.shutdown()
             throw error

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1851,6 +1851,88 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpBatchForwardsDocumentationSearchNotificationWithProvider() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let documentationRequests = NIOLockedValueBox<[String]>([])
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "OtherAllowedTool")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "other-tool-result"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let params = try #require(object["params"] as? [String: Any])
+                let arguments = try #require(params["arguments"] as? [String: Any])
+                documentationRequests.withLockedValue { requests in
+                    requests.append(arguments["query"] as? String ?? "")
+                }
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"docs\"}"
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-docs-batch-notification",
+                payload: [
+                    [
+                        "jsonrpc": "2.0",
+                        "method": "tools/call",
+                        "params": [
+                            "name": "DocumentationSearch",
+                            "arguments": [
+                                "query": "UIView notification",
+                            ],
+                        ],
+                    ],
+                    toolsCallPayload(
+                        id: 703,
+                        name: "OtherAllowedTool",
+                        arguments: [:]
+                    ),
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 1)
+
+            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 703 }
+            let otherResult = other?["result"] as? [String: Any]
+            let otherContent = otherResult?["content"] as? [[String: Any]]
+            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
+
+            #expect(sessionManager.sentToolNames() == [
+                "DocumentationSearch",
+                "OtherAllowedTool",
+            ])
+            #expect(documentationRequests.withLockedValue { $0 }.isEmpty)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpBatchForwardsOtherCallsWhileDocumentationSearchIsStillResolving() async throws {
         let config = makeConfig(requestTimeout: 2)
         let documentationStarted = NIOLockedValueBox(false)

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -2411,6 +2411,93 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpBatchStartsDocumentationFallbackBeforeOtherForwardedRequestTimesOut()
+        async throws
+    {
+        let config = makeConfig(requestTimeout: 0.25)
+        let localDocumentationRequests = NIOLockedValueBox(0)
+        let fallbackDocumentationRequests = NIOLockedValueBox(0)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                if toolName == "DocumentationSearch" {
+                    fallbackDocumentationRequests.withLockedValue { $0 += 1 }
+                    return .immediate(
+                        try makeToolSuccessResponse(
+                            id: originalID,
+                            text: "{\"answer\":\"upstream-docs\"}"
+                        )
+                    )
+                }
+                #expect(toolName == "OtherAllowedTool")
+                return .manual(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "other-tool-result"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                _ = requestData
+                localDocumentationRequests.withLockedValue { $0 += 1 }
+                throw UpstreamSlotAcquisitionError.unavailable
+            },
+            documentationProviderIsActive: false
+        )
+        sessionManager.setAvailableUpstreamIndices([0, 1])
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-docs-fallback-before-other-timeout",
+                payload: [
+                    toolsCallPayload(
+                        id: 761,
+                        name: "DocumentationSearch",
+                        arguments: [
+                            "query": "UIView fallback before timeout",
+                        ]
+                    ),
+                    toolsCallPayload(
+                        id: 762,
+                        name: "OtherAllowedTool",
+                        arguments: [:]
+                    ),
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+
+            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 761 }
+            let docsResult = docs?["result"] as? [String: Any]
+            let docsContent = docsResult?["content"] as? [[String: Any]]
+            #expect(docsContent?.first?["text"] as? String == "{\"answer\":\"upstream-docs\"}")
+
+            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 762 }
+            let otherError = other?["error"] as? [String: Any]
+            #expect(otherError?["message"] as? String == "upstream timeout")
+
+            #expect(sessionManager.sentToolRequests() == [
+                "OtherAllowedTool@0",
+                "DocumentationSearch@1",
+            ])
+            #expect(localDocumentationRequests.withLockedValue { $0 } == 1)
+            #expect(fallbackDocumentationRequests.withLockedValue { $0 } == 1)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpBatchDocumentationSearchSharesSingleDeadline() async throws {
         let config = makeConfig(requestTimeout: 0.1)
         let documentationRequests = NIOLockedValueBox<[String]>([])

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1609,41 +1609,24 @@ struct HTTPHandlerTests {
 
     @Test func httpToolCallNormalizesColdSchemaWithoutCatalogPrewarm() async throws {
         let config = makeConfig(requestTimeout: 2)
+        let documentationRequests = NIOLockedValueBox<[String]>([])
         let sessionManager = TestRuntimeCoordinator(
             config: config,
-            upstreamRequestResponder: { method, toolName, originalID in
-                switch (method, toolName) {
-                case ("tools/list", nil):
-                    return .immediate(
-                        try makeToolResultResponse(
-                            id: originalID,
-                            result: [
-                                "tools": [
-                                    [
-                                        "name": "DocumentationSearch",
-                                        "outputSchema": [
-                                            "type": "object",
-                                        ],
-                                    ],
-                                ],
-                            ]
-                        )
-                    )
-                case ("tools/call", "DocumentationSearch"):
-                    return .immediate(
-                        try makeToolSuccessResponse(
-                            id: originalID,
-                            text: "{\"answer\":\"ok\"}"
-                        )
-                    )
-                default:
-                    return .immediate(
-                        try makeToolErrorResponse(
-                            id: originalID,
-                            text: "unexpected request"
-                        )
-                    )
+            documentationSearchResponder: { requestData in
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let params = try #require(object["params"] as? [String: Any])
+                let arguments = try #require(params["arguments"] as? [String: Any])
+                documentationRequests.withLockedValue { requests in
+                    requests.append(arguments["query"] as? String ?? "")
                 }
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"ok\"}"
+                )
             }
         )
         sessionManager.setInitialized(true)
@@ -1670,8 +1653,9 @@ struct HTTPHandlerTests {
             let structuredContent = result?["structuredContent"] as? [String: Any]
             #expect(structuredContent?["answer"] as? String == "ok")
             #expect(sessionManager.cachedToolsListResult() == nil)
-            #expect(sessionManager.sentMethods() == ["tools/call"])
-            #expect(sessionManager.sentToolNames() == ["DocumentationSearch"])
+            #expect(sessionManager.sentMethods() == [])
+            #expect(sessionManager.sentToolNames() == [])
+            #expect(documentationRequests.withLockedValue { $0 } == ["hello"])
         } catch {
             try? await server.shutdown()
             throw error
@@ -5451,42 +5435,53 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         (@Sendable (_ method: String, _ originalID: RPCID) throws -> UpstreamResponsePlan)?
     private let legacyUpstreamResponder:
         (@Sendable (_ method: String, _ originalID: RPCID) throws -> Data)?
+    private let documentationSearchResponder:
+        (@Sendable (_ requestData: Data) throws -> Data)?
     private let cancelAfterStartingEnqueueRequest: Bool
     private let requestLeaseRegistry = RequestLeaseRegistry()
 
     init(
         config: ProxyConfig,
         upstreamResponder: (@Sendable (_ method: String, _ originalID: RPCID) throws -> Data)? = nil,
+        documentationSearchResponder:
+            (@Sendable (_ requestData: Data) throws -> Data)? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
         self.upstreamRequestResponder = nil
         self.upstreamResponder = nil
         self.legacyUpstreamResponder = upstreamResponder
+        self.documentationSearchResponder = documentationSearchResponder
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
     }
 
     init(
         config: ProxyConfig,
         upstreamPlanResponder: (@Sendable (_ method: String, _ originalID: RPCID) throws -> UpstreamResponsePlan)?,
+        documentationSearchResponder:
+            (@Sendable (_ requestData: Data) throws -> Data)? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
         self.upstreamRequestResponder = nil
         self.upstreamResponder = upstreamPlanResponder
         self.legacyUpstreamResponder = nil
+        self.documentationSearchResponder = documentationSearchResponder
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
     }
 
     init(
         config: ProxyConfig,
         upstreamRequestResponder: (@Sendable (_ method: String, _ toolName: String?, _ originalID: RPCID) throws -> UpstreamResponsePlan)?,
+        documentationSearchResponder:
+            (@Sendable (_ requestData: Data) throws -> Data)? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
         self.upstreamRequestResponder = upstreamRequestResponder
         self.upstreamResponder = nil
         self.legacyUpstreamResponder = nil
+        self.documentationSearchResponder = documentationSearchResponder
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
     }
 
@@ -5632,6 +5627,17 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
             throw NSError(domain: "TestRuntimeCoordinator", code: 3)
         }
         return result
+    }
+
+    func callDocumentationSearch(
+        requestData: Data,
+        requestTimeoutOverride: TimeAmount?
+    ) async throws -> Data {
+        _ = requestTimeoutOverride
+        guard let documentationSearchResponder else {
+            throw UpstreamSlotAcquisitionError.unavailable
+        }
+        return try documentationSearchResponder(requestData)
     }
 
     func chooseUpstreamIndex() -> Int? {

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1709,6 +1709,60 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpDocumentationSearchFallsThroughWhenDocumentationProviderIsInactive() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let localDocumentationRequests = NIOLockedValueBox(0)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "DocumentationSearch")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "{\"answer\":\"upstream-docs\"}"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                _ = requestData
+                localDocumentationRequests.withLockedValue { $0 += 1 }
+                throw UpstreamSlotAcquisitionError.unavailable
+            },
+            documentationProviderIsActive: false
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-docs-inactive-fallthrough",
+                payload: toolsCallPayload(
+                    id: 65,
+                    name: "DocumentationSearch",
+                    arguments: [
+                        "query": "hello",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            let content = result?["content"] as? [[String: Any]]
+            #expect(content?.first?["text"] as? String == "{\"answer\":\"upstream-docs\"}")
+            #expect(sessionManager.sentToolNames() == ["DocumentationSearch"])
+            #expect(localDocumentationRequests.withLockedValue { $0 } == 0)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpBatchDocumentationSearchFallsThroughWhenNoDocumentationProviderExists() async throws {
         let config = makeConfig(requestTimeout: 2)
         let sessionManager = TestRuntimeCoordinator(
@@ -6110,6 +6164,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         (@Sendable (_ method: String, _ originalID: RPCID) throws -> Data)?
     private let documentationSearchResponder:
         (@Sendable (_ requestData: Data) throws -> Data)?
+    private let documentationProviderIsActive: Bool
     private let cancelAfterStartingEnqueueRequest: Bool
     private let requestLeaseRegistry = RequestLeaseRegistry()
 
@@ -6118,6 +6173,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         upstreamResponder: (@Sendable (_ method: String, _ originalID: RPCID) throws -> Data)? = nil,
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) throws -> Data)? = nil,
+        documentationProviderIsActive: Bool? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
@@ -6125,6 +6181,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         self.upstreamResponder = nil
         self.legacyUpstreamResponder = upstreamResponder
         self.documentationSearchResponder = documentationSearchResponder
+        self.documentationProviderIsActive = documentationProviderIsActive ?? (documentationSearchResponder != nil)
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
     }
 
@@ -6133,6 +6190,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         upstreamPlanResponder: (@Sendable (_ method: String, _ originalID: RPCID) throws -> UpstreamResponsePlan)?,
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) throws -> Data)? = nil,
+        documentationProviderIsActive: Bool? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
@@ -6140,6 +6198,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         self.upstreamResponder = upstreamPlanResponder
         self.legacyUpstreamResponder = nil
         self.documentationSearchResponder = documentationSearchResponder
+        self.documentationProviderIsActive = documentationProviderIsActive ?? (documentationSearchResponder != nil)
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
     }
 
@@ -6148,6 +6207,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         upstreamRequestResponder: (@Sendable (_ method: String, _ toolName: String?, _ originalID: RPCID) throws -> UpstreamResponsePlan)?,
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) throws -> Data)? = nil,
+        documentationProviderIsActive: Bool? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
@@ -6155,6 +6215,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         self.upstreamResponder = nil
         self.legacyUpstreamResponder = nil
         self.documentationSearchResponder = documentationSearchResponder
+        self.documentationProviderIsActive = documentationProviderIsActive ?? (documentationSearchResponder != nil)
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
     }
 
@@ -6315,6 +6376,10 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     func hasDocumentationProvider() -> Bool {
         documentationSearchResponder != nil
+    }
+
+    func hasActiveDocumentationProvider() -> Bool {
+        documentationProviderIsActive
     }
 
     func chooseUpstreamIndex() -> Int? {

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1744,6 +1744,166 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpBatchDocumentationSearchSharesSingleDeadline() async throws {
+        let config = makeConfig(requestTimeout: 0.1)
+        let documentationRequests = NIOLockedValueBox<[String]>([])
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            documentationSearchResponder: { requestData in
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let params = try #require(object["params"] as? [String: Any])
+                let arguments = try #require(params["arguments"] as? [String: Any])
+                let query = arguments["query"] as? String ?? ""
+                documentationRequests.withLockedValue { requests in
+                    requests.append(query)
+                }
+                Thread.sleep(forTimeInterval: 0.2)
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"\(query)\"}"
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-docs-batch-deadline",
+                payload: [
+                    toolsCallPayload(
+                        id: 711,
+                        name: "DocumentationSearch",
+                        arguments: [
+                            "query": "first",
+                        ]
+                    ),
+                    toolsCallPayload(
+                        id: 712,
+                        name: "DocumentationSearch",
+                        arguments: [
+                            "query": "second",
+                        ]
+                    ),
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+
+            let first = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 711 }
+            #expect(first?["result"] != nil)
+
+            let second = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 712 }
+            let secondError = try #require(second?["error"] as? [String: Any])
+            #expect((secondError["code"] as? NSNumber)?.intValue == -32000)
+            #expect(secondError["message"] as? String == "upstream timeout")
+            #expect(documentationRequests.withLockedValue { $0 } == ["first"])
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+
+        try await server.shutdown()
+    }
+
+    @Test func httpBatchDocumentationSearchCancellationAbandonsPrefilterLease() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let documentationStarted = DispatchSemaphore(value: 0)
+        let documentationRelease = DispatchSemaphore(value: 0)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                Issue.record("unexpected forwarded request: \(method) \(toolName ?? "")")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "unexpected"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                documentationStarted.signal()
+                _ = documentationRelease.wait(timeout: .now() + 2)
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"cancelled\"}"
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        do {
+            let service = HTTPPostService(
+                config: config,
+                sessionManager: sessionManager,
+                refreshCodeIssuesCoordinator: .makeDefault(),
+                refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState(
+                    defaultRequestTimeoutSeconds: config.requestTimeout
+                )
+            )
+            let payload: [[String: Any]] = [
+                toolsCallPayload(
+                    id: 721,
+                    name: "DocumentationSearch",
+                    arguments: [
+                        "query": "UIView",
+                    ]
+                ),
+                toolsCallPayload(
+                    id: 722,
+                    name: "OtherAllowedTool",
+                    arguments: [:]
+                ),
+            ]
+            let bodyData = try JSONSerialization.data(withJSONObject: payload, options: [])
+            let operation = service.handle(
+                bodyData: bodyData,
+                headerSessionID: "session-docs-batch-cancel",
+                headerSessionExists: true,
+                prefersEventStream: false,
+                eventLoop: group.next()
+            )
+            let cancellationHandle = try #require(operation.cancellationHandle)
+
+            try #require(await waitForHTTPTestSemaphore(documentationStarted, timeoutSeconds: 1) == .success)
+            service.cancel(cancellationHandle)
+            documentationRelease.signal()
+
+            do {
+                _ = try await operation.future.get()
+                Issue.record("cancelled documentation batch should not complete successfully")
+            } catch {
+                #expect(error is CancellationError)
+            }
+            let abandonedLease = try #require(
+                sessionManager.leaseDebugSnapshots().first { $0.state == .abandoned }
+            )
+            #expect(abandonedLease.releaseReason == "clientDisconnected")
+            #expect(sessionManager.sentToolNames().isEmpty)
+            try await group.shutdownGracefully()
+        } catch {
+            documentationRelease.signal()
+            try? await group.shutdownGracefully()
+            throw error
+        }
+    }
+
     @Test func httpResourcesListReturnsEmptyArray() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
@@ -6236,6 +6396,22 @@ private func makeHTTPTemporaryWorkspaceRoot() -> String {
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
     try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     return url.path
+}
+
+private func waitForHTTPTestSemaphore(
+    _ semaphore: DispatchSemaphore,
+    timeoutSeconds: TimeInterval
+) async -> DispatchTimeoutResult {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            let timeoutMilliseconds = Int((timeoutSeconds * 1000).rounded(.up))
+            continuation.resume(
+                returning: semaphore.wait(
+                    timeout: .now() + .milliseconds(timeoutMilliseconds)
+                )
+            )
+        }
+    }
 }
 
 private func addHTTPHandler(

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -2157,6 +2157,112 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpBatchRoutesDocumentationSearchAfterSameBatchToolsListActivatesProvider() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let documentationRequests = NIOLockedValueBox<[String]>([])
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "OtherAllowedTool")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "other-tool-result"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let params = try #require(object["params"] as? [String: Any])
+                let arguments = try #require(params["arguments"] as? [String: Any])
+                documentationRequests.withLockedValue { requests in
+                    requests.append(arguments["query"] as? String ?? "")
+                }
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"docs\"}"
+                )
+            },
+            documentationProviderIsActive: false
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setCachedToolsListResult(
+            JSONValue(any: [
+                "tools": [
+                    [
+                        "name": "DocumentationSearch",
+                        "description": "docs provider",
+                    ],
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])!
+        )
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-tools-list-activates-docs-route",
+                payload: [
+                    [
+                        "jsonrpc": "2.0",
+                        "id": 741,
+                        "method": "tools/list",
+                    ],
+                    toolsCallPayload(
+                        id: 742,
+                        name: "DocumentationSearch",
+                        arguments: [
+                            "query": "UIView same batch",
+                        ]
+                    ),
+                    toolsCallPayload(
+                        id: 743,
+                        name: "OtherAllowedTool",
+                        arguments: [:]
+                    ),
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 3)
+
+            let toolsList = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 741 }
+            let toolsResult = toolsList?["result"] as? [String: Any]
+            let tools = try #require(toolsResult?["tools"] as? [[String: Any]])
+            #expect(tools.map { $0["name"] as? String }.contains("DocumentationSearch"))
+
+            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 742 }
+            let docsResult = docs?["result"] as? [String: Any]
+            let structuredContent = docsResult?["structuredContent"] as? [String: Any]
+            #expect(structuredContent?["answer"] as? String == "docs")
+
+            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 743 }
+            let otherResult = other?["result"] as? [String: Any]
+            let otherContent = otherResult?["content"] as? [[String: Any]]
+            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
+
+            #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
+            #expect(documentationRequests.withLockedValue { $0 } == ["UIView same batch"])
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpBatchDocumentationSearchSharesSingleDeadline() async throws {
         let config = makeConfig(requestTimeout: 0.1)
         let documentationRequests = NIOLockedValueBox<[String]>([])

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1744,6 +1744,100 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpBatchForwardsOtherCallsWhileDocumentationSearchIsStillResolving() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let documentationStarted = NIOLockedValueBox(false)
+        let releaseDocumentation = DispatchSemaphore(value: 0)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "OtherAllowedTool")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "other-tool-result"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                documentationStarted.withLockedValue { $0 = true }
+                _ = releaseDocumentation.wait(timeout: .now() + 2)
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"docs\"}"
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+        defer {
+            releaseDocumentation.signal()
+        }
+
+        do {
+            let postTask = Task {
+                try await postHTTPAnyData(
+                    url: server.url,
+                    sessionID: "session-docs-batch-forwarding-not-blocked",
+                    payload: [
+                        toolsCallPayload(
+                            id: 721,
+                            name: "DocumentationSearch",
+                            arguments: [
+                                "query": "UIView animate",
+                            ]
+                        ),
+                        toolsCallPayload(
+                            id: 722,
+                            name: "OtherAllowedTool",
+                            arguments: [:]
+                        ),
+                    ]
+                )
+            }
+
+            let didStartDocumentation = await waitUntil(timeout: .seconds(1)) {
+                documentationStarted.withLockedValue { $0 }
+            }
+            #expect(didStartDocumentation)
+            let didForwardOtherTool = await waitUntil(timeout: .seconds(1)) {
+                sessionManager.sentToolNames() == ["OtherAllowedTool"]
+            }
+            #expect(didForwardOtherTool)
+            releaseDocumentation.signal()
+
+            let rawResponse = try await postTask.value
+            #expect(rawResponse.statusCode == 200)
+            let bodyData = try JSONSerialization.jsonObject(
+                with: rawResponse.bodyData,
+                options: []
+            )
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 721 }
+            let docsResult = docs?["result"] as? [String: Any]
+            let structuredContent = docsResult?["structuredContent"] as? [String: Any]
+            #expect(structuredContent?["answer"] as? String == "docs")
+            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 722 }
+            let otherResult = other?["result"] as? [String: Any]
+            let otherContent = otherResult?["content"] as? [[String: Any]]
+            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpBatchToolsListUsesLocalToolSurfaceAndForwardsOtherCalls() async throws {
         let config = makeConfig(requestTimeout: 2)
         let sessionManager = TestRuntimeCoordinator(
@@ -1899,11 +1993,12 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(
             config: config,
             upstreamRequestResponder: { method, toolName, originalID in
-                Issue.record("unexpected forwarded request: \(method) \(toolName ?? "")")
+                #expect(method == "tools/call")
+                #expect(toolName == "OtherAllowedTool")
                 return .immediate(
                     try makeToolSuccessResponse(
                         id: originalID,
-                        text: "unexpected"
+                        text: "other-tool-result"
                     )
                 )
             },
@@ -1971,7 +2066,7 @@ struct HTTPHandlerTests {
                 sessionManager.leaseDebugSnapshots().first { $0.state == .abandoned }
             )
             #expect(abandonedLease.releaseReason == "clientDisconnected")
-            #expect(sessionManager.sentToolNames().isEmpty)
+            #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
             try await group.shutdownGracefully()
         } catch {
             documentationRelease.signal()
@@ -6690,6 +6785,28 @@ private func postHTTPAnyJSON(
         }
         let object = try JSONSerialization.jsonObject(with: responseData, options: [])
         return (httpResponse, object)
+    }
+}
+
+private func postHTTPAnyData(
+    url: URL,
+    sessionID: String,
+    payload: [Any]
+) async throws -> RawHTTPResponse {
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = data
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+
+    return try await withTestURLSession { session in
+        let (responseData, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPTestError.missingResponseHead
+        }
+        return RawHTTPResponse(statusCode: httpResponse.statusCode, bodyData: responseData)
     }
 }
 

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1663,6 +1663,87 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpBatchRoutesDocumentationSearchThroughProviderAndForwardsOtherCalls() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let documentationRequests = NIOLockedValueBox<[String]>([])
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "OtherAllowedTool")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "other-tool-result"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let params = try #require(object["params"] as? [String: Any])
+                let arguments = try #require(params["arguments"] as? [String: Any])
+                documentationRequests.withLockedValue { requests in
+                    requests.append(arguments["query"] as? String ?? "")
+                }
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"docs\"}"
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-docs-batch",
+                payload: [
+                    toolsCallPayload(
+                        id: 701,
+                        name: "DocumentationSearch",
+                        arguments: [
+                            "query": "UIView animate",
+                        ]
+                    ),
+                    toolsCallPayload(
+                        id: 702,
+                        name: "OtherAllowedTool",
+                        arguments: [:]
+                    ),
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+
+            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 701 }
+            let docsResult = docs?["result"] as? [String: Any]
+            let structuredContent = docsResult?["structuredContent"] as? [String: Any]
+            #expect(structuredContent?["answer"] as? String == "docs")
+
+            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 702 }
+            let otherResult = other?["result"] as? [String: Any]
+            let otherContent = otherResult?["content"] as? [[String: Any]]
+            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
+
+            #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
+            #expect(documentationRequests.withLockedValue { $0 } == ["UIView animate"])
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpResourcesListReturnsEmptyArray() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -2188,7 +2188,8 @@ struct HTTPHandlerTests {
                     text: "{\"answer\":\"docs\"}"
                 )
             },
-            documentationProviderIsActive: false
+            documentationProviderIsActive: false,
+            activatesDocumentationProviderOnSharedToolsList: true
         )
         sessionManager.setInitialized(true)
         sessionManager.setCachedToolsListResult(
@@ -2256,6 +2257,89 @@ struct HTTPHandlerTests {
 
             #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
             #expect(documentationRequests.withLockedValue { $0 } == ["UIView same batch"])
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
+    @Test func httpBatchFallsBackDocumentationSearchWhenSameBatchToolsListDoesNotActivateProvider()
+        async throws
+    {
+        let config = makeConfig(requestTimeout: 2)
+        let localDocumentationRequests = NIOLockedValueBox(0)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "DocumentationSearch")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "{\"answer\":\"upstream-docs\"}"
+                    )
+                )
+            },
+            documentationSearchResponder: { requestData in
+                _ = requestData
+                localDocumentationRequests.withLockedValue { $0 += 1 }
+                throw UpstreamSlotAcquisitionError.unavailable
+            },
+            documentationProviderIsActive: false
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setCachedToolsListResult(
+            JSONValue(any: [
+                "tools": [
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])!
+        )
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-tools-list-docs-fallback",
+                payload: [
+                    [
+                        "jsonrpc": "2.0",
+                        "id": 751,
+                        "method": "tools/list",
+                    ],
+                    toolsCallPayload(
+                        id: 752,
+                        name: "DocumentationSearch",
+                        arguments: [
+                            "query": "UIView same batch fallback",
+                        ]
+                    ),
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+
+            let toolsList = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 751 }
+            let toolsResult = toolsList?["result"] as? [String: Any]
+            let tools = try #require(toolsResult?["tools"] as? [[String: Any]])
+            #expect(tools.map { $0["name"] as? String }.contains("DocumentationSearch") == false)
+
+            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 752 }
+            let docsResult = docs?["result"] as? [String: Any]
+            let docsContent = docsResult?["content"] as? [[String: Any]]
+            #expect(docsContent?.first?["text"] as? String == "{\"answer\":\"upstream-docs\"}")
+
+            #expect(sessionManager.sentToolNames() == ["DocumentationSearch"])
+            #expect(localDocumentationRequests.withLockedValue { $0 } == 0)
         } catch {
             try? await server.shutdown()
             throw error
@@ -6258,6 +6342,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         var sentRequests: [SentRequest] = []
         var availableUpstreamIndices: [Int?] = []
         var requeuedLeaseCount = 0
+        var documentationProviderIsActive = false
     }
 
     private let state = NIOLockedValueBox(State())
@@ -6270,7 +6355,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         (@Sendable (_ method: String, _ originalID: RPCID) throws -> Data)?
     private let documentationSearchResponder:
         (@Sendable (_ requestData: Data) throws -> Data)?
-    private let documentationProviderIsActive: Bool
+    private let activatesDocumentationProviderOnSharedToolsList: Bool
     private let cancelAfterStartingEnqueueRequest: Bool
     private let requestLeaseRegistry = RequestLeaseRegistry()
 
@@ -6280,6 +6365,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) throws -> Data)? = nil,
         documentationProviderIsActive: Bool? = nil,
+        activatesDocumentationProviderOnSharedToolsList: Bool = false,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
@@ -6287,8 +6373,13 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         self.upstreamResponder = nil
         self.legacyUpstreamResponder = upstreamResponder
         self.documentationSearchResponder = documentationSearchResponder
-        self.documentationProviderIsActive = documentationProviderIsActive ?? (documentationSearchResponder != nil)
+        self.activatesDocumentationProviderOnSharedToolsList =
+            activatesDocumentationProviderOnSharedToolsList
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
+        state.withLockedValue { state in
+            state.documentationProviderIsActive =
+                documentationProviderIsActive ?? (documentationSearchResponder != nil)
+        }
     }
 
     init(
@@ -6297,6 +6388,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) throws -> Data)? = nil,
         documentationProviderIsActive: Bool? = nil,
+        activatesDocumentationProviderOnSharedToolsList: Bool = false,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
@@ -6304,8 +6396,13 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         self.upstreamResponder = upstreamPlanResponder
         self.legacyUpstreamResponder = nil
         self.documentationSearchResponder = documentationSearchResponder
-        self.documentationProviderIsActive = documentationProviderIsActive ?? (documentationSearchResponder != nil)
+        self.activatesDocumentationProviderOnSharedToolsList =
+            activatesDocumentationProviderOnSharedToolsList
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
+        state.withLockedValue { state in
+            state.documentationProviderIsActive =
+                documentationProviderIsActive ?? (documentationSearchResponder != nil)
+        }
     }
 
     init(
@@ -6314,6 +6411,7 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) throws -> Data)? = nil,
         documentationProviderIsActive: Bool? = nil,
+        activatesDocumentationProviderOnSharedToolsList: Bool = false,
         cancelAfterStartingEnqueueRequest: Bool = false
     ) {
         self.config = config
@@ -6321,8 +6419,13 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         self.upstreamResponder = nil
         self.legacyUpstreamResponder = nil
         self.documentationSearchResponder = documentationSearchResponder
-        self.documentationProviderIsActive = documentationProviderIsActive ?? (documentationSearchResponder != nil)
+        self.activatesDocumentationProviderOnSharedToolsList =
+            activatesDocumentationProviderOnSharedToolsList
         self.cancelAfterStartingEnqueueRequest = cancelAfterStartingEnqueueRequest
+        state.withLockedValue { state in
+            state.documentationProviderIsActive =
+                documentationProviderIsActive ?? (documentationSearchResponder != nil)
+        }
     }
 
     func session(id: String) -> SessionContext {
@@ -6411,6 +6514,12 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
         requestTimeoutOverride: TimeAmount?
     ) async throws -> JSONValue {
         _ = requestTimeoutOverride
+        if activatesDocumentationProviderOnSharedToolsList,
+           documentationSearchResponder != nil {
+            state.withLockedValue { state in
+                state.documentationProviderIsActive = true
+            }
+        }
         if let cached = state.withLockedValue({ $0.cachedToolsList }) {
             return cached
         }
@@ -6485,7 +6594,9 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
     }
 
     func hasActiveDocumentationProvider() -> Bool {
-        documentationProviderIsActive
+        state.withLockedValue { state in
+            state.documentationProviderIsActive
+        }
     }
 
     func chooseUpstreamIndex() -> Int? {

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1744,6 +1744,82 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpBatchToolsListUsesLocalToolSurfaceAndForwardsOtherCalls() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "OtherAllowedTool")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "other-tool-result"
+                    )
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setCachedToolsListResult(
+            JSONValue(any: [
+                "tools": [
+                    [
+                        "name": "DocumentationSearch",
+                        "description": "docs provider",
+                    ],
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])!
+        )
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-tools-list-batch-local",
+                payload: [
+                    [
+                        "jsonrpc": "2.0",
+                        "id": 731,
+                        "method": "tools/list",
+                    ],
+                    toolsCallPayload(
+                        id: 732,
+                        name: "OtherAllowedTool",
+                        arguments: [:]
+                    ),
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+
+            let toolsList = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 731 }
+            let toolsResult = toolsList?["result"] as? [String: Any]
+            let tools = try #require(toolsResult?["tools"] as? [[String: Any]])
+            #expect(tools.map { $0["name"] as? String }.contains("DocumentationSearch"))
+
+            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 732 }
+            let otherResult = other?["result"] as? [String: Any]
+            let otherContent = otherResult?["content"] as? [[String: Any]]
+            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
+
+            #expect(sessionManager.sentMethods() == ["tools/call"])
+            #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpBatchDocumentationSearchSharesSingleDeadline() async throws {
         let config = makeConfig(requestTimeout: 0.1)
         let documentationRequests = NIOLockedValueBox<[String]>([])

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -1663,6 +1663,113 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpDocumentationSearchFallsThroughWhenNoDocumentationProviderExists() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                #expect(toolName == "DocumentationSearch")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: "{\"answer\":\"upstream-docs\"}"
+                    )
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-docs-fallthrough",
+                payload: toolsCallPayload(
+                    id: 62,
+                    name: "DocumentationSearch",
+                    arguments: [
+                        "query": "hello",
+                    ]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            let content = result?["content"] as? [[String: Any]]
+            #expect(content?.first?["text"] as? String == "{\"answer\":\"upstream-docs\"}")
+            #expect(sessionManager.sentToolNames() == ["DocumentationSearch"])
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
+    @Test func httpBatchDocumentationSearchFallsThroughWhenNoDocumentationProviderExists() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { method, toolName, originalID in
+                #expect(method == "tools/call")
+                return .immediate(
+                    try makeToolSuccessResponse(
+                        id: originalID,
+                        text: toolName == "DocumentationSearch"
+                            ? "{\"answer\":\"upstream-docs\"}"
+                            : "other-tool-result"
+                    )
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, bodyData) = try await postHTTPAnyJSON(
+                url: server.url,
+                sessionID: "session-docs-batch-fallthrough",
+                payload: [
+                    toolsCallPayload(
+                        id: 63,
+                        name: "DocumentationSearch",
+                        arguments: [
+                            "query": "hello",
+                        ]
+                    ),
+                    toolsCallPayload(
+                        id: 64,
+                        name: "OtherAllowedTool",
+                        arguments: [:]
+                    ),
+                ]
+            )
+
+            #expect(response.statusCode == 200)
+            let bodyArray = try #require(bodyData as? [[String: Any]])
+            #expect(bodyArray.count == 2)
+            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 63 }
+            let docsResult = docs?["result"] as? [String: Any]
+            let docsContent = docsResult?["content"] as? [[String: Any]]
+            #expect(docsContent?.first?["text"] as? String == "{\"answer\":\"upstream-docs\"}")
+            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 64 }
+            let otherResult = other?["result"] as? [String: Any]
+            let otherContent = otherResult?["content"] as? [[String: Any]]
+            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
+            #expect(sessionManager.sentToolNames() == ["DocumentationSearch", "OtherAllowedTool"])
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpBatchRoutesDocumentationSearchThroughProviderAndForwardsOtherCalls() async throws {
         let config = makeConfig(requestTimeout: 2)
         let documentationRequests = NIOLockedValueBox<[String]>([])
@@ -6050,6 +6157,10 @@ private final class TestRuntimeCoordinator: RuntimeCoordinating {
             throw UpstreamSlotAcquisitionError.unavailable
         }
         return try documentationSearchResponder(requestData)
+    }
+
+    func hasDocumentationProvider() -> Bool {
+        documentationSearchResponder != nil
     }
 
     func chooseUpstreamIndex() -> Int? {

--- a/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPTransportTests/HTTPHandlerTests.swift
@@ -2175,6 +2175,78 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpSingleDocumentationSearchCancellationAbandonsPrefilterLease() async throws {
+        let config = makeConfig(requestTimeout: 2)
+        let documentationStarted = DispatchSemaphore(value: 0)
+        let documentationRelease = DispatchSemaphore(value: 0)
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            documentationSearchResponder: { requestData in
+                documentationStarted.signal()
+                _ = documentationRelease.wait(timeout: .now() + 2)
+                let object = try #require(
+                    JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
+                )
+                let originalIDValue = try #require(object["id"])
+                let originalID = try #require(RPCID(any: originalIDValue))
+                return try makeToolSuccessResponse(
+                    id: originalID,
+                    text: "{\"answer\":\"cancelled\"}"
+                )
+            }
+        )
+        sessionManager.setInitialized(true)
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        do {
+            let service = HTTPPostService(
+                config: config,
+                sessionManager: sessionManager,
+                refreshCodeIssuesCoordinator: .makeDefault(),
+                refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState(
+                    defaultRequestTimeoutSeconds: config.requestTimeout
+                )
+            )
+            let payload = toolsCallPayload(
+                id: 720,
+                name: "DocumentationSearch",
+                arguments: [
+                    "query": "UIView",
+                ]
+            )
+            let bodyData = try JSONSerialization.data(withJSONObject: payload, options: [])
+            let operation = service.handle(
+                bodyData: bodyData,
+                headerSessionID: "session-docs-single-cancel",
+                headerSessionExists: true,
+                prefersEventStream: false,
+                eventLoop: group.next()
+            )
+            let cancellationHandle = try #require(operation.cancellationHandle)
+
+            try #require(await waitForHTTPTestSemaphore(documentationStarted, timeoutSeconds: 1) == .success)
+            service.cancel(cancellationHandle)
+            documentationRelease.signal()
+
+            do {
+                _ = try await operation.future.get()
+                Issue.record("cancelled documentation request should not complete successfully")
+            } catch {
+                #expect(error is CancellationError)
+            }
+            let abandonedLease = try #require(
+                sessionManager.leaseDebugSnapshots().first { $0.state == .abandoned }
+            )
+            #expect(abandonedLease.releaseReason == "clientDisconnected")
+            #expect(sessionManager.sentToolNames().isEmpty)
+            try await group.shutdownGracefully()
+        } catch {
+            documentationRelease.signal()
+            try? await group.shutdownGracefully()
+            throw error
+        }
+    }
+
     @Test func httpBatchDocumentationSearchCancellationAbandonsPrefilterLease() async throws {
         let config = makeConfig(requestTimeout: 2)
         let documentationStarted = DispatchSemaphore(value: 0)

--- a/Tests/ProxyHTTPTransportTests/ToolSurfaceTests.swift
+++ b/Tests/ProxyHTTPTransportTests/ToolSurfaceTests.swift
@@ -437,6 +437,7 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
     }
 
     func hasDocumentationProvider() -> Bool { false }
+    func hasActiveDocumentationProvider() -> Bool { false }
 
     func chooseUpstreamIndex() -> Int? { nil }
 

--- a/Tests/ProxyHTTPTransportTests/ToolSurfaceTests.swift
+++ b/Tests/ProxyHTTPTransportTests/ToolSurfaceTests.swift
@@ -436,6 +436,8 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
         fatalError("unused in ToolSurfaceTests")
     }
 
+    func hasDocumentationProvider() -> Bool { false }
+
     func chooseUpstreamIndex() -> Int? { nil }
 
     func enqueueOnUpstreamSlot<Output>(

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -190,6 +190,32 @@ struct XcodePermissionDialogAutoApproverTests {
         #expect(decision?.defaultButtonTitle == "allow")
     }
 
+    @Test func matcherMatchesDeveloperSystemPolicyDialogWithTitleNameAndBodyPID() {
+        let snapshot = makeSnapshot(
+            processBundleIdentifier: "com.apple.dt.Xcode.DeveloperSystemPolicyService",
+            title: #"Allow "XcodeMCPKit" to access Xcode?"#,
+            textValues: [
+                "The agent wants to use Xcode's tools to perform actions like building, testing, or modifying code.",
+                "Path: /Users/kn/Dev/XcodeMCPKit/.build/arm64-apple-macosx/debug/xcode-mcp-proxy-server",
+                "PID: 23474",
+                "Signed by: xcode-mcp-proxy-server-55554944e4908a045cea3fc2aa2f6e03b9059810",
+            ],
+            defaultButton: makeButton(title: "Allow")
+        )
+
+        let decision = XcodePermissionDialogMatcher.decision(
+            for: snapshot,
+            processID: 1036,
+            agentPathCandidates: [
+                "/Users/kn/Dev/XcodeMCPKit/.build/arm64-apple-macosx/debug/xcode-mcp-proxy-server",
+            ],
+            assistantNameCandidates: ["XcodeMCPKit"],
+            serverProcessIDCandidates: [23474]
+        )
+
+        #expect(decision?.defaultButtonTitle == "allow")
+    }
+
     @Test func matcherMatchesWhenAnyPIDCandidateSharesAWindowWithAssistantName() {
         let snapshot = makeSnapshot(
             processBundleIdentifier: "com.apple.dt.Xcode",

--- a/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
+++ b/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
@@ -1,12 +1,86 @@
+import Darwin
 import Foundation
 import NIO
 import ProxyCore
 import Testing
 
 @testable import XcodeMCPProxy
+@testable import ProxyXcodeSupport
 
 @Suite(.serialized, .enabled(if: LiveMCPBridgeTestEnvironment.isEnabled))
 struct LiveMCPBridgeTests {
+    @Test(.enabled(if: DirectMCPBridgeTestEnvironment.isEnabled))
+    func directMCPBridgeToolsListCanAutoApprovePermissionDialog() async throws {
+        let xcrunResult = try runProcess("/usr/bin/xcrun", ["--find", "mcpbridge"])
+        guard xcrunResult.terminationStatus == 0 else {
+            Issue.record("mcpbridge is not available in the selected Xcode toolchain")
+            throw LiveMCPBridgeTestError.mcpbridgeNotFound
+        }
+        let mcpbridgePath = xcrunResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard mcpbridgePath.isEmpty == false else {
+            Issue.record("xcrun --find mcpbridge returned an empty path")
+            throw LiveMCPBridgeTestError.mcpbridgeNotFound
+        }
+
+        let session = try DirectMCPBridgeSession(executablePath: mcpbridgePath)
+        defer { session.stop() }
+
+        let assistantName = "XcodeMCPKitLiveDirectTest"
+        let directMCPBridgeProcessID = session.processIdentifier
+        let approver = XcodePermissionDialogAutoApprover(
+            dependencies: .live(
+                agentPathCandidates: {
+                    XcodePermissionDialogAutoApprover.defaultAgentPathCandidates(
+                        additionalExecutableCandidates: [mcpbridgePath]
+                    )
+                },
+                assistantNameCandidates: {
+                    ["XcodeMCPKit", assistantName]
+                },
+                serverProcessIDCandidates: {
+                    XcodePermissionDialogAutoApprover.defaultServerProcessIDCandidates()
+                        .union([directMCPBridgeProcessID])
+                }
+            )
+        )
+        approver.start()
+        defer { approver.stop() }
+
+        let initialize = try session.request(
+            [
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": [
+                    "protocolVersion": "2025-03-26",
+                    "clientInfo": [
+                        "name": assistantName,
+                        "version": "dev",
+                    ],
+                    "capabilities": [:],
+                ],
+            ],
+            timeout: 20
+        )
+        #expect((initialize["result"] as? [String: Any])?["serverInfo"] != nil)
+
+        try session.notify([
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        ])
+
+        let tools = try session.request(
+            [
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+            ],
+            timeout: 30
+        )
+        let toolList = ((tools["result"] as? [String: Any])?["tools"] as? [[String: Any]]) ?? []
+        #expect(toolList.isEmpty == false)
+    }
+
     @Test func proxyServerTalksToLiveMCPBridge() async throws {
         let xcrunResult = try runProcess("/usr/bin/xcrun", ["--find", "mcpbridge"])
         guard xcrunResult.terminationStatus == 0,
@@ -163,6 +237,11 @@ struct LiveMCPBridgeTests {
 private enum LiveMCPBridgeTestEnvironment {
     static let isEnabled =
         ProcessInfo.processInfo.environment["XCODE_MCP_RUN_LIVE_MCPBRIDGE_TESTS"] == "1"
+}
+
+private enum DirectMCPBridgeTestEnvironment {
+    static let isEnabled =
+        ProcessInfo.processInfo.environment["XCODE_MCP_RUN_DIRECT_MCPBRIDGE_TESTS"] == "1"
 }
 
 private struct CommandResult {
@@ -341,4 +420,117 @@ private enum LiveMCPBridgeTestError: Error {
     case httpServerNotReady
     case refreshToolNotFound
     case windowSelectionNotFound
+    case directMCPBridgeResponseTimedOut
+    case directMCPBridgeTerminated(String)
+    case directMCPBridgeInvalidResponse
+}
+
+private final class DirectMCPBridgeSession {
+    let processIdentifier: pid_t
+
+    private let process: Process
+    private let stdin: FileHandle
+    private let stdout: FileHandle
+    private let stderr: FileHandle
+    private var stdoutBuffer = Data()
+    private var stderrBuffer = Data()
+
+    init(executablePath: String) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+
+        self.process = process
+        self.processIdentifier = process.processIdentifier
+        self.stdin = stdinPipe.fileHandleForWriting
+        self.stdout = stdoutPipe.fileHandleForReading
+        self.stderr = stderrPipe.fileHandleForReading
+
+        setNonBlocking(stdout.fileDescriptor)
+        setNonBlocking(stderr.fileDescriptor)
+    }
+
+    func request(_ object: [String: Any], timeout: TimeInterval) throws -> [String: Any] {
+        try send(object)
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !process.isRunning {
+                throw LiveMCPBridgeTestError.directMCPBridgeTerminated(stderrText())
+            }
+            drain(stderr, into: &stderrBuffer)
+            drain(stdout, into: &stdoutBuffer)
+            if let line = nextStdoutLine() {
+                guard let data = line.data(using: .utf8),
+                      let response = try JSONSerialization.jsonObject(with: data, options: [])
+                        as? [String: Any] else {
+                    throw LiveMCPBridgeTestError.directMCPBridgeInvalidResponse
+                }
+                return response
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        throw LiveMCPBridgeTestError.directMCPBridgeResponseTimedOut
+    }
+
+    func notify(_ object: [String: Any]) throws {
+        try send(object)
+    }
+
+    func stop() {
+        try? stdin.close()
+        if process.isRunning {
+            process.terminate()
+        }
+        process.waitUntilExit()
+        try? stdout.close()
+        try? stderr.close()
+    }
+
+    private func send(_ object: [String: Any]) throws {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [])
+        try stdin.write(contentsOf: data + Data([0x0A]))
+    }
+
+    private func nextStdoutLine() -> String? {
+        guard let newlineIndex = stdoutBuffer.firstIndex(of: 0x0A) else {
+            return nil
+        }
+        let lineData = stdoutBuffer[..<newlineIndex]
+        stdoutBuffer.removeSubrange(...newlineIndex)
+        return String(data: lineData, encoding: .utf8)
+    }
+
+    private func stderrText() -> String {
+        drain(stderr, into: &stderrBuffer)
+        return String(data: stderrBuffer, encoding: .utf8) ?? ""
+    }
+
+    private func drain(_ handle: FileHandle, into buffer: inout Data) {
+        var chunk = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = unsafe Darwin.read(handle.fileDescriptor, &chunk, chunk.count)
+            if count > 0 {
+                buffer.append(contentsOf: chunk.prefix(count))
+                continue
+            }
+            if count == 0 || errno == EAGAIN || errno == EWOULDBLOCK {
+                return
+            }
+            return
+        }
+    }
+
+    private func setNonBlocking(_ fileDescriptor: Int32) {
+        let flags = fcntl(fileDescriptor, F_GETFL, 0)
+        guard flags >= 0 else { return }
+        _ = fcntl(fileDescriptor, F_SETFL, flags | O_NONBLOCK)
+    }
 }

--- a/Tests/ProxyRuntimeTests/ProxyRouterTests.swift
+++ b/Tests/ProxyRuntimeTests/ProxyRouterTests.swift
@@ -75,6 +75,89 @@ struct ProxyRouterTests {
         #expect(string == response)
     }
 
+    @Test func proxyRouterMatchesOutOfOrderBatchResponseByID() async throws {
+        let eventLoop = EmbeddedEventLoop()
+        let router = ProxyRouter(
+            requestTimeout: .seconds(5),
+            hasActiveClients: { false },
+            sendNotification: { _ in }
+        )
+        let completions = NIOLockedValueBox<[String]>([])
+
+        let first = router.registerBatchPending(
+            on: eventLoop,
+            responseIDKeys: ["1"]
+        ).future
+        let second = router.registerBatchPending(
+            on: eventLoop,
+            responseIDKeys: ["2"]
+        ).future
+        first.whenSuccess { buffer in
+            completions.withLockedValue { values in
+                values.append("first:\(bufferString(buffer))")
+            }
+        }
+        second.whenSuccess { buffer in
+            completions.withLockedValue { values in
+                values.append("second:\(bufferString(buffer))")
+            }
+        }
+
+        let secondResponse = "[{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{}}]"
+        router.handleIncoming(Data(secondResponse.utf8))
+        eventLoop.run()
+        #expect(completions.withLockedValue { $0 } == ["second:\(secondResponse)"])
+
+        let firstResponse = "[{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}]"
+        router.handleIncoming(Data(firstResponse.utf8))
+        eventLoop.run()
+        #expect(completions.withLockedValue { $0 } == [
+            "second:\(secondResponse)",
+            "first:\(firstResponse)",
+        ])
+    }
+
+    @Test func proxyRouterTimesOutMatchingBatchByToken() async throws {
+        let eventLoop = EmbeddedEventLoop()
+        let router = ProxyRouter(
+            requestTimeout: nil,
+            hasActiveClients: { false },
+            sendNotification: { _ in }
+        )
+        let firstFailed = NIOLockedValueBox(false)
+        let secondFailed = NIOLockedValueBox(false)
+        let firstSucceeded = NIOLockedValueBox<String?>(nil)
+
+        let first = router.registerBatchPending(
+            on: eventLoop,
+            timeout: .seconds(2),
+            responseIDKeys: ["1"]
+        ).future
+        let second = router.registerBatchPending(
+            on: eventLoop,
+            timeout: .seconds(1),
+            responseIDKeys: ["2"]
+        ).future
+        first.whenFailure { _ in firstFailed.withLockedValue { $0 = true } }
+        second.whenFailure { _ in secondFailed.withLockedValue { $0 = true } }
+        first.whenSuccess { buffer in
+            firstSucceeded.withLockedValue { $0 = bufferString(buffer) }
+        }
+
+        eventLoop.advanceTime(by: .seconds(1))
+        eventLoop.run()
+
+        #expect(secondFailed.withLockedValue { $0 } == true)
+        #expect(firstFailed.withLockedValue { $0 } == false)
+
+        let firstResponse = "[{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}]"
+        router.handleIncoming(Data(firstResponse.utf8))
+        eventLoop.run()
+
+        #expect(firstSucceeded.withLockedValue { $0 } == firstResponse)
+        #expect(firstFailed.withLockedValue { $0 } == false)
+    }
+
     @Test func proxyRouterTimesOutRequests() async throws {
         let eventLoop = EmbeddedEventLoop()
         let router = ProxyRouter(
@@ -136,5 +219,9 @@ struct ProxyRouterTests {
         #expect(buffered.count == 2)
         #expect(String(data: buffered[0], encoding: .utf8)?.contains("n2") == true)
         #expect(String(data: buffered[1], encoding: .utf8)?.contains("n3") == true)
+    }
+
+    private func bufferString(_ buffer: ByteBuffer) -> String {
+        buffer.getString(at: buffer.readerIndex, length: buffer.readableBytes) ?? ""
     }
 }

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -143,6 +143,227 @@ struct RuntimeCoordinatorTests {
         #expect(RuntimeCoordinator.isDefaultXcrunMCPBridgeInvocation(config: config) == false)
     }
 
+    @Test func sharedToolsListMergesDocumentationProviderDescriptor() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0"))
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider
+        )
+        defer { manager.shutdownAndWait() }
+
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])
+        )
+
+        let result = try await manager.sharedToolsList(
+            sessionID: "session-docs-tools",
+            requestTimeoutOverride: nil
+        )
+
+        #expect(toolNames(in: result) == ["XcodeRead", "DocumentationSearch"])
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+    }
+
+    @Test func sharedToolsListRemovesStaleDocumentationSearchWhenProviderUnavailable() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let documentationProvider = StubDocumentationProviderManager(toolListUpdate: .unavailable)
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider
+        )
+        defer { manager.shutdownAndWait() }
+
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    documentationDescriptor(version: "26.6").foundationObject,
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])
+        )
+
+        let result = try await manager.sharedToolsList(
+            sessionID: "session-docs-unavailable",
+            requestTimeoutOverride: nil
+        )
+
+        #expect(toolNames(in: result) == ["XcodeRead"])
+        #expect(DocumentationToolCatalog.descriptor(in: result) == nil)
+    }
+
+    @Test func documentationSearchInvalidatesCanonicalToolsCatalogWhenProviderStales() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let providerResponse = try makeJSONRPCResponse(
+            id: 41,
+            result: [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "Tool 'DocumentationSearch' is not enabled.",
+                    ],
+                ],
+                "isError": true,
+            ]
+        )
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0")),
+            callResults: [
+                DocumentationProviderCallResult(
+                    data: providerResponse,
+                    didInvalidateProvider: true
+                ),
+            ]
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider
+        )
+        defer { manager.shutdownAndWait() }
+
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    documentationDescriptor(version: "27.0").foundationObject,
+                ],
+            ])
+        )
+        #expect(manager.cachedToolsListResult() != nil)
+
+        let responseData = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 41, query: "UIView"),
+            requestTimeoutOverride: nil
+        )
+
+        #expect(responseData == providerResponse)
+        #expect(manager.cachedToolsListResult() == nil)
+        #expect(await documentationProvider.callCount() == 1)
+    }
+
+    @Test func documentationProviderManagerRejectsDescriptorWhenProbeCallIsNotEnabled() async throws {
+        let target = documentationProviderTarget(processID: 101)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .notEnabled
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let update = await manager.toolListUpdate()
+        let result = DocumentationToolCatalog.applying(
+            update,
+            to: try jsonValue([
+                "tools": [
+                    documentationDescriptor(version: "stale").foundationObject,
+                ],
+            ])
+        )
+
+        #expect(DocumentationToolCatalog.descriptor(in: result) == nil)
+        #expect(await factory.startedPIDs() == [target.processID])
+    }
+
+    @Test func documentationProviderManagerRetriesDocumentationSearchOnAlternateCandidate() async throws {
+        let xcode26 = documentationProviderTarget(processID: 201)
+        let xcode27 = documentationProviderTarget(processID: 202)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 50,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.notEnabled]
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 50,
+                        includesDocumentationSearch: true,
+                        probeResponse: .notEnabled
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.successText("{\"answer\":\"retry\"}")]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let initialTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
+
+        let result = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 73, query: "UIView"),
+            requestTimeoutOverride: nil
+        )
+
+        #expect(result.didInvalidateProvider)
+        #expect(DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data) == false)
+        #expect(try toolContentText(in: result.data) == "{\"answer\":\"retry\"}")
+        #expect(await factory.startedPIDs() == [
+            xcode26.processID,
+            xcode27.processID,
+            xcode26.processID,
+            xcode27.processID,
+        ])
+    }
+
     @Test func readinessGateDefersStartupUntilXcodeIsAvailable() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -5204,6 +5425,325 @@ private func makeConfig(requestTimeout: TimeInterval) -> ProxyConfig {
         requestTimeout: requestTimeout,
         prewarmToolsList: false
     )
+}
+
+private func jsonValue(_ object: [String: Any]) throws -> JSONValue {
+    try #require(JSONValue(any: object))
+}
+
+private func documentationDescriptor(version: String) -> JSONValue {
+    JSONValue(any: [
+        "name": DocumentationToolCatalog.toolName,
+        "description": "docs-\(version)",
+        "inputSchema": [
+            "type": "object",
+            "properties": [
+                "query": [
+                    "type": "string",
+                ],
+            ],
+            "required": ["query"],
+        ],
+    ])!
+}
+
+private func toolNames(in result: JSONValue) -> [String] {
+    guard case .object(let object) = result,
+          case .array(let tools)? = object["tools"] else {
+        return []
+    }
+    return tools.compactMap { tool in
+        guard case .object(let toolObject) = tool,
+              case .string(let name)? = toolObject["name"] else {
+            return nil
+        }
+        return name
+    }
+}
+
+private func documentationDescriptorDescription(in result: JSONValue) -> String? {
+    guard let descriptor = DocumentationToolCatalog.descriptor(in: result),
+          case .object(let object) = descriptor,
+          case .string(let description)? = object["description"] else {
+        return nil
+    }
+    return description
+}
+
+private func makeDocumentationSearchRequest(id: Int64, query: String) throws -> Data {
+    try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": [
+                "name": DocumentationToolCatalog.toolName,
+                "arguments": [
+                    "query": query,
+                ],
+            ],
+        ],
+        options: []
+    )
+}
+
+private func makeJSONRPCResponse(id: Int64, result: [String: Any]) throws -> Data {
+    try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        ],
+        options: []
+    )
+}
+
+private func toolContentText(in responseData: Data) throws -> String? {
+    let object = try #require(
+        JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any]
+    )
+    let result = try #require(object["result"] as? [String: Any])
+    let content = try #require(result["content"] as? [[String: Any]])
+    return content.first?["text"] as? String
+}
+
+private func documentationProviderTarget(processID: pid_t) -> DocumentationProviderTarget {
+    DocumentationProviderTarget(
+        processID: processID,
+        appPath: "/Applications/Xcode-\(processID).app",
+        developerDir: "/Applications/Xcode-\(processID).app/Contents/Developer",
+        mcpbridgePath: "/Applications/Xcode-\(processID).app/Contents/Developer/usr/bin/mcpbridge"
+    )
+}
+
+private struct StubXcodeTargetDiscovery: XcodeTargetDiscovering {
+    let targets: [DocumentationProviderTarget]
+
+    func runningXcodeTargets() -> [DocumentationProviderTarget] {
+        targets
+    }
+}
+
+private enum ScriptedDocumentationResponse: Sendable {
+    case success
+    case successText(String)
+    case notEnabled
+}
+
+private struct ScriptedDocumentationSessionPlan: Sendable {
+    let serverVersion: String
+    let toolCount: Int
+    let includesDocumentationSearch: Bool
+    let probeResponse: ScriptedDocumentationResponse
+    let userCallResponses: [ScriptedDocumentationResponse]
+
+    init(
+        serverVersion: String,
+        toolCount: Int,
+        includesDocumentationSearch: Bool,
+        probeResponse: ScriptedDocumentationResponse,
+        userCallResponses: [ScriptedDocumentationResponse] = []
+    ) {
+        self.serverVersion = serverVersion
+        self.toolCount = toolCount
+        self.includesDocumentationSearch = includesDocumentationSearch
+        self.probeResponse = probeResponse
+        self.userCallResponses = userCallResponses
+    }
+}
+
+private actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
+    private var plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]]
+    private var startedProcessIDs: [pid_t] = []
+
+    init(plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]]) {
+        self.plansByPID = plansByPID
+    }
+
+    func startSession(for target: DocumentationProviderTarget) async throws -> any UpstreamSession {
+        guard var plans = plansByPID[target.processID],
+              plans.isEmpty == false else {
+            throw UpstreamSlotAcquisitionError.unavailable
+        }
+        let plan = plans.removeFirst()
+        plansByPID[target.processID] = plans
+        startedProcessIDs.append(target.processID)
+        return ScriptedDocumentationSession(plan: plan)
+    }
+
+    func startedPIDs() -> [pid_t] {
+        startedProcessIDs
+    }
+}
+
+private actor ScriptedDocumentationSession: UpstreamSession {
+    nonisolated let events: AsyncStream<UpstreamEvent>
+    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    private let plan: ScriptedDocumentationSessionPlan
+    private var documentationCallCount = 0
+    private var remainingUserCallResponses: [ScriptedDocumentationResponse]
+
+    init(plan: ScriptedDocumentationSessionPlan) {
+        self.plan = plan
+        self.remainingUserCallResponses = plan.userCallResponses
+        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        self.events = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+    }
+
+    func send(_ data: Data) async -> UpstreamSendResult {
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [])
+            as? [String: Any],
+            let method = object["method"] as? String else {
+            return .accepted
+        }
+        guard let requestID = object["id"] else {
+            return .accepted
+        }
+
+        switch method {
+        case "initialize":
+            yieldResponse(
+                id: requestID,
+                result: [
+                    "serverInfo": [
+                        "name": "mcpbridge",
+                        "version": plan.serverVersion,
+                    ],
+                ]
+            )
+        case "tools/list":
+            yieldResponse(
+                id: requestID,
+                result: [
+                    "tools": toolsList(),
+                ]
+            )
+        case "tools/call":
+            documentationCallCount += 1
+            let response: ScriptedDocumentationResponse
+            if documentationCallCount == 1 {
+                response = plan.probeResponse
+            } else if remainingUserCallResponses.isEmpty == false {
+                response = remainingUserCallResponses.removeFirst()
+            } else {
+                response = .success
+            }
+            yieldDocumentationResponse(id: requestID, response: response)
+        default:
+            break
+        }
+        return .accepted
+    }
+
+    func stop() async {
+        continuation.finish()
+    }
+
+    private func toolsList() -> [[String: Any]] {
+        let fillerCount = max(0, plan.toolCount - (plan.includesDocumentationSearch ? 1 : 0))
+        var tools: [[String: Any]] = (0..<fillerCount).map { index in
+            [
+                "name": "Tool\(index)",
+                "description": "tool-\(index)",
+            ]
+        }
+        if plan.includesDocumentationSearch {
+            if let descriptor = documentationDescriptor(version: plan.serverVersion).foundationObject
+                as? [String: Any] {
+                tools.append(descriptor)
+            }
+        }
+        return tools
+    }
+
+    private func yieldDocumentationResponse(id: Any, response: ScriptedDocumentationResponse) {
+        switch response {
+        case .success:
+            yieldToolResponse(id: id, text: "{\"ok\":true}", isError: false)
+        case .successText(let text):
+            yieldToolResponse(id: id, text: text, isError: false)
+        case .notEnabled:
+            yieldToolResponse(
+                id: id,
+                text: "Tool 'DocumentationSearch' is not enabled.",
+                isError: true
+            )
+        }
+    }
+
+    private func yieldToolResponse(id: Any, text: String, isError: Bool) {
+        yieldResponse(
+            id: id,
+            result: [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": text,
+                    ],
+                ],
+                "isError": isError,
+            ]
+        )
+    }
+
+    private func yieldResponse(id: Any, result: [String: Any]) {
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        ]
+        guard JSONSerialization.isValidJSONObject(response),
+              let data = try? JSONSerialization.data(withJSONObject: response, options: []) else {
+            return
+        }
+        continuation.yield(.message(data))
+    }
+}
+
+private actor StubDocumentationProviderManager: DocumentationProviderManaging {
+    private var update: DocumentationToolListUpdate
+    private var callResults: [DocumentationProviderCallResult]
+    private var callCountValue = 0
+    private var invalidateReasons: [String] = []
+
+    init(
+        toolListUpdate: DocumentationToolListUpdate,
+        callResults: [DocumentationProviderCallResult] = []
+    ) {
+        self.update = toolListUpdate
+        self.callResults = callResults
+    }
+
+    func toolListUpdate() async -> DocumentationToolListUpdate {
+        update
+    }
+
+    func callDocumentationSearch(
+        requestData _: Data,
+        requestTimeoutOverride _: TimeAmount?
+    ) async throws -> DocumentationProviderCallResult {
+        callCountValue += 1
+        guard callResults.isEmpty == false else {
+            throw UpstreamSlotAcquisitionError.unavailable
+        }
+        return callResults.removeFirst()
+    }
+
+    func invalidate(reason: String) async {
+        invalidateReasons.append(reason)
+        update = .unavailable
+    }
+
+    func shutdown() async {
+        invalidateReasons.append("shutdown")
+    }
+
+    func callCount() -> Int {
+        callCountValue
+    }
 }
 
 private func defaultUpstreamEnvironment(sharedSessionID: String?) throws -> [String: String] {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -297,6 +297,30 @@ struct RuntimeCoordinatorTests {
         #expect(await documentationProvider.toolListUpdateCount() == 1)
     }
 
+    @Test func shutdownCancelsPendingDocumentationProviderStartupPrewarm() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0")),
+            prewarmDelayNanoseconds: 300_000_000
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 300),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider,
+            prewarmDocumentationProviderOnStartup: true
+        )
+
+        await manager.shutdown()
+        try? await Task.sleep(nanoseconds: 400_000_000)
+
+        #expect(await documentationProvider.prewarmCount() == 0)
+        #expect(await documentationProvider.shutdownCount() == 1)
+    }
+
     @Test func documentationProviderManagerRejectsDescriptorWhenProbeCallIsNotEnabled() async throws {
         let target = documentationProviderTarget(processID: 101)
         let factory = ScriptedDocumentationSessionFactory(
@@ -428,6 +452,42 @@ struct RuntimeCoordinatorTests {
         #expect(await factory.startedPIDs() == [target.processID])
     }
 
+    @Test func documentationProviderManagerKeepsSelectionAfterStartingCallerTimesOut() async throws {
+        let target = documentationProviderTarget(processID: 123)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ],
+            startDelayNanoseconds: 100_000_000
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        async let shortUpdate = manager.toolListUpdate(requestTimeout: .milliseconds(1))
+        try await spinUntil("waiting for provider selection to start") {
+            await factory.startAttempts() == [target.processID]
+        }
+
+        let longUpdate = await manager.toolListUpdate(requestTimeout: .seconds(2))
+        if case .unavailable = await shortUpdate {
+        } else {
+            Issue.record("short tools/list should time out without cancelling provider selection")
+        }
+
+        let result = DocumentationToolCatalog.applying(longUpdate, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [target.processID])
+    }
+
     @Test func documentationProviderManagerChecksAllRunningXcodeTargetsBeforePublishingDescriptor() async throws {
         let xcode26 = documentationProviderTarget(processID: 201)
         let xcode27 = documentationProviderTarget(processID: 202)
@@ -439,6 +499,41 @@ struct RuntimeCoordinatorTests {
                         toolCount: 20,
                         includesDocumentationSearch: true,
                         probeResponse: .notEnabled
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
+    }
+
+    @Test func documentationProviderManagerPrefersNewerServerVersionWhenToolCountsTie() async throws {
+        let xcode26 = documentationProviderTarget(processID: 211)
+        let xcode27 = documentationProviderTarget(processID: 212)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
                     ),
                 ],
                 xcode27.processID: [
@@ -5800,7 +5895,7 @@ private actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionM
     func startSession(for target: DocumentationProviderTarget) async throws -> any UpstreamSession {
         startAttemptProcessIDs.append(target.processID)
         if let startDelayNanoseconds {
-            try? await Task.sleep(nanoseconds: startDelayNanoseconds)
+            try await Task.sleep(nanoseconds: startDelayNanoseconds)
         }
         guard var plans = plansByPID[target.processID],
               plans.isEmpty == false else {
@@ -5961,16 +6056,23 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
     private var prewarmTimeouts: [TimeAmount?] = []
     private var toolListTimeouts: [TimeAmount?] = []
     private var callTimeouts: [TimeAmount?] = []
+    private let prewarmDelayNanoseconds: UInt64?
 
     init(
         toolListUpdate: DocumentationToolListUpdate,
-        callResults: [DocumentationProviderCallResult] = []
+        callResults: [DocumentationProviderCallResult] = [],
+        prewarmDelayNanoseconds: UInt64? = nil
     ) {
         self.update = toolListUpdate
         self.callResults = callResults
+        self.prewarmDelayNanoseconds = prewarmDelayNanoseconds
     }
 
     func prewarm(requestTimeout: TimeAmount?) async {
+        if let prewarmDelayNanoseconds {
+            try? await Task.sleep(nanoseconds: prewarmDelayNanoseconds)
+            guard !Task.isCancelled else { return }
+        }
         prewarmTimeouts.append(requestTimeout)
         _ = await toolListUpdate(requestTimeout: requestTimeout)
     }
@@ -6015,6 +6117,10 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
 
     func lastPrewarmTimeout() -> TimeAmount? {
         prewarmTimeouts.last ?? nil
+    }
+
+    func shutdownCount() -> Int {
+        invalidateReasons.filter { $0 == "shutdown" }.count
     }
 
     func lastToolListTimeout() -> TimeAmount? {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -232,6 +232,44 @@ struct RuntimeCoordinatorTests {
         #expect(DocumentationToolCatalog.descriptor(in: result) == nil)
     }
 
+    @Test func sharedToolsListTimeoutDoesNotInvalidateDocumentationProvider() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0")),
+            toolListDelayNanoseconds: 50_000_000
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider
+        )
+        defer { manager.shutdownAndWait() }
+
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    documentationDescriptor(version: "26.6").foundationObject,
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])
+        )
+
+        let result = try await manager.sharedToolsList(
+            sessionID: "session-docs-timeout",
+            requestTimeoutOverride: .milliseconds(1)
+        )
+
+        #expect(toolNames(in: result) == ["XcodeRead"])
+        #expect(await documentationProvider.recordedInvalidateReasons().isEmpty)
+    }
+
     @Test func documentationSearchInvalidatesCanonicalToolsCatalogWhenProviderStales() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -6114,15 +6152,18 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
     private var toolListTimeouts: [TimeAmount?] = []
     private var callTimeouts: [TimeAmount?] = []
     private let prewarmDelayNanoseconds: UInt64?
+    private let toolListDelayNanoseconds: UInt64?
 
     init(
         toolListUpdate: DocumentationToolListUpdate,
         callResults: [DocumentationProviderCallResult] = [],
-        prewarmDelayNanoseconds: UInt64? = nil
+        prewarmDelayNanoseconds: UInt64? = nil,
+        toolListDelayNanoseconds: UInt64? = nil
     ) {
         self.update = toolListUpdate
         self.callResults = callResults
         self.prewarmDelayNanoseconds = prewarmDelayNanoseconds
+        self.toolListDelayNanoseconds = toolListDelayNanoseconds
     }
 
     func prewarm(requestTimeout: TimeAmount?) async {
@@ -6136,6 +6177,10 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
 
     func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
         toolListTimeouts.append(requestTimeout)
+        if let toolListDelayNanoseconds {
+            try? await Task.sleep(nanoseconds: toolListDelayNanoseconds)
+            guard !Task.isCancelled else { return .unavailable }
+        }
         return update
     }
 
@@ -6178,6 +6223,10 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
 
     func shutdownCount() -> Int {
         invalidateReasons.filter { $0 == "shutdown" }.count
+    }
+
+    func recordedInvalidateReasons() -> [String] {
+        invalidateReasons
     }
 
     func lastToolListTimeout() -> TimeAmount? {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -147,6 +147,10 @@ struct RuntimeCoordinatorTests {
         var config = makeConfig(requestTimeout: 5)
         #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config) != nil)
 
+        config.disabledToolNames = [DocumentationToolCatalog.toolName]
+        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config) == nil)
+
+        config.disabledToolNames = []
         config.upstreamArgs = ["--sdk", "macosx", "swift"]
         #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config) == nil)
 

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -674,6 +674,47 @@ struct RuntimeCoordinatorTests {
         #expect(await factory.startedPIDs() == [xcode.processID])
     }
 
+    @Test func documentationProviderManagerKeepsProviderWhenDocumentationCallIsCancelled() async throws {
+        let xcode = documentationProviderTarget(processID: 302)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.hang]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode]),
+            sessionFactory: factory
+        )
+        let task = Task {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 92, query: "UIView"),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        let didStart = await waitUntil(timeout: .seconds(1)) {
+            await factory.startedPIDs() == [xcode.processID]
+        }
+        #expect(didStart)
+
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [xcode.processID])
+    }
+
     @Test func readinessGateDefersStartupUntilXcodeIsAvailable() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -329,6 +329,62 @@ struct RuntimeCoordinatorTests {
         #expect(observedTimeout.nanoseconds == TimeAmount.seconds(5).nanoseconds)
     }
 
+    @Test func documentationSearchDoesNotInvalidateWhenSuccessfulAnswerMentionsNotEnabled()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let providerResponse = try makeJSONRPCResponse(
+            id: 43,
+            result: [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "A user may see: Tool 'DocumentationSearch' is not enabled.",
+                    ],
+                ],
+                "isError": false,
+            ]
+        )
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0")),
+            callResults: [
+                DocumentationProviderCallResult(
+                    data: providerResponse,
+                    didInvalidateProvider: false
+                ),
+            ]
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider
+        )
+        defer { manager.shutdownAndWait() }
+
+        let cachedTools = try jsonValue([
+            "tools": [
+                documentationDescriptor(version: "27.0").foundationObject,
+            ],
+        ])
+        manager.setCachedToolsListResult(cachedTools)
+
+        let responseData = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 43, query: "not enabled error"),
+            requestTimeoutOverride: nil
+        )
+
+        #expect(DocumentationToolCatalog.responseIsDocumentationNotEnabled(responseData) == false)
+        #expect(responseData == providerResponse)
+        let cachedResult = try #require(manager.cachedToolsListResult())
+        #expect(DocumentationToolCatalog.descriptor(in: cachedResult) != nil)
+        #expect(manager.hasActiveDocumentationProvider())
+        #expect(await documentationProvider.callCount() == 1)
+    }
+
     @Test func documentationSearchKeepsProviderActiveAfterSuccessfulRetryInvalidatesCatalog() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -177,6 +177,8 @@ struct RuntimeCoordinatorTests {
 
         #expect(toolNames(in: result) == ["XcodeRead", "DocumentationSearch"])
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        let observedTimeout = try #require(await documentationProvider.lastToolListTimeout())
+        #expect(observedTimeout.nanoseconds > 0)
     }
 
     @Test func sharedToolsListRemovesStaleDocumentationSearchWhenProviderUnavailable() async throws {
@@ -265,6 +267,8 @@ struct RuntimeCoordinatorTests {
         #expect(responseData == providerResponse)
         #expect(manager.cachedToolsListResult() == nil)
         #expect(await documentationProvider.callCount() == 1)
+        let observedTimeout = try #require(await documentationProvider.lastCallTimeout())
+        #expect(observedTimeout.nanoseconds == TimeAmount.seconds(5).nanoseconds)
     }
 
     @Test func documentationProviderManagerRejectsDescriptorWhenProbeCallIsNotEnabled() async throws {
@@ -286,7 +290,7 @@ struct RuntimeCoordinatorTests {
             sessionFactory: factory
         )
 
-        let update = await manager.toolListUpdate()
+        let update = await manager.toolListUpdate(requestTimeout: nil)
         let result = DocumentationToolCatalog.applying(
             update,
             to: try jsonValue([
@@ -343,7 +347,7 @@ struct RuntimeCoordinatorTests {
         )
 
         let initialTools = DocumentationToolCatalog.applying(
-            await manager.toolListUpdate(),
+            await manager.toolListUpdate(requestTimeout: nil),
             to: try jsonValue(["tools": []])
         )
         #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
@@ -5708,6 +5712,8 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
     private var callResults: [DocumentationProviderCallResult]
     private var callCountValue = 0
     private var invalidateReasons: [String] = []
+    private var toolListTimeouts: [TimeAmount?] = []
+    private var callTimeouts: [TimeAmount?] = []
 
     init(
         toolListUpdate: DocumentationToolListUpdate,
@@ -5717,15 +5723,17 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
         self.callResults = callResults
     }
 
-    func toolListUpdate() async -> DocumentationToolListUpdate {
-        update
+    func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
+        toolListTimeouts.append(requestTimeout)
+        return update
     }
 
     func callDocumentationSearch(
         requestData _: Data,
-        requestTimeoutOverride _: TimeAmount?
+        requestTimeoutOverride: TimeAmount?
     ) async throws -> DocumentationProviderCallResult {
         callCountValue += 1
+        callTimeouts.append(requestTimeoutOverride)
         guard callResults.isEmpty == false else {
             throw UpstreamSlotAcquisitionError.unavailable
         }
@@ -5743,6 +5751,14 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
 
     func callCount() -> Int {
         callCountValue
+    }
+
+    func lastToolListTimeout() -> TimeAmount? {
+        toolListTimeouts.last ?? nil
+    }
+
+    func lastCallTimeout() -> TimeAmount? {
+        callTimeouts.last ?? nil
     }
 }
 

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -368,6 +368,46 @@ struct RuntimeCoordinatorTests {
         ])
     }
 
+    @Test func documentationProviderManagerDoesNotRetryAfterRequestTimeoutExpires() async throws {
+        let xcode = documentationProviderTarget(processID: 301)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.hang]
+                    ),
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.successText("{\"answer\":\"late\"}")]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode]),
+            sessionFactory: factory
+        )
+
+        do {
+            _ = try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 91, query: "UIView"),
+                requestTimeoutOverride: .milliseconds(1)
+            )
+            Issue.record("DocumentationSearch should time out without retrying")
+        } catch {
+            #expect(error is TimeoutError)
+        }
+
+        #expect(await factory.startedPIDs() == [xcode.processID])
+    }
+
     @Test func readinessGateDefersStartupUntilXcodeIsAvailable() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -5531,6 +5571,7 @@ private struct StubXcodeTargetDiscovery: XcodeTargetDiscovering {
 private enum ScriptedDocumentationResponse: Sendable {
     case success
     case successText(String)
+    case hang
     case notEnabled
 }
 
@@ -5669,6 +5710,8 @@ private actor ScriptedDocumentationSession: UpstreamSession {
             yieldToolResponse(id: id, text: "{\"ok\":true}", isError: false)
         case .successText(let text):
             yieldToolResponse(id: id, text: text, isError: false)
+        case .hang:
+            break
         case .notEnabled:
             yieldToolResponse(
                 id: id,

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -193,6 +193,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(toolNames(in: result) == ["XcodeRead", "DocumentationSearch"])
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(manager.hasActiveDocumentationProvider())
         let observedTimeout = try #require(await documentationProvider.lastToolListTimeout())
         #expect(observedTimeout.nanoseconds > 0)
     }
@@ -230,6 +231,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(toolNames(in: result) == ["XcodeRead"])
         #expect(DocumentationToolCatalog.descriptor(in: result) == nil)
+        #expect(manager.hasActiveDocumentationProvider() == false)
     }
 
     @Test func sharedToolsListTimeoutDoesNotInvalidateDocumentationProvider() async throws {
@@ -267,6 +269,7 @@ struct RuntimeCoordinatorTests {
         )
 
         #expect(toolNames(in: result) == ["XcodeRead"])
+        #expect(manager.hasActiveDocumentationProvider() == false)
         #expect(await documentationProvider.recordedInvalidateReasons().isEmpty)
     }
 
@@ -320,6 +323,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(responseData == providerResponse)
         #expect(manager.cachedToolsListResult() == nil)
+        #expect(manager.hasActiveDocumentationProvider() == false)
         #expect(await documentationProvider.callCount() == 1)
         let observedTimeout = try #require(await documentationProvider.lastCallTimeout())
         #expect(observedTimeout.nanoseconds == TimeAmount.seconds(5).nanoseconds)
@@ -349,6 +353,7 @@ struct RuntimeCoordinatorTests {
         let observedTimeout = try #require(await documentationProvider.lastPrewarmTimeout())
         #expect(observedTimeout.nanoseconds == TimeAmount.seconds(30).nanoseconds)
         #expect(await documentationProvider.toolListUpdateCount() == 1)
+        #expect(manager.hasActiveDocumentationProvider())
     }
 
     @Test func shutdownCancelsPendingDocumentationProviderStartupPrewarm() async throws {
@@ -433,6 +438,69 @@ struct RuntimeCoordinatorTests {
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [target.processID])
+    }
+
+    @Test func documentationProviderManagerUsesConfiguredInitializeParamsForProbe() async throws {
+        let target = documentationProviderTarget(processID: 112)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let initializeParams = try jsonValue([
+            "protocolVersion": "2025-03-26",
+            "capabilities": [
+                "roots": [
+                    "listChanged": true,
+                ],
+            ],
+            "clientInfo": [
+                "name": "ConfiguredAssistant",
+                "version": "9.9.9",
+            ],
+        ])
+        guard case .object(let initializeObject) = initializeParams else {
+            Issue.record("expected initialize params object")
+            return
+        }
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            initializeParams: initializeObject
+        )
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        let observedParams = try #require(await factory.initializeParams(for: target.processID).first)
+        guard case .object(let observedObject) = observedParams else {
+            Issue.record("expected initialize params object")
+            return
+        }
+        guard case .string("2025-03-26")? = observedObject["protocolVersion"] else {
+            Issue.record("expected configured protocol version")
+            return
+        }
+        guard case .object(let capabilities)? = observedObject["capabilities"],
+              case .object(let roots)? = capabilities["roots"],
+              case .bool(true)? = roots["listChanged"] else {
+            Issue.record("expected configured capabilities")
+            return
+        }
+        guard case .object(let clientInfo)? = observedObject["clientInfo"],
+              case .string("ConfiguredAssistant")? = clientInfo["name"],
+              case .string("9.9.9")? = clientInfo["version"] else {
+            Issue.record("expected configured client info")
+            return
+        }
     }
 
     @Test func documentationProviderManagerCoalescesConcurrentProviderSelection() async throws {
@@ -618,6 +686,42 @@ struct RuntimeCoordinatorTests {
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
+    }
+
+    @Test func documentationProviderManagerHonorsPinnedProcessID() async throws {
+        let pinned = documentationProviderTarget(processID: 203)
+        let other = documentationProviderTarget(processID: 204)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                pinned.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+                other.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [pinned, other]),
+            sessionFactory: factory,
+            pinnedProcessID: pinned.processID
+        )
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-26.6")
+        #expect(await factory.startedPIDs() == [pinned.processID])
     }
 
     @Test func documentationProviderManagerPrefersNewerServerVersionWhenToolCountsTie() async throws {
@@ -6020,6 +6124,7 @@ private actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionM
     private var plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]]
     private var startAttemptProcessIDs: [pid_t] = []
     private var startedProcessIDs: [pid_t] = []
+    private var initializeParamsByPID: [pid_t: [JSONValue]] = [:]
     private let startDelayNanoseconds: UInt64?
 
     init(
@@ -6042,7 +6147,11 @@ private actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionM
         let plan = plans.removeFirst()
         plansByPID[target.processID] = plans
         startedProcessIDs.append(target.processID)
-        return ScriptedDocumentationSession(plan: plan)
+        return ScriptedDocumentationSession(
+            processID: target.processID,
+            plan: plan,
+            recorder: self
+        )
     }
 
     func startedPIDs() -> [pid_t] {
@@ -6052,17 +6161,33 @@ private actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionM
     func startAttempts() -> [pid_t] {
         startAttemptProcessIDs
     }
+
+    func recordInitializeParams(_ params: JSONValue, for processID: pid_t) {
+        initializeParamsByPID[processID, default: []].append(params)
+    }
+
+    func initializeParams(for processID: pid_t) -> [JSONValue] {
+        initializeParamsByPID[processID] ?? []
+    }
 }
 
 private actor ScriptedDocumentationSession: UpstreamSession {
     nonisolated let events: AsyncStream<UpstreamEvent>
     private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    private let processID: pid_t
     private let plan: ScriptedDocumentationSessionPlan
+    private let recorder: ScriptedDocumentationSessionFactory
     private var documentationCallCount = 0
     private var remainingUserCallResponses: [ScriptedDocumentationResponse]
 
-    init(plan: ScriptedDocumentationSessionPlan) {
+    init(
+        processID: pid_t,
+        plan: ScriptedDocumentationSessionPlan,
+        recorder: ScriptedDocumentationSessionFactory
+    ) {
+        self.processID = processID
         self.plan = plan
+        self.recorder = recorder
         self.remainingUserCallResponses = plan.userCallResponses
         var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
         self.events = AsyncStream { continuation in
@@ -6086,6 +6211,9 @@ private actor ScriptedDocumentationSession: UpstreamSession {
 
         switch method {
         case "initialize":
+            if let params = object["params"], let value = JSONValue(any: params) {
+                await recorder.recordInitializeParams(value, for: processID)
+            }
             yieldResponse(
                 id: requestID,
                 result: [
@@ -6209,13 +6337,13 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
         self.toolListDelayNanoseconds = toolListDelayNanoseconds
     }
 
-    func prewarm(requestTimeout: TimeAmount?) async {
+    func prewarm(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
         if let prewarmDelayNanoseconds {
             try? await Task.sleep(nanoseconds: prewarmDelayNanoseconds)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else { return .unavailable }
         }
         prewarmTimeouts.append(requestTimeout)
-        _ = await toolListUpdate(requestTimeout: requestTimeout)
+        return await toolListUpdate(requestTimeout: requestTimeout)
     }
 
     func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -357,6 +357,38 @@ struct RuntimeCoordinatorTests {
         #expect(await factory.startedPIDs() == [target.processID])
     }
 
+    @Test func documentationProviderManagerCoalescesConcurrentProviderSelection() async throws {
+        let target = documentationProviderTarget(processID: 121)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ],
+            startDelayNanoseconds: 100_000_000
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        async let firstUpdate = manager.toolListUpdate(requestTimeout: .seconds(2))
+        async let secondUpdate = manager.toolListUpdate(requestTimeout: .seconds(2))
+        let results = await [firstUpdate, secondUpdate]
+
+        for update in results {
+            let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+            #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        }
+        #expect(await factory.startAttempts() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID])
+    }
+
     @Test func documentationProviderManagerChecksAllRunningXcodeTargetsBeforePublishingDescriptor() async throws {
         let xcode26 = documentationProviderTarget(processID: 201)
         let xcode27 = documentationProviderTarget(processID: 202)
@@ -5714,13 +5746,23 @@ private struct ScriptedDocumentationSessionPlan: Sendable {
 
 private actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
     private var plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]]
+    private var startAttemptProcessIDs: [pid_t] = []
     private var startedProcessIDs: [pid_t] = []
+    private let startDelayNanoseconds: UInt64?
 
-    init(plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]]) {
+    init(
+        plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]],
+        startDelayNanoseconds: UInt64? = nil
+    ) {
         self.plansByPID = plansByPID
+        self.startDelayNanoseconds = startDelayNanoseconds
     }
 
     func startSession(for target: DocumentationProviderTarget) async throws -> any UpstreamSession {
+        startAttemptProcessIDs.append(target.processID)
+        if let startDelayNanoseconds {
+            try? await Task.sleep(nanoseconds: startDelayNanoseconds)
+        }
         guard var plans = plansByPID[target.processID],
               plans.isEmpty == false else {
             throw UpstreamSlotAcquisitionError.unavailable
@@ -5733,6 +5775,10 @@ private actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionM
 
     func startedPIDs() -> [pid_t] {
         startedProcessIDs
+    }
+
+    func startAttempts() -> [pid_t] {
+        startAttemptProcessIDs
     }
 }
 

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -389,6 +389,45 @@ struct RuntimeCoordinatorTests {
         #expect(await factory.startedPIDs() == [target.processID])
     }
 
+    @Test func documentationProviderManagerBoundsReusedProviderSelectionByCallerTimeout() async throws {
+        let target = documentationProviderTarget(processID: 122)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ],
+            startDelayNanoseconds: 500_000_000
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        async let longUpdate = manager.toolListUpdate(requestTimeout: .seconds(2))
+        try await spinUntil("waiting for provider selection to start") {
+            await factory.startAttempts() == [target.processID]
+        }
+
+        let shortStart = Date()
+        let shortUpdate = await manager.toolListUpdate(requestTimeout: .milliseconds(1))
+        #expect(Date().timeIntervalSince(shortStart) < 0.1)
+        if case .unavailable = shortUpdate {
+        } else {
+            Issue.record("short tools/list should time out while reusing provider selection")
+        }
+
+        let finalUpdate = await longUpdate
+        let result = DocumentationToolCatalog.applying(finalUpdate, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [target.processID])
+    }
+
     @Test func documentationProviderManagerChecksAllRunningXcodeTargetsBeforePublishingDescriptor() async throws {
         let xcode26 = documentationProviderTarget(processID: 201)
         let xcode27 = documentationProviderTarget(processID: 202)

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -143,6 +143,18 @@ struct RuntimeCoordinatorTests {
         #expect(RuntimeCoordinator.isDefaultXcrunMCPBridgeInvocation(config: config) == false)
     }
 
+    @Test func defaultDocumentationProviderIsEnabledOnlyForDefaultMCPBridgeInvocation() {
+        var config = makeConfig(requestTimeout: 5)
+        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config) != nil)
+
+        config.upstreamArgs = ["--sdk", "macosx", "swift"]
+        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config) == nil)
+
+        config.upstreamCommand = "/bin/echo"
+        config.upstreamArgs = ["xcrun", "mcpbridge"]
+        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config) == nil)
+    }
+
     @Test func sharedToolsListMergesDocumentationProviderDescriptor() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -304,6 +304,33 @@ struct RuntimeCoordinatorTests {
         #expect(await factory.startedPIDs() == [target.processID])
     }
 
+    @Test func documentationProviderManagerUsesNumericIDsForMCPBridgeProbe() async throws {
+        let target = documentationProviderTarget(processID: 111)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        requiresNumericRequestIDs: true
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [target.processID])
+    }
+
     @Test func documentationProviderManagerRetriesDocumentationSearchOnAlternateCandidate() async throws {
         let xcode26 = documentationProviderTarget(processID: 201)
         let xcode27 = documentationProviderTarget(processID: 202)
@@ -5581,19 +5608,22 @@ private struct ScriptedDocumentationSessionPlan: Sendable {
     let includesDocumentationSearch: Bool
     let probeResponse: ScriptedDocumentationResponse
     let userCallResponses: [ScriptedDocumentationResponse]
+    let requiresNumericRequestIDs: Bool
 
     init(
         serverVersion: String,
         toolCount: Int,
         includesDocumentationSearch: Bool,
         probeResponse: ScriptedDocumentationResponse,
-        userCallResponses: [ScriptedDocumentationResponse] = []
+        userCallResponses: [ScriptedDocumentationResponse] = [],
+        requiresNumericRequestIDs: Bool = false
     ) {
         self.serverVersion = serverVersion
         self.toolCount = toolCount
         self.includesDocumentationSearch = includesDocumentationSearch
         self.probeResponse = probeResponse
         self.userCallResponses = userCallResponses
+        self.requiresNumericRequestIDs = requiresNumericRequestIDs
     }
 }
 
@@ -5645,6 +5675,9 @@ private actor ScriptedDocumentationSession: UpstreamSession {
             return .accepted
         }
         guard let requestID = object["id"] else {
+            return .accepted
+        }
+        if plan.requiresNumericRequestIDs, !(requestID is NSNumber) {
             return .accepted
         }
 

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -542,6 +542,49 @@ struct RuntimeCoordinatorTests {
         #expect(await factory.startedPIDs() == [target.processID])
     }
 
+    @Test func documentationProviderManagerCancelsSelectionWaitForCancelledCaller() async throws {
+        let target = documentationProviderTarget(processID: 124)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ],
+            startDelayNanoseconds: 500_000_000
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let task = Task {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 74, query: "UIView"),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        try await spinUntil("waiting for provider selection to start") {
+            await factory.startAttempts() == [target.processID]
+        }
+
+        let cancelStart = Date()
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(Date().timeIntervalSince(cancelStart) < 0.25)
+
+        let longUpdate = await manager.toolListUpdate(requestTimeout: .seconds(2))
+        let result = DocumentationToolCatalog.applying(longUpdate, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [target.processID])
+    }
+
     @Test func documentationProviderManagerChecksAllRunningXcodeTargetsBeforePublishingDescriptor() async throws {
         let xcode26 = documentationProviderTarget(processID: 201)
         let xcode27 = documentationProviderTarget(processID: 202)

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -271,6 +271,32 @@ struct RuntimeCoordinatorTests {
         #expect(observedTimeout.nanoseconds == TimeAmount.seconds(5).nanoseconds)
     }
 
+    @Test func startupPrewarmsDocumentationProviderWhenEnabled() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0"))
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 300),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider,
+            prewarmDocumentationProviderOnStartup: true
+        )
+        defer { manager.shutdownAndWait() }
+
+        try await spinUntil("waiting for documentation provider startup prewarm") {
+            await documentationProvider.prewarmCount() == 1
+        }
+
+        let observedTimeout = try #require(await documentationProvider.lastPrewarmTimeout())
+        #expect(observedTimeout.nanoseconds == TimeAmount.seconds(30).nanoseconds)
+        #expect(await documentationProvider.toolListUpdateCount() == 1)
+    }
+
     @Test func documentationProviderManagerRejectsDescriptorWhenProbeCallIsNotEnabled() async throws {
         let target = documentationProviderTarget(processID: 101)
         let factory = ScriptedDocumentationSessionFactory(
@@ -329,6 +355,41 @@ struct RuntimeCoordinatorTests {
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [target.processID])
+    }
+
+    @Test func documentationProviderManagerChecksAllRunningXcodeTargetsBeforePublishingDescriptor() async throws {
+        let xcode26 = documentationProviderTarget(processID: 201)
+        let xcode27 = documentationProviderTarget(processID: 202)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: true,
+                        probeResponse: .notEnabled
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
     }
 
     @Test func documentationProviderManagerRetriesDocumentationSearchOnAlternateCandidate() async throws {
@@ -5812,6 +5873,7 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
     private var callResults: [DocumentationProviderCallResult]
     private var callCountValue = 0
     private var invalidateReasons: [String] = []
+    private var prewarmTimeouts: [TimeAmount?] = []
     private var toolListTimeouts: [TimeAmount?] = []
     private var callTimeouts: [TimeAmount?] = []
 
@@ -5821,6 +5883,11 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
     ) {
         self.update = toolListUpdate
         self.callResults = callResults
+    }
+
+    func prewarm(requestTimeout: TimeAmount?) async {
+        prewarmTimeouts.append(requestTimeout)
+        _ = await toolListUpdate(requestTimeout: requestTimeout)
     }
 
     func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
@@ -5851,6 +5918,18 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
 
     func callCount() -> Int {
         callCountValue
+    }
+
+    func prewarmCount() -> Int {
+        prewarmTimeouts.count
+    }
+
+    func toolListUpdateCount() -> Int {
+        toolListTimeouts.count
+    }
+
+    func lastPrewarmTimeout() -> TimeAmount? {
+        prewarmTimeouts.last ?? nil
     }
 
     func lastToolListTimeout() -> TimeAmount? {

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -329,6 +329,68 @@ struct RuntimeCoordinatorTests {
         #expect(observedTimeout.nanoseconds == TimeAmount.seconds(5).nanoseconds)
     }
 
+    @Test func documentationSearchKeepsProviderActiveAfterSuccessfulRetryInvalidatesCatalog() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let providerResponse = try makeJSONRPCResponse(
+            id: 42,
+            result: [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": "{\"answer\":\"retry\"}",
+                    ],
+                ],
+                "isError": false,
+            ]
+        )
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0")),
+            callResults: [
+                DocumentationProviderCallResult(
+                    data: providerResponse,
+                    didInvalidateProvider: true
+                ),
+            ]
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider
+        )
+        defer { manager.shutdownAndWait() }
+
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])
+        )
+        _ = try await manager.sharedToolsList(
+            sessionID: "session-docs-retry-active",
+            requestTimeoutOverride: nil
+        )
+        #expect(manager.hasActiveDocumentationProvider())
+        #expect(manager.cachedToolsListResult() != nil)
+
+        let responseData = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 42, query: "UIView"),
+            requestTimeoutOverride: nil
+        )
+
+        #expect(responseData == providerResponse)
+        #expect(manager.cachedToolsListResult() == nil)
+        #expect(manager.hasActiveDocumentationProvider())
+        #expect(await documentationProvider.callCount() == 1)
+    }
+
     @Test func startupPrewarmsDocumentationProviderWhenEnabled() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -816,6 +878,76 @@ struct RuntimeCoordinatorTests {
         #expect(DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data) == false)
         #expect(try toolContentText(in: result.data) == "{\"answer\":\"retry\"}")
         #expect(await factory.startedPIDs() == [
+            xcode26.processID,
+            xcode27.processID,
+            xcode26.processID,
+            xcode27.processID,
+        ])
+    }
+
+    @Test func documentationProviderManagerInvalidatesReplacementWhenRetryReturnsNotEnabled() async throws {
+        let xcode26 = documentationProviderTarget(processID: 221)
+        let xcode27 = documentationProviderTarget(processID: 222)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 50,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.exit]
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 50,
+                        includesDocumentationSearch: true,
+                        probeResponse: .notEnabled
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.notEnabled]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let initialTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: nil),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
+
+        let result = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 75, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        #expect(result.didInvalidateProvider)
+        #expect(DocumentationToolCatalog.responseIsDocumentationNotEnabled(result.data))
+        let followUpTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: .seconds(1)),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(await factory.startAttempts() == [
+            xcode26.processID,
+            xcode27.processID,
             xcode26.processID,
             xcode27.processID,
             xcode26.processID,
@@ -6093,6 +6225,7 @@ private enum ScriptedDocumentationResponse: Sendable {
     case successText(String)
     case hang
     case notEnabled
+    case exit
 }
 
 private struct ScriptedDocumentationSessionPlan: Sendable {
@@ -6282,6 +6415,8 @@ private actor ScriptedDocumentationSession: UpstreamSession {
                 text: "Tool 'DocumentationSearch' is not enabled.",
                 isError: true
             )
+        case .exit:
+            continuation.yield(.exit(1))
         }
     }
 

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -461,6 +461,30 @@ struct RuntimeCoordinatorTests {
         #expect(await upstream.startCount() > 0)
     }
 
+    @Test func readinessGateStartsOnlyPrimaryUpstreamBeforePrimaryAttachCompletes() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            upstreamReadinessGate: makeTestReadinessGate(readiness: readiness)
+        )
+        defer { manager.shutdownAndWait() }
+
+        await readiness.setReady(true)
+        let sent = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: sent) == "initialize")
+        #expect(await upstream0.startCount() > 0)
+        #expect(await upstream1.startCount() == 0)
+        #expect(await upstream1.sentCount() == 0)
+    }
+
     @Test func readinessGateLaunchesXcodeWhenUnavailable() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -800,6 +800,42 @@ struct RuntimeCoordinatorTests {
         #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
     }
 
+    @Test func documentationProviderManagerContinuesAfterCandidateProbeTimesOut() async throws {
+        let hung = documentationProviderTarget(processID: 205)
+        let working = documentationProviderTarget(processID: 206)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                hung.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 50,
+                        includesDocumentationSearch: true,
+                        probeResponse: .hang
+                    ),
+                ],
+                working.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [hung, working]),
+            sessionFactory: factory,
+            providerSelectionTimeout: .milliseconds(50)
+        )
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [hung.processID, working.processID])
+    }
+
     @Test func documentationProviderManagerHonorsPinnedProcessID() async throws {
         let pinned = documentationProviderTarget(processID: 203)
         let other = documentationProviderTarget(processID: 204)
@@ -995,6 +1031,153 @@ struct RuntimeCoordinatorTests {
             to: try jsonValue(["tools": []])
         )
         #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(await factory.startAttempts() == [
+            xcode26.processID,
+            xcode27.processID,
+            xcode26.processID,
+            xcode27.processID,
+            xcode26.processID,
+            xcode27.processID,
+        ])
+    }
+
+    @Test func documentationProviderManagerInvalidatesReplacementWhenRetryTransportFails() async throws {
+        let xcode26 = documentationProviderTarget(processID: 225)
+        let xcode27 = documentationProviderTarget(processID: 226)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 50,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.exit]
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.exit]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let initialTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: nil),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
+
+        do {
+            _ = try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 77, query: "UIView"),
+                requestTimeoutOverride: .seconds(1)
+            )
+            Issue.record("DocumentationSearch should report an invalidated retry failure")
+        } catch let failure as DocumentationProviderCallFailure {
+            #expect(failure.providerIsActive == false)
+            #expect(failure.underlying is UpstreamSlotAcquisitionError)
+        }
+
+        let followUpTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: .seconds(1)),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(await factory.startedPIDs() == [
+            xcode26.processID,
+            xcode27.processID,
+            xcode27.processID,
+        ])
+    }
+
+    @Test func documentationProviderManagerInvalidatesReplacementWhenNotEnabledRetryTransportFails()
+        async throws
+    {
+        let xcode26 = documentationProviderTarget(processID: 227)
+        let xcode27 = documentationProviderTarget(processID: 228)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 50,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.notEnabled]
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 50,
+                        includesDocumentationSearch: true,
+                        probeResponse: .notEnabled
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.exit]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let initialTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: nil),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
+
+        do {
+            _ = try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 78, query: "UIView"),
+                requestTimeoutOverride: .seconds(1)
+            )
+            Issue.record("DocumentationSearch should report an invalidated not-enabled retry failure")
+        } catch let failure as DocumentationProviderCallFailure {
+            #expect(failure.providerIsActive == false)
+            #expect(failure.underlying is UpstreamSlotAcquisitionError)
+        }
+
+        let followUpTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: .seconds(1)),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(await factory.startedPIDs() == [
+            xcode26.processID,
+            xcode27.processID,
+            xcode26.processID,
+            xcode27.processID,
+        ])
         #expect(await factory.startAttempts() == [
             xcode26.processID,
             xcode27.processID,

--- a/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -391,6 +391,56 @@ struct RuntimeCoordinatorTests {
         #expect(await documentationProvider.callCount() == 1)
     }
 
+    @Test func documentationSearchClearsProviderStateWhenRecoveryFailsAfterInvalidation() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0")),
+            callFailures: [
+                DocumentationProviderCallFailure(
+                    underlying: UpstreamSlotAcquisitionError.unavailable,
+                    providerIsActive: false
+                ),
+            ]
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider
+        )
+        defer { manager.shutdownAndWait() }
+
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])
+        )
+        _ = try await manager.sharedToolsList(
+            sessionID: "session-docs-recovery-failed",
+            requestTimeoutOverride: nil
+        )
+        #expect(manager.hasActiveDocumentationProvider())
+        #expect(manager.cachedToolsListResult() != nil)
+
+        await #expect(throws: UpstreamSlotAcquisitionError.self) {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 43, query: "UIView"),
+                requestTimeoutOverride: nil
+            )
+        }
+        #expect(manager.cachedToolsListResult() == nil)
+        #expect(manager.hasActiveDocumentationProvider() == false)
+        #expect(await documentationProvider.callCount() == 1)
+    }
+
     @Test func startupPrewarmsDocumentationProviderWhenEnabled() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -955,6 +1005,50 @@ struct RuntimeCoordinatorTests {
         ])
     }
 
+    @Test func documentationProviderManagerReportsInactiveProviderWhenRecoveryFindsNoReplacement() async throws {
+        let xcode = documentationProviderTarget(processID: 231)
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        probeResponse: .success,
+                        userCallResponses: [.exit]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode]),
+            sessionFactory: factory
+        )
+
+        let initialTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: nil),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(documentationDescriptorDescription(in: initialTools) == "docs-27.0")
+
+        do {
+            _ = try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 76, query: "UIView"),
+                requestTimeoutOverride: .seconds(1)
+            )
+            Issue.record("DocumentationSearch should report an invalidated provider failure")
+        } catch let failure as DocumentationProviderCallFailure {
+            #expect(failure.providerIsActive == false)
+            #expect(failure.underlying is UpstreamSlotAcquisitionError)
+        }
+
+        let followUpTools = DocumentationToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: .seconds(1)),
+            to: try jsonValue(["tools": []])
+        )
+        #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+    }
+
     @Test func documentationProviderManagerDoesNotRetryAfterRequestTimeoutExpires() async throws {
         let xcode = documentationProviderTarget(processID: 301)
         let factory = ScriptedDocumentationSessionFactory(
@@ -988,8 +1082,11 @@ struct RuntimeCoordinatorTests {
                 requestTimeoutOverride: .milliseconds(1)
             )
             Issue.record("DocumentationSearch should time out without retrying")
+        } catch let failure as DocumentationProviderCallFailure {
+            #expect(failure.underlying is TimeoutError)
+            #expect(failure.providerIsActive == false)
         } catch {
-            #expect(error is TimeoutError)
+            Issue.record("expected DocumentationProviderCallFailure, got \(error)")
         }
 
         #expect(await factory.startedPIDs() == [xcode.processID])
@@ -6452,6 +6549,7 @@ private actor ScriptedDocumentationSession: UpstreamSession {
 private actor StubDocumentationProviderManager: DocumentationProviderManaging {
     private var update: DocumentationToolListUpdate
     private var callResults: [DocumentationProviderCallResult]
+    private var callFailures: [DocumentationProviderCallFailure]
     private var callCountValue = 0
     private var invalidateReasons: [String] = []
     private var prewarmTimeouts: [TimeAmount?] = []
@@ -6463,11 +6561,13 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
     init(
         toolListUpdate: DocumentationToolListUpdate,
         callResults: [DocumentationProviderCallResult] = [],
+        callFailures: [DocumentationProviderCallFailure] = [],
         prewarmDelayNanoseconds: UInt64? = nil,
         toolListDelayNanoseconds: UInt64? = nil
     ) {
         self.update = toolListUpdate
         self.callResults = callResults
+        self.callFailures = callFailures
         self.prewarmDelayNanoseconds = prewarmDelayNanoseconds
         self.toolListDelayNanoseconds = toolListDelayNanoseconds
     }
@@ -6496,6 +6596,9 @@ private actor StubDocumentationProviderManager: DocumentationProviderManaging {
     ) async throws -> DocumentationProviderCallResult {
         callCountValue += 1
         callTimeouts.append(requestTimeoutOverride)
+        if callFailures.isEmpty == false {
+            throw callFailures.removeFirst()
+        }
         guard callResults.isEmpty == false else {
             throw UpstreamSlotAcquisitionError.unavailable
         }


### PR DESCRIPTION
## Purpose
Fix an issue where DocumentationSearch could become unavailable when multiple Xcode processes are running.

## Changes
- Route DocumentationSearch through a verified documentation provider when using the default xcrun mcpbridge upstream.
- Prefer provider candidates by available tool count, then newer server version when tied.
- Merge provider-backed DocumentationSearch into tools/list, including batched tools/list requests.
- Keep local DocumentationSearch routing synchronized when provider retry recovery succeeds, fails, or reports the tool as disabled.
- Honor configured initialize params and inherited MCP_XCODE_PID pins for documentation provider probes.
- Preserve custom-upstream and disabled-tool behavior by falling through when no provider is active.
- Keep provider prewarm, selection, cancellation, and mixed batch forwarding bounded and independent.

## Testing
- swift test -Xswiftc -strict-concurrency=minimal
- codex-review against refs/pr-fix/base/63/053afcdeb0f33e354cf603db3f43a269d7cfb11a (clean)
