### PR TITLE
Make documentation provider timeout tests deterministic

### DIFF
--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -239,12 +239,14 @@ private final class DocumentationPendingResponse: @unchecked Sendable {
 
 package actor DocumentationProviderConnection {
     private let session: any UpstreamSession
+    private let clock: ClockClient
     private var eventTask: Task<Void, Never>?
     private var pendingResponses: [String: DocumentationPendingResponse] = [:]
     private var nextID: Int64 = 1
 
-    package init(session: any UpstreamSession) {
+    package init(session: any UpstreamSession, clock: ClockClient = .liveValue) {
         self.session = session
+        self.clock = clock
     }
 
     package func start() {
@@ -325,9 +327,11 @@ package actor DocumentationProviderConnection {
         guard let timeout, timeout.nanoseconds > 0 else {
             return
         }
-        let nanoseconds = UInt64(timeout.nanoseconds)
-        pending.timeoutTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: nanoseconds)
+        pending.timeoutTask = Task { [weak self, clock] in
+            await clock.sleep(.nanoseconds(timeout.nanoseconds))
+            guard Task.isCancelled == false else {
+                return
+            }
             await self?.failPending(id: id, error: TimeoutError())
         }
     }
@@ -647,10 +651,14 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             let profile = await selection.task.value
             state.resume(.completed(profile))
         }
+        let clock = clock
         let timeoutTask: Task<Void, Never>?
         if let requestTimeout, requestTimeout.nanoseconds > 0 {
             timeoutTask = Task {
-                try? await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
+                await clock.sleep(.nanoseconds(requestTimeout.nanoseconds))
+                guard Task.isCancelled == false else {
+                    return
+                }
                 state.resume(.timedOut)
             }
         } else {
@@ -783,8 +791,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             group.addTask {
                 try await self.probe(target: target, requestTimeout: requestTimeout)
             }
+            let clock = clock
             group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
+                await clock.sleep(.nanoseconds(requestTimeout.nanoseconds))
+                try Task.checkCancellation()
                 throw TimeoutError()
             }
             do {
@@ -807,7 +817,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let probeDeadline = Deadline.fromNow(requestTimeout ?? .seconds(30), clock: clock)
         try Task.checkCancellation()
         let session = try await sessionFactory.startSession(for: target)
-        let connection = DocumentationProviderConnection(session: session)
+        let connection = DocumentationProviderConnection(session: session, clock: clock)
         do {
             try Task.checkCancellation()
             await connection.start()

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -662,6 +662,8 @@ extension RuntimeCoordinatorTests {
     @Test func documentationProviderManagerContinuesAfterCandidateProbeTimesOut() async throws {
         let hung = documentationProviderTarget(processID: 205)
         let working = documentationProviderTarget(processID: 206)
+        let timeoutClock = TestClock()
+        let uptimeClock = TestUptimeClock()
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 hung.processID: [
@@ -685,10 +687,38 @@ extension RuntimeCoordinatorTests {
         let manager = DocumentationProviderManager(
             discovery: StubXcodeTargetDiscovery(targets: [hung, working]),
             sessionFactory: factory,
-            providerSelectionTimeout: .milliseconds(50)
+            providerSelectionTimeout: .seconds(1),
+            clock: makeDeterministicClockClient(
+                timeoutClock: timeoutClock,
+                uptimeClock: uptimeClock
+            )
         )
 
-        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let updateTask = Task {
+            await manager.toolListUpdate(requestTimeout: .seconds(2))
+        }
+        defer { updateTask.cancel() }
+        try await waitWithTimeout("waiting for hung documentation probe") {
+            try await factory.waitForRequestCount(
+                1,
+                processID: hung.processID,
+                method: "tools/call"
+            )
+        }
+        await timeoutClock.sleep(untilSuspendedBy: 2)
+        uptimeClock.advance(by: .milliseconds(500))
+        timeoutClock.advance(by: .milliseconds(500))
+        try await waitWithTimeout("waiting for replacement documentation probe") {
+            try await factory.waitForRequestCount(
+                1,
+                processID: working.processID,
+                method: "tools/call"
+            )
+        }
+
+        let update = try await waitWithTimeout("waiting for documentation provider selection") {
+            await updateTask.value
+        }
         let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -165,10 +165,20 @@ struct ScriptedDocumentationSessionPlan: Sendable {
 }
 
 actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
+    private struct RequestCountWaiter {
+        let id: UUID
+        let processID: pid_t
+        let method: String
+        let count: Int
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
     private var plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]]
     private var startAttemptProcessIDs: [pid_t] = []
     private var startedProcessIDs: [pid_t] = []
     private var initializeParamsByPID: [pid_t: [JSONValue]] = [:]
+    private var requestCountsByPID: [pid_t: [String: Int]] = [:]
+    private var requestCountWaiters: [RequestCountWaiter] = []
     private let startDelayNanoseconds: UInt64?
 
     init(
@@ -213,6 +223,64 @@ actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
     func initializeParams(for processID: pid_t) -> [JSONValue] {
         initializeParamsByPID[processID] ?? []
     }
+
+    func recordRequest(method: String, for processID: pid_t) {
+        requestCountsByPID[processID, default: [:]][method, default: 0] += 1
+        resumeRequestCountWaiters()
+    }
+
+    func requestCount(processID: pid_t, method: String) -> Int {
+        requestCountsByPID[processID]?[method] ?? 0
+    }
+
+    func waitForRequestCount(_ count: Int, processID: pid_t, method: String) async throws {
+        if requestCount(processID: processID, method: method) >= count {
+            return
+        }
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if requestCount(processID: processID, method: method) >= count {
+                    continuation.resume(returning: ())
+                    return
+                }
+                requestCountWaiters.append(
+                    RequestCountWaiter(
+                        id: waiterID,
+                        processID: processID,
+                        method: method,
+                        count: count,
+                        continuation: continuation
+                    )
+                )
+            }
+        } onCancel: {
+            Task {
+                await self.cancelRequestCountWaiter(id: waiterID)
+            }
+        }
+    }
+
+    private func resumeRequestCountWaiters() {
+        var remaining: [RequestCountWaiter] = []
+        for waiter in requestCountWaiters {
+            if requestCount(processID: waiter.processID, method: waiter.method) >= waiter.count {
+                waiter.continuation.resume(returning: ())
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        requestCountWaiters = remaining
+    }
+
+    private func cancelRequestCountWaiter(id: UUID) {
+        guard let index = requestCountWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = requestCountWaiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
 }
 
 actor ScriptedDocumentationSession: UpstreamSession {
@@ -252,6 +320,7 @@ actor ScriptedDocumentationSession: UpstreamSession {
         if plan.requiresNumericRequestIDs, !(requestID is NSNumber) {
             return .accepted
         }
+        await recorder.recordRequest(method: method, for: processID)
 
         switch method {
         case "initialize":
@@ -954,6 +1023,22 @@ func makeDeterministicRuntimeTimeoutScheduler(
             task.cancel()
         }
     }
+}
+
+func makeDeterministicClockClient(
+    timeoutClock: TestClock,
+    uptimeClock: TestUptimeClock
+) -> ClockClient {
+    ClockClient(
+        now: {
+            Date(timeIntervalSince1970: Double(uptimeClock.now()) / 1_000_000_000)
+        },
+        uptimeNanoseconds: uptimeClock.now,
+        sleep: { duration in
+            try? await timeoutClock.sleep(for: duration)
+        },
+        sleepForTimeInterval: { _ in }
+    )
 }
 
 func spinUntilSentCount(


### PR DESCRIPTION
## Purpose

Fix the release CI failure caused by a documentation provider timeout test depending on wall-clock scheduling under runner load.

## Changes

- Route DocumentationProvider timeout sleeps through the injected ClockClient.
- Add deterministic request-count waiting support to the scripted documentation provider test session.
- Rewrite the hung-candidate provider selection test to drive timeout progression with a test clock instead of a 50 ms real-time sleep.

## Testing

- `swift test --filter documentationProviderManagerContinuesAfterCandidateProbeTimesOut -Xswiftc -strict-concurrency=minimal`
- `swift test -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`
- Codex review: clean, 0 findings
