### PR TITLE
Modernize MCP Streamable HTTP transport

### DIFF
--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -1,13 +1,15 @@
 # XcodeMCPProxy Architecture
 
 ## Summary
-- `xcode-mcp-proxy-server` runs as the proxy server (HTTP/SSE; spawns `xcrun mcpbridge`).
+- `xcode-mcp-proxy-server` runs as the proxy server (Streamable HTTP; spawns `xcrun mcpbridge`).
 - HTTP-capable MCP clients connect directly to the proxy server (default: `http://localhost:8765/mcp`).
-- `xcode-mcp-proxy` runs as a STDIO adapter for clients that require STDIO, forwarding to the proxy server over HTTP/SSE.
+- `xcode-mcp-proxy` remains as a supported STDIO compatibility adapter, forwarding to the proxy server as a modern Streamable HTTP client.
+- The proxy targets MCP protocol version `2025-06-18`, matching current Xcode `mcpbridge` negotiation.
+- JSON-RPC batch requests are rejected at the HTTP boundary.
 
 ## Diagrams
 
-### Proxy Server (HTTP/SSE)
+### Proxy Server (Streamable HTTP)
 ```mermaid
 flowchart LR
   subgraph Clients["MCP clients (multiple)"]
@@ -16,7 +18,7 @@ flowchart LR
     clientB(["Client B"])
     clientN(["Client N"])
   end
-  proxy["xcode-mcp-proxy-server<br/>HTTP/SSE"]
+  proxy["xcode-mcp-proxy-server<br/>Streamable HTTP"]
   subgraph Upstreams["Upstream (mcpbridge pool)"]
     direction TB
     upstream1(["xcrun mcpbridge #1<br/>stdio JSON-RPC"])
@@ -25,9 +27,9 @@ flowchart LR
   end
   xcode["Xcode MCP server"]
 
-  clientA -->|HTTP POST / SSE| proxy
-  clientB -->|HTTP POST / SSE| proxy
-  clientN -->|HTTP POST / SSE| proxy
+  clientA -->|POST/GET/DELETE /mcp| proxy
+  clientB -->|POST/GET/DELETE /mcp| proxy
+  clientN -->|POST/GET/DELETE /mcp| proxy
   proxy -->|stdio JSON-RPC| upstream1
   proxy -->|stdio JSON-RPC| upstream2
   proxy -->|stdio JSON-RPC| upstreamN
@@ -51,7 +53,7 @@ flowchart LR
     clientB -->|NDJSON over STDIO| adapterB
   end
 
-  proxy["xcode-mcp-proxy-server<br/>HTTP/SSE"]
+  proxy["xcode-mcp-proxy-server<br/>Streamable HTTP"]
   subgraph Upstreams["Upstream (mcpbridge pool)"]
     direction TB
     upstream1(["xcrun mcpbridge #1<br/>stdio JSON-RPC"])
@@ -60,8 +62,8 @@ flowchart LR
   end
   xcode["Xcode MCP server"]
 
-  adapterA -->|HTTP POST / SSE| proxy
-  adapterB -->|HTTP POST / SSE| proxy
+  adapterA -->|POST/GET/DELETE /mcp| proxy
+  adapterB -->|POST/GET/DELETE /mcp| proxy
   proxy -->|stdio JSON-RPC| upstream1
   proxy -->|stdio JSON-RPC| upstream2
   proxy -->|stdio JSON-RPC| upstreamN
@@ -77,3 +79,10 @@ flowchart LR
   - `XCODE_MCP_PROXY_ENDPOINT`
   - discovery file (`~/Library/Caches/XcodeMCPProxy/endpoint.json`)
 - default (`http://localhost:8765/mcp`)
+
+## Streamable HTTP Contract
+- `POST /mcp` requires `Content-Type: application/json` and `Accept` containing both `application/json` and `text/event-stream`.
+- The server generates `MCP-Session-Id` on `initialize`; caller-provided session ids are ignored for initialize.
+- After initialize, `POST`, `GET`, and `DELETE` require both `MCP-Session-Id` and `MCP-Protocol-Version: 2025-06-18`.
+- Missing session ids return `400`; unknown or terminated session ids return `404`.
+- `DELETE /mcp` terminates the session; later requests with that session id return `404`.

--- a/Docs/maintainer-architecture.md
+++ b/Docs/maintainer-architecture.md
@@ -13,9 +13,9 @@
 - `ProxyXcodeFeatures`
   - `XcodeRefreshCodeIssuesInFile` planning, target resolution, queueing, tool-list rewriting.
 - `ProxyHTTPGateway`
-  - HTTP/SSE request handling, local MCP responses, forwarding, batch orchestration.
+  - Streamable HTTP request handling, transport validation, local MCP responses, forwarding.
 - `ProxyStdioTransport`
-  - STDIO adapter that forwards through the HTTP/SSE proxy.
+  - STDIO compatibility adapter that forwards through the Streamable HTTP proxy.
 - `XcodeMCPProxy`
   - Composition root only.
 
@@ -24,7 +24,8 @@
 - `ProxySession`
   - Owns client sessions, cached initialize state, canonical tools catalog, control-plane waiters, upstream routing, and lease cleanup.
 - `ProxyHTTPGateway`
-  - Owns request/response transport concerns only.
+  - Owns HTTP transport validation, server-issued session ids, protocol-version enforcement, and request/response transport concerns.
+  - Rejects JSON-RPC batch arrays at the HTTP boundary.
   - Tool-specific response shaping lives in dedicated surface helpers, not inline in forwarding hot paths.
 - `ProxyXcodeFeatures`
   - Owns refresh workflow and other Xcode-specific feature logic.

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -20,11 +20,13 @@ it’s usually because the upstream (`xcrun mcpbridge` / Xcode) was slow on the 
 - The tool list cache is **not persisted to disk**. It survives repeated Codex restarts as long as the proxy server stays running.
 - `tools/list` is intentionally treated as stable for the lifetime of the proxy process (no background refresh), to avoid upstream churn and surprise Xcode permission dialogs.
 
-## HTTP/SSE client cannot connect
+## Streamable HTTP client cannot connect
 - Ensure `xcode-mcp-proxy-server` is running.
 - Confirm the URL is correct (default: `http://localhost:8765/mcp`).
 - If you changed the listen address/port, check the discovery file: `~/Library/Caches/XcodeMCPProxy/endpoint.json`.
 - Confirm `pid` is alive and `updatedAt` is recent; stale data should be ignored.
+- Ensure `POST /mcp` sends `Content-Type: application/json` and `Accept: application/json, text/event-stream`.
+- After initialize, ensure the client sends the server-issued `MCP-Session-Id` and `MCP-Protocol-Version: 2025-06-18`.
 
 ## `Address already in use` / `errno: 48`
 Another process is already listening on the same port (default: `8765`).
@@ -84,4 +86,7 @@ When the proxy runs in `--refresh-code-issues-mode upstream`, Xcode's live diagn
 - If you need Xcode's native live diagnostics behavior, start the proxy with `--refresh-code-issues-mode upstream` (or `MCP_XCODE_REFRESH_CODE_ISSUES_MODE=upstream`).
 
 ## `session not found`
-Ensure the client is using the same session.
+Ensure the client is using the server-issued `MCP-Session-Id`. Initialize requests must not rely on a caller-provided session id, and `DELETE /mcp` permanently terminates the session.
+
+## `protocol version required` / `protocol version mismatch`
+The proxy only accepts `MCP-Protocol-Version: 2025-06-18` after initialize. Reinitialize the client session if it cached an older protocol version or omitted the header.

--- a/README.ja.md
+++ b/README.ja.md
@@ -94,6 +94,10 @@ codex mcp add xcode -- xcode-mcp-proxy
 
 ```bash
 claude mcp remove xcode
+# 推奨: Streamable HTTP
+claude mcp add --transport http xcode http://localhost:8765/mcp
+
+# 互換モード: STDIO
 claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 ```
 
@@ -170,7 +174,7 @@ python3 scripts/benchmark-live-server.py --agents 4 --requests-per-agent 100
 
 | キー | 型 | 既定値 |
 |------|----|--------|
-| `upstream_handshake.protocolVersion` | string | `"2025-03-26"` |
+| `upstream_handshake.protocolVersion` | string | `"2025-06-18"` |
 | `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
 | `upstream_handshake.clientVersion` | string | `"dev"` |
 | `upstream_handshake.capabilities` | table | `{}` |
@@ -178,6 +182,8 @@ python3 scripts/benchmark-live-server.py --agents 4 --requests-per-agent 100
 `clientVersion` を省略した場合、`clientName` に対応する Xcode の `IDEChat*Version` があれば、その version を自動で使います。
 
 ### アダプタ: `xcode-mcp-proxy`
+
+STDIO が必要な MCP クライアント向けの互換アダプタです。HTTP に対応しているクライアントは `xcode-mcp-proxy-server` に Streamable HTTP で直接接続してください。
 
 #### オプション
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ codex mcp add xcode -- xcode-mcp-proxy
 
 ```bash
 claude mcp remove xcode
+# Recommended: Streamable HTTP
+claude mcp add --transport http xcode http://localhost:8765/mcp
+
+# Compatibility mode: STDIO
 claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 ```
 
@@ -171,7 +175,7 @@ python3 scripts/benchmark-live-server.py --agents 4 --requests-per-agent 100
 
 | Key | Type | Default |
 |-----|------|---------|
-| `upstream_handshake.protocolVersion` | string | `"2025-03-26"` |
+| `upstream_handshake.protocolVersion` | string | `"2025-06-18"` |
 | `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
 | `upstream_handshake.clientVersion` | string | `"dev"` |
 | `upstream_handshake.capabilities` | table | `{}` |
@@ -192,6 +196,8 @@ disabled = ["RunAllTests", "RunSomeTests"]
 Disabled tools are removed from `tools/list` and rejected on direct `tools/call` requests with a tool error. The config is loaded when the proxy starts; restart `xcode-mcp-proxy-server` after editing the file.
 
 ### Adapter: `xcode-mcp-proxy`
+
+Compatibility adapter for MCP clients that still require STDIO. HTTP-capable clients should connect directly to `xcode-mcp-proxy-server` with Streamable HTTP.
 
 #### Options
 

--- a/Sources/ProxyCLI/Adapter/XcodeMCPProxyCLICommand+Parsing.swift
+++ b/Sources/ProxyCLI/Adapter/XcodeMCPProxyCLICommand+Parsing.swift
@@ -70,7 +70,7 @@ extension XcodeMCPProxyCLICommand {
           xcode-mcp-proxy [options]
 
         Description:
-          STDIO adapter that forwards MCP traffic to a running xcode-mcp-proxy-server (HTTP/SSE).
+          STDIO compatibility adapter that forwards MCP traffic to a running xcode-mcp-proxy-server (Streamable HTTP).
 
         Options:
           --request-timeout seconds  Request timeout (default: 300, 0 disables)

--- a/Sources/ProxyCLI/Server/ProxyServerCommandRuntime.swift
+++ b/Sources/ProxyCLI/Server/ProxyServerCommandRuntime.swift
@@ -29,6 +29,7 @@ package struct ProxyServerCommandRuntime {
 
             let proxyArgs = ["xcode-mcp-proxy"] + options.forwardedArgs
             let config = try CLIParser.parse(args: proxyArgs, environment: environment)
+            try config.validateModernProtocolConfiguration()
 
             let isDryRun = options.dryRun || XcodeMCPProxyServerCommand.isTruthy(environment["DRY_RUN"])
             if isDryRun {

--- a/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand+Parsing.swift
+++ b/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand+Parsing.swift
@@ -89,8 +89,8 @@ extension XcodeMCPProxyServerCommand {
           -h, --help
 
         Notes:
-          - Starts the HTTP/SSE proxy server (and spawns xcrun mcpbridge as upstream processes).
-          - Use xcode-mcp-proxy as a STDIO adapter for Codex / Claude Code.
+          - Starts the Streamable HTTP proxy server (and spawns xcrun mcpbridge as upstream processes).
+          - HTTP-capable clients should connect directly; xcode-mcp-proxy is the STDIO compatibility adapter.
           - Default listen: localhost:8765 (override via --listen / --host / --port or env LISTEN/HOST/PORT).
           - --auto-approve opt-in enables automatic approval of the Xcode permission dialog.
           - Initialize config path: --config or env \(CLIParser.configPathEnv)

--- a/Sources/ProxyCore/MCPProtocolVersion.swift
+++ b/Sources/ProxyCore/MCPProtocolVersion.swift
@@ -1,0 +1,7 @@
+public enum MCPProtocolVersion {
+    public static let current = "2025-06-18"
+
+    public static func isSupported(_ version: String) -> Bool {
+        version == current
+    }
+}

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -98,6 +98,17 @@ public struct ProxyConfig: Sendable {
             logger: logger
         )
     }
+
+    public func validateModernProtocolConfiguration() throws {
+        guard let protocolVersion = initializeParamsOverride?.protocolVersion else {
+            return
+        }
+        guard MCPProtocolVersion.isSupported(protocolVersion) else {
+            throw CLIError.message(
+                "upstream_handshake.protocolVersion must be \(MCPProtocolVersion.current); \(protocolVersion) is not supported"
+            )
+        }
+    }
 }
 
 public enum CLIError: Error, CustomStringConvertible {

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
@@ -77,6 +77,7 @@ package final class HTTPControlService: Sendable {
         let session = runtimeCoordinator.session(id: sessionID)
         let hadClients = session.notificationHub.hasSseClients
         session.notificationHub.addSse(channel)
+        runtimeCoordinator.markNotificationClientConnected(sessionID: sessionID)
         let bufferedNotifications = hadClients ? [] : session.router.drainBufferedNotifications()
         return HTTPSSEOpenResult(bufferedNotifications: bufferedNotifications)
     }

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
@@ -96,6 +96,10 @@ package final class HTTPControlService: Sendable {
         runtimeCoordinator.hasSession(id: sessionID)
     }
 
+    package func negotiatedProtocolVersion(id sessionID: String) -> String? {
+        runtimeCoordinator.negotiatedProtocolVersion(id: sessionID)
+    }
+
     package func debugReset(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
         let promise = eventLoop.makePromise(of: Void.self)
         promise.completeWithTask { [runtimeCoordinator, refreshCodeIssuesCoordinator, refreshCodeIssuesDebugState] in

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler+Responses.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler+Responses.swift
@@ -86,7 +86,7 @@ extension HTTPHandler {
         }
     }
 
-    func sendSingleSSE(on channel: Channel, data: Data, keepAlive: Bool, sessionID: String, requestLog: RequestLogContext) -> EventLoopFuture<Void> {
+    func sendSingleSSE(on channel: Channel, data: Data, keepAlive: Bool, sessionID: String?, requestLog: RequestLogContext) -> EventLoopFuture<Void> {
         responseWriter.sendSingleSSE(
             on: channel,
             data: data,
@@ -96,7 +96,7 @@ extension HTTPHandler {
         )
     }
 
-    func sendJSON(on channel: Channel, buffer: ByteBuffer, keepAlive: Bool, sessionID: String, requestLog: RequestLogContext) -> EventLoopFuture<Void> {
+    func sendJSON(on channel: Channel, buffer: ByteBuffer, keepAlive: Bool, sessionID: String?, requestLog: RequestLogContext) -> EventLoopFuture<Void> {
         responseWriter.sendJSON(
             on: channel,
             buffer: buffer,

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler+Responses.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler+Responses.swift
@@ -158,7 +158,7 @@ extension HTTPHandler {
         forceBatchArray: Bool = false,
         prefersEventStream: Bool,
         keepAlive: Bool,
-        sessionID: String,
+        sessionID: String?,
         requestLog: RequestLogContext
     ) -> EventLoopFuture<Void> {
         responseWriter.sendMCPError(
@@ -182,7 +182,7 @@ extension HTTPHandler {
         forceBatchArray: Bool = false,
         prefersEventStream: Bool,
         keepAlive: Bool,
-        sessionID: String,
+        sessionID: String?,
         requestLog: RequestLogContext
     ) -> EventLoopFuture<Void> {
         responseWriter.sendMCPError(

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -562,6 +562,20 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             effectiveSessionID = sessionID
             headerSessionExists = true
         }
+        if !isInitializeRequest,
+            let parsedRequestObject,
+            Self.isJSONRPCResponse(parsedRequestObject)
+        {
+            guard let responseSessionID = effectiveSessionID else { return }
+            _ = sendEmpty(
+                on: context.channel,
+                status: .accepted,
+                keepAlive: head.isKeepAlive,
+                sessionID: responseSessionID,
+                requestLog: requestLog
+            )
+            return
+        }
         let keepAlive = head.isKeepAlive
         let channel = context.channel
         let operation = postService.handle(
@@ -623,6 +637,17 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
                 }
             }
         }
+    }
+
+    private static func isJSONRPCResponse(_ object: [String: Any]) -> Bool {
+        guard object["method"] == nil,
+            let id = object["id"],
+            !(id is NSNull),
+            RPCID(any: id) != nil
+        else {
+            return false
+        }
+        return object["result"] != nil || object["error"] != nil
     }
 
     private func validateExistingSession(

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -328,15 +328,13 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             return false
         }
 
-        let originPort = components.port
+        let originPort = components.port ?? Self.defaultPort(for: scheme)
         if let hostHeaderPort = Self.port(fromHostHeader: requestHead.headers.first(name: "Host")),
-            let originPort,
             originPort != hostHeaderPort
         {
             return false
         }
         if config.listenPort > 0,
-            let originPort,
             originPort != config.listenPort
         {
             return false
@@ -348,6 +346,10 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         host
             .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
             .lowercased()
+    }
+
+    private static func defaultPort(for scheme: String) -> Int {
+        scheme == "https" ? 443 : 80
     }
 
     private static func isLoopbackOrConfiguredHost(

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -538,9 +538,10 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         let parsedRequestObject = parsedRequestJSON as? [String: Any]
         let isInitializeRequest = parsedRequestObject?["method"] as? String == "initialize"
         let hasValidInitializeID: Bool = {
-            guard isInitializeRequest,
-                let idValue = parsedRequestObject?["id"],
-                RPCID(any: idValue) != nil
+            guard let parsedRequestObject,
+                case .request("initialize", _) = JSONRPCMessageInspector.kind(
+                    of: parsedRequestObject
+                )
             else {
                 return false
             }
@@ -561,20 +562,6 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             }
             effectiveSessionID = sessionID
             headerSessionExists = true
-        }
-        if !isInitializeRequest,
-            let parsedRequestObject,
-            Self.isJSONRPCResponse(parsedRequestObject)
-        {
-            guard let responseSessionID = effectiveSessionID else { return }
-            _ = sendEmpty(
-                on: context.channel,
-                status: .accepted,
-                keepAlive: head.isKeepAlive,
-                sessionID: responseSessionID,
-                requestLog: requestLog
-            )
-            return
         }
         let keepAlive = head.isKeepAlive
         let channel = context.channel
@@ -637,17 +624,6 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
                 }
             }
         }
-    }
-
-    private static func isJSONRPCResponse(_ object: [String: Any]) -> Bool {
-        guard object["method"] == nil,
-            let id = object["id"],
-            !(id is NSNull),
-            RPCID(any: id) != nil
-        else {
-            return false
-        }
-        return object["result"] != nil || object["error"] != nil
     }
 
     private func validateExistingSession(

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -321,15 +321,17 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         }
 
         let normalizedOriginHost = Self.normalizedHost(originHost)
-        guard Self.isLoopbackOrConfiguredHost(
+        let hostHeader = requestHead.headers.first(name: "Host")
+        guard Self.originHostIsAllowed(
             normalizedOriginHost,
-            configuredHost: config.listenHost
+            configuredHost: config.listenHost,
+            hostHeader: hostHeader
         ) else {
             return false
         }
 
         let originPort = components.port ?? Self.defaultPort(for: scheme)
-        if let hostHeaderPort = Self.port(fromHostHeader: requestHead.headers.first(name: "Host")),
+        if let hostHeaderPort = Self.port(fromHostHeader: hostHeader),
             originPort != hostHeaderPort
         {
             return false
@@ -352,6 +354,22 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         scheme == "https" ? 443 : 80
     }
 
+    private static func originHostIsAllowed(
+        _ originHost: String,
+        configuredHost: String,
+        hostHeader: String?
+    ) -> Bool {
+        if isLoopbackOrConfiguredHost(originHost, configuredHost: configuredHost) {
+            return true
+        }
+        guard isWildcardHost(configuredHost),
+            let requestHost = host(fromHostHeader: hostHeader)
+        else {
+            return false
+        }
+        return originHost == normalizedHost(requestHost)
+    }
+
     private static func isLoopbackOrConfiguredHost(
         _ host: String,
         configuredHost: String
@@ -367,6 +385,15 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             return true
         }
         return false
+    }
+
+    private static func isWildcardHost(_ host: String) -> Bool {
+        switch normalizedHost(host) {
+        case "0.0.0.0", "::", "0:0:0:0:0:0:0:0":
+            return true
+        default:
+            return false
+        }
     }
 
     private static func isIPv4LoopbackHost(_ host: String) -> Bool {
@@ -385,6 +412,29 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             octets.append(value)
         }
         return octets.first == 127
+    }
+
+    private static func host(fromHostHeader hostHeader: String?) -> String? {
+        guard let hostHeader = hostHeader?.trimmingCharacters(in: .whitespacesAndNewlines),
+            hostHeader.isEmpty == false
+        else {
+            return nil
+        }
+        if hostHeader.hasPrefix("["),
+            let closeBracket = hostHeader.firstIndex(of: "]")
+        {
+            return String(hostHeader[hostHeader.index(after: hostHeader.startIndex)..<closeBracket])
+        }
+        let colonCount = hostHeader.reduce(0) { count, character in
+            character == ":" ? count + 1 : count
+        }
+        if colonCount == 1,
+            let colon = hostHeader.lastIndex(of: ":"),
+            Int(hostHeader[hostHeader.index(after: colon)...]) != nil
+        {
+            return String(hostHeader[..<colon])
+        }
+        return hostHeader
     }
 
     private static func port(fromHostHeader hostHeader: String?) -> Int? {

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -5,6 +5,7 @@ import NIOFoundationCompat
 import NIOHTTP1
 import NIOConcurrencyHelpers
 import ProxyCore
+import ProxyMCP
 import ProxySession
 import ProxyXcodeFeatures
 
@@ -532,12 +533,21 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        let isInitializeRequest =
-            (parsedRequestJSON as? [String: Any])?["method"] as? String == "initialize"
-        let effectiveSessionID: String
+        let parsedRequestObject = parsedRequestJSON as? [String: Any]
+        let isInitializeRequest = parsedRequestObject?["method"] as? String == "initialize"
+        let hasValidInitializeID: Bool = {
+            guard isInitializeRequest,
+                let idValue = parsedRequestObject?["id"],
+                RPCID(any: idValue) != nil
+            else {
+                return false
+            }
+            return true
+        }()
+        let effectiveSessionID: String?
         let headerSessionExists: Bool
         if isInitializeRequest {
-            effectiveSessionID = UUID().uuidString
+            effectiveSessionID = hasValidInitializeID ? UUID().uuidString : nil
             headerSessionExists = false
         } else {
             guard let sessionID = validateExistingSession(

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -166,7 +166,14 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        switch HTTPRoute.resolve(method: head.method, path: path) {
+        let route = HTTPRoute.resolve(method: head.method, path: path)
+        if routeRequiresOriginValidation(route),
+            rejectInvalidOriginIfNeeded(context: context, head: head, requestLog: requestLog)
+        {
+            return
+        }
+
+        switch route {
         case .health:
             _ = sendPlain(on: context.channel, status: .ok, body: "ok", keepAlive: head.isKeepAlive, sessionID: nil, requestLog: requestLog)
         case .debugSnapshot:
@@ -270,6 +277,110 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         }) == true
     }
 
+    private func routeRequiresOriginValidation(_ route: HTTPRoute) -> Bool {
+        switch route {
+        case .sse, .deleteSession, .post:
+            return true
+        case .health, .debugSnapshot, .debugReset, .notFound:
+            return false
+        }
+    }
+
+    private func rejectInvalidOriginIfNeeded(
+        context: ChannelHandlerContext,
+        head: HTTPRequestHead,
+        requestLog: RequestLogContext
+    ) -> Bool {
+        guard let origin = head.headers.first(name: "Origin"),
+            origin.isEmpty == false
+        else {
+            return false
+        }
+        guard originIsAllowed(origin, requestHead: head) else {
+            _ = sendPlain(
+                on: context.channel,
+                status: .forbidden,
+                body: "origin not allowed",
+                keepAlive: head.isKeepAlive,
+                sessionID: nil,
+                requestLog: requestLog
+            )
+            return true
+        }
+        return false
+    }
+
+    private func originIsAllowed(_ origin: String, requestHead: HTTPRequestHead) -> Bool {
+        guard let components = URLComponents(string: origin),
+            let scheme = components.scheme?.lowercased(),
+            scheme == "http" || scheme == "https",
+            let originHost = components.host
+        else {
+            return false
+        }
+
+        let normalizedOriginHost = Self.normalizedHost(originHost)
+        guard Self.isLoopbackOrConfiguredHost(
+            normalizedOriginHost,
+            configuredHost: config.listenHost
+        ) else {
+            return false
+        }
+
+        let originPort = components.port
+        if let hostHeaderPort = Self.port(fromHostHeader: requestHead.headers.first(name: "Host")),
+            let originPort,
+            originPort != hostHeaderPort
+        {
+            return false
+        }
+        if config.listenPort > 0,
+            let originPort,
+            originPort != config.listenPort
+        {
+            return false
+        }
+        return true
+    }
+
+    private static func normalizedHost(_ host: String) -> String {
+        host
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+            .lowercased()
+    }
+
+    private static func isLoopbackOrConfiguredHost(
+        _ host: String,
+        configuredHost: String
+    ) -> Bool {
+        let configured = normalizedHost(configuredHost)
+        if host == configured {
+            return true
+        }
+        if host == "localhost" || host == "::1" || host == "0:0:0:0:0:0:0:1" {
+            return true
+        }
+        if host == "127.0.0.1" || host.hasPrefix("127.") {
+            return true
+        }
+        return false
+    }
+
+    private static func port(fromHostHeader hostHeader: String?) -> Int? {
+        guard let hostHeader else { return nil }
+        if hostHeader.hasPrefix("["),
+            let closeBracket = hostHeader.firstIndex(of: "]")
+        {
+            let rest = hostHeader[hostHeader.index(after: closeBracket)...]
+            guard rest.first == ":" else { return nil }
+            return Int(rest.dropFirst())
+        }
+        guard let colon = hostHeader.lastIndex(of: ":") else {
+            return nil
+        }
+        return Int(hostHeader[hostHeader.index(after: colon)...])
+    }
+
     private func handleSSE(context: ChannelHandlerContext, head: HTTPRequestHead, requestLog: RequestLogContext) {
         let alreadySSE = state.withLockedValue { $0.isSSE }
         if alreadySSE {
@@ -288,15 +399,11 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        guard let sessionID = HTTPRequestValidator.sessionID(from: head.headers) else {
-            _ = sendPlain(
-                on: context.channel,
-                status: .unauthorized,
-                body: "session id required",
-                keepAlive: head.isKeepAlive,
-                sessionID: nil,
-                requestLog: requestLog
-            )
+        guard let sessionID = validateExistingSession(
+            on: context.channel,
+            head: head,
+            requestLog: requestLog
+        ) else {
             return
         }
 
@@ -332,19 +439,15 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private func handleDelete(context: ChannelHandlerContext, head: HTTPRequestHead, requestLog: RequestLogContext) {
-        guard let sessionID = HTTPRequestValidator.sessionID(from: head.headers) else {
-            _ = sendPlain(
-                on: context.channel,
-                status: .unauthorized,
-                body: "session id required",
-                keepAlive: head.isKeepAlive,
-                sessionID: nil,
-                requestLog: requestLog
-            )
+        guard let sessionID = validateExistingSession(
+            on: context.channel,
+            head: head,
+            requestLog: requestLog
+        ) else {
             return
         }
         controlService.deleteSession(id: sessionID)
-        _ = sendEmpty(on: context.channel, status: .accepted, keepAlive: head.isKeepAlive, sessionID: sessionID, requestLog: requestLog)
+        _ = sendEmpty(on: context.channel, status: .ok, keepAlive: head.isKeepAlive, sessionID: sessionID, requestLog: requestLog)
     }
 
     private func handlePost(context: ChannelHandlerContext, head: HTTPRequestHead, requestLog: RequestLogContext) {
@@ -355,7 +458,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             _ = sendPlain(
                 on: context.channel,
                 status: .notAcceptable,
-                body: "client must accept application/json or text/event-stream",
+                body: "client must accept application/json and text/event-stream",
                 keepAlive: head.isKeepAlive,
                 sessionID: nil,
                 requestLog: requestLog
@@ -398,13 +501,42 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
-        let headerSessionID = HTTPRequestValidator.sessionID(from: head.headers)
-        let headerSessionExists = headerSessionID.map { controlService.hasSession(id: $0) } ?? false
+        let parsedRequestJSON = try? JSONSerialization.jsonObject(with: bodyData, options: [])
+        if parsedRequestJSON is [Any] {
+            _ = sendPlain(
+                on: context.channel,
+                status: .badRequest,
+                body: "JSON-RPC batching is not supported",
+                keepAlive: head.isKeepAlive,
+                sessionID: nil,
+                requestLog: requestLog
+            )
+            return
+        }
+
+        let isInitializeRequest =
+            (parsedRequestJSON as? [String: Any])?["method"] as? String == "initialize"
+        let effectiveSessionID: String
+        let headerSessionExists: Bool
+        if isInitializeRequest {
+            effectiveSessionID = UUID().uuidString
+            headerSessionExists = false
+        } else {
+            guard let sessionID = validateExistingSession(
+                on: context.channel,
+                head: head,
+                requestLog: requestLog
+            ) else {
+                return
+            }
+            effectiveSessionID = sessionID
+            headerSessionExists = true
+        }
         let keepAlive = head.isKeepAlive
         let channel = context.channel
         let operation = postService.handle(
             bodyData: bodyData,
-            headerSessionID: headerSessionID,
+            headerSessionID: effectiveSessionID,
             headerSessionExists: headerSessionExists,
             prefersEventStream: prefersEventStream,
             eventLoop: context.eventLoop
@@ -455,12 +587,83 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
                         status: .internalServerError,
                         body: "internal server error",
                         keepAlive: keepAlive,
-                        sessionID: headerSessionID,
+                        sessionID: effectiveSessionID,
                         requestLog: requestLog
                     )
                 }
             }
         }
+    }
+
+    private func validateExistingSession(
+        on channel: Channel,
+        head: HTTPRequestHead,
+        requestLog: RequestLogContext
+    ) -> String? {
+        guard let sessionID = HTTPRequestValidator.sessionID(from: head.headers),
+            sessionID.isEmpty == false
+        else {
+            _ = sendPlain(
+                on: channel,
+                status: .badRequest,
+                body: "session id required",
+                keepAlive: head.isKeepAlive,
+                sessionID: nil,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        guard controlService.hasSession(id: sessionID) else {
+            _ = sendPlain(
+                on: channel,
+                status: .notFound,
+                body: "session not found",
+                keepAlive: head.isKeepAlive,
+                sessionID: sessionID,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        guard let expectedProtocolVersion = controlService.negotiatedProtocolVersion(id: sessionID),
+            expectedProtocolVersion.isEmpty == false
+        else {
+            _ = sendPlain(
+                on: channel,
+                status: .badRequest,
+                body: "session is not initialized",
+                keepAlive: head.isKeepAlive,
+                sessionID: sessionID,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        guard let protocolVersion = HTTPRequestValidator.protocolVersion(from: head.headers),
+            protocolVersion.isEmpty == false
+        else {
+            _ = sendPlain(
+                on: channel,
+                status: .badRequest,
+                body: "protocol version required",
+                keepAlive: head.isKeepAlive,
+                sessionID: sessionID,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        guard MCPProtocolVersion.isSupported(protocolVersion),
+            protocolVersion == expectedProtocolVersion
+        else {
+            _ = sendPlain(
+                on: channel,
+                status: .badRequest,
+                body: "protocol version mismatch",
+                keepAlive: head.isKeepAlive,
+                sessionID: sessionID,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        return sessionID
     }
 
     private func enqueueOrderedWrite(

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -457,7 +457,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     private func handleDelete(context: ChannelHandlerContext, head: HTTPRequestHead, requestLog: RequestLogContext) {
-        guard let sessionID = validateExistingSession(
+        guard let sessionID = validateDeletableSession(
             on: context.channel,
             head: head,
             requestLog: requestLog
@@ -654,6 +654,69 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
                 requestLog: requestLog
             )
             return nil
+        }
+        guard let protocolVersion = HTTPRequestValidator.protocolVersion(from: head.headers),
+            protocolVersion.isEmpty == false
+        else {
+            _ = sendPlain(
+                on: channel,
+                status: .badRequest,
+                body: "protocol version required",
+                keepAlive: head.isKeepAlive,
+                sessionID: sessionID,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        guard MCPProtocolVersion.isSupported(protocolVersion),
+            protocolVersion == expectedProtocolVersion
+        else {
+            _ = sendPlain(
+                on: channel,
+                status: .badRequest,
+                body: "protocol version mismatch",
+                keepAlive: head.isKeepAlive,
+                sessionID: sessionID,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        return sessionID
+    }
+
+    private func validateDeletableSession(
+        on channel: Channel,
+        head: HTTPRequestHead,
+        requestLog: RequestLogContext
+    ) -> String? {
+        guard let sessionID = HTTPRequestValidator.sessionID(from: head.headers),
+            sessionID.isEmpty == false
+        else {
+            _ = sendPlain(
+                on: channel,
+                status: .badRequest,
+                body: "session id required",
+                keepAlive: head.isKeepAlive,
+                sessionID: nil,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        guard controlService.hasSession(id: sessionID) else {
+            _ = sendPlain(
+                on: channel,
+                status: .notFound,
+                body: "session not found",
+                keepAlive: head.isKeepAlive,
+                sessionID: sessionID,
+                requestLog: requestLog
+            )
+            return nil
+        }
+        guard let expectedProtocolVersion = controlService.negotiatedProtocolVersion(id: sessionID),
+            expectedProtocolVersion.isEmpty == false
+        else {
+            return sessionID
         }
         guard let protocolVersion = HTTPRequestValidator.protocolVersion(from: head.headers),
             protocolVersion.isEmpty == false

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -360,10 +360,28 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         if host == "localhost" || host == "::1" || host == "0:0:0:0:0:0:0:1" {
             return true
         }
-        if host == "127.0.0.1" || host.hasPrefix("127.") {
+        if isIPv4LoopbackHost(host) {
             return true
         }
         return false
+    }
+
+    private static func isIPv4LoopbackHost(_ host: String) -> Bool {
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return false }
+
+        var octets: [Int] = []
+        for part in parts {
+            guard part.isEmpty == false,
+                part.allSatisfy({ $0.isNumber }),
+                let value = Int(part),
+                (0...255).contains(value)
+            else {
+                return false
+            }
+            octets.append(value)
+        }
+        return octets.first == 127
     }
 
     private static func port(fromHostHeader hostHeader: String?) -> Int? {

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPRequestValidator.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPRequestValidator.swift
@@ -19,12 +19,14 @@ enum HTTPRequestValidator {
     }
 
     static func acceptsEventStream(_ headers: HTTPHeaders) -> Bool {
-        guard let accept = headers.first(name: "Accept")?.lowercased() else { return false }
+        let accept = combinedHeaderValue(name: "Accept", from: headers).lowercased()
+        guard accept.isEmpty == false else { return false }
         return accept.contains("text/event-stream")
     }
 
     static func acceptsJSON(_ headers: HTTPHeaders) -> Bool {
-        guard let accept = headers.first(name: "Accept")?.lowercased() else { return false }
+        let accept = combinedHeaderValue(name: "Accept", from: headers).lowercased()
+        guard accept.isEmpty == false else { return false }
         return accept.contains("application/json") || accept.contains("*/*")
     }
 
@@ -46,5 +48,14 @@ enum HTTPRequestValidator {
         }
         // The gateway currently chooses JSON responses for single POST replies.
         return false
+    }
+
+    private static func combinedHeaderValue(name: String, from headers: HTTPHeaders) -> String {
+        headers
+            .filter { header in
+                header.name.compare(name, options: .caseInsensitive) == .orderedSame
+            }
+            .map(\.value)
+            .joined(separator: ",")
     }
 }

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPRequestValidator.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPRequestValidator.swift
@@ -7,8 +7,15 @@ enum HTTPRequestValidationFailure: Error {
 }
 
 enum HTTPRequestValidator {
+    static let sessionHeader = "MCP-Session-Id"
+    static let protocolVersionHeader = "MCP-Protocol-Version"
+
     static func sessionID(from headers: HTTPHeaders) -> String? {
-        headers.first(name: "Mcp-Session-Id")
+        headers.first(name: sessionHeader)
+    }
+
+    static func protocolVersion(from headers: HTTPHeaders) -> String? {
+        headers.first(name: protocolVersionHeader)
     }
 
     static func acceptsEventStream(_ headers: HTTPHeaders) -> Bool {
@@ -17,7 +24,7 @@ enum HTTPRequestValidator {
     }
 
     static func acceptsJSON(_ headers: HTTPHeaders) -> Bool {
-        guard let accept = headers.first(name: "Accept")?.lowercased() else { return true }
+        guard let accept = headers.first(name: "Accept")?.lowercased() else { return false }
         return accept.contains("application/json") || accept.contains("*/*")
     }
 
@@ -31,13 +38,13 @@ enum HTTPRequestValidator {
     ) throws -> Bool {
         let wantsEventStream = acceptsEventStream(headers)
         let wantsJSON = acceptsJSON(headers)
-        guard wantsEventStream || wantsJSON else {
+        guard wantsEventStream && wantsJSON else {
             throw HTTPRequestValidationFailure.notAcceptable
         }
         guard contentTypeIsJSON(headers) else {
             throw HTTPRequestValidationFailure.unsupportedMediaType
         }
-        // Prefer JSON when both are acceptable.
-        return wantsEventStream && !wantsJSON
+        // The gateway currently chooses JSON responses for single POST replies.
+        return false
     }
 }

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPResponseWriter.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPResponseWriter.swift
@@ -16,7 +16,7 @@ package struct HTTPResponseWriter: Sendable {
         on channel: Channel,
         data: Data,
         keepAlive: Bool,
-        sessionID: String,
+        sessionID: String?,
         requestLog: HTTPHandler.RequestLogContext
     ) -> EventLoopFuture<Void> {
         guard SSECodec.encodeDataEvent(data) != nil else {
@@ -42,7 +42,7 @@ package struct HTTPResponseWriter: Sendable {
         on channel: Channel,
         buffer: ByteBuffer,
         keepAlive: Bool,
-        sessionID: String,
+        sessionID: String?,
         requestLog: HTTPHandler.RequestLogContext
     ) -> EventLoopFuture<Void> {
         logResponse(requestLog, status: .ok, sessionID: sessionID)
@@ -114,7 +114,7 @@ package struct HTTPResponseWriter: Sendable {
         forceBatchArray: Bool = false,
         prefersEventStream: Bool,
         keepAlive: Bool,
-        sessionID: String,
+        sessionID: String?,
         requestLog: HTTPHandler.RequestLogContext
     ) -> EventLoopFuture<Void> {
         guard let data = MCPErrorResponder.errorResponseData(
@@ -150,7 +150,7 @@ package struct HTTPResponseWriter: Sendable {
         forceBatchArray: Bool = false,
         prefersEventStream: Bool,
         keepAlive: Bool,
-        sessionID: String,
+        sessionID: String?,
         requestLog: HTTPHandler.RequestLogContext
     ) -> EventLoopFuture<Void> {
         guard let data = MCPErrorResponder.errorResponseData(
@@ -228,7 +228,7 @@ package struct HTTPResponseWriter: Sendable {
         data: Data,
         prefersEventStream: Bool,
         keepAlive: Bool,
-        sessionID: String,
+        sessionID: String?,
         requestLog: HTTPHandler.RequestLogContext
     ) -> EventLoopFuture<Void> {
         if prefersEventStream {

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -49,8 +49,7 @@ package struct LocalMCPResponder {
         sessionID: String,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> Data {
-        guard let originalIDValue = object["id"],
-              let originalID = RPCID(any: originalIDValue) else {
+        guard let originalID = JSONRPCMessageInspector.requestID(from: object) else {
             throw ControlPlaneError.invalidResponse("missing id")
         }
         let result = try await sessionManager.sharedToolsList(
@@ -76,12 +75,12 @@ package struct LocalMCPResponder {
         eventLoop: EventLoop,
         requestTimeoutOverride: TimeAmount? = nil
     ) -> LocalPostHandling? {
-        guard let method = object["method"] as? String else {
+        guard let method = JSONRPCMessageInspector.method(from: object) else {
             return nil
         }
 
         if method == "initialize" {
-            guard let originalIDValue = object["id"], let originalID = RPCID(any: originalIDValue) else {
+            guard let originalID = JSONRPCMessageInspector.requestID(from: object) else {
                 return .mcpError(
                     id: nil,
                     code: -32600,
@@ -106,7 +105,7 @@ package struct LocalMCPResponder {
         }
 
         if (method == "resources/list" || method == "resources/templates/list") && sessionManager.isInitialized() == false {
-            guard let originalIDValue = object["id"], let originalID = RPCID(any: originalIDValue) else {
+            guard let originalID = JSONRPCMessageInspector.requestID(from: object) else {
                 return .mcpError(
                     id: nil,
                     code: -32600,
@@ -139,8 +138,7 @@ package struct LocalMCPResponder {
         if method == "tools/list",
             let headerSessionID,
             sessionManager.isInitialized(),
-            let originalIDValue = object["id"],
-            let originalID = RPCID(any: originalIDValue)
+            let originalID = JSONRPCMessageInspector.requestID(from: object)
         {
             if headerSessionExists == false {
                 _ = sessionManager.session(id: headerSessionID)
@@ -218,8 +216,7 @@ package struct LocalMCPResponder {
         if method == "tools/call",
             let headerSessionID,
             sessionManager.isInitialized(),
-            let originalIDValue = object["id"],
-            let originalID = RPCID(any: originalIDValue),
+            let originalID = JSONRPCMessageInspector.requestID(from: object),
             let params = object["params"] as? [String: Any],
             let toolName = params["name"] as? String,
             toolName == "XcodeListWindows",

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -11,6 +11,7 @@ package enum LocalPostHandling {
     case pendingResponse(
         future: EventLoopFuture<ByteBuffer>,
         sessionID: String,
+        errorSessionID: String?,
         originalID: RPCID
     )
     case immediateResponse(data: Data, sessionID: String)
@@ -99,6 +100,7 @@ package struct LocalMCPResponder {
             return .pendingResponse(
                 future: future,
                 sessionID: sessionID,
+                errorSessionID: nil,
                 originalID: originalID
             )
         }
@@ -208,6 +210,7 @@ package struct LocalMCPResponder {
             return .pendingResponse(
                 future: promise.futureResult,
                 sessionID: headerSessionID,
+                errorSessionID: headerSessionID,
                 originalID: originalID
             )
         }
@@ -280,6 +283,7 @@ package struct LocalMCPResponder {
             return .pendingResponse(
                 future: promise.futureResult,
                 sessionID: headerSessionID,
+                errorSessionID: headerSessionID,
                 originalID: originalID
             )
         }

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -14,7 +14,7 @@ package enum LocalPostHandling {
         originalID: RPCID
     )
     case immediateResponse(data: Data, sessionID: String)
-    case mcpError(id: RPCID?, code: Int, message: String, sessionID: String)
+    case mcpError(id: RPCID?, code: Int, message: String, sessionID: String?)
 }
 
 package struct LocalMCPResponder {
@@ -85,7 +85,7 @@ package struct LocalMCPResponder {
                     id: nil,
                     code: -32600,
                     message: "missing id",
-                    sessionID: headerSessionID ?? UUID().uuidString
+                    sessionID: headerSessionID
                 )
             }
             let sessionID = headerSessionID ?? UUID().uuidString

--- a/Sources/ProxyHTTPGateway/MCP/MCPErrorResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/MCPErrorResponder.swift
@@ -67,26 +67,8 @@ enum MCPErrorResponder {
     }
 
     static func requestMetadata(fromParsed json: Any?) -> (ids: [RPCID], isBatch: Bool) {
-        guard let json else {
-            return ([], false)
-        }
-        if let object = json as? [String: Any] {
-            if let id = object["id"], let rpcID = RPCID(any: id) {
-                return ([rpcID], false)
-            }
-            return ([], false)
-        }
-        if let array = json as? [Any] {
-            let ids: [RPCID] = array.compactMap { item -> RPCID? in
-                guard let object = item as? [String: Any],
-                      let id = object["id"] else {
-                    return nil
-                }
-                return RPCID(any: id)
-            }
-            return (ids, true)
-        }
-        return ([], false)
+        let metadata = JSONRPCMessageInspector.requestMetadata(fromParsed: json)
+        return (metadata.ids, metadata.isBatch)
     }
 
     private static func makeErrorObject(

--- a/Sources/ProxyHTTPGateway/MCP/MCPResponseEmitter.swift
+++ b/Sources/ProxyHTTPGateway/MCP/MCPResponseEmitter.swift
@@ -27,7 +27,7 @@ enum MCPResponseEmitter {
         on channel: Channel,
         data: Data,
         keepAlive: Bool,
-        sessionID: String
+        sessionID: String?
     ) -> EventLoopFuture<Void> {
         guard let payload = SSECodec.encodeDataEvent(data) else {
             return channel.eventLoop.makeFailedFuture(EmitterError.invalidEventStreamPayload)
@@ -36,7 +36,9 @@ enum MCPResponseEmitter {
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "text/event-stream")
         headers.add(name: "Cache-Control", value: "no-cache")
-        headers.add(name: "Mcp-Session-Id", value: sessionID)
+        if let sessionID {
+            headers.add(name: "Mcp-Session-Id", value: sessionID)
+        }
 
         var head = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
         head.headers.add(name: "Connection", value: keepAlive ? "keep-alive" : "close")

--- a/Sources/ProxyHTTPGateway/MCP/ToolCallNormalizer.swift
+++ b/Sources/ProxyHTTPGateway/MCP/ToolCallNormalizer.swift
@@ -138,9 +138,7 @@ package struct ToolCallNormalizer: Sendable {
         if let explicitMethod {
             return explicitMethod
         }
-        guard let responseIDValue = object["id"],
-            let responseID = RPCID(any: responseIDValue)
-        else {
+        guard let responseID = JSONRPCMessageInspector.responseID(from: object) else {
             return nil
         }
         return responseMethodsByIDKey[responseID.key]
@@ -150,9 +148,7 @@ package struct ToolCallNormalizer: Sendable {
         for object: [String: Any],
         responseToolNamesByIDKey: [String: String]
     ) -> String? {
-        guard let responseIDValue = object["id"],
-            let responseID = RPCID(any: responseIDValue)
-        else {
+        guard let responseID = JSONRPCMessageInspector.responseID(from: object) else {
             return nil
         }
         return responseToolNamesByIDKey[responseID.key]

--- a/Sources/ProxyHTTPGateway/MCP/ToolSurface.swift
+++ b/Sources/ProxyHTTPGateway/MCP/ToolSurface.swift
@@ -111,8 +111,7 @@ package struct ToolSurface: Sendable {
                 if let method, let originalID {
                     return (method, originalID)
                 }
-                guard let responseIDValue = object["id"],
-                    let responseID = RPCID(any: responseIDValue),
+                guard let responseID = JSONRPCMessageInspector.responseID(from: object),
                     let method = responseMethodsByIDKey[responseID.key],
                     let originalID = responseOriginalIDsByKey[responseID.key]
                 else {
@@ -144,8 +143,7 @@ package struct ToolSurface: Sendable {
         var rewroteAny = false
         let rewrittenArray = array.map { item -> Any in
             guard let object = item as? [String: Any],
-                let responseIDValue = object["id"],
-                let responseID = RPCID(any: responseIDValue),
+                let responseID = JSONRPCMessageInspector.responseID(from: object),
                 let method = responseMethodsByIDKey[responseID.key],
                 let originalID = responseOriginalIDsByKey[responseID.key]
             else {
@@ -281,8 +279,7 @@ package struct ToolSurface: Sendable {
             return nil
         }
         if let object = payload as? [String: Any] {
-            guard let responseIDValue = object["id"],
-                let responseID = RPCID(any: responseIDValue),
+            guard let responseID = JSONRPCMessageInspector.responseID(from: object),
                 responseID.key == responseIDKey
             else {
                 return nil
@@ -294,8 +291,7 @@ package struct ToolSurface: Sendable {
         }
         for item in array {
             guard let object = item as? [String: Any],
-                let responseIDValue = object["id"],
-                let responseID = RPCID(any: responseIDValue),
+                let responseID = JSONRPCMessageInspector.responseID(from: object),
                 responseID.key == responseIDKey
             else {
                 continue

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -18,7 +18,7 @@ extension HTTPPostService {
         forceBatchArray: Bool
     ) -> EventLoopFuture<HTTPPostResolution> {
         switch handling {
-        case .pendingResponse(let future, let sessionID, let originalID):
+        case .pendingResponse(let future, let sessionID, let errorSessionID, let originalID):
             return future.map { buffer in
                 var buffer = buffer
                 guard let data = buffer.readData(length: buffer.readableBytes) else {
@@ -31,9 +31,12 @@ extension HTTPPostService {
                 let responseData = forceBatchArray
                     ? Self.forceBatchArrayResponseDataIfNeeded(data)
                     : data
+                let responseSessionID = Self.isJSONRPCErrorResponse(data)
+                    ? errorSessionID
+                    : sessionID
                 return .responseData(
                     data: responseData,
-                    sessionID: sessionID,
+                    sessionID: responseSessionID,
                     prefersEventStream: prefersEventStream
                 )
             }.flatMapError { _ in
@@ -44,7 +47,7 @@ extension HTTPPostService {
                         code: -32000,
                         message: "upstream timeout",
                         forceBatchArray: forceBatchArray,
-                        sessionID: sessionID,
+                        sessionID: errorSessionID,
                         prefersEventStream: prefersEventStream
                     )
                 )
@@ -102,6 +105,17 @@ extension HTTPPostService {
             return data
         }
         return (try? JSONSerialization.data(withJSONObject: [payload], options: [])) ?? data
+    }
+
+    private static func isJSONRPCErrorResponse(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [])
+                as? [String: Any],
+            object["method"] == nil,
+            object["error"] != nil
+        else {
+            return false
+        }
+        return object["id"] != nil
     }
 
     package struct ToolCallRouting {

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -110,12 +110,11 @@ extension HTTPPostService {
     private static func isJSONRPCErrorResponse(_ data: Data) -> Bool {
         guard let object = try? JSONSerialization.jsonObject(with: data, options: [])
                 as? [String: Any],
-            object["method"] == nil,
             object["error"] != nil
         else {
             return false
         }
-        return object["id"] != nil
+        return JSONRPCMessageInspector.responseID(from: object) != nil
     }
 
     package struct ToolCallRouting {
@@ -370,8 +369,7 @@ extension HTTPPostService {
             guard !Task.isCancelled else {
                 break
             }
-            guard let idValue = request["id"],
-                  let originalID = RPCID(any: idValue) else {
+            guard let originalID = JSONRPCMessageInspector.requestID(from: request) else {
                 continue
             }
             let requestTimeout = Self.remainingRequestTimeout(until: deadline)
@@ -438,8 +436,7 @@ extension HTTPPostService {
             guard !Task.isCancelled else {
                 break
             }
-            guard let idValue = request["id"],
-                  let originalID = RPCID(any: idValue) else {
+            guard let originalID = JSONRPCMessageInspector.requestID(from: request) else {
                 continue
             }
             guard JSONSerialization.isValidJSONObject(request),
@@ -514,19 +511,18 @@ extension HTTPPostService {
         guard sessionManager.hasDocumentationProvider() else {
             return false
         }
-        guard object["method"] as? String == "tools/call",
-              object["id"] != nil,
-              let params = object["params"] as? [String: Any],
-              params["name"] as? String == DocumentationToolCatalog.toolName,
-              disabledToolNames.contains(DocumentationToolCatalog.toolName) == false else {
+        guard case .request("tools/call", _) = JSONRPCMessageInspector.kind(of: object),
+            let params = object["params"] as? [String: Any],
+            params["name"] as? String == DocumentationToolCatalog.toolName,
+            disabledToolNames.contains(DocumentationToolCatalog.toolName) == false else {
             return false
         }
         return true
     }
 
     private func isToolsListRequest(_ object: [String: Any]) -> Bool {
-        object["method"] as? String == "tools/list"
-            && object["id"] != nil
+        JSONRPCMessageInspector.requestID(from: object) != nil
+            && JSONRPCMessageInspector.method(from: object) == "tools/list"
             && sessionManager.isInitialized()
     }
 

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
@@ -144,9 +144,10 @@ extension HTTPPostService {
 
     package static func requestRequiresInitialize(_ parsedRequestJSON: Any) -> Bool {
         if let object = parsedRequestJSON as? [String: Any] {
-            let method = object["method"] as? String
-            let expectsResponse = object["id"] != nil
-            return method != "initialize" || !expectsResponse
+            if case .request("initialize", _) = JSONRPCMessageInspector.kind(of: object) {
+                return false
+            }
+            return true
         }
         if parsedRequestJSON is [Any] {
             return true

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
@@ -396,7 +396,7 @@ extension HTTPPostService {
         requestObject: [String: Any],
         toolName: String
     ) -> [[String: Any]] {
-        guard let requestID = requestObject["id"], let rpcID = RPCID(any: requestID) else {
+        guard let rpcID = JSONRPCMessageInspector.requestID(from: requestObject) else {
             return []
         }
         return [makeToolResultErrorResponseObject(id: rpcID, toolName: toolName)]
@@ -496,7 +496,7 @@ extension HTTPPostService {
 
     package static func extractResponseIDs(from requestJSON: Any) -> [RPCID] {
         if let object = requestJSON as? [String: Any] {
-            guard let rawID = object["id"], let rpcID = RPCID(any: rawID) else {
+            guard let rpcID = JSONRPCMessageInspector.requestID(from: object) else {
                 return []
             }
             return [rpcID]
@@ -506,12 +506,10 @@ extension HTTPPostService {
             return []
         }
         return array.compactMap { item in
-            guard let object = item as? [String: Any],
-                let rawID = object["id"]
-            else {
+            guard let object = item as? [String: Any] else {
                 return nil
             }
-            return RPCID(any: rawID)
+            return JSONRPCMessageInspector.requestID(from: object)
         }
     }
 }

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -140,7 +140,7 @@ package final class HTTPPostService: Sendable {
             let responseID = JSONRPCMessageInspector.responseID(from: responseObject)
         {
             return makeClientResponseForwardingOperation(
-                bodyData: bodyData,
+                responseObject: responseObject,
                 sessionID: sessionID,
                 responseID: responseID,
                 eventLoop: eventLoop
@@ -513,16 +513,31 @@ package final class HTTPPostService: Sendable {
     }
 
     private func makeClientResponseForwardingOperation(
-        bodyData: Data,
+        responseObject: [String: Any],
         sessionID: String,
         responseID: RPCID,
         eventLoop: EventLoop
     ) -> HTTPPostOperation {
         let session = sessionManager.session(id: sessionID)
-        if let upstreamIndex = session.serverRequestTracker.consume(idKey: responseID.key) {
+        if let route = session.serverRequestTracker.consume(clientID: responseID) {
+            guard let upstreamData = Self.rewriteClientResponse(
+                responseObject,
+                id: route.upstreamID
+            ) else {
+                return HTTPPostOperation(
+                    future: eventLoop.makeSucceededFuture(
+                        .plain(
+                            status: .badRequest,
+                            body: "invalid json-rpc response",
+                            sessionID: sessionID
+                        )
+                    ),
+                    cancellationHandle: nil
+                )
+            }
             sessionManager.sendUpstream(
-                bodyData,
-                upstreamIndex: upstreamIndex,
+                upstreamData,
+                upstreamIndex: route.upstreamIndex,
                 ensureRunning: false
             )
         } else {
@@ -540,5 +555,17 @@ package final class HTTPPostService: Sendable {
             ),
             cancellationHandle: nil
         )
+    }
+
+    private static func rewriteClientResponse(
+        _ responseObject: [String: Any],
+        id: RPCID
+    ) -> Data? {
+        var rewritten = responseObject
+        rewritten["id"] = id.value.foundationObject
+        guard JSONSerialization.isValidJSONObject(rewritten) else {
+            return nil
+        }
+        return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
     }
 }

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -136,15 +136,33 @@ package final class HTTPPostService: Sendable {
             )
         }
 
-        if let responseObject = parsedRequestJSON as? [String: Any],
-            let responseID = JSONRPCMessageInspector.responseID(from: responseObject)
-        {
-            return makeClientResponseForwardingOperation(
-                responseObject: responseObject,
-                sessionID: sessionID,
-                responseID: responseID,
-                eventLoop: eventLoop
-            )
+        if let requestObject = parsedRequestJSON as? [String: Any] {
+            switch JSONRPCMessageInspector.kind(of: requestObject) {
+            case .malformed(let invalidID):
+                return HTTPPostOperation(
+                    future: eventLoop.makeSucceededFuture(
+                        .mcpError(
+                            id: invalidID,
+                            ids: [],
+                            code: -32600,
+                            message: "invalid request",
+                            forceBatchArray: false,
+                            sessionID: sessionID,
+                            prefersEventStream: prefersEventStream
+                        )
+                    ),
+                    cancellationHandle: nil
+                )
+            case .response(let responseID):
+                return makeClientResponseForwardingOperation(
+                    responseObject: requestObject,
+                    sessionID: sessionID,
+                    responseID: responseID,
+                    eventLoop: eventLoop
+                )
+            case .request, .notification, .other:
+                break
+            }
         }
 
         if sessionManager.isInitialized() == false {

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -110,11 +110,31 @@ package final class HTTPPostService: Sendable {
             )
         }
 
-        if let headerSessionID, !headerSessionExists {
-            _ = sessionManager.session(id: headerSessionID)
+        guard let sessionID = headerSessionID, sessionID.isEmpty == false else {
+            return HTTPPostOperation(
+                future: eventLoop.makeSucceededFuture(
+                    .plain(
+                        status: .badRequest,
+                        body: "session id required",
+                        sessionID: nil
+                    )
+                ),
+                cancellationHandle: nil
+            )
         }
 
-        let sessionID = headerSessionID ?? UUID().uuidString
+        guard headerSessionExists else {
+            return HTTPPostOperation(
+                future: eventLoop.makeSucceededFuture(
+                    .plain(
+                        status: .notFound,
+                        body: "session not found",
+                        sessionID: sessionID
+                    )
+                ),
+                cancellationHandle: nil
+            )
+        }
 
         if sessionManager.isInitialized() == false {
             return HTTPPostOperation(

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -136,6 +136,17 @@ package final class HTTPPostService: Sendable {
             )
         }
 
+        if let responseObject = parsedRequestJSON as? [String: Any],
+            let responseID = JSONRPCMessageInspector.responseID(from: responseObject)
+        {
+            return makeClientResponseForwardingOperation(
+                bodyData: bodyData,
+                sessionID: sessionID,
+                responseID: responseID,
+                eventLoop: eventLoop
+            )
+        }
+
         if sessionManager.isInitialized() == false {
             return HTTPPostOperation(
                 future: eventLoop.makeSucceededFuture(
@@ -498,6 +509,36 @@ package final class HTTPPostService: Sendable {
         return HTTPPostOperation(
             future: future,
             cancellationHandle: cancellationHandle
+        )
+    }
+
+    private func makeClientResponseForwardingOperation(
+        bodyData: Data,
+        sessionID: String,
+        responseID: RPCID,
+        eventLoop: EventLoop
+    ) -> HTTPPostOperation {
+        let session = sessionManager.session(id: sessionID)
+        if let upstreamIndex = session.serverRequestTracker.consume(idKey: responseID.key) {
+            sessionManager.sendUpstream(
+                bodyData,
+                upstreamIndex: upstreamIndex,
+                ensureRunning: false
+            )
+        } else {
+            logger.debug(
+                "Acknowledging client JSON-RPC response without a routed upstream request",
+                metadata: [
+                    "session": .string(sessionID),
+                    "id": .string(responseID.key),
+                ]
+            )
+        }
+        return HTTPPostOperation(
+            future: eventLoop.makeSucceededFuture(
+                .empty(status: .accepted, sessionID: sessionID)
+            ),
+            cancellationHandle: nil
         )
     }
 }

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -536,54 +536,46 @@ package final class HTTPPostService: Sendable {
         responseID: RPCID,
         eventLoop: EventLoop
     ) -> HTTPPostOperation {
-        let session = sessionManager.session(id: sessionID)
-        if let route = session.serverRequestTracker.consume(clientID: responseID) {
-            guard let upstreamData = Self.rewriteClientResponse(
-                responseObject,
-                id: route.upstreamID
-            ) else {
-                return HTTPPostOperation(
-                    future: eventLoop.makeSucceededFuture(
-                        .plain(
-                            status: .badRequest,
-                            body: "invalid json-rpc response",
-                            sessionID: sessionID
-                        )
-                    ),
-                    cancellationHandle: nil
+        guard JSONSerialization.isValidJSONObject(responseObject),
+            let responseData = try? JSONSerialization.data(withJSONObject: responseObject, options: [])
+        else {
+            return HTTPPostOperation(
+                future: eventLoop.makeSucceededFuture(
+                    .plain(
+                        status: .badRequest,
+                        body: "invalid json-rpc response",
+                        sessionID: sessionID
+                    )
+                ),
+                cancellationHandle: nil
+            )
+        }
+        let future = sessionManager.forwardServerRequestResponse(
+            responseData: responseData,
+            sessionID: sessionID,
+            responseID: responseID,
+            on: eventLoop
+        ).map { forwardingResult -> HTTPPostResolution in
+            switch forwardingResult {
+            case .accepted, .missingRoute:
+                return .empty(status: .accepted, sessionID: sessionID)
+            case .invalidResponse:
+                return .plain(
+                    status: .badRequest,
+                    body: "invalid json-rpc response",
+                    sessionID: sessionID
+                )
+            case .upstreamUnavailable:
+                return .plain(
+                    status: .serviceUnavailable,
+                    body: "upstream unavailable",
+                    sessionID: sessionID
                 )
             }
-            sessionManager.sendUpstream(
-                upstreamData,
-                upstreamIndex: route.upstreamIndex,
-                ensureRunning: false
-            )
-        } else {
-            logger.debug(
-                "Acknowledging client JSON-RPC response without a routed upstream request",
-                metadata: [
-                    "session": .string(sessionID),
-                    "id": .string(responseID.key),
-                ]
-            )
         }
         return HTTPPostOperation(
-            future: eventLoop.makeSucceededFuture(
-                .empty(status: .accepted, sessionID: sessionID)
-            ),
+            future: future,
             cancellationHandle: nil
         )
-    }
-
-    private static func rewriteClientResponse(
-        _ responseObject: [String: Any],
-        id: RPCID
-    ) -> Data? {
-        var rewritten = responseObject
-        rewritten["id"] = id.value.foundationObject
-        guard JSONSerialization.isValidJSONObject(rewritten) else {
-            return nil
-        }
-        return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
     }
 }

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
@@ -13,7 +13,7 @@ import ProxySession
 package enum HTTPPostResolution {
     case responseData(
         data: Data,
-        sessionID: String,
+        sessionID: String?,
         prefersEventStream: Bool
     )
     case mcpError(

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
@@ -22,7 +22,7 @@ package enum HTTPPostResolution {
         code: Int,
         message: String,
         forceBatchArray: Bool,
-        sessionID: String,
+        sessionID: String?,
         prefersEventStream: Bool
     )
     case plain(

--- a/Sources/ProxyMCP/JSONRPCMessageInspector.swift
+++ b/Sources/ProxyMCP/JSONRPCMessageInspector.swift
@@ -4,7 +4,32 @@ package enum JSONRPCMessageKind: Sendable {
     case request(method: String, id: RPCID)
     case notification(method: String)
     case response(id: RPCID)
-    case invalidOrOther
+    case malformed(id: RPCID?)
+    case other
+
+    package var requestID: RPCID? {
+        guard case .request(_, let id) = self else { return nil }
+        return id
+    }
+
+    package var responseID: RPCID? {
+        guard case .response(let id) = self else { return nil }
+        return id
+    }
+
+    package var malformedID: RPCID? {
+        guard case .malformed(let id) = self else { return nil }
+        return id
+    }
+
+    package var isServerInitiated: Bool {
+        switch self {
+        case .request, .notification:
+            return true
+        case .response, .malformed, .other:
+            return false
+        }
+    }
 }
 
 package struct JSONRPCRequestMetadata: Sendable {
@@ -14,21 +39,29 @@ package struct JSONRPCRequestMetadata: Sendable {
 
 package enum JSONRPCMessageInspector {
     package static func kind(of object: [String: Any]) -> JSONRPCMessageKind {
-        if let method = object["method"] as? String {
-            guard let idValue = object["id"],
-                let id = RPCID(any: idValue)
-            else {
+        let rawID = object["id"]
+        let parsedID = rawID.flatMap { RPCID(any: $0) }
+
+        if let methodValue = object["method"] {
+            guard let method = methodValue as? String else {
+                return .malformed(id: parsedID)
+            }
+            guard rawID != nil else {
                 return .notification(method: method)
             }
-            return .request(method: method, id: id)
+            guard let parsedID else {
+                return .notification(method: method)
+            }
+            return .request(method: method, id: parsedID)
         }
 
-        guard object["method"] == nil,
-            let idValue = object["id"],
-            let id = RPCID(any: idValue),
+        guard let id = parsedID,
             object["result"] != nil || object["error"] != nil
         else {
-            return .invalidOrOther
+            if rawID != nil {
+                return .malformed(id: parsedID)
+            }
+            return .other
         }
         return .response(id: id)
     }
@@ -37,23 +70,21 @@ package enum JSONRPCMessageInspector {
         switch kind(of: object) {
         case .request(let method, _), .notification(let method):
             return method
-        case .response, .invalidOrOther:
+        case .response, .malformed, .other:
             return nil
         }
     }
 
     package static func requestID(from object: [String: Any]) -> RPCID? {
-        guard case .request(_, let id) = kind(of: object) else {
-            return nil
-        }
-        return id
+        kind(of: object).requestID
     }
 
     package static func responseID(from object: [String: Any]) -> RPCID? {
-        guard case .response(let id) = kind(of: object) else {
-            return nil
-        }
-        return id
+        kind(of: object).responseID
+    }
+
+    package static func invalidMessageID(from object: [String: Any]) -> RPCID? {
+        kind(of: object).malformedID
     }
 
     package static func isResponse(_ object: [String: Any]) -> Bool {

--- a/Sources/ProxyMCP/JSONRPCMessageInspector.swift
+++ b/Sources/ProxyMCP/JSONRPCMessageInspector.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+package enum JSONRPCMessageKind: Sendable {
+    case request(method: String, id: RPCID)
+    case notification(method: String)
+    case response(id: RPCID)
+    case invalidOrOther
+}
+
+package struct JSONRPCRequestMetadata: Sendable {
+    package let ids: [RPCID]
+    package let isBatch: Bool
+}
+
+package enum JSONRPCMessageInspector {
+    package static func kind(of object: [String: Any]) -> JSONRPCMessageKind {
+        if let method = object["method"] as? String {
+            guard let idValue = object["id"],
+                let id = RPCID(any: idValue)
+            else {
+                return .notification(method: method)
+            }
+            return .request(method: method, id: id)
+        }
+
+        guard object["method"] == nil,
+            let idValue = object["id"],
+            let id = RPCID(any: idValue),
+            object["result"] != nil || object["error"] != nil
+        else {
+            return .invalidOrOther
+        }
+        return .response(id: id)
+    }
+
+    package static func method(from object: [String: Any]) -> String? {
+        switch kind(of: object) {
+        case .request(let method, _), .notification(let method):
+            return method
+        case .response, .invalidOrOther:
+            return nil
+        }
+    }
+
+    package static func requestID(from object: [String: Any]) -> RPCID? {
+        guard case .request(_, let id) = kind(of: object) else {
+            return nil
+        }
+        return id
+    }
+
+    package static func responseID(from object: [String: Any]) -> RPCID? {
+        guard case .response(let id) = kind(of: object) else {
+            return nil
+        }
+        return id
+    }
+
+    package static func isResponse(_ object: [String: Any]) -> Bool {
+        responseID(from: object) != nil
+    }
+
+    package static func requestMetadata(fromParsed json: Any?) -> JSONRPCRequestMetadata {
+        guard let json else {
+            return JSONRPCRequestMetadata(ids: [], isBatch: false)
+        }
+        if let object = json as? [String: Any] {
+            return JSONRPCRequestMetadata(
+                ids: requestID(from: object).map { [$0] } ?? [],
+                isBatch: false
+            )
+        }
+        if let array = json as? [Any] {
+            let ids = array.compactMap { item -> RPCID? in
+                guard let object = item as? [String: Any] else {
+                    return nil
+                }
+                return requestID(from: object)
+            }
+            return JSONRPCRequestMetadata(ids: ids, isBatch: true)
+        }
+        return JSONRPCRequestMetadata(ids: [], isBatch: false)
+    }
+}

--- a/Sources/ProxyMCP/JSONRPCMessageInspector.swift
+++ b/Sources/ProxyMCP/JSONRPCMessageInspector.swift
@@ -22,6 +22,17 @@ package enum JSONRPCMessageKind: Sendable {
         return id
     }
 
+    package var responseCorrelationID: RPCID? {
+        switch self {
+        case .response(let id):
+            return id
+        case .malformed(let id):
+            return id
+        case .request, .notification, .other:
+            return nil
+        }
+    }
+
     package var isServerInitiated: Bool {
         switch self {
         case .request, .notification:
@@ -81,6 +92,10 @@ package enum JSONRPCMessageInspector {
 
     package static func responseID(from object: [String: Any]) -> RPCID? {
         kind(of: object).responseID
+    }
+
+    package static func responseCorrelationID(from object: [String: Any]) -> RPCID? {
+        kind(of: object).responseCorrelationID
     }
 
     package static func invalidMessageID(from object: [String: Any]) -> RPCID? {

--- a/Sources/ProxyMCP/RequestInspector.swift
+++ b/Sources/ProxyMCP/RequestInspector.swift
@@ -26,12 +26,16 @@ package enum RequestInspector {
     ) throws -> RequestTransform {
         let json = try parsedJSON ?? JSONSerialization.jsonObject(with: data, options: [])
         if var object = json as? [String: Any] {
-            let method = object["method"] as? String
+            let kind = JSONRPCMessageInspector.kind(of: object)
+            let method = JSONRPCMessageInspector.method(from: object)
             let toolName = toolName(from: object, method: method)
             // We intentionally treat tools/list as stable and cache it regardless of params.
             // Some clients attach pagination-like params even when they expect the full list.
-            let isCacheableToolsListRequest = (method == "tools/list")
-            if let id = object["id"], let rpcID = RPCID(any: id) {
+            let isCacheableToolsListRequest: Bool = {
+                guard case .request(let method, _) = kind else { return false }
+                return method == "tools/list"
+            }()
+            if case .request(let method, let rpcID) = kind {
                 let upstreamID = mapID(sessionID, rpcID)
                 object["id"] = upstreamID
                 let upstream = try JSONSerialization.data(withJSONObject: object, options: [])
@@ -41,7 +45,7 @@ package enum RequestInspector {
                     isBatch: false,
                     idKey: rpcID.key,
                     responseIDs: [rpcID],
-                    responseMethodsByIDKey: method.map { [rpcID.key: $0] } ?? [:],
+                    responseMethodsByIDKey: [rpcID.key: method],
                     responseToolNamesByIDKey: toolName.map { [rpcID.key: $0] } ?? [:],
                     responseOriginalIDsByKey: [rpcID.key: rpcID],
                     method: method,
@@ -80,16 +84,16 @@ package enum RequestInspector {
             responseIDs.reserveCapacity(array.count)
             for item in array {
                 if var object = item as? [String: Any] {
-                    if let id = object["id"], let rpcID = RPCID(any: id) {
+                    if case .request(let method, let rpcID) =
+                        JSONRPCMessageInspector.kind(of: object)
+                    {
                         let upstreamID = mapID(sessionID, rpcID)
                         object["id"] = upstreamID
                         responseIDs.append(rpcID)
                         responseOriginalIDsByKey[rpcID.key] = rpcID
-                        if let method = object["method"] as? String {
-                            responseMethodsByIDKey[rpcID.key] = method
-                            if let toolName = toolName(from: object, method: method) {
-                                responseToolNamesByIDKey[rpcID.key] = toolName
-                            }
+                        responseMethodsByIDKey[rpcID.key] = method
+                        if let toolName = toolName(from: object, method: method) {
+                            responseToolNamesByIDKey[rpcID.key] = toolName
                         }
                     }
                     transformed.append(object)
@@ -100,9 +104,8 @@ package enum RequestInspector {
             let normalizationToolsListResponseIDKey: String? = {
                 for item in array {
                     guard let object = item as? [String: Any],
-                        object["method"] as? String == "tools/list",
-                        let id = object["id"],
-                        let rpcID = RPCID(any: id)
+                        case .request("tools/list", let rpcID) =
+                            JSONRPCMessageInspector.kind(of: object)
                     else {
                         continue
                     }
@@ -116,15 +119,14 @@ package enum RequestInspector {
                 }
                 for item in array {
                     guard let object = item as? [String: Any],
-                        let id = object["id"],
-                        let rpcID = RPCID(any: id)
+                        case .request(let method, _) =
+                            JSONRPCMessageInspector.kind(of: object)
                     else {
                         continue
                     }
-                    guard object["method"] as? String == "tools/list" else {
+                    guard method == "tools/list" else {
                         return nil
                     }
-                    _ = rpcID
                 }
                 return normalizationToolsListResponseIDKey
             }()

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -281,8 +281,7 @@ package actor DocumentationProviderConnection {
     package func call(_ requestData: Data, timeout: TimeAmount?) async throws -> Data {
         guard var object = try JSONSerialization.jsonObject(with: requestData, options: [])
             as? [String: Any],
-            let originalIDValue = object["id"],
-            let originalID = RPCID(any: originalIDValue) else {
+            let originalID = JSONRPCMessageInspector.requestID(from: object) else {
             throw ControlPlaneError.invalidResponse("missing DocumentationSearch request id")
         }
 
@@ -349,8 +348,7 @@ package actor DocumentationProviderConnection {
 
     private func handleMessage(_ data: Data) {
         guard var object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-              let responseIDValue = object["id"],
-              let responseID = RPCID(any: responseIDValue),
+              let responseID = JSONRPCMessageInspector.responseID(from: object),
               let pending = pendingResponses.removeValue(forKey: responseID.key) else {
             return
         }

--- a/Sources/ProxySession/Runtime/InitializeHandshakeJSON.swift
+++ b/Sources/ProxySession/Runtime/InitializeHandshakeJSON.swift
@@ -20,7 +20,7 @@ package enum InitializeHandshakeJSON {
 
     package static func defaultParams() -> [String: JSONValue] {
         [
-            "protocolVersion": .string("2025-03-26"),
+            "protocolVersion": .string(MCPProtocolVersion.current),
             "capabilities": .object([:]),
             "clientInfo": .object([
                 "name": .string(InitializeHandshakeParams.defaultProxyClientName()),

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -147,9 +147,7 @@ extension RuntimeCoordinator {
         let internalSessionID = controlPlaneSessionID(for: purpose, route: route)
         let session = session(id: internalSessionID)
         let router = session.router
-        guard let originalIDValue = requestObject["id"],
-            let originalID = RPCID(any: originalIDValue)
-        else {
+        guard let originalID = JSONRPCMessageInspector.requestID(from: requestObject) else {
             throw ControlPlaneError.invalidResponse("missing request id")
         }
         let requestTemplate = requestObject.reduce(into: [String: JSONValue]()) { partial, entry in

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -140,7 +140,10 @@ extension RuntimeCoordinator {
         result: JSONValue
     ) {
         for item in pending {
-            sessionRegistry.markInitialized(id: item.sessionID)
+            sessionRegistry.markInitialized(
+                id: item.sessionID,
+                negotiatedProtocolVersion: Self.protocolVersion(fromInitializeResult: result)
+            )
             if let buffer = encodeInitializeResponse(
                 originalID: item.originalID,
                 result: result
@@ -170,6 +173,15 @@ extension RuntimeCoordinator {
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
         buffer.writeBytes(data)
         return buffer
+    }
+
+    static func protocolVersion(fromInitializeResult result: JSONValue) -> String? {
+        guard case .object(let object) = result,
+              case .string(let version)? = object["protocolVersion"]
+        else {
+            return nil
+        }
+        return version
     }
 
     func encodeInitializeErrorResponse(originalID: RPCID, errorObject: [String: Any])

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -267,13 +267,7 @@ extension RuntimeCoordinator {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
-            if sessionRegistry.sessionStillMatchesPendingInitialize(
-                sessionID: item.sessionID,
-                sessionGeneration: item.sessionGeneration
-            ) {
-                let context = sessionRegistry.removeSession(id: item.sessionID)
-                context?.notificationHub.closeAll()
-            }
+            removePendingInitializeSessionIfCurrent(item)
             if let buffer = encodeInitializeErrorResponse(
                 originalID: item.originalID, errorObject: errorObject)
             {
@@ -381,6 +375,7 @@ extension RuntimeCoordinator {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
+            removePendingInitializeSessionIfCurrent(item)
             item.eventLoop.execute {
                 item.promise.fail(error)
             }
@@ -390,6 +385,19 @@ extension RuntimeCoordinator {
             startEagerInitializePrimary(applyBackoff: true)
         }
         failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+    }
+
+    private func removePendingInitializeSessionIfCurrent(
+        _ item: InitializeManager.PendingInitialize
+    ) {
+        guard sessionRegistry.sessionStillMatchesPendingInitialize(
+            sessionID: item.sessionID,
+            sessionGeneration: item.sessionGeneration
+        ) else {
+            return
+        }
+        let context = sessionRegistry.removeSession(id: item.sessionID)
+        context?.notificationHub.closeAll()
     }
 
     func markUpstreamInitInFlight(upstreamIndex: Int, upstreamID: Int64) {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -140,10 +140,16 @@ extension RuntimeCoordinator {
         result: JSONValue
     ) {
         for item in pending {
-            sessionRegistry.markInitialized(
-                id: item.sessionID,
-                negotiatedProtocolVersion: Self.protocolVersion(fromInitializeResult: result)
-            )
+            if sessionRegistry.sessionStillMatchesPendingInitialize(
+                sessionID: item.sessionID,
+                sessionGeneration: item.sessionGeneration
+            ) {
+                sessionRegistry.markInitialized(
+                    id: item.sessionID,
+                    negotiatedProtocolVersion: Self.protocolVersion(fromInitializeResult: result),
+                    buffersUnmappedNotificationsUntilClientConnects: true
+                )
+            }
             if let buffer = encodeInitializeResponse(
                 originalID: item.originalID,
                 result: result

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -78,6 +78,13 @@ extension RuntimeCoordinator {
             return
         }
 
+        guard let negotiatedProtocolVersion = Self.supportedProtocolVersion(
+            fromInitializeResult: result
+        ) else {
+            handleUnsupportedInitializeProtocolVersion(result, upstreamIndex: upstreamIndex)
+            return
+        }
+
         if upstreamIndex != 0 {
             if let canonicalInitialize = canonicalBrokerState.initializeResult(),
                 !initializeResultsEquivalent(canonicalInitialize, result)
@@ -117,14 +124,24 @@ extension RuntimeCoordinator {
                 self.warmUpSecondaryUpstreams()
             }
             self.refreshToolsListIfNeeded()
-            self.completePendingInitializes(pending, result: result)
+            self.completePendingInitializes(
+                pending,
+                result: result,
+                negotiatedProtocolVersion: negotiatedProtocolVersion
+            )
         } onRejected: { [weak self] in
             guard let self else { return }
             if upstreamIndex == 0,
                 self.hasUsableInitializedSecondaryUpstreams(),
                 let completion = self.initializeManager.finishPrimaryInitializeUsingCachedResult()
             {
-                self.completePendingInitializes(completion.pending, result: completion.result)
+                self.completePendingInitializes(
+                    completion.pending,
+                    result: completion.result,
+                    negotiatedProtocolVersion: Self.supportedProtocolVersion(
+                        fromInitializeResult: completion.result
+                    )
+                )
                 self.eventLoop.execute { [weak self] in
                     self?.handleInitializedNotificationSendOverload(upstreamIndex: upstreamIndex)
                 }
@@ -137,7 +154,8 @@ extension RuntimeCoordinator {
 
     func completePendingInitializes(
         _ pending: [InitializeManager.PendingInitialize],
-        result: JSONValue
+        result: JSONValue,
+        negotiatedProtocolVersion: String?
     ) {
         for item in pending {
             if sessionRegistry.sessionStillMatchesPendingInitialize(
@@ -146,7 +164,7 @@ extension RuntimeCoordinator {
             ) {
                 sessionRegistry.markInitialized(
                     id: item.sessionID,
-                    negotiatedProtocolVersion: Self.protocolVersion(fromInitializeResult: result),
+                    negotiatedProtocolVersion: negotiatedProtocolVersion,
                     buffersUnmappedNotificationsUntilClientConnects: true
                 )
             }
@@ -190,6 +208,37 @@ extension RuntimeCoordinator {
         return version
     }
 
+    static func supportedProtocolVersion(fromInitializeResult result: JSONValue) -> String? {
+        guard let version = protocolVersion(fromInitializeResult: result),
+            MCPProtocolVersion.isSupported(version)
+        else {
+            return nil
+        }
+        return version
+    }
+
+    func handleUnsupportedInitializeProtocolVersion(_ result: JSONValue, upstreamIndex: Int) {
+        let version = Self.protocolVersion(fromInitializeResult: result)
+        let errorObject: [String: Any] = [
+            "code": -32000,
+            "message": "unsupported upstream protocol version",
+            "data": [
+                "protocolVersion": version as Any? ?? NSNull(),
+                "supportedProtocolVersions": [MCPProtocolVersion.current],
+            ],
+        ]
+        if upstreamIndex == 0 {
+            completeInitPendingWithError(errorObject)
+        } else {
+            noteIncompatibleUpstream(
+                upstreamIndex: upstreamIndex,
+                kind: "initialize",
+                reason: "unsupported protocol version"
+            )
+            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+        }
+    }
+
     func encodeInitializeErrorResponse(originalID: RPCID, errorObject: [String: Any])
         -> ByteBuffer?
     {
@@ -218,6 +267,13 @@ extension RuntimeCoordinator {
         }
         clearUpstreamInitInFlight(upstreamIndex: 0)
         for item in result.pending {
+            if sessionRegistry.sessionStillMatchesPendingInitialize(
+                sessionID: item.sessionID,
+                sessionGeneration: item.sessionGeneration
+            ) {
+                let context = sessionRegistry.removeSession(id: item.sessionID)
+                context?.notificationHub.closeAll()
+            }
             if let buffer = encodeInitializeErrorResponse(
                 originalID: item.originalID, errorObject: errorObject)
             {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -611,6 +611,7 @@ extension RuntimeCoordinator {
 
         var routedTargets: [SessionContext] = []
         var routedSessionIDs = Set<String>()
+        var pendingInitializeTargets: [SessionContext] = []
 
         if upstreamIndex == 0 {
             for pending in initializeManager.pendingInitializes() {
@@ -623,6 +624,7 @@ extension RuntimeCoordinator {
                 else {
                     continue
                 }
+                pendingInitializeTargets.append(target)
                 routedTargets.append(target)
             }
         }
@@ -641,21 +643,39 @@ extension RuntimeCoordinator {
             routedTargets.append(target)
         }
 
-        if !routedTargets.isEmpty {
-            for payload in serverInitiatedPayloads {
-                let payloadTargets = payload.expectsResponse
-                    ? Array(routedTargets.prefix(1))
-                    : routedTargets
-                for session in payloadTargets {
-                    guard let routedData = payload.routedData(
-                        for: session,
-                        upstreamIndex: upstreamIndex
-                    ) else {
-                        continue
-                    }
-                    session.router.handleIncoming(routedData)
-                }
+        let owningTarget = activeLeaseSessionTarget(upstreamIndex: upstreamIndex)
+        var routedAnyPayload = false
+
+        for payload in serverInitiatedPayloads {
+            let payloadTargets = serverInitiatedTargets(
+                expectsResponse: payload.expectsResponse,
+                owningTarget: owningTarget,
+                pendingInitializeTargets: pendingInitializeTargets,
+                routedTargets: routedTargets
+            )
+            if payload.expectsResponse && payloadTargets.isEmpty {
+                logger.debug(
+                    "Dropping response-requiring server request without an owning session",
+                    metadata: [
+                        "upstream": .string("\(upstreamIndex)"),
+                        "bytes": .string("\(payload.data.count)"),
+                    ]
+                )
+                continue
             }
+            for session in payloadTargets {
+                guard let routedData = payload.routedData(
+                    for: session,
+                    upstreamIndex: upstreamIndex
+                ) else {
+                    continue
+                }
+                session.router.handleIncoming(routedData)
+                routedAnyPayload = true
+            }
+        }
+
+        if routedAnyPayload {
             return
         }
 
@@ -667,6 +687,34 @@ extension RuntimeCoordinator {
             ]
         )
         debugRecorder.recordDroppedUnmappedNotification(upstreamIndex: upstreamIndex)
+    }
+
+    private func activeLeaseSessionTarget(upstreamIndex: Int) -> SessionContext? {
+        guard let sessionID = leaseManager.activeSessionID(upstreamIndex: upstreamIndex) else {
+            return nil
+        }
+        return sessionRegistry.contextIfPresent(id: sessionID)
+    }
+
+    private func serverInitiatedTargets(
+        expectsResponse: Bool,
+        owningTarget: SessionContext?,
+        pendingInitializeTargets: [SessionContext],
+        routedTargets: [SessionContext]
+    ) -> [SessionContext] {
+        guard expectsResponse else {
+            return routedTargets
+        }
+        if let owningTarget {
+            return [owningTarget]
+        }
+        if pendingInitializeTargets.count == 1 {
+            return pendingInitializeTargets
+        }
+        if routedTargets.count == 1 {
+            return routedTargets
+        }
+        return []
     }
 
     func handleUpstreamStderr(_ message: String, upstreamIndex: Int) {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -515,13 +515,23 @@ extension RuntimeCoordinator {
             return
         }
 
-        let serverInitiatedPayloads: [Data] = {
+        struct ServerInitiatedPayload {
+            let data: Data
+            let responseIDKey: String?
+        }
+
+        let serverInitiatedPayloads: [ServerInitiatedPayload] = {
             if let object = any as? [String: Any] {
                 guard object["method"] is String else { return [] }
-                return [data]
+                return [
+                    ServerInitiatedPayload(
+                        data: data,
+                        responseIDKey: object["id"].flatMap { RPCID(any: $0)?.key }
+                    )
+                ]
             }
             if let array = any as? [Any] {
-                var payloads: [Data] = []
+                var payloads: [ServerInitiatedPayload] = []
                 payloads.reserveCapacity(array.count)
                 for item in array {
                     guard let object = item as? [String: Any],
@@ -532,7 +542,12 @@ extension RuntimeCoordinator {
                     else {
                         continue
                     }
-                    payloads.append(encoded)
+                    payloads.append(
+                        ServerInitiatedPayload(
+                            data: encoded,
+                            responseIDKey: object["id"].flatMap { RPCID(any: $0)?.key }
+                        )
+                    )
                 }
                 return payloads
             }
@@ -585,7 +600,13 @@ extension RuntimeCoordinator {
         if !routedTargets.isEmpty {
             for payload in serverInitiatedPayloads {
                 for session in routedTargets {
-                    session.router.handleIncoming(payload)
+                    if let responseIDKey = payload.responseIDKey {
+                        session.serverRequestTracker.record(
+                            idKey: responseIDKey,
+                            upstreamIndex: upstreamIndex
+                        )
+                    }
+                    session.router.handleIncoming(payload.data)
                 }
             }
             return

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -24,7 +24,8 @@ extension RuntimeCoordinator {
         }
 
         if var object = json as? [String: Any],
-            let upstreamID = upstreamID(from: object["id"])
+            let responseID = JSONRPCMessageInspector.responseID(from: object),
+            let upstreamID = upstreamID(from: responseID)
         {
             if let mapping = upstreamRouter.consume(
                 upstreamIndex: upstreamIndex,
@@ -74,7 +75,9 @@ extension RuntimeCoordinator {
                     transformed.append(item)
                     continue
                 }
-                guard let upstreamID = upstreamID(from: object["id"]) else {
+                guard let responseID = JSONRPCMessageInspector.responseID(from: object),
+                    let upstreamID = upstreamID(from: responseID)
+                else {
                     transformed.append(item)
                     continue
                 }
@@ -436,24 +439,23 @@ extension RuntimeCoordinator {
 
         let responseAny: Any? = {
             if let object = any as? [String: Any] {
-                guard let id = object["id"], !(id is NSNull) else { return nil }
+                guard let id = JSONRPCMessageInspector.requestID(from: object) else { return nil }
                 return [
                     "jsonrpc": "2.0",
-                    "id": id,
+                    "id": id.value.foundationObject,
                     "error": overloadError,
                 ]
             }
             if let array = any as? [Any] {
                 let objects = array.compactMap { item -> [String: Any]? in
                     guard let object = item as? [String: Any],
-                        let id = object["id"],
-                        !(id is NSNull)
+                        let id = JSONRPCMessageInspector.requestID(from: object)
                     else {
                         return nil
                     }
                     return [
                         "jsonrpc": "2.0",
-                        "id": id,
+                        "id": id.value.foundationObject,
                         "error": overloadError,
                     ]
                 }
@@ -485,14 +487,28 @@ extension RuntimeCoordinator {
         return nil
     }
 
+    func upstreamID(from id: RPCID) -> Int64? {
+        upstreamID(from: id.value.foundationObject)
+    }
+
     func isServerInitiatedMessage(_ value: Any) -> Bool {
         if let object = value as? [String: Any] {
-            return object["method"] is String
+            switch JSONRPCMessageInspector.kind(of: object) {
+            case .request, .notification:
+                return true
+            case .response, .malformed, .other:
+                return false
+            }
         }
         if let array = value as? [Any] {
             return array.contains { item in
                 guard let object = item as? [String: Any] else { return false }
-                return object["method"] is String
+                switch JSONRPCMessageInspector.kind(of: object) {
+                case .request, .notification:
+                    return true
+                case .response, .malformed, .other:
+                    return false
+                }
             }
         }
         return false
@@ -544,12 +560,13 @@ extension RuntimeCoordinator {
 
         let serverInitiatedPayloads: [ServerInitiatedPayload] = {
             if let object = any as? [String: Any] {
-                guard object["method"] is String else { return [] }
+                let kind = JSONRPCMessageInspector.kind(of: object)
+                guard kind.isServerInitiated else { return [] }
                 return [
                     ServerInitiatedPayload(
                         data: data,
                         object: object,
-                        expectsResponse: JSONRPCMessageInspector.requestID(from: object) != nil
+                        expectsResponse: kind.requestID != nil
                     )
                 ]
             }
@@ -558,18 +575,21 @@ extension RuntimeCoordinator {
                 payloads.reserveCapacity(array.count)
                 for item in array {
                     guard let object = item as? [String: Any],
-                        object["method"] is String,
                         JSONSerialization.isValidJSONObject(object),
                         let encoded = try? JSONSerialization.data(
                             withJSONObject: object, options: [])
                     else {
                         continue
                     }
+                    let kind = JSONRPCMessageInspector.kind(of: object)
+                    guard kind.isServerInitiated else {
+                        continue
+                    }
                     payloads.append(
                         ServerInitiatedPayload(
                             data: encoded,
                             object: object,
-                            expectsResponse: JSONRPCMessageInspector.requestID(from: object) != nil
+                            expectsResponse: kind.requestID != nil
                         )
                     )
                 }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -575,6 +575,13 @@ extension RuntimeCoordinator {
             routedTargets.append(target)
         }
 
+        for target in sessionRegistry.pendingNotificationClientTargets() {
+            guard routedSessionIDs.insert(target.id).inserted else {
+                continue
+            }
+            routedTargets.append(target)
+        }
+
         if !routedTargets.isEmpty {
             for payload in serverInitiatedPayloads {
                 for session in routedTargets {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -17,39 +17,160 @@ extension RuntimeCoordinator {
         upstreamSlotScheduler.failQueuedRequests()
     }
 
+    private enum MappedResponseRoutingOutcome {
+        case routed(sessionID: String, object: [String: Any])
+        case handled
+        case late
+        case unmappedResponse
+        case notResponse
+    }
+
+    private struct ServerInitiatedPayload {
+        let data: Data
+        let object: [String: Any]
+        let expectsResponse: Bool
+
+        func routedData(
+            for session: SessionContext,
+            upstreamIndex: Int
+        ) -> Data? {
+            guard case .request(_, let upstreamID) =
+                JSONRPCMessageInspector.kind(of: object)
+            else {
+                return data
+            }
+            var rewritten = object
+            let clientID = session.serverRequestTracker.record(
+                upstreamID: upstreamID,
+                upstreamIndex: upstreamIndex
+            )
+            rewritten["id"] = clientID.value.foundationObject
+            guard JSONSerialization.isValidJSONObject(rewritten) else {
+                return nil
+            }
+            return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
+        }
+    }
+
     func routeUpstreamMessage(_ data: Data, upstreamIndex: Int) {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
             routeUnmappedUpstreamMessage(data, upstreamIndex: upstreamIndex)
             return
         }
 
-        if var object = json as? [String: Any],
-            let responseID = JSONRPCMessageInspector.responseID(from: object),
-            let upstreamID = upstreamID(from: responseID)
-        {
-            if let mapping = upstreamRouter.consume(
-                upstreamIndex: upstreamIndex,
-                upstreamID: upstreamID
-            ) {
-                if mapping.isInitialize {
-                    handleInitializeResponse(object, upstreamIndex: upstreamIndex)
+        if let object = json as? [String: Any] {
+            switch mappedResponseRoutingOutcome(object, upstreamIndex: upstreamIndex) {
+            case .routed(let sessionID, let object):
+                if deliverClientResponseObjects([object], sessionID: sessionID, upstreamIndex: upstreamIndex) {
                     return
                 }
-                if let sessionID = mapping.sessionID, let originalID = mapping.originalID {
-                    object["id"] = originalID.value.foundationObject
-                    if let rewritten = try? JSONSerialization.data(withJSONObject: object, options: [])
-                    {
-                        recordTraffic(
-                            upstreamIndex: upstreamIndex,
-                            direction: "inbound",
-                            data: rewritten
-                        )
-                        let target = session(id: sessionID)
-                        target.router.handleIncoming(rewritten)
-                        return
-                    }
+            case .handled, .late:
+                return
+            case .unmappedResponse, .notResponse:
+                break
+            }
+            routeUnmappedUpstreamMessage(data, upstreamIndex: upstreamIndex)
+            return
+        }
+
+        if let array = json as? [Any] {
+            routeUpstreamBatch(array, originalData: data, upstreamIndex: upstreamIndex)
+            return
+        }
+
+        routeUnmappedUpstreamMessage(data, upstreamIndex: upstreamIndex)
+    }
+
+    private func routeUpstreamBatch(
+        _ array: [Any],
+        originalData: Data,
+        upstreamIndex: Int
+    ) {
+        var responseObjectsBySessionID: [String: [Any]] = [:]
+        var mappedSessionIDs = Set<String>()
+        var serverInitiatedPayloads: [ServerInitiatedPayload] = []
+        var unmappedItems: [Any] = []
+        var droppedLateResponse = false
+
+        for item in array {
+            guard let object = item as? [String: Any] else {
+                unmappedItems.append(item)
+                continue
+            }
+
+            switch mappedResponseRoutingOutcome(object, upstreamIndex: upstreamIndex) {
+            case .routed(let sessionID, let object):
+                responseObjectsBySessionID[sessionID, default: []].append(object)
+                mappedSessionIDs.insert(sessionID)
+            case .handled:
+                continue
+            case .late:
+                droppedLateResponse = true
+            case .unmappedResponse:
+                unmappedItems.append(item)
+            case .notResponse:
+                if let payload = serverInitiatedPayload(from: object) {
+                    serverInitiatedPayloads.append(payload)
+                } else {
+                    unmappedItems.append(item)
                 }
-            } else if upstreamRouter.consumeReleasedResponseMarker(
+            }
+        }
+
+        let owningTargetOverride: SessionContext? = {
+            guard mappedSessionIDs.count == 1,
+                let sessionID = mappedSessionIDs.first
+            else {
+                return nil
+            }
+            return sessionRegistry.contextIfPresent(id: sessionID)
+        }()
+        let routedServerInitiated = routeServerInitiatedPayloads(
+            serverInitiatedPayloads,
+            upstreamIndex: upstreamIndex,
+            sourceByteCount: originalData.count,
+            owningTargetOverride: owningTargetOverride
+        )
+        let routedClientResponses = routeClientResponses(
+            responseObjectsBySessionID,
+            upstreamIndex: upstreamIndex
+        )
+
+        if unmappedItems.isEmpty {
+            if droppedLateResponse && !routedClientResponses && !routedServerInitiated {
+                logger.debug(
+                    "Dropping late upstream batch response",
+                    metadata: [
+                        "upstream": .string("\(upstreamIndex)"),
+                    ]
+                )
+            }
+            return
+        }
+
+        if routedClientResponses || routedServerInitiated || droppedLateResponse {
+            routeUnmappedBatchItems(unmappedItems, upstreamIndex: upstreamIndex)
+            return
+        }
+
+        routeUnmappedUpstreamMessage(originalData, upstreamIndex: upstreamIndex)
+    }
+
+    private func mappedResponseRoutingOutcome(
+        _ object: [String: Any],
+        upstreamIndex: Int
+    ) -> MappedResponseRoutingOutcome {
+        guard let responseID = JSONRPCMessageInspector.responseCorrelationID(from: object),
+            let upstreamID = upstreamID(from: responseID)
+        else {
+            return .notResponse
+        }
+
+        guard let mapping = upstreamRouter.consume(
+            upstreamIndex: upstreamIndex,
+            upstreamID: upstreamID
+        ) else {
+            if upstreamRouter.consumeReleasedResponseMarker(
                 upstreamIndex: upstreamIndex,
                 upstreamID: upstreamID
             ) {
@@ -61,85 +182,85 @@ extension RuntimeCoordinator {
                     ]
                 )
                 debugRecorder.recordLateResponse(upstreamIndex: upstreamIndex)
-                return
+                return .late
             }
+            return .unmappedResponse
         }
 
-        if let array = json as? [Any] {
-            var sessionID: String?
-            var rewrittenAny = false
-            var droppedLateResponse = false
-            var transformed: [Any] = []
-            for item in array {
-                guard var object = item as? [String: Any] else {
-                    transformed.append(item)
-                    continue
-                }
-                guard let responseID = JSONRPCMessageInspector.responseID(from: object),
-                    let upstreamID = upstreamID(from: responseID)
-                else {
-                    transformed.append(item)
-                    continue
-                }
-                guard let mapping = upstreamRouter.consume(
-                    upstreamIndex: upstreamIndex,
-                    upstreamID: upstreamID
-                ) else {
-                    if upstreamRouter.consumeReleasedResponseMarker(
-                        upstreamIndex: upstreamIndex,
-                        upstreamID: upstreamID
-                    ) {
-                        droppedLateResponse = true
-                        debugRecorder.recordLateResponse(upstreamIndex: upstreamIndex)
-                        continue
-                    }
-                    transformed.append(item)
-                    continue
-                }
-                if mapping.isInitialize {
-                    handleInitializeResponse(object, upstreamIndex: upstreamIndex)
-                    continue
-                }
-                guard let originalID = mapping.originalID else {
-                    transformed.append(item)
-                    continue
-                }
-                object["id"] = originalID.value.foundationObject
-                sessionID = sessionID ?? mapping.sessionID
-                rewrittenAny = true
-                transformed.append(object)
-            }
-            if rewrittenAny, let sessionID,
-                let rewritten = try? JSONSerialization.data(
-                    withJSONObject: transformed, options: [])
-            {
-                recordTraffic(
-                    upstreamIndex: upstreamIndex,
-                    direction: "inbound",
-                    data: rewritten
-                )
-                let target = session(id: sessionID)
-                target.router.handleIncoming(rewritten)
-                return
-            }
-            if droppedLateResponse, transformed.isEmpty {
-                logger.debug(
-                    "Dropping late upstream batch response",
-                    metadata: [
-                        "upstream": .string("\(upstreamIndex)"),
-                    ]
-                )
-                return
-            }
-            if droppedLateResponse,
-                let rewritten = try? JSONSerialization.data(withJSONObject: transformed, options: [])
-            {
-                routeUnmappedUpstreamMessage(rewritten, upstreamIndex: upstreamIndex)
-                return
-            }
+        if mapping.isInitialize {
+            handleInitializeResponse(object, upstreamIndex: upstreamIndex)
+            return .handled
         }
 
-        routeUnmappedUpstreamMessage(data, upstreamIndex: upstreamIndex)
+        guard let sessionID = mapping.sessionID,
+            let originalID = mapping.originalID
+        else {
+            return .handled
+        }
+        return .routed(
+            sessionID: sessionID,
+            object: clientResponseObject(from: object, originalID: originalID)
+        )
+    }
+
+    private func clientResponseObject(
+        from object: [String: Any],
+        originalID: RPCID
+    ) -> [String: Any] {
+        if case .malformed = JSONRPCMessageInspector.kind(of: object) {
+            return [
+                "jsonrpc": "2.0",
+                "id": originalID.value.foundationObject,
+                "error": [
+                    "code": -32000,
+                    "message": "invalid upstream response",
+                ],
+            ]
+        }
+        var rewritten = object
+        rewritten["id"] = originalID.value.foundationObject
+        return rewritten
+    }
+
+    private func routeClientResponses(
+        _ responseObjectsBySessionID: [String: [Any]],
+        upstreamIndex: Int
+    ) -> Bool {
+        var routedAny = false
+        for (sessionID, objects) in responseObjectsBySessionID {
+            if deliverClientResponseObjects(
+                objects,
+                sessionID: sessionID,
+                upstreamIndex: upstreamIndex
+            ) {
+                routedAny = true
+            }
+        }
+        return routedAny
+    }
+
+    private func deliverClientResponseObjects(
+        _ objects: [Any],
+        sessionID: String,
+        upstreamIndex: Int
+    ) -> Bool {
+        guard !objects.isEmpty else {
+            return false
+        }
+        let payload: Any = objects.count == 1 ? objects[0] : objects
+        guard JSONSerialization.isValidJSONObject(payload),
+            let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        else {
+            return false
+        }
+        recordTraffic(
+            upstreamIndex: upstreamIndex,
+            direction: "inbound",
+            data: data
+        )
+        let target = session(id: sessionID)
+        target.router.handleIncoming(data)
+        return true
     }
 
     /// The staleness rule for the canonical tools catalog: it must not
@@ -275,6 +396,106 @@ extension RuntimeCoordinator {
                 )
             }
         }
+    }
+
+    package func forwardServerRequestResponse(
+        responseData: Data,
+        sessionID: String,
+        responseID: RPCID,
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<ServerRequestResponseForwardingResult> {
+        let promise = eventLoop.makePromise(of: ServerRequestResponseForwardingResult.self)
+        Task { [weak self] in
+            guard let self else {
+                promise.succeed(.upstreamUnavailable)
+                return
+            }
+            let result = await self.performServerRequestResponseForwarding(
+                responseData: responseData,
+                sessionID: sessionID,
+                responseID: responseID
+            )
+            promise.succeed(result)
+        }
+        return promise.futureResult
+    }
+
+    private func performServerRequestResponseForwarding(
+        responseData: Data,
+        sessionID: String,
+        responseID: RPCID
+    ) async -> ServerRequestResponseForwardingResult {
+        guard let session = sessionRegistry.contextIfPresent(id: sessionID) else {
+            return .missingRoute
+        }
+        guard let route = session.serverRequestTracker.lookup(clientID: responseID) else {
+            logger.debug(
+                "Acknowledging client JSON-RPC response without a routed upstream request",
+                metadata: [
+                    "session": .string(sessionID),
+                    "id": .string(responseID.key),
+                ]
+            )
+            return .missingRoute
+        }
+        guard let responseObject = try? JSONSerialization.jsonObject(
+            with: responseData,
+            options: []
+        ) as? [String: Any] else {
+            return .invalidResponse
+        }
+        guard let upstreamData = Self.rewriteServerRequestResponse(
+            responseObject,
+            id: route.upstreamID
+        ) else {
+            return .invalidResponse
+        }
+
+        switch await sendServerRequestResponseUpstream(
+            upstreamData,
+            upstreamIndex: route.upstreamIndex
+        ) {
+        case .accepted:
+            _ = session.serverRequestTracker.complete(clientID: responseID, route: route)
+            return .accepted
+        case .backpressure, .unavailable:
+            return .upstreamUnavailable
+        }
+    }
+
+    private func sendServerRequestResponseUpstream(
+        _ data: Data,
+        upstreamIndex: Int
+    ) async -> UpstreamSendResult {
+        guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
+            return .unavailable(.notStarted)
+        }
+        switch await upstreams[upstreamIndex].send(data) {
+        case .accepted:
+            recordTraffic(
+                upstreamIndex: upstreamIndex,
+                direction: "outbound",
+                data: data
+            )
+            return .accepted
+        case .backpressure:
+            markUpstreamOverloaded(upstreamIndex: upstreamIndex)
+            return .backpressure
+        case .unavailable(let reason):
+            return .unavailable(reason)
+        }
+    }
+
+    private static func rewriteServerRequestResponse(
+        _ responseObject: [String: Any],
+        id: RPCID
+    ) -> Data? {
+        var rewritten = responseObject
+        rewritten["id"] = id.value.foundationObject
+        guard JSONSerialization.isValidJSONObject(rewritten) else {
+            return nil
+        }
+        return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
     }
 
     package func debugSnapshot() -> ProxyDebugSnapshot {
@@ -531,72 +752,7 @@ extension RuntimeCoordinator {
             return
         }
 
-        struct ServerInitiatedPayload {
-            let data: Data
-            let object: [String: Any]
-            let expectsResponse: Bool
-
-            func routedData(
-                for session: SessionContext,
-                upstreamIndex: Int
-            ) -> Data? {
-                guard case .request(_, let upstreamID) =
-                    JSONRPCMessageInspector.kind(of: object)
-                else {
-                    return data
-                }
-                var rewritten = object
-                let clientID = session.serverRequestTracker.record(
-                    upstreamID: upstreamID,
-                    upstreamIndex: upstreamIndex
-                )
-                rewritten["id"] = clientID.value.foundationObject
-                guard JSONSerialization.isValidJSONObject(rewritten) else {
-                    return nil
-                }
-                return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
-            }
-        }
-
-        let serverInitiatedPayloads: [ServerInitiatedPayload] = {
-            if let object = any as? [String: Any] {
-                let kind = JSONRPCMessageInspector.kind(of: object)
-                guard kind.isServerInitiated else { return [] }
-                return [
-                    ServerInitiatedPayload(
-                        data: data,
-                        object: object,
-                        expectsResponse: kind.requestID != nil
-                    )
-                ]
-            }
-            if let array = any as? [Any] {
-                var payloads: [ServerInitiatedPayload] = []
-                payloads.reserveCapacity(array.count)
-                for item in array {
-                    guard let object = item as? [String: Any],
-                        JSONSerialization.isValidJSONObject(object),
-                        let encoded = try? JSONSerialization.data(
-                            withJSONObject: object, options: [])
-                    else {
-                        continue
-                    }
-                    let kind = JSONRPCMessageInspector.kind(of: object)
-                    guard kind.isServerInitiated else {
-                        continue
-                    }
-                    payloads.append(
-                        ServerInitiatedPayload(
-                            data: encoded,
-                            object: object,
-                            expectsResponse: kind.requestID != nil
-                        )
-                    )
-                }
-                return payloads
-            }
-            return []
-        }()
+        let serverInitiatedPayloads = serverInitiatedPayloads(from: any, originalData: data)
 
         guard !serverInitiatedPayloads.isEmpty else {
             logger.debug(
@@ -607,6 +763,88 @@ extension RuntimeCoordinator {
                 ]
             )
             return
+        }
+
+        if routeServerInitiatedPayloads(
+            serverInitiatedPayloads,
+            upstreamIndex: upstreamIndex,
+            sourceByteCount: data.count,
+            owningTargetOverride: nil
+        ) {
+            return
+        }
+    }
+
+    private func serverInitiatedPayload(from object: [String: Any]) -> ServerInitiatedPayload? {
+        guard JSONSerialization.isValidJSONObject(object),
+            let encoded = try? JSONSerialization.data(withJSONObject: object, options: [])
+        else {
+            return nil
+        }
+        let kind = JSONRPCMessageInspector.kind(of: object)
+        guard kind.isServerInitiated else {
+            return nil
+        }
+        return ServerInitiatedPayload(
+            data: encoded,
+            object: object,
+            expectsResponse: kind.requestID != nil
+        )
+    }
+
+    private func serverInitiatedPayloads(
+        from any: Any,
+        originalData: Data
+    ) -> [ServerInitiatedPayload] {
+        if let object = any as? [String: Any] {
+            let kind = JSONRPCMessageInspector.kind(of: object)
+            guard kind.isServerInitiated else { return [] }
+            return [
+                ServerInitiatedPayload(
+                    data: originalData,
+                    object: object,
+                    expectsResponse: kind.requestID != nil
+                )
+            ]
+        }
+        if let array = any as? [Any] {
+            var payloads: [ServerInitiatedPayload] = []
+            payloads.reserveCapacity(array.count)
+            for item in array {
+                guard let object = item as? [String: Any],
+                    let payload = serverInitiatedPayload(from: object)
+                else {
+                    continue
+                }
+                payloads.append(payload)
+            }
+            return payloads
+        }
+        return []
+    }
+
+    private func routeUnmappedBatchItems(_ items: [Any], upstreamIndex: Int) {
+        guard !items.isEmpty else {
+            return
+        }
+        let payload: Any = items.count == 1 ? items[0] : items
+        guard JSONSerialization.isValidJSONObject(payload),
+            let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        else {
+            return
+        }
+        routeUnmappedUpstreamMessage(data, upstreamIndex: upstreamIndex)
+    }
+
+    @discardableResult
+    private func routeServerInitiatedPayloads(
+        _ serverInitiatedPayloads: [ServerInitiatedPayload],
+        upstreamIndex: Int,
+        sourceByteCount: Int,
+        owningTargetOverride: SessionContext?
+    ) -> Bool {
+        guard !serverInitiatedPayloads.isEmpty else {
+            return false
         }
 
         var routedTargets: [SessionContext] = []
@@ -643,7 +881,8 @@ extension RuntimeCoordinator {
             routedTargets.append(target)
         }
 
-        let owningTarget = activeLeaseSessionTarget(upstreamIndex: upstreamIndex)
+        let owningTarget =
+            owningTargetOverride ?? activeLeaseSessionTarget(upstreamIndex: upstreamIndex)
         var routedAnyPayload = false
 
         for payload in serverInitiatedPayloads {
@@ -675,18 +914,19 @@ extension RuntimeCoordinator {
             }
         }
 
-        if routedAnyPayload {
-            return
+        guard routedAnyPayload else {
+            logger.debug(
+                "Dropping unmapped upstream message (no routed target sessions)",
+                metadata: [
+                    "upstream": .string("\(upstreamIndex)"),
+                    "bytes": .string("\(sourceByteCount)"),
+                ]
+            )
+            debugRecorder.recordDroppedUnmappedNotification(upstreamIndex: upstreamIndex)
+            return false
         }
 
-        logger.debug(
-            "Dropping unmapped upstream message (no routed target sessions)",
-            metadata: [
-                "upstream": .string("\(upstreamIndex)"),
-                "bytes": .string("\(data.count)"),
-            ]
-        )
-        debugRecorder.recordDroppedUnmappedNotification(upstreamIndex: upstreamIndex)
+        return true
     }
 
     private func activeLeaseSessionTarget(upstreamIndex: Int) -> SessionContext? {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -517,7 +517,28 @@ extension RuntimeCoordinator {
 
         struct ServerInitiatedPayload {
             let data: Data
-            let responseIDKey: String?
+            let object: [String: Any]
+
+            func routedData(
+                for session: SessionContext,
+                upstreamIndex: Int
+            ) -> Data? {
+                guard case .request(_, let upstreamID) =
+                    JSONRPCMessageInspector.kind(of: object)
+                else {
+                    return data
+                }
+                var rewritten = object
+                let clientID = session.serverRequestTracker.record(
+                    upstreamID: upstreamID,
+                    upstreamIndex: upstreamIndex
+                )
+                rewritten["id"] = clientID.value.foundationObject
+                guard JSONSerialization.isValidJSONObject(rewritten) else {
+                    return nil
+                }
+                return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
+            }
         }
 
         let serverInitiatedPayloads: [ServerInitiatedPayload] = {
@@ -526,7 +547,7 @@ extension RuntimeCoordinator {
                 return [
                     ServerInitiatedPayload(
                         data: data,
-                        responseIDKey: object["id"].flatMap { RPCID(any: $0)?.key }
+                        object: object
                     )
                 ]
             }
@@ -545,7 +566,7 @@ extension RuntimeCoordinator {
                     payloads.append(
                         ServerInitiatedPayload(
                             data: encoded,
-                            responseIDKey: object["id"].flatMap { RPCID(any: $0)?.key }
+                            object: object
                         )
                     )
                 }
@@ -600,13 +621,13 @@ extension RuntimeCoordinator {
         if !routedTargets.isEmpty {
             for payload in serverInitiatedPayloads {
                 for session in routedTargets {
-                    if let responseIDKey = payload.responseIDKey {
-                        session.serverRequestTracker.record(
-                            idKey: responseIDKey,
-                            upstreamIndex: upstreamIndex
-                        )
+                    guard let routedData = payload.routedData(
+                        for: session,
+                        upstreamIndex: upstreamIndex
+                    ) else {
+                        continue
                     }
-                    session.router.handleIncoming(payload.data)
+                    session.router.handleIncoming(routedData)
                 }
             }
             return

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -518,6 +518,7 @@ extension RuntimeCoordinator {
         struct ServerInitiatedPayload {
             let data: Data
             let object: [String: Any]
+            let expectsResponse: Bool
 
             func routedData(
                 for session: SessionContext,
@@ -547,7 +548,8 @@ extension RuntimeCoordinator {
                 return [
                     ServerInitiatedPayload(
                         data: data,
-                        object: object
+                        object: object,
+                        expectsResponse: JSONRPCMessageInspector.requestID(from: object) != nil
                     )
                 ]
             }
@@ -566,7 +568,8 @@ extension RuntimeCoordinator {
                     payloads.append(
                         ServerInitiatedPayload(
                             data: encoded,
-                            object: object
+                            object: object,
+                            expectsResponse: JSONRPCMessageInspector.requestID(from: object) != nil
                         )
                     )
                 }
@@ -620,7 +623,10 @@ extension RuntimeCoordinator {
 
         if !routedTargets.isEmpty {
             for payload in serverInitiatedPayloads {
-                for session in routedTargets {
+                let payloadTargets = payload.expectsResponse
+                    ? Array(routedTargets.prefix(1))
+                    : routedTargets
+                for session in payloadTargets {
                     guard let routedData = payload.routedData(
                         for: session,
                         upstreamIndex: upstreamIndex

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -731,7 +731,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             _ = session(id: sessionID)
             sessionRegistry.markInitialized(
                 id: sessionID,
-                negotiatedProtocolVersion: Self.protocolVersion(fromInitializeResult: cachedResult)
+                negotiatedProtocolVersion: Self.protocolVersion(fromInitializeResult: cachedResult),
+                buffersUnmappedNotificationsUntilClientConnects: true
             )
             if let buffer = encodeInitializeResponse(originalID: originalID, result: cachedResult) {
                 return eventLoop.makeSucceededFuture(buffer)

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -15,7 +15,9 @@ package final class SessionContext: Sendable {
     package init(id: String, config: ProxyConfig) {
         self.id = id
         self.notificationHub = NotificationHub()
-        self.serverRequestTracker = ServerRequestTracker()
+        self.serverRequestTracker = ServerRequestTracker(
+            routeTimeout: makeRequestTimeout(config.requestTimeout) ?? .seconds(300)
+        )
         self.router = ProxyRouter(
             requestTimeout: makeRequestTimeout(config.requestTimeout),
             hasActiveClients: { [weak notificationHub] in

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -44,6 +44,7 @@ package protocol RuntimeCoordinating: Sendable {
     func start()
     func session(id: String) -> SessionContext
     func hasSession(id: String) -> Bool
+    func negotiatedProtocolVersion(id: String) -> String?
     func removeSession(id: String)
     func debugReset()
     func shutdown() async
@@ -114,6 +115,10 @@ package protocol RuntimeCoordinating: Sendable {
 
 extension RuntimeCoordinating {
     package func start() {}
+
+    package func negotiatedProtocolVersion(id _: String) -> String? {
+        nil
+    }
 
     package func hasDocumentationProvider() -> Bool {
         false
@@ -429,6 +434,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         sessionRegistry.hasSession(id: id)
     }
 
+    package func negotiatedProtocolVersion(id: String) -> String? {
+        sessionRegistry.negotiatedProtocolVersion(id: id)
+    }
+
     package func removeSession(id: String) {
         let context = sessionRegistry.removeSession(id: id)
         context?.notificationHub.closeAll()
@@ -717,7 +726,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
         if let cachedResult {
             _ = session(id: sessionID)
-            sessionRegistry.markInitialized(id: sessionID)
+            sessionRegistry.markInitialized(
+                id: sessionID,
+                negotiatedProtocolVersion: Self.protocolVersion(fromInitializeResult: cachedResult)
+            )
             if let buffer = encodeInitializeResponse(originalID: originalID, result: cachedResult) {
                 return eventLoop.makeSucceededFuture(buffer)
             }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -45,6 +45,7 @@ package protocol RuntimeCoordinating: Sendable {
     func session(id: String) -> SessionContext
     func hasSession(id: String) -> Bool
     func negotiatedProtocolVersion(id: String) -> String?
+    func markNotificationClientConnected(sessionID: String)
     func removeSession(id: String)
     func debugReset()
     func shutdown() async
@@ -119,6 +120,8 @@ extension RuntimeCoordinating {
     package func negotiatedProtocolVersion(id _: String) -> String? {
         nil
     }
+
+    package func markNotificationClientConnected(sessionID _: String) {}
 
     package func hasDocumentationProvider() -> Bool {
         false
@@ -765,6 +768,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             requestObject: requestObject,
             on: eventLoop
         )
+    }
+
+    package func markNotificationClientConnected(sessionID: String) {
+        sessionRegistry.markNotificationClientConnected(id: sessionID)
     }
 
     package func sharedToolsList(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -44,6 +44,13 @@ package enum DocumentationSearchOutcome: Sendable {
     case unavailable(DocumentationProviderUnavailableReason)
 }
 
+package enum ServerRequestResponseForwardingResult: Sendable, Equatable {
+    case accepted
+    case missingRoute
+    case invalidResponse
+    case upstreamUnavailable
+}
+
 package protocol RuntimeCoordinating: Sendable {
     func start()
     func session(id: String) -> SessionContext
@@ -88,6 +95,12 @@ package protocol RuntimeCoordinating: Sendable {
     func onRequestTimeout(sessionID: String, requestIDKey: String, upstreamIndex: Int)
     func onRequestSucceeded(sessionID: String, requestIDKey: String, upstreamIndex: Int)
     func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool)
+    func forwardServerRequestResponse(
+        responseData: Data,
+        sessionID: String,
+        responseID: RPCID,
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<ServerRequestResponseForwardingResult>
     func debugSnapshot() -> ProxyDebugSnapshot
     func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebugSnapshot
     func createRequestLease(descriptor: SessionPipelineRequestDescriptor) -> RequestLeaseID
@@ -133,6 +146,15 @@ extension RuntimeCoordinating {
 
     func sendUpstream(_ data: Data, upstreamIndex: Int) {
         sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: false)
+    }
+
+    package func forwardServerRequestResponse(
+        responseData _: Data,
+        sessionID _: String,
+        responseID _: RPCID,
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<ServerRequestResponseForwardingResult> {
+        eventLoop.makeSucceededFuture(.missingRoute)
     }
 
     func enqueueOnUpstreamSlot<Output: Sendable>(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -10,10 +10,12 @@ package final class SessionContext: Sendable {
     package let id: String
     package let router: ProxyRouter
     package let notificationHub: NotificationHub
+    package let serverRequestTracker: ServerRequestTracker
 
     package init(id: String, config: ProxyConfig) {
         self.id = id
         self.notificationHub = NotificationHub()
+        self.serverRequestTracker = ServerRequestTracker()
         self.router = ProxyRouter(
             requestTimeout: makeRequestTimeout(config.requestTimeout),
             hasActiveClients: { [weak notificationHub] in
@@ -731,7 +733,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             _ = session(id: sessionID)
             sessionRegistry.markInitialized(
                 id: sessionID,
-                negotiatedProtocolVersion: Self.protocolVersion(fromInitializeResult: cachedResult),
+                negotiatedProtocolVersion: Self.supportedProtocolVersion(
+                    fromInitializeResult: cachedResult
+                ),
                 buffersUnmappedNotificationsUntilClientConnects: true
             )
             if let buffer = encodeInitializeResponse(originalID: originalID, result: cachedResult) {

--- a/Sources/ProxySession/Session/LeaseManager.swift
+++ b/Sources/ProxySession/Session/LeaseManager.swift
@@ -302,6 +302,25 @@ package final class LeaseManager: Sendable {
         }
     }
 
+    package func activeSessionID(upstreamIndex: Int) -> String? {
+        state.withLockedValue { state in
+            let leaseIDs = state.activeLeaseIDsByUpstream[upstreamIndex] ?? []
+            let records = leaseIDs.compactMap { state.leasesByID[$0] }
+                .filter { $0.state == .active }
+            guard records.isEmpty == false else {
+                return nil
+            }
+            return records.sorted { lhs, rhs in
+                if lhs.descriptor.isTopLevelClientRequest
+                    != rhs.descriptor.isTopLevelClientRequest
+                {
+                    return lhs.descriptor.isTopLevelClientRequest
+                }
+                return (lhs.startedAt ?? .distantPast) < (rhs.startedAt ?? .distantPast)
+            }.first?.descriptor.sessionID
+        }
+    }
+
     private func finishLease(
         _ leaseID: RequestLeaseID,
         terminalState: RequestLeaseState,

--- a/Sources/ProxySession/Session/ProxyRouter.swift
+++ b/Sources/ProxySession/Session/ProxyRouter.swift
@@ -1,6 +1,7 @@
 import Foundation
 import NIO
 import NIOConcurrencyHelpers
+import ProxyMCP
 
 package final class ProxyRouter: Sendable {
     package struct PendingRegistration {
@@ -142,7 +143,7 @@ package final class ProxyRouter: Sendable {
         }
 
         if let array = json as? [Any] {
-            let responseIDKeys = Self.idKeys(from: array)
+            let responseIDKeys = Self.responseIDKeys(from: array)
             if let pending = popBatch(matching: responseIDKeys) {
                 complete(pending: pending, data: data)
             } else {
@@ -152,7 +153,7 @@ package final class ProxyRouter: Sendable {
         }
 
         if let object = json as? [String: Any] {
-            if let idKey = Self.idKey(from: object), let pending = pop(idKey: idKey) {
+            if let idKey = Self.responseIDKey(from: object), let pending = pop(idKey: idKey) {
                 complete(pending: pending, data: data)
             } else {
                 notify(data)
@@ -238,24 +239,17 @@ package final class ProxyRouter: Sendable {
         }
     }
 
-    private static func idKey(from object: [String: Any]) -> String? {
-        guard let id = object["id"], !(id is NSNull) else { return nil }
-        if let stringID = id as? String {
-            return stringID
-        }
-        if let numberID = id as? NSNumber {
-            return numberID.stringValue
-        }
-        return String(describing: id)
+    private static func responseIDKey(from object: [String: Any]) -> String? {
+        JSONRPCMessageInspector.responseID(from: object)?.key
     }
 
-    private static func idKeys(from array: [Any]) -> Set<String> {
+    private static func responseIDKeys(from array: [Any]) -> Set<String> {
         Set(
             array.compactMap { item -> String? in
                 guard let object = item as? [String: Any] else {
                     return nil
                 }
-                return idKey(from: object)
+                return responseIDKey(from: object)
             }
         )
     }

--- a/Sources/ProxySession/Session/ProxyRouter.swift
+++ b/Sources/ProxySession/Session/ProxyRouter.swift
@@ -146,6 +146,11 @@ package final class ProxyRouter: Sendable {
             let responseIDKeys = Self.responseIDKeys(from: array)
             if let pending = popBatch(matching: responseIDKeys) {
                 complete(pending: pending, data: data)
+            } else if responseIDKeys.count == 1,
+                let idKey = responseIDKeys.first,
+                let pending = pop(idKey: idKey)
+            {
+                complete(pending: pending, data: data)
             } else {
                 notify(data)
             }
@@ -154,6 +159,10 @@ package final class ProxyRouter: Sendable {
 
         if let object = json as? [String: Any] {
             if let idKey = Self.responseIDKey(from: object), let pending = pop(idKey: idKey) {
+                complete(pending: pending, data: data)
+            } else if let idKey = Self.responseIDKey(from: object),
+                let pending = popBatch(matching: [idKey])
+            {
                 complete(pending: pending, data: data)
             } else {
                 notify(data)
@@ -240,7 +249,7 @@ package final class ProxyRouter: Sendable {
     }
 
     private static func responseIDKey(from object: [String: Any]) -> String? {
-        JSONRPCMessageInspector.responseID(from: object)?.key
+        JSONRPCMessageInspector.responseCorrelationID(from: object)?.key
     }
 
     private static func responseIDKeys(from array: [Any]) -> Set<String> {

--- a/Sources/ProxySession/Session/SSEHub.swift
+++ b/Sources/ProxySession/Session/SSEHub.swift
@@ -9,6 +9,57 @@ import ProxyMCP
 final class SSEHub: Sendable {
     private struct State: Sendable {
         var clients: [ObjectIdentifier: Channel] = [:]
+        var clientOrder: [ObjectIdentifier] = []
+        var nextClientIndex = 0
+
+        mutating func add(_ channel: Channel) {
+            let id = ObjectIdentifier(channel)
+            if clients[id] == nil {
+                clientOrder.append(id)
+            }
+            clients[id] = channel
+        }
+
+        mutating func remove(_ channel: Channel) {
+            remove(id: ObjectIdentifier(channel))
+        }
+
+        mutating func remove(id: ObjectIdentifier) {
+            clients.removeValue(forKey: id)
+            guard let index = clientOrder.firstIndex(of: id) else { return }
+            clientOrder.remove(at: index)
+            if clientOrder.isEmpty {
+                nextClientIndex = 0
+            } else if index < nextClientIndex {
+                nextClientIndex -= 1
+            } else if nextClientIndex >= clientOrder.count {
+                nextClientIndex = 0
+            }
+        }
+
+        mutating func nextActiveClient() -> Channel? {
+            guard clientOrder.isEmpty == false else { return nil }
+            let originalCount = clientOrder.count
+            var checked = 0
+            while checked < originalCount, clientOrder.isEmpty == false {
+                if nextClientIndex >= clientOrder.count {
+                    nextClientIndex = 0
+                }
+                let id = clientOrder[nextClientIndex]
+                nextClientIndex = (nextClientIndex + 1) % clientOrder.count
+                checked += 1
+                guard let channel = clients[id] else {
+                    remove(id: id)
+                    continue
+                }
+                guard channel.isActive else {
+                    remove(id: id)
+                    continue
+                }
+                return channel
+            }
+            return nil
+        }
     }
 
     private let state = NIOLockedValueBox(State())
@@ -20,13 +71,13 @@ final class SSEHub: Sendable {
 
     func add(_ channel: Channel) {
         state.withLockedValue { state in
-            state.clients[ObjectIdentifier(channel)] = channel
+            state.add(channel)
         }
     }
 
     func remove(_ channel: Channel) {
-        _ = state.withLockedValue { state in
-            state.clients.removeValue(forKey: ObjectIdentifier(channel))
+        state.withLockedValue { state in
+            state.remove(channel)
         }
     }
 
@@ -35,20 +86,24 @@ final class SSEHub: Sendable {
             logger.warning("Dropping non-UTF8 SSE payload", metadata: ["bytes": "\(data.count)"])
             return
         }
-        let channels = state.withLockedValue { Array($0.clients.values) }
-        for channel in channels {
-            channel.eventLoop.execute {
-                guard channel.isActive else { return }
-                var buffer = channel.allocator.buffer(capacity: payload.utf8.count)
-                buffer.writeString(payload)
-                _ = channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buffer)))
-            }
+        guard let channel = state.withLockedValue({ $0.nextActiveClient() }) else {
+            return
+        }
+        channel.eventLoop.execute {
+            guard channel.isActive else { return }
+            var buffer = channel.allocator.buffer(capacity: payload.utf8.count)
+            buffer.writeString(payload)
+            _ = channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buffer)))
         }
     }
 
     func closeAll() {
         let channels = state.withLockedValue { Array($0.clients.values) }
-        state.withLockedValue { $0.clients.removeAll() }
+        state.withLockedValue { state in
+            state.clients.removeAll()
+            state.clientOrder.removeAll()
+            state.nextClientIndex = 0
+        }
         for channel in channels {
             channel.eventLoop.execute {
                 channel.close(promise: nil)

--- a/Sources/ProxySession/Session/ServerRequestTracker.swift
+++ b/Sources/ProxySession/Session/ServerRequestTracker.swift
@@ -1,0 +1,19 @@
+import NIOConcurrencyHelpers
+
+package final class ServerRequestTracker: Sendable {
+    private let upstreamByIDKey = NIOLockedValueBox<[String: Int]>([:])
+
+    package init() {}
+
+    package func record(idKey: String, upstreamIndex: Int) {
+        upstreamByIDKey.withLockedValue { upstreamByIDKey in
+            upstreamByIDKey[idKey] = upstreamIndex
+        }
+    }
+
+    package func consume(idKey: String) -> Int? {
+        upstreamByIDKey.withLockedValue { upstreamByIDKey in
+            upstreamByIDKey.removeValue(forKey: idKey)
+        }
+    }
+}

--- a/Sources/ProxySession/Session/ServerRequestTracker.swift
+++ b/Sources/ProxySession/Session/ServerRequestTracker.swift
@@ -67,6 +67,33 @@ package final class ServerRequestTracker: Sendable {
         }
     }
 
+    package func lookup(clientID: RPCID, now: Date = Date()) -> ServerRequestRoute? {
+        state.withLockedValue { state in
+            Self.removeExpiredRoutes(now: now, state: &state)
+            return state.routesByClientIDKey[clientID.key]?.route
+        }
+    }
+
+    @discardableResult
+    package func complete(
+        clientID: RPCID,
+        route: ServerRequestRoute,
+        now: Date = Date()
+    ) -> Bool {
+        state.withLockedValue { state in
+            Self.removeExpiredRoutes(now: now, state: &state)
+            guard let stored = state.routesByClientIDKey[clientID.key],
+                stored.route.upstreamIndex == route.upstreamIndex,
+                stored.route.upstreamID.key == route.upstreamID.key
+            else {
+                return false
+            }
+            state.routesByClientIDKey.removeValue(forKey: clientID.key)
+            state.clientIDKeysInOrder.removeAll { $0 == clientID.key }
+            return true
+        }
+    }
+
     private static func expirationDate(now: Date, timeout: TimeAmount) -> Date {
         let seconds = Double(max(timeout.nanoseconds, 0)) / 1_000_000_000
         return now.addingTimeInterval(seconds)

--- a/Sources/ProxySession/Session/ServerRequestTracker.swift
+++ b/Sources/ProxySession/Session/ServerRequestTracker.swift
@@ -1,19 +1,38 @@
 import NIOConcurrencyHelpers
+import ProxyMCP
+
+package struct ServerRequestRoute: Sendable {
+    package let upstreamIndex: Int
+    package let upstreamID: RPCID
+}
 
 package final class ServerRequestTracker: Sendable {
-    private let upstreamByIDKey = NIOLockedValueBox<[String: Int]>([:])
+    private struct State: Sendable {
+        var nextClientID: Int64 = 0
+        var routesByClientIDKey: [String: ServerRequestRoute] = [:]
+    }
+
+    private let state = NIOLockedValueBox(State())
 
     package init() {}
 
-    package func record(idKey: String, upstreamIndex: Int) {
-        upstreamByIDKey.withLockedValue { upstreamByIDKey in
-            upstreamByIDKey[idKey] = upstreamIndex
+    package func record(upstreamID: RPCID, upstreamIndex: Int) -> RPCID {
+        state.withLockedValue { state in
+            state.nextClientID += 1
+            let clientID = RPCID(
+                any: "xcode-mcp-proxy.server-request.\(state.nextClientID)"
+            )!
+            state.routesByClientIDKey[clientID.key] = ServerRequestRoute(
+                upstreamIndex: upstreamIndex,
+                upstreamID: upstreamID
+            )
+            return clientID
         }
     }
 
-    package func consume(idKey: String) -> Int? {
-        upstreamByIDKey.withLockedValue { upstreamByIDKey in
-            upstreamByIDKey.removeValue(forKey: idKey)
+    package func consume(clientID: RPCID) -> ServerRequestRoute? {
+        state.withLockedValue { state in
+            state.routesByClientIDKey.removeValue(forKey: clientID.key)
         }
     }
 }

--- a/Sources/ProxySession/Session/ServerRequestTracker.swift
+++ b/Sources/ProxySession/Session/ServerRequestTracker.swift
@@ -1,3 +1,5 @@
+import Foundation
+import NIO
 import NIOConcurrencyHelpers
 import ProxyMCP
 
@@ -7,32 +9,90 @@ package struct ServerRequestRoute: Sendable {
 }
 
 package final class ServerRequestTracker: Sendable {
+    private struct StoredRoute: Sendable {
+        let route: ServerRequestRoute
+        let expiresAt: Date
+    }
+
     private struct State: Sendable {
         var nextClientID: Int64 = 0
-        var routesByClientIDKey: [String: ServerRequestRoute] = [:]
+        var routesByClientIDKey: [String: StoredRoute] = [:]
+        var clientIDKeysInOrder: [String] = []
     }
 
     private let state = NIOLockedValueBox(State())
+    private let routeTimeout: TimeAmount
+    private let maxRoutes: Int
 
-    package init() {}
+    package init(
+        routeTimeout: TimeAmount = .seconds(300),
+        maxRoutes: Int = 256
+    ) {
+        self.routeTimeout = routeTimeout
+        self.maxRoutes = max(0, maxRoutes)
+    }
 
-    package func record(upstreamID: RPCID, upstreamIndex: Int) -> RPCID {
+    package func record(
+        upstreamID: RPCID,
+        upstreamIndex: Int,
+        now: Date = Date()
+    ) -> RPCID {
         state.withLockedValue { state in
+            Self.removeExpiredRoutes(now: now, state: &state)
             state.nextClientID += 1
             let clientID = RPCID(
                 any: "xcode-mcp-proxy.server-request.\(state.nextClientID)"
             )!
-            state.routesByClientIDKey[clientID.key] = ServerRequestRoute(
-                upstreamIndex: upstreamIndex,
-                upstreamID: upstreamID
+            state.routesByClientIDKey[clientID.key] = StoredRoute(
+                route: ServerRequestRoute(
+                    upstreamIndex: upstreamIndex,
+                    upstreamID: upstreamID
+                ),
+                expiresAt: Self.expirationDate(now: now, timeout: routeTimeout)
             )
+            state.clientIDKeysInOrder.append(clientID.key)
+            Self.removeOverflowRoutes(maxRoutes: maxRoutes, state: &state)
             return clientID
         }
     }
 
-    package func consume(clientID: RPCID) -> ServerRequestRoute? {
+    package func consume(clientID: RPCID, now: Date = Date()) -> ServerRequestRoute? {
         state.withLockedValue { state in
-            state.routesByClientIDKey.removeValue(forKey: clientID.key)
+            Self.removeExpiredRoutes(now: now, state: &state)
+            guard let stored = state.routesByClientIDKey.removeValue(forKey: clientID.key) else {
+                return nil
+            }
+            state.clientIDKeysInOrder.removeAll { $0 == clientID.key }
+            return stored.route
+        }
+    }
+
+    private static func expirationDate(now: Date, timeout: TimeAmount) -> Date {
+        let seconds = Double(max(timeout.nanoseconds, 0)) / 1_000_000_000
+        return now.addingTimeInterval(seconds)
+    }
+
+    private static func removeExpiredRoutes(now: Date, state: inout State) {
+        let expiredKeys = state.routesByClientIDKey.compactMap { key, stored in
+            stored.expiresAt <= now ? key : nil
+        }
+        guard expiredKeys.isEmpty == false else { return }
+        let expiredKeySet = Set(expiredKeys)
+        state.routesByClientIDKey = state.routesByClientIDKey.filter { key, _ in
+            expiredKeySet.contains(key) == false
+        }
+        state.clientIDKeysInOrder.removeAll { expiredKeySet.contains($0) }
+    }
+
+    private static func removeOverflowRoutes(maxRoutes: Int, state: inout State) {
+        guard maxRoutes > 0 else {
+            state.routesByClientIDKey.removeAll()
+            state.clientIDKeysInOrder.removeAll()
+            return
+        }
+        while state.clientIDKeysInOrder.count > maxRoutes {
+            let removedKey = state.clientIDKeysInOrder.removeFirst()
+            state.routesByClientIDKey.removeValue(forKey: removedKey)
         }
     }
 }

--- a/Sources/ProxySession/Session/SessionRegistry.swift
+++ b/Sources/ProxySession/Session/SessionRegistry.swift
@@ -7,6 +7,7 @@ package struct SessionRecord: Sendable {
     package let generation: UInt64
     package var isInitialized: Bool
     package var negotiatedProtocolVersion: String?
+    package var buffersUnmappedNotificationsUntilClientConnects: Bool
 }
 
 package final class SessionRegistry: Sendable {
@@ -33,7 +34,8 @@ package final class SessionRegistry: Sendable {
                 context: context,
                 generation: state.nextGeneration,
                 isInitialized: false,
-                negotiatedProtocolVersion: nil
+                negotiatedProtocolVersion: nil,
+                buffersUnmappedNotificationsUntilClientConnects: false
             )
             return context
         }
@@ -77,14 +79,35 @@ package final class SessionRegistry: Sendable {
         }
     }
 
+    package func pendingNotificationClientTargets() -> [SessionContext] {
+        state.withLockedValue { state in
+            state.sessions.values.compactMap { record in
+                record.isInitialized && record.buffersUnmappedNotificationsUntilClientConnects
+                    ? record.context
+                    : nil
+            }
+        }
+    }
+
     package func markInitialized(
         id sessionID: String,
-        negotiatedProtocolVersion: String?
+        negotiatedProtocolVersion: String?,
+        buffersUnmappedNotificationsUntilClientConnects: Bool = false
     ) {
         state.withLockedValue { state in
             guard var record = state.sessions[sessionID] else { return }
             record.isInitialized = true
             record.negotiatedProtocolVersion = negotiatedProtocolVersion
+            record.buffersUnmappedNotificationsUntilClientConnects =
+                buffersUnmappedNotificationsUntilClientConnects
+            state.sessions[sessionID] = record
+        }
+    }
+
+    package func markNotificationClientConnected(id sessionID: String) {
+        state.withLockedValue { state in
+            guard var record = state.sessions[sessionID] else { return }
+            record.buffersUnmappedNotificationsUntilClientConnects = false
             state.sessions[sessionID] = record
         }
     }

--- a/Sources/ProxySession/Session/SessionRegistry.swift
+++ b/Sources/ProxySession/Session/SessionRegistry.swift
@@ -6,6 +6,7 @@ package struct SessionRecord: Sendable {
     package let context: SessionContext
     package let generation: UInt64
     package var isInitialized: Bool
+    package var negotiatedProtocolVersion: String?
 }
 
 package final class SessionRegistry: Sendable {
@@ -31,7 +32,8 @@ package final class SessionRegistry: Sendable {
             state.sessions[id] = SessionRecord(
                 context: context,
                 generation: state.nextGeneration,
-                isInitialized: false
+                isInitialized: false,
+                negotiatedProtocolVersion: nil
             )
             return context
         }
@@ -75,10 +77,14 @@ package final class SessionRegistry: Sendable {
         }
     }
 
-    package func markInitialized(id sessionID: String) {
+    package func markInitialized(
+        id sessionID: String,
+        negotiatedProtocolVersion: String?
+    ) {
         state.withLockedValue { state in
             guard var record = state.sessions[sessionID] else { return }
             record.isInitialized = true
+            record.negotiatedProtocolVersion = negotiatedProtocolVersion
             state.sessions[sessionID] = record
         }
     }
@@ -86,6 +92,12 @@ package final class SessionRegistry: Sendable {
     package func isInitialized(id sessionID: String) -> Bool {
         state.withLockedValue { state in
             state.sessions[sessionID]?.isInitialized ?? false
+        }
+    }
+
+    package func negotiatedProtocolVersion(id sessionID: String) -> String? {
+        state.withLockedValue { state in
+            state.sessions[sessionID]?.negotiatedProtocolVersion
         }
     }
 

--- a/Sources/ProxySession/Upstream/ManagedUpstreamSlot.swift
+++ b/Sources/ProxySession/Upstream/ManagedUpstreamSlot.swift
@@ -79,6 +79,9 @@ package actor ManagedUpstreamSlot: UpstreamSlotControlling {
             }
             return await running.session.send(data)
         } catch {
+            if self.pendingStart === pendingStart {
+                self.pendingStart = nil
+            }
             return .unavailable(.startFailed)
         }
     }

--- a/Sources/ProxyStdioTransport/StdioAdapter.swift
+++ b/Sources/ProxyStdioTransport/StdioAdapter.swift
@@ -417,17 +417,16 @@ public actor StdioAdapter {
             return RequestEnvelope(method: nil, ids: [])
         }
         if let object = json as? [String: Any] {
-            if let id = object["id"], !(id is NSNull), let jsonID = JSONValue(any: id) {
-                return RequestEnvelope(method: object["method"] as? String, ids: [jsonID])
-            }
-            return RequestEnvelope(method: object["method"] as? String, ids: [])
+            let method = JSONRPCMessageInspector.method(from: object)
+            let ids = JSONRPCMessageInspector.requestID(from: object).map { [$0.value] } ?? []
+            return RequestEnvelope(method: method, ids: ids)
         }
         if let array = json as? [Any] {
             var ids: [JSONValue] = []
             for item in array {
                 guard let object = item as? [String: Any] else { continue }
-                if let id = object["id"], !(id is NSNull), let jsonID = JSONValue(any: id) {
-                    ids.append(jsonID)
+                if let id = JSONRPCMessageInspector.requestID(from: object) {
+                    ids.append(id.value)
                 }
             }
             return RequestEnvelope(method: nil, ids: ids)

--- a/Sources/ProxyStdioTransport/StdioAdapter.swift
+++ b/Sources/ProxyStdioTransport/StdioAdapter.swift
@@ -134,6 +134,7 @@ public actor StdioAdapter {
                 await emitError(for: envelope, message: "upstream returned empty response")
             }
         } catch let error as AdapterError {
+            if stopped || Task.isCancelled { return }
             logger.error("STDIO upstream request failed", metadata: ["error": "\(error)"])
             switch error {
             case .httpStatus(let status):
@@ -142,6 +143,7 @@ public actor StdioAdapter {
                 await emitError(for: envelope, message: "invalid upstream response")
             }
         } catch {
+            if stopped || Task.isCancelled { return }
             logger.error("STDIO upstream request failed", metadata: ["error": "\(error)"])
             await emitError(for: envelope, message: "upstream unavailable")
         }
@@ -245,10 +247,11 @@ public actor StdioAdapter {
             } catch is CancellationError {
                 return
             } catch {
+                if stopped || Task.isCancelled { return }
                 logger.warning("SSE disconnected", metadata: ["error": "\(error)"])
             }
 
-            if stopped { break }
+            if stopped || Task.isCancelled { break }
             let delay = backoffDelay(for: attempt)
             attempt += 1
             try? await Task.sleep(nanoseconds: delay)
@@ -330,8 +333,12 @@ public actor StdioAdapter {
         }
 
         guard !requestTasks.isEmpty else { return }
-        stopped = true
         sseTask?.cancel()
+        await deleteSessionIfNeeded()
+        for task in requestTasks.values {
+            task.cancel()
+        }
+        stopped = true
         session.invalidateAndCancel()
         await drainRequestTasks()
     }

--- a/Sources/ProxyStdioTransport/StdioAdapter.swift
+++ b/Sources/ProxyStdioTransport/StdioAdapter.swift
@@ -345,14 +345,27 @@ public actor StdioAdapter {
 
     private func deleteSessionIfNeeded() async {
         guard let sessionID, let negotiatedProtocolVersion else { return }
+        defer {
+            self.sessionID = nil
+            self.negotiatedProtocolVersion = nil
+        }
         var request = URLRequest(url: upstreamURL)
         request.httpMethod = "DELETE"
         request.setValue(sessionID, forHTTPHeaderField: "MCP-Session-Id")
         request.setValue(negotiatedProtocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
         applyTimeout(to: &request)
-        _ = try? await session.data(for: request)
-        self.sessionID = nil
-        self.negotiatedProtocolVersion = nil
+        let urlSession = session
+        let deleteRequest = request
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                _ = try? await urlSession.data(for: deleteRequest)
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 250_000_000)
+            }
+            _ = await group.next()
+            group.cancelAll()
+        }
     }
 
     private func stopLocked(cancelReadTask: Bool) {

--- a/Sources/ProxyStdioTransport/StdioAdapter.swift
+++ b/Sources/ProxyStdioTransport/StdioAdapter.swift
@@ -5,6 +5,7 @@ import ProxyMCP
 
 public actor StdioAdapter {
     private struct RequestEnvelope {
+        let method: String?
         let ids: [JSONValue]
 
         var expectsResponse: Bool {
@@ -23,9 +24,11 @@ public actor StdioAdapter {
     private let outputWriter: StdioWriter
     private let logger: Logger
     private let session: URLSession
-    private let sessionID: String
+    private var sessionID: String?
+    private var negotiatedProtocolVersion: String?
     private var framer = StdioFramer()
     private var requestTasks: [UUID: Task<Void, Never>] = [:]
+    private var requestTail: Task<Void, Never>?
     private var readTask: Task<Void, Never>?
     private var sseTask: Task<Void, Never>?
     private var started = false
@@ -45,15 +48,11 @@ public actor StdioAdapter {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.waitsForConnectivity = true
         self.session = URLSession(configuration: configuration)
-        self.sessionID = "stdio-\(UUID().uuidString)"
     }
 
     public func start() async {
         guard !started else { return }
         started = true
-        sseTask = Task { [weak self] in
-            await self?.sseLoop()
-        }
         readTask = Task { [weak self] in
             await self?.readLoop()
         }
@@ -89,10 +88,13 @@ public actor StdioAdapter {
         let result = framer.append(data)
         for message in result.messages {
             let requestID = UUID()
+            let previous = requestTail
             let task = Task { [weak self] in
+                _ = await previous?.value
                 guard let self else { return }
                 await self.runRequestTask(id: requestID, data: message)
             }
+            requestTail = task
             requestTasks[requestID] = task
         }
 
@@ -143,11 +145,17 @@ public actor StdioAdapter {
     }
 
     private func sendRequest(_ data: Data) async throws -> Data? {
+        let envelope = inspectRequest(data)
         var request = URLRequest(url: upstreamURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+        if envelope.method != "initialize", let sessionID {
+            request.setValue(sessionID, forHTTPHeaderField: "MCP-Session-Id")
+        }
+        if envelope.method != "initialize", let negotiatedProtocolVersion {
+            request.setValue(negotiatedProtocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
+        }
         applyTimeout(to: &request)
         request.httpBody = data
 
@@ -156,16 +164,73 @@ public actor StdioAdapter {
             throw AdapterError.invalidResponse
         }
         if (200...299).contains(http.statusCode) {
-            guard !responseData.isEmpty else { return nil }
-            guard isValidJSONPayload(responseData) else {
+            guard let payload = responsePayloadData(responseData, from: http) else { return nil }
+            if envelope.method == "initialize" {
+                updateSessionState(from: http, responseData: payload)
+                startSSEIfNeeded()
+            }
+            guard isValidJSONPayload(payload) else {
                 throw AdapterError.invalidResponse
             }
-            return responseData
+            return payload
         }
-        if !responseData.isEmpty, isValidJSONPayload(responseData) {
-            return responseData
+        if let payload = responsePayloadData(responseData, from: http),
+            isValidJSONPayload(payload)
+        {
+            return payload
         }
         throw AdapterError.httpStatus(http.statusCode)
+    }
+
+    private func updateSessionState(from response: HTTPURLResponse, responseData: Data) {
+        if let returnedSessionID = response.value(forHTTPHeaderField: "MCP-Session-Id"),
+            returnedSessionID.isEmpty == false
+        {
+            sessionID = returnedSessionID
+        }
+        if let version = initializeProtocolVersion(from: responseData) {
+            negotiatedProtocolVersion = version
+        }
+    }
+
+    private func responsePayloadData(_ data: Data, from response: HTTPURLResponse) -> Data? {
+        guard !data.isEmpty else { return nil }
+        let contentType = response.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
+        guard contentType.hasPrefix("text/event-stream") else { return data }
+        return singleSSEPayloadData(from: data)
+    }
+
+    private func singleSSEPayloadData(from data: Data) -> Data? {
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        var decoder = SSEDecoder()
+        var payload: Data?
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.hasSuffix("\r") ? rawLine.dropLast() : Substring(rawLine)
+            if let eventPayload = decoder.feed(line: String(line)) {
+                payload = eventPayload
+            }
+        }
+        return payload ?? decoder.flushIfNeeded()
+    }
+
+    private func initializeProtocolVersion(from data: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+            let result = object["result"] as? [String: Any],
+            let protocolVersion = result["protocolVersion"] as? String,
+            MCPProtocolVersion.isSupported(protocolVersion)
+        else {
+            return nil
+        }
+        return protocolVersion
+    }
+
+    private func startSSEIfNeeded() {
+        guard sessionID != nil, negotiatedProtocolVersion != nil, sseTask == nil, !stopped else {
+            return
+        }
+        sseTask = Task { [weak self] in
+            await self?.sseLoop()
+        }
     }
 
     private func sseLoop() async {
@@ -188,10 +253,14 @@ public actor StdioAdapter {
     }
 
     private func consumeSSE() async throws {
+        guard let sessionID, let negotiatedProtocolVersion else {
+            throw AdapterError.invalidResponse
+        }
         var request = URLRequest(url: upstreamURL)
         request.httpMethod = "GET"
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
-        request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        request.setValue(sessionID, forHTTPHeaderField: "MCP-Session-Id")
+        request.setValue(negotiatedProtocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
         applyTimeout(to: &request, allowLongRunning: true)
 
         let (bytes, response) = try await session.bytes(for: request)
@@ -265,7 +334,22 @@ public actor StdioAdapter {
     }
 
     private func stop(cancelReadTask: Bool) async {
+        if !stopped {
+            await deleteSessionIfNeeded()
+        }
         stopLocked(cancelReadTask: cancelReadTask)
+    }
+
+    private func deleteSessionIfNeeded() async {
+        guard let sessionID, let negotiatedProtocolVersion else { return }
+        var request = URLRequest(url: upstreamURL)
+        request.httpMethod = "DELETE"
+        request.setValue(sessionID, forHTTPHeaderField: "MCP-Session-Id")
+        request.setValue(negotiatedProtocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
+        applyTimeout(to: &request)
+        _ = try? await session.data(for: request)
+        self.sessionID = nil
+        self.negotiatedProtocolVersion = nil
     }
 
     private func stopLocked(cancelReadTask: Bool) {
@@ -283,13 +367,13 @@ public actor StdioAdapter {
 
     private func inspectRequest(_ data: Data) -> RequestEnvelope {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
-            return RequestEnvelope(ids: [])
+            return RequestEnvelope(method: nil, ids: [])
         }
         if let object = json as? [String: Any] {
             if let id = object["id"], !(id is NSNull), let jsonID = JSONValue(any: id) {
-                return RequestEnvelope(ids: [jsonID])
+                return RequestEnvelope(method: object["method"] as? String, ids: [jsonID])
             }
-            return RequestEnvelope(ids: [])
+            return RequestEnvelope(method: object["method"] as? String, ids: [])
         }
         if let array = json as? [Any] {
             var ids: [JSONValue] = []
@@ -299,9 +383,9 @@ public actor StdioAdapter {
                     ids.append(jsonID)
                 }
             }
-            return RequestEnvelope(ids: ids)
+            return RequestEnvelope(method: nil, ids: ids)
         }
-        return RequestEnvelope(ids: [])
+        return RequestEnvelope(method: nil, ids: [])
     }
 
     private func emitError(for envelope: RequestEnvelope, message: String) async {

--- a/Sources/ProxyStdioTransport/StdioAdapter.swift
+++ b/Sources/ProxyStdioTransport/StdioAdapter.swift
@@ -28,7 +28,7 @@ public actor StdioAdapter {
     private var negotiatedProtocolVersion: String?
     private var framer = StdioFramer()
     private var requestTasks: [UUID: Task<Void, Never>] = [:]
-    private var requestTail: Task<Void, Never>?
+    private var initializationTask: Task<Void, Never>?
     private var readTask: Task<Void, Never>?
     private var sseTask: Task<Void, Never>?
     private var started = false
@@ -88,13 +88,16 @@ public actor StdioAdapter {
         let result = framer.append(data)
         for message in result.messages {
             let requestID = UUID()
-            let previous = requestTail
+            let method = inspectRequest(message).method
+            let pendingInitialization = initializationTask
             let task = Task { [weak self] in
-                _ = await previous?.value
+                _ = await pendingInitialization?.value
                 guard let self else { return }
                 await self.runRequestTask(id: requestID, data: message)
             }
-            requestTail = task
+            if method == "initialize" {
+                initializationTask = task
+            }
             requestTasks[requestID] = task
         }
 

--- a/Sources/ProxyStdioTransport/StdioAdapter.swift
+++ b/Sources/ProxyStdioTransport/StdioAdapter.swift
@@ -351,7 +351,8 @@ public actor StdioAdapter {
     }
 
     private func deleteSessionIfNeeded() async {
-        guard let sessionID, let negotiatedProtocolVersion else { return }
+        guard let sessionID else { return }
+        let negotiatedProtocolVersion = self.negotiatedProtocolVersion
         defer {
             self.sessionID = nil
             self.negotiatedProtocolVersion = nil
@@ -359,7 +360,9 @@ public actor StdioAdapter {
         var request = URLRequest(url: upstreamURL)
         request.httpMethod = "DELETE"
         request.setValue(sessionID, forHTTPHeaderField: "MCP-Session-Id")
-        request.setValue(negotiatedProtocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
+        if let negotiatedProtocolVersion {
+            request.setValue(negotiatedProtocolVersion, forHTTPHeaderField: "MCP-Protocol-Version")
+        }
         applyTimeout(to: &request)
         let urlSession = session
         let deleteRequest = request

--- a/Sources/ProxyStdioTransport/StdioAdapter.swift
+++ b/Sources/ProxyStdioTransport/StdioAdapter.swift
@@ -13,6 +13,11 @@ public actor StdioAdapter {
         }
     }
 
+    private struct RequestResult {
+        let payloads: [Data]
+        let shouldStartSSEAfterOutput: Bool
+    }
+
     private enum AdapterError: Error {
         case invalidResponse
         case httpStatus(Int)
@@ -127,11 +132,18 @@ public actor StdioAdapter {
         if stopped { return }
         let envelope = inspectRequest(data)
         do {
-            let responseData = try await sendRequest(data)
-            if let responseData {
-                await outputWriter.send(responseData)
+            let result = try await sendRequest(data)
+            if result.payloads.isEmpty == false {
+                for payload in result.payloads {
+                    await outputWriter.send(payload)
+                }
+                if result.shouldStartSSEAfterOutput {
+                    startSSEIfNeeded()
+                }
             } else if envelope.expectsResponse {
                 await emitError(for: envelope, message: "upstream returned empty response")
+            } else if result.shouldStartSSEAfterOutput {
+                startSSEIfNeeded()
             }
         } catch let error as AdapterError {
             if stopped || Task.isCancelled { return }
@@ -149,7 +161,7 @@ public actor StdioAdapter {
         }
     }
 
-    private func sendRequest(_ data: Data) async throws -> Data? {
+    private func sendRequest(_ data: Data) async throws -> RequestResult {
         let envelope = inspectRequest(data)
         var request = URLRequest(url: upstreamURL)
         request.httpMethod = "POST"
@@ -169,53 +181,62 @@ public actor StdioAdapter {
             throw AdapterError.invalidResponse
         }
         if (200...299).contains(http.statusCode) {
-            guard let payload = responsePayloadData(responseData, from: http) else { return nil }
-            if envelope.method == "initialize" {
-                updateSessionState(from: http, responseData: payload)
-                startSSEIfNeeded()
+            let payloads = responsePayloadsData(responseData, from: http)
+            if payloads.isEmpty {
+                return RequestResult(payloads: [], shouldStartSSEAfterOutput: false)
             }
-            guard isValidJSONPayload(payload) else {
+            if envelope.method == "initialize" {
+                updateSessionState(from: http, payloads: payloads)
+            }
+            guard payloads.allSatisfy({ isValidJSONPayload($0) }) else {
                 throw AdapterError.invalidResponse
             }
-            return payload
+            return RequestResult(
+                payloads: payloads,
+                shouldStartSSEAfterOutput: envelope.method == "initialize"
+            )
         }
-        if let payload = responsePayloadData(responseData, from: http),
-            isValidJSONPayload(payload)
+        let payloads = responsePayloadsData(responseData, from: http)
+        if payloads.isEmpty == false,
+            payloads.allSatisfy({ isValidJSONPayload($0) })
         {
-            return payload
+            return RequestResult(payloads: payloads, shouldStartSSEAfterOutput: false)
         }
         throw AdapterError.httpStatus(http.statusCode)
     }
 
-    private func updateSessionState(from response: HTTPURLResponse, responseData: Data) {
+    private func updateSessionState(from response: HTTPURLResponse, payloads: [Data]) {
         if let returnedSessionID = response.value(forHTTPHeaderField: "MCP-Session-Id"),
             returnedSessionID.isEmpty == false
         {
             sessionID = returnedSessionID
         }
-        if let version = initializeProtocolVersion(from: responseData) {
+        if let version = payloads.lazy.compactMap({ self.initializeProtocolVersion(from: $0) }).first {
             negotiatedProtocolVersion = version
         }
     }
 
-    private func responsePayloadData(_ data: Data, from response: HTTPURLResponse) -> Data? {
-        guard !data.isEmpty else { return nil }
+    private func responsePayloadsData(_ data: Data, from response: HTTPURLResponse) -> [Data] {
+        guard !data.isEmpty else { return [] }
         let contentType = response.value(forHTTPHeaderField: "Content-Type")?.lowercased() ?? ""
-        guard contentType.hasPrefix("text/event-stream") else { return data }
-        return singleSSEPayloadData(from: data)
+        guard contentType.hasPrefix("text/event-stream") else { return [data] }
+        return ssePayloadsData(from: data)
     }
 
-    private func singleSSEPayloadData(from data: Data) -> Data? {
-        guard let text = String(data: data, encoding: .utf8) else { return nil }
+    private func ssePayloadsData(from data: Data) -> [Data] {
+        guard let text = String(data: data, encoding: .utf8) else { return [] }
         var decoder = SSEDecoder()
-        var payload: Data?
+        var payloads: [Data] = []
         for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
             let line = rawLine.hasSuffix("\r") ? rawLine.dropLast() : Substring(rawLine)
             if let eventPayload = decoder.feed(line: String(line)) {
-                payload = eventPayload
+                payloads.append(eventPayload)
             }
         }
-        return payload ?? decoder.flushIfNeeded()
+        if let tail = decoder.flushIfNeeded() {
+            payloads.append(tail)
+        }
+        return payloads
     }
 
     private func initializeProtocolVersion(from data: Data) -> String? {

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesToolsListRewriter.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesToolsListRewriter.swift
@@ -106,9 +106,7 @@ package enum RefreshCodeIssuesToolsListRewriter {
         if let explicitMethod {
             return explicitMethod
         }
-        guard let responseIDValue = object["id"],
-            let responseID = RPCID(any: responseIDValue)
-        else {
+        guard let responseID = JSONRPCMessageInspector.responseID(from: object) else {
             return nil
         }
         return responseMethodsByIDKey[responseID.key]

--- a/Sources/XcodeMCPProxy/ProxyServer+Startup.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer+Startup.swift
@@ -5,6 +5,7 @@ import ProxySession
 
 extension ProxyServer {
     public func start() throws -> Channel {
+        try config.validateModernProtocolConfiguration()
         let preparedRuntime = try prepareRuntimeForStart()
         let sessionManager = preparedRuntime.sessionManager
         let childInitializer = ProxyHTTPChildChannelInitializer(

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -19,6 +19,174 @@ struct CLICommandIntegrationTests {
         try await runCLICommandRoundTrip(responseMode: .sse)
     }
 
+    @Test func cliCommandEmitsEverySSEPostEventFromModernStubHTTPServer() async throws {
+        let progressNotification: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": ["value": 1],
+        ]
+        let server = try StubMCPHTTPServer.start(
+            responseMode: .sse,
+            postSSEPreludeEventsByMethod: ["tools/list": [progressNotification]]
+        )
+        let errors = CapturedLines()
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { errors.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { upstreamURL, requestTimeout, input, output in
+                    StdioAdapter(
+                        upstreamURL: upstreamURL,
+                        requestTimeout: requestTimeout,
+                        input: input,
+                        output: output
+                    )
+                },
+                input: inputPipe.fileHandleForReading,
+                output: outputPipe.fileHandleForWriting
+            )
+        )
+
+        do {
+            let initialize =
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#
+            let toolsList = #"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#
+            inputPipe.fileHandleForWriting.write(
+                Data(initialize.utf8) + Data("\n".utf8) + Data(toolsList.utf8) + Data("\n".utf8)
+            )
+            inputPipe.fileHandleForWriting.closeFile()
+
+            let exitCode = try await waitWithTimeout(
+                "CLI command should emit all SSE POST events",
+                timeout: .seconds(5)
+            ) {
+                await command.run(
+                    args: [
+                        "xcode-mcp-proxy",
+                        "--url",
+                        server.url.absoluteString,
+                    ],
+                    environment: [:]
+                )
+            }
+            outputPipe.fileHandleForWriting.closeFile()
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+
+            #expect(exitCode == 0)
+            #expect(errors.snapshot().isEmpty)
+
+            let responseObjects = try parseOutputObjects(outputData)
+            #expect(responseObjects.count == 3)
+            #expect((responseObjects.first?["id"] as? NSNumber)?.intValue == 1)
+            let notificationIndex = try #require(
+                responseObjects.firstIndex {
+                    ($0["method"] as? String) == "notifications/progress"
+                }
+            )
+            let toolsListIndex = try #require(
+                responseObjects.firstIndex {
+                    ($0["id"] as? NSNumber)?.intValue == 2
+                }
+            )
+            #expect(notificationIndex < toolsListIndex)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+
+        try await server.shutdown()
+    }
+
+    @Test func cliCommandStartsSSEAfterInitializeResponseIsWritten() async throws {
+        let startupNotification: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": "notifications/startup",
+            "params": ["value": 1],
+        ]
+        let server = try StubMCPHTTPServer.start(
+            responseMode: .json,
+            delayedResponseMethod: "tools/list",
+            delayedResponseMilliseconds: 1_000,
+            getSSEEvents: [startupNotification]
+        )
+        let errors = CapturedLines()
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { errors.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { upstreamURL, requestTimeout, input, output in
+                    StdioAdapter(
+                        upstreamURL: upstreamURL,
+                        requestTimeout: requestTimeout,
+                        input: input,
+                        output: output
+                    )
+                },
+                input: inputPipe.fileHandleForReading,
+                output: outputPipe.fileHandleForWriting
+            )
+        )
+
+        do {
+            let initialize =
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#
+            let toolsList = #"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#
+            inputPipe.fileHandleForWriting.write(
+                Data(initialize.utf8) + Data("\n".utf8) + Data(toolsList.utf8) + Data("\n".utf8)
+            )
+            inputPipe.fileHandleForWriting.closeFile()
+            let exitCode = try await waitWithTimeout(
+                "CLI command should finish after stdin closes",
+                timeout: .seconds(5)
+            ) {
+                await command.run(
+                    args: [
+                        "xcode-mcp-proxy",
+                        "--url",
+                        server.url.absoluteString,
+                    ],
+                    environment: [:]
+                )
+            }
+            outputPipe.fileHandleForWriting.closeFile()
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+
+            #expect(exitCode == 0)
+            #expect(errors.snapshot().isEmpty)
+
+            let responseObjects = try parseOutputObjects(outputData)
+            #expect((responseObjects.first?["id"] as? NSNumber)?.intValue == 1)
+            #expect(server.recorder.snapshot().contains { $0.httpMethod == "GET" })
+            if let notificationIndex = responseObjects.firstIndex(where: {
+                ($0["method"] as? String) == "notifications/startup"
+            }) {
+                #expect(notificationIndex > 0)
+            }
+        } catch {
+            inputPipe.fileHandleForWriting.closeFile()
+            try? await server.shutdown()
+            throw error
+        }
+
+        try await server.shutdown()
+    }
+
     @Test func cliCommandDoesNotSerializeRequestsAfterInitialize() async throws {
         let server = try StubMCPHTTPServer.start(
             responseMode: .json,
@@ -386,15 +554,7 @@ struct CLICommandIntegrationTests {
             #expect(exitCode == 0)
             #expect(errors.snapshot().isEmpty)
 
-            let output = String(decoding: outputData, as: UTF8.self)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let responseObjects = try output
-                .split(separator: "\n")
-                .map { line in
-                    try #require(
-                        JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
-                    )
-                }
+            let responseObjects = try parseOutputObjects(outputData)
             #expect(responseObjects.count == 2)
             #expect((responseObjects.first?["id"] as? NSNumber)?.intValue == 1)
             #expect((responseObjects.last?["id"] as? NSNumber)?.intValue == 2)
@@ -431,6 +591,19 @@ struct CLICommandIntegrationTests {
 
         try await server.shutdown()
     }
+
+    private func parseOutputObjects(_ data: Data) throws -> [[String: Any]] {
+        let output = String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard output.isEmpty == false else { return [] }
+        return try output
+            .split(separator: "\n")
+            .map { line in
+                try #require(
+                    JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+                )
+            }
+    }
 }
 
 private struct StubMCPHTTPServer {
@@ -443,10 +616,17 @@ private struct StubMCPHTTPServer {
     static func start(
         responseMode: StubMCPHTTPResponseMode,
         delayedResponseMethod: String? = nil,
+        delayedResponseMilliseconds: Int = 250,
         hangingResponseMethod: String? = nil,
         initializeProtocolVersion: String? = MCPProtocolVersion.current,
-        hangsDELETE: Bool = false
+        hangsDELETE: Bool = false,
+        postSSEPreludeEventsByMethod: [String: [[String: Any]]] = [:],
+        getSSEEvents: [[String: Any]] = []
     ) throws -> StubMCPHTTPServer {
+        let postSSEPreludeEventDataByMethod = postSSEPreludeEventsByMethod.mapValues { events in
+            events.compactMap { stubSSEEventData(for: $0) }
+        }
+        let getSSEEventData = getSSEEvents.compactMap { stubSSEEventData(for: $0) }
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let childChannelTracker = HTTPTestServerChannelTracker()
         let recorder = StubMCPHTTPRecorder()
@@ -460,9 +640,12 @@ private struct StubMCPHTTPServer {
                             recorder: recorder,
                             responseMode: responseMode,
                             delayedResponseMethod: delayedResponseMethod,
+                            delayedResponseMilliseconds: delayedResponseMilliseconds,
                             hangingResponseMethod: hangingResponseMethod,
                             initializeProtocolVersion: initializeProtocolVersion,
-                            hangsDELETE: hangsDELETE
+                            hangsDELETE: hangsDELETE,
+                            postSSEPreludeEventDataByMethod: postSSEPreludeEventDataByMethod,
+                            getSSEEventData: getSSEEventData
                         )
                     )
                 }
@@ -527,9 +710,12 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
     private let recorder: StubMCPHTTPRecorder
     private let responseMode: StubMCPHTTPResponseMode
     private let delayedResponseMethod: String?
+    private let delayedResponseMilliseconds: Int
     private let hangingResponseMethod: String?
     private let initializeProtocolVersion: String?
     private let hangsDELETE: Bool
+    private let postSSEPreludeEventDataByMethod: [String: [Data]]
+    private let getSSEEventData: [Data]
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer = ByteBufferAllocator().buffer(capacity: 0)
 
@@ -537,16 +723,22 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
         recorder: StubMCPHTTPRecorder,
         responseMode: StubMCPHTTPResponseMode,
         delayedResponseMethod: String?,
+        delayedResponseMilliseconds: Int,
         hangingResponseMethod: String?,
         initializeProtocolVersion: String?,
-        hangsDELETE: Bool
+        hangsDELETE: Bool,
+        postSSEPreludeEventDataByMethod: [String: [Data]],
+        getSSEEventData: [Data]
     ) {
         self.recorder = recorder
         self.responseMode = responseMode
         self.delayedResponseMethod = delayedResponseMethod
+        self.delayedResponseMilliseconds = delayedResponseMilliseconds
         self.hangingResponseMethod = hangingResponseMethod
         self.initializeProtocolVersion = initializeProtocolVersion
         self.hangsDELETE = hangsDELETE
+        self.postSSEPreludeEventDataByMethod = postSSEPreludeEventDataByMethod
+        self.getSSEEventData = getSSEEventData
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -591,6 +783,14 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
                 headers: headers
             )
             context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
+            var preamble = context.channel.allocator.buffer(capacity: 6)
+            preamble.writeString(": ok\n\n")
+            context.write(wrapOutboundOut(.body(.byteBuffer(preamble))), promise: nil)
+            for eventData in getSSEEventData {
+                var buffer = context.channel.allocator.buffer(capacity: eventData.count)
+                buffer.writeBytes(eventData)
+                context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+            }
             context.flush()
         case .POST:
             if requestObject?["method"] as? String == hangingResponseMethod {
@@ -630,7 +830,12 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
                 responseBody = responseData
                 headers.add(name: "Content-Type", value: "application/json")
             case .sse:
-                responseBody = Data("event: message\ndata: \(String(decoding: responseData, as: UTF8.self))\n\n".utf8)
+                let method = requestObject?["method"] as? String
+                var events = method.flatMap { postSSEPreludeEventDataByMethod[$0] } ?? []
+                if let responseEvent = stubSSEEventData(for: responseObject) {
+                    events.append(responseEvent)
+                }
+                responseBody = Self.sseResponseData(events: events)
                 headers.add(name: "Content-Type", value: "text/event-stream")
             }
             headers.add(name: "Content-Length", value: "\(responseBody.count)")
@@ -641,7 +846,7 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
             )
             if requestObject?["method"] as? String == delayedResponseMethod {
                 let sendableContext = SendableChannelHandlerContext(value: context)
-                context.eventLoop.scheduleTask(in: .milliseconds(250)) {
+                context.eventLoop.scheduleTask(in: .milliseconds(Int64(delayedResponseMilliseconds))) {
                     self.sendPOSTResponse(
                         context: sendableContext.value,
                         responseHead: responseHead,
@@ -680,10 +885,25 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
         context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
         context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
     }
+
+    private static func sseResponseData(events: [Data]) -> Data {
+        var data = Data()
+        for eventData in events {
+            data.append(eventData)
+        }
+        return data
+    }
 }
 
 private struct SendableChannelHandlerContext: @unchecked Sendable {
     let value: ChannelHandlerContext
+}
+
+private func stubSSEEventData(for object: [String: Any]) -> Data? {
+    guard let data = try? JSONSerialization.data(withJSONObject: object, options: []) else {
+        return nil
+    }
+    return Data("event: message\ndata: \(String(decoding: data, as: UTF8.self))\n\n".utf8)
 }
 
 extension XcodeMCPProxyCLICommand: @unchecked Sendable {}

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -257,6 +257,79 @@ struct CLICommandIntegrationTests {
         try await server.shutdown()
     }
 
+    @Test func cliCommandDeletesUninitializedSessionAfterInitializeWithoutProtocol() async throws {
+        let server = try StubMCPHTTPServer.start(
+            responseMode: .json,
+            initializeProtocolVersion: nil
+        )
+        let errors = CapturedLines()
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { errors.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { upstreamURL, requestTimeout, input, output in
+                    StdioAdapter(
+                        upstreamURL: upstreamURL,
+                        requestTimeout: requestTimeout,
+                        input: input,
+                        output: output
+                    )
+                },
+                input: inputPipe.fileHandleForReading,
+                output: outputPipe.fileHandleForWriting
+            )
+        )
+
+        do {
+            let initialize =
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#
+            inputPipe.fileHandleForWriting.write(Data(initialize.utf8) + Data("\n".utf8))
+            inputPipe.fileHandleForWriting.closeFile()
+
+            let exitCode = try await waitWithTimeout(
+                "CLI command should delete uninitialized session after EOF",
+                timeout: .seconds(5)
+            ) {
+                await command.run(
+                    args: [
+                        "xcode-mcp-proxy",
+                        "--url",
+                        server.url.absoluteString,
+                    ],
+                    environment: [:]
+                )
+            }
+            outputPipe.fileHandleForWriting.closeFile()
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+
+            #expect(exitCode == 0)
+            #expect(errors.snapshot().isEmpty)
+            let output = String(decoding: outputData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let responseObject = try #require(
+                JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+            )
+            #expect((responseObject["id"] as? NSNumber)?.intValue == 1)
+
+            let delete = try #require(server.recorder.snapshot().first { $0.httpMethod == "DELETE" })
+            #expect(delete.sessionID == "server-session")
+            #expect(delete.protocolVersion == nil)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+
+        try await server.shutdown()
+    }
+
     private func runCLICommandRoundTrip(responseMode: StubMCPHTTPResponseMode) async throws {
         let server = try StubMCPHTTPServer.start(responseMode: responseMode)
         let errors = CapturedLines()
@@ -371,6 +444,7 @@ private struct StubMCPHTTPServer {
         responseMode: StubMCPHTTPResponseMode,
         delayedResponseMethod: String? = nil,
         hangingResponseMethod: String? = nil,
+        initializeProtocolVersion: String? = MCPProtocolVersion.current,
         hangsDELETE: Bool = false
     ) throws -> StubMCPHTTPServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -387,6 +461,7 @@ private struct StubMCPHTTPServer {
                             responseMode: responseMode,
                             delayedResponseMethod: delayedResponseMethod,
                             hangingResponseMethod: hangingResponseMethod,
+                            initializeProtocolVersion: initializeProtocolVersion,
                             hangsDELETE: hangsDELETE
                         )
                     )
@@ -453,6 +528,7 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
     private let responseMode: StubMCPHTTPResponseMode
     private let delayedResponseMethod: String?
     private let hangingResponseMethod: String?
+    private let initializeProtocolVersion: String?
     private let hangsDELETE: Bool
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer = ByteBufferAllocator().buffer(capacity: 0)
@@ -462,12 +538,14 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
         responseMode: StubMCPHTTPResponseMode,
         delayedResponseMethod: String?,
         hangingResponseMethod: String?,
+        initializeProtocolVersion: String?,
         hangsDELETE: Bool
     ) {
         self.recorder = recorder
         self.responseMode = responseMode
         self.delayedResponseMethod = delayedResponseMethod
         self.hangingResponseMethod = hangingResponseMethod
+        self.initializeProtocolVersion = initializeProtocolVersion
         self.hangsDELETE = hangsDELETE
     }
 
@@ -521,10 +599,13 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
             let isInitialize = requestObject?["method"] as? String == "initialize"
             let resultObject: [String: Any]
             if isInitialize {
-                resultObject = [
-                    "protocolVersion": MCPProtocolVersion.current,
+                var initializeResult: [String: Any] = [
                     "capabilities": [String: Any](),
                 ]
+                if let initializeProtocolVersion {
+                    initializeResult["protocolVersion"] = initializeProtocolVersion
+                }
+                resultObject = initializeResult
             } else {
                 resultObject = [
                     "transport": "stub",

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -19,6 +19,91 @@ struct CLICommandIntegrationTests {
         try await runCLICommandRoundTrip(responseMode: .sse)
     }
 
+    @Test func cliCommandDoesNotSerializeRequestsAfterInitialize() async throws {
+        let server = try StubMCPHTTPServer.start(
+            responseMode: .json,
+            delayedResponseMethod: "tools/call"
+        )
+        let errors = CapturedLines()
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { errors.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { upstreamURL, requestTimeout, input, output in
+                    StdioAdapter(
+                        upstreamURL: upstreamURL,
+                        requestTimeout: requestTimeout,
+                        input: input,
+                        output: output
+                    )
+                },
+                input: inputPipe.fileHandleForReading,
+                output: outputPipe.fileHandleForWriting
+            )
+        )
+
+        do {
+            let initialize =
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#
+            let slowCall = #"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"slow"}}"#
+            let toolsList = #"{"jsonrpc":"2.0","id":3,"method":"tools/list"}"#
+            inputPipe.fileHandleForWriting.write(
+                Data(initialize.utf8) + Data("\n".utf8)
+                    + Data(slowCall.utf8) + Data("\n".utf8)
+                    + Data(toolsList.utf8) + Data("\n".utf8)
+            )
+            inputPipe.fileHandleForWriting.closeFile()
+
+            let exitCode = try await waitWithTimeout(
+                "CLI command should finish after delayed concurrent request completes",
+                timeout: .seconds(5)
+            ) {
+                await command.run(
+                    args: [
+                        "xcode-mcp-proxy",
+                        "--url",
+                        server.url.absoluteString,
+                    ],
+                    environment: [:]
+                )
+            }
+            outputPipe.fileHandleForWriting.closeFile()
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+
+            #expect(exitCode == 0)
+            #expect(errors.snapshot().isEmpty)
+
+            let output = String(decoding: outputData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let responseIDs = try output
+                .split(separator: "\n")
+                .map { line in
+                    let object = try #require(
+                        JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+                    )
+                    return try #require((object["id"] as? NSNumber)?.intValue)
+                }
+            #expect(responseIDs.count == 3)
+            #expect(responseIDs.first == 1)
+            let slowResponseIndex = try #require(responseIDs.firstIndex(of: 2))
+            let fastResponseIndex = try #require(responseIDs.firstIndex(of: 3))
+            #expect(fastResponseIndex < slowResponseIndex)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+
+        try await server.shutdown()
+    }
+
     private func runCLICommandRoundTrip(responseMode: StubMCPHTTPResponseMode) async throws {
         let server = try StubMCPHTTPServer.start(responseMode: responseMode)
         let errors = CapturedLines()
@@ -129,7 +214,10 @@ private struct StubMCPHTTPServer {
     let childChannelTracker: HTTPTestServerChannelTracker
     let recorder: StubMCPHTTPRecorder
 
-    static func start(responseMode: StubMCPHTTPResponseMode) throws -> StubMCPHTTPServer {
+    static func start(
+        responseMode: StubMCPHTTPResponseMode,
+        delayedResponseMethod: String? = nil
+    ) throws -> StubMCPHTTPServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let childChannelTracker = HTTPTestServerChannelTracker()
         let recorder = StubMCPHTTPRecorder()
@@ -141,7 +229,8 @@ private struct StubMCPHTTPServer {
                     channel.pipeline.addHandler(
                         StubMCPHTTPHandler(
                             recorder: recorder,
-                            responseMode: responseMode
+                            responseMode: responseMode,
+                            delayedResponseMethod: delayedResponseMethod
                         )
                     )
                 }
@@ -205,15 +294,18 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
 
     private let recorder: StubMCPHTTPRecorder
     private let responseMode: StubMCPHTTPResponseMode
+    private let delayedResponseMethod: String?
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer = ByteBufferAllocator().buffer(capacity: 0)
 
     init(
         recorder: StubMCPHTTPRecorder,
-        responseMode: StubMCPHTTPResponseMode
+        responseMode: StubMCPHTTPResponseMode,
+        delayedResponseMethod: String?
     ) {
         self.recorder = recorder
         self.responseMode = responseMode
+        self.delayedResponseMethod = delayedResponseMethod
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -300,11 +392,22 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
                 status: .ok,
                 headers: headers
             )
-            var buffer = context.channel.allocator.buffer(capacity: responseBody.count)
-            buffer.writeBytes(responseBody)
-            context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
-            context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
-            context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+            if requestObject?["method"] as? String == delayedResponseMethod {
+                let sendableContext = SendableChannelHandlerContext(value: context)
+                context.eventLoop.scheduleTask(in: .milliseconds(250)) {
+                    self.sendPOSTResponse(
+                        context: sendableContext.value,
+                        responseHead: responseHead,
+                        responseBody: responseBody
+                    )
+                }
+            } else {
+                sendPOSTResponse(
+                    context: context,
+                    responseHead: responseHead,
+                    responseBody: responseBody
+                )
+            }
         case .DELETE:
             let responseHead = HTTPResponseHead(version: requestHead.version, status: .ok)
             context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
@@ -315,6 +418,22 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
             context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
         }
     }
+
+    private func sendPOSTResponse(
+        context: ChannelHandlerContext,
+        responseHead: HTTPResponseHead,
+        responseBody: Data
+    ) {
+        var buffer = context.channel.allocator.buffer(capacity: responseBody.count)
+        buffer.writeBytes(responseBody)
+        context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
+        context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+    }
+}
+
+private struct SendableChannelHandlerContext: @unchecked Sendable {
+    let value: ChannelHandlerContext
 }
 
 extension XcodeMCPProxyCLICommand: @unchecked Sendable {}

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -104,6 +104,75 @@ struct CLICommandIntegrationTests {
         try await server.shutdown()
     }
 
+    @Test func cliCommandBoundsDeleteOnShutdownWhenTimeoutIsDisabled() async throws {
+        let server = try StubMCPHTTPServer.start(responseMode: .json, hangsDELETE: true)
+        let errors = CapturedLines()
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { errors.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { upstreamURL, requestTimeout, input, output in
+                    StdioAdapter(
+                        upstreamURL: upstreamURL,
+                        requestTimeout: requestTimeout,
+                        input: input,
+                        output: output
+                    )
+                },
+                input: inputPipe.fileHandleForReading,
+                output: outputPipe.fileHandleForWriting
+            )
+        )
+
+        do {
+            let initialize =
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#
+            inputPipe.fileHandleForWriting.write(Data(initialize.utf8) + Data("\n".utf8))
+            inputPipe.fileHandleForWriting.closeFile()
+
+            let exitCode = try await waitWithTimeout(
+                "CLI command should not hang waiting for best-effort DELETE",
+                timeout: .seconds(5)
+            ) {
+                await command.run(
+                    args: [
+                        "xcode-mcp-proxy",
+                        "--url",
+                        server.url.absoluteString,
+                        "--request-timeout",
+                        "0",
+                    ],
+                    environment: [:]
+                )
+            }
+            outputPipe.fileHandleForWriting.closeFile()
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+
+            #expect(exitCode == 0)
+            #expect(errors.snapshot().isEmpty)
+            let output = String(decoding: outputData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let responseObject = try #require(
+                JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+            )
+            #expect((responseObject["id"] as? NSNumber)?.intValue == 1)
+            #expect(server.recorder.snapshot().contains { $0.httpMethod == "DELETE" })
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+
+        try await server.shutdown()
+    }
+
     private func runCLICommandRoundTrip(responseMode: StubMCPHTTPResponseMode) async throws {
         let server = try StubMCPHTTPServer.start(responseMode: responseMode)
         let errors = CapturedLines()
@@ -216,7 +285,8 @@ private struct StubMCPHTTPServer {
 
     static func start(
         responseMode: StubMCPHTTPResponseMode,
-        delayedResponseMethod: String? = nil
+        delayedResponseMethod: String? = nil,
+        hangsDELETE: Bool = false
     ) throws -> StubMCPHTTPServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let childChannelTracker = HTTPTestServerChannelTracker()
@@ -230,7 +300,8 @@ private struct StubMCPHTTPServer {
                         StubMCPHTTPHandler(
                             recorder: recorder,
                             responseMode: responseMode,
-                            delayedResponseMethod: delayedResponseMethod
+                            delayedResponseMethod: delayedResponseMethod,
+                            hangsDELETE: hangsDELETE
                         )
                     )
                 }
@@ -295,17 +366,20 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
     private let recorder: StubMCPHTTPRecorder
     private let responseMode: StubMCPHTTPResponseMode
     private let delayedResponseMethod: String?
+    private let hangsDELETE: Bool
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer = ByteBufferAllocator().buffer(capacity: 0)
 
     init(
         recorder: StubMCPHTTPRecorder,
         responseMode: StubMCPHTTPResponseMode,
-        delayedResponseMethod: String?
+        delayedResponseMethod: String?,
+        hangsDELETE: Bool
     ) {
         self.recorder = recorder
         self.responseMode = responseMode
         self.delayedResponseMethod = delayedResponseMethod
+        self.hangsDELETE = hangsDELETE
     }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -409,6 +483,9 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
                 )
             }
         case .DELETE:
+            if hangsDELETE {
+                return
+            }
             let responseHead = HTTPResponseHead(version: requestHead.version, status: .ok)
             context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
             context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -173,6 +173,90 @@ struct CLICommandIntegrationTests {
         try await server.shutdown()
     }
 
+    @Test func cliCommandSendsDeleteAfterTimedOutDrainWithLongRunningRequest() async throws {
+        let server = try StubMCPHTTPServer.start(
+            responseMode: .json,
+            hangingResponseMethod: "tools/call"
+        )
+        let errors = CapturedLines()
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { errors.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { upstreamURL, requestTimeout, input, output in
+                    StdioAdapter(
+                        upstreamURL: upstreamURL,
+                        requestTimeout: requestTimeout,
+                        input: input,
+                        output: output
+                    )
+                },
+                input: inputPipe.fileHandleForReading,
+                output: outputPipe.fileHandleForWriting
+            )
+        )
+
+        do {
+            let initialize =
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#
+            let longRunningCall = #"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"slow"}}"#
+            inputPipe.fileHandleForWriting.write(
+                Data(initialize.utf8) + Data("\n".utf8)
+                    + Data(longRunningCall.utf8) + Data("\n".utf8)
+            )
+            inputPipe.fileHandleForWriting.closeFile()
+
+            let exitCode = try await waitWithTimeout(
+                "CLI command should delete the session after timed-out drain",
+                timeout: .seconds(6)
+            ) {
+                await command.run(
+                    args: [
+                        "xcode-mcp-proxy",
+                        "--url",
+                        server.url.absoluteString,
+                        "--request-timeout",
+                        "0",
+                    ],
+                    environment: [:]
+                )
+            }
+            outputPipe.fileHandleForWriting.closeFile()
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+
+            #expect(exitCode == 0)
+            #expect(errors.snapshot().isEmpty)
+            let output = String(decoding: outputData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let responseIDs = try output
+                .split(separator: "\n")
+                .map { line in
+                    let object = try #require(
+                        JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+                    )
+                    return try #require((object["id"] as? NSNumber)?.intValue)
+                }
+            #expect(responseIDs.contains(1))
+
+            let delete = try #require(server.recorder.snapshot().first { $0.httpMethod == "DELETE" })
+            #expect(delete.sessionID == "server-session")
+            #expect(delete.protocolVersion == MCPProtocolVersion.current)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+
+        try await server.shutdown()
+    }
+
     private func runCLICommandRoundTrip(responseMode: StubMCPHTTPResponseMode) async throws {
         let server = try StubMCPHTTPServer.start(responseMode: responseMode)
         let errors = CapturedLines()
@@ -286,6 +370,7 @@ private struct StubMCPHTTPServer {
     static func start(
         responseMode: StubMCPHTTPResponseMode,
         delayedResponseMethod: String? = nil,
+        hangingResponseMethod: String? = nil,
         hangsDELETE: Bool = false
     ) throws -> StubMCPHTTPServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -301,6 +386,7 @@ private struct StubMCPHTTPServer {
                             recorder: recorder,
                             responseMode: responseMode,
                             delayedResponseMethod: delayedResponseMethod,
+                            hangingResponseMethod: hangingResponseMethod,
                             hangsDELETE: hangsDELETE
                         )
                     )
@@ -366,6 +452,7 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
     private let recorder: StubMCPHTTPRecorder
     private let responseMode: StubMCPHTTPResponseMode
     private let delayedResponseMethod: String?
+    private let hangingResponseMethod: String?
     private let hangsDELETE: Bool
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer = ByteBufferAllocator().buffer(capacity: 0)
@@ -374,11 +461,13 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
         recorder: StubMCPHTTPRecorder,
         responseMode: StubMCPHTTPResponseMode,
         delayedResponseMethod: String?,
+        hangingResponseMethod: String?,
         hangsDELETE: Bool
     ) {
         self.recorder = recorder
         self.responseMode = responseMode
         self.delayedResponseMethod = delayedResponseMethod
+        self.hangingResponseMethod = hangingResponseMethod
         self.hangsDELETE = hangsDELETE
     }
 
@@ -426,6 +515,9 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
             context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
             context.flush()
         case .POST:
+            if requestObject?["method"] as? String == hangingResponseMethod {
+                return
+            }
             let isInitialize = requestObject?["method"] as? String == "initialize"
             let resultObject: [String: Any]
             if isInitialize {

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -1,4 +1,5 @@
 import ProxyCore
+import ProxyMCP
 import ProxyStdioTransport
 import Foundation
 import NIO
@@ -333,6 +334,82 @@ struct CLICommandIntegrationTests {
             )
             #expect((responseObject["id"] as? NSNumber)?.intValue == 1)
             #expect(server.recorder.snapshot().contains { $0.httpMethod == "DELETE" })
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+
+        try await server.shutdown()
+    }
+
+    @Test func cliCommandTreatsAcceptedJSONRPCResponseAsAcknowledged() async throws {
+        let server = try StubMCPHTTPServer.start(responseMode: .json)
+        let errors = CapturedLines()
+        let inputPipe = Pipe()
+        let outputPipe = Pipe()
+        let command = XcodeMCPProxyCLICommand(
+            dependencies: .init(
+                bootstrapLogging: { _ in },
+                stdout: { _ in },
+                makeLogSink: {
+                    CLICommandLogSink(
+                        error: { errors.append($0) },
+                        info: { _, _ in }
+                    )
+                },
+                makeAdapter: { upstreamURL, requestTimeout, input, output in
+                    StdioAdapter(
+                        upstreamURL: upstreamURL,
+                        requestTimeout: requestTimeout,
+                        input: input,
+                        output: output
+                    )
+                },
+                input: inputPipe.fileHandleForReading,
+                output: outputPipe.fileHandleForWriting
+            )
+        )
+
+        do {
+            let initialize =
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#
+            let response = #"{"jsonrpc":"2.0","id":99,"result":{"ok":true}}"#
+            inputPipe.fileHandleForWriting.write(
+                Data(initialize.utf8) + Data("\n".utf8)
+                    + Data(response.utf8) + Data("\n".utf8)
+            )
+            inputPipe.fileHandleForWriting.closeFile()
+
+            let exitCode = try await waitWithTimeout(
+                "CLI command should treat accepted JSON-RPC response as acknowledged",
+                timeout: .seconds(5)
+            ) {
+                await command.run(
+                    args: [
+                        "xcode-mcp-proxy",
+                        "--url",
+                        server.url.absoluteString,
+                    ],
+                    environment: [:]
+                )
+            }
+            outputPipe.fileHandleForWriting.closeFile()
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+
+            #expect(exitCode == 0)
+            #expect(errors.snapshot().isEmpty)
+
+            let responseObjects = try parseOutputObjects(outputData)
+            #expect(responseObjects.count == 1)
+            #expect((responseObjects.first?["id"] as? NSNumber)?.intValue == 1)
+
+            let responsePost = try #require(
+                server.recorder.snapshot().first {
+                    $0.httpMethod == "POST" && $0.bodyMethod == nil
+                }
+            )
+            #expect(responsePost.sessionID == "server-session")
+            #expect(responsePost.protocolVersion == MCPProtocolVersion.current)
         } catch {
             try? await server.shutdown()
             throw error
@@ -793,6 +870,20 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
             }
             context.flush()
         case .POST:
+            if let requestObject,
+                stubIsJSONRPCResponse(requestObject)
+            {
+                var headers = HTTPHeaders()
+                headers.add(name: "Content-Length", value: "0")
+                let responseHead = HTTPResponseHead(
+                    version: requestHead.version,
+                    status: .accepted,
+                    headers: headers
+                )
+                context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
+                context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+                return
+            }
             if requestObject?["method"] as? String == hangingResponseMethod {
                 return
             }
@@ -904,6 +995,16 @@ private func stubSSEEventData(for object: [String: Any]) -> Data? {
         return nil
     }
     return Data("event: message\ndata: \(String(decoding: data, as: UTF8.self))\n\n".utf8)
+}
+
+private func stubIsJSONRPCResponse(_ object: [String: Any]) -> Bool {
+    guard object["method"] == nil,
+        let id = object["id"],
+        RPCID(any: id) != nil
+    else {
+        return false
+    }
+    return object["result"] != nil || object["error"] != nil
 }
 
 extension XcodeMCPProxyCLICommand: @unchecked Sendable {}

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -2,6 +2,7 @@ import ProxyCore
 import ProxyStdioTransport
 import Foundation
 import NIO
+import NIOConcurrencyHelpers
 import NIOHTTP1
 import Testing
 import XcodeMCPProxy
@@ -10,8 +11,16 @@ import XcodeMCPTestSupport
 
 @Suite(.serialized)
 struct CLICommandIntegrationTests {
-    @Test func cliCommandRoundTripsJSONOverStubHTTPServer() async throws {
-        let server = try StubMCPHTTPServer.start()
+    @Test func cliCommandRoundTripsJSONOverModernStubHTTPServer() async throws {
+        try await runCLICommandRoundTrip(responseMode: .json)
+    }
+
+    @Test func cliCommandAcceptsSingleSSEPostResponsesFromModernStubHTTPServer() async throws {
+        try await runCLICommandRoundTrip(responseMode: .sse)
+    }
+
+    private func runCLICommandRoundTrip(responseMode: StubMCPHTTPResponseMode) async throws {
+        let server = try StubMCPHTTPServer.start(responseMode: responseMode)
         let errors = CapturedLines()
         let inputPipe = Pipe()
         let outputPipe = Pipe()
@@ -39,8 +48,12 @@ struct CLICommandIntegrationTests {
         )
 
         do {
-            let request = Data(#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#.utf8) + Data("\n".utf8)
-            inputPipe.fileHandleForWriting.write(request)
+            let initialize =
+                #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{}}}"#
+            let toolsList = #"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#
+            inputPipe.fileHandleForWriting.write(
+                Data(initialize.utf8) + Data("\n".utf8) + Data(toolsList.utf8) + Data("\n".utf8)
+            )
             inputPipe.fileHandleForWriting.closeFile()
 
             let exitCode = try await waitWithTimeout(
@@ -64,12 +77,42 @@ struct CLICommandIntegrationTests {
 
             let output = String(decoding: outputData, as: UTF8.self)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            let responseObject = try #require(
-                JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
-            )
-            #expect((responseObject["id"] as? NSNumber)?.intValue == 1)
-            let result = responseObject["result"] as? [String: Any]
+            let responseObjects = try output
+                .split(separator: "\n")
+                .map { line in
+                    try #require(
+                        JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+                    )
+                }
+            #expect(responseObjects.count == 2)
+            #expect((responseObjects.first?["id"] as? NSNumber)?.intValue == 1)
+            #expect((responseObjects.last?["id"] as? NSNumber)?.intValue == 2)
+            let result = responseObjects.last?["result"] as? [String: Any]
             #expect(result?["transport"] as? String == "stub")
+
+            let requests = server.recorder.snapshot()
+            let initializePost = try #require(requests.first { $0.bodyMethod == "initialize" })
+            #expect(initializePost.httpMethod == "POST")
+            #expect(initializePost.sessionID == nil)
+            #expect(initializePost.protocolVersion == nil)
+            #expect(initializePost.accept == "application/json, text/event-stream")
+            #expect(initializePost.contentType == "application/json")
+
+            let toolsPost = try #require(requests.first { $0.bodyMethod == "tools/list" })
+            #expect(toolsPost.httpMethod == "POST")
+            #expect(toolsPost.sessionID == "server-session")
+            #expect(toolsPost.protocolVersion == MCPProtocolVersion.current)
+            #expect(toolsPost.accept == "application/json, text/event-stream")
+            #expect(toolsPost.contentType == "application/json")
+
+            let sseGet = try #require(requests.first { $0.httpMethod == "GET" })
+            #expect(sseGet.sessionID == "server-session")
+            #expect(sseGet.protocolVersion == MCPProtocolVersion.current)
+            #expect(sseGet.accept == "text/event-stream")
+
+            let delete = try #require(requests.first { $0.httpMethod == "DELETE" })
+            #expect(delete.sessionID == "server-session")
+            #expect(delete.protocolVersion == MCPProtocolVersion.current)
         } catch {
             try? await server.shutdown()
             throw error
@@ -84,16 +127,23 @@ private struct StubMCPHTTPServer {
     let channel: Channel
     let url: URL
     let childChannelTracker: HTTPTestServerChannelTracker
+    let recorder: StubMCPHTTPRecorder
 
-    static func start() throws -> StubMCPHTTPServer {
+    static func start(responseMode: StubMCPHTTPResponseMode) throws -> StubMCPHTTPServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let childChannelTracker = HTTPTestServerChannelTracker()
+        let recorder = StubMCPHTTPRecorder()
         let bootstrap = ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.backlog, value: 32)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 return channel.pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
-                    channel.pipeline.addHandler(StubMCPHTTPHandler())
+                    channel.pipeline.addHandler(
+                        StubMCPHTTPHandler(
+                            recorder: recorder,
+                            responseMode: responseMode
+                        )
+                    )
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -107,7 +157,8 @@ private struct StubMCPHTTPServer {
             group: group,
             channel: channel,
             url: URL(string: "http://127.0.0.1:\(port)/mcp")!,
-            childChannelTracker: childChannelTracker
+            childChannelTracker: childChannelTracker,
+            recorder: recorder
         )
     }
 
@@ -120,12 +171,50 @@ private struct StubMCPHTTPServer {
     }
 }
 
+private enum StubMCPHTTPResponseMode: Sendable {
+    case json
+    case sse
+}
+
+private struct StubMCPHTTPRequest: Sendable {
+    let httpMethod: String
+    let bodyMethod: String?
+    let sessionID: String?
+    let protocolVersion: String?
+    let accept: String?
+    let contentType: String?
+}
+
+private final class StubMCPHTTPRecorder: @unchecked Sendable {
+    private let requests = NIOLockedValueBox<[StubMCPHTTPRequest]>([])
+
+    func append(_ request: StubMCPHTTPRequest) {
+        requests.withLockedValue { requests in
+            requests.append(request)
+        }
+    }
+
+    func snapshot() -> [StubMCPHTTPRequest] {
+        requests.withLockedValue { $0 }
+    }
+}
+
 private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 
+    private let recorder: StubMCPHTTPRecorder
+    private let responseMode: StubMCPHTTPResponseMode
     private var requestHead: HTTPRequestHead?
     private var bodyBuffer = ByteBufferAllocator().buffer(capacity: 0)
+
+    init(
+        recorder: StubMCPHTTPRecorder,
+        responseMode: StubMCPHTTPResponseMode
+    ) {
+        self.recorder = recorder
+        self.responseMode = responseMode
+    }
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         switch unwrapInboundIn(data) {
@@ -143,6 +232,19 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
 
     private func handleRequest(context: ChannelHandlerContext) {
         guard let requestHead else { return }
+        let requestData = Data(bodyBuffer.readableBytesView)
+        let requestObject =
+            (try? JSONSerialization.jsonObject(with: requestData)) as? [String: Any]
+        recorder.append(
+            StubMCPHTTPRequest(
+                httpMethod: requestHead.method.rawValue,
+                bodyMethod: requestObject?["method"] as? String,
+                sessionID: requestHead.headers.first(name: "MCP-Session-Id"),
+                protocolVersion: requestHead.headers.first(name: "MCP-Protocol-Version"),
+                accept: requestHead.headers.first(name: "Accept"),
+                contentType: requestHead.headers.first(name: "Content-Type")
+            )
+        )
 
         switch requestHead.method {
         case .GET:
@@ -158,34 +260,54 @@ private final class StubMCPHTTPHandler: ChannelInboundHandler, @unchecked Sendab
             context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
             context.flush()
         case .POST:
-            let requestData = Data(
-                bodyBuffer.readableBytesView
-            )
-            let requestObject =
-                (try? JSONSerialization.jsonObject(with: requestData)) as? [String: Any]
+            let isInitialize = requestObject?["method"] as? String == "initialize"
+            let resultObject: [String: Any]
+            if isInitialize {
+                resultObject = [
+                    "protocolVersion": MCPProtocolVersion.current,
+                    "capabilities": [String: Any](),
+                ]
+            } else {
+                resultObject = [
+                    "transport": "stub",
+                ]
+            }
             let responseObject: [String: Any] = [
                 "jsonrpc": "2.0",
                 "id": requestObject?["id"] as Any,
-                "result": [
-                    "transport": "stub"
-                ],
+                "result": resultObject,
             ]
             let responseData =
                 (try? JSONSerialization.data(withJSONObject: responseObject, options: []))
                 ?? Data("{}".utf8)
 
             var headers = HTTPHeaders()
-            headers.add(name: "Content-Type", value: "application/json")
-            headers.add(name: "Content-Length", value: "\(responseData.count)")
+            if isInitialize {
+                headers.add(name: "MCP-Session-Id", value: "server-session")
+            }
+            let responseBody: Data
+            switch responseMode {
+            case .json:
+                responseBody = responseData
+                headers.add(name: "Content-Type", value: "application/json")
+            case .sse:
+                responseBody = Data("event: message\ndata: \(String(decoding: responseData, as: UTF8.self))\n\n".utf8)
+                headers.add(name: "Content-Type", value: "text/event-stream")
+            }
+            headers.add(name: "Content-Length", value: "\(responseBody.count)")
             let responseHead = HTTPResponseHead(
                 version: requestHead.version,
                 status: .ok,
                 headers: headers
             )
-            var buffer = context.channel.allocator.buffer(capacity: responseData.count)
-            buffer.writeBytes(responseData)
+            var buffer = context.channel.allocator.buffer(capacity: responseBody.count)
+            buffer.writeBytes(responseBody)
             context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
             context.write(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+            context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+        case .DELETE:
+            let responseHead = HTTPResponseHead(version: requestHead.version, status: .ok)
+            context.write(wrapOutboundOut(.head(responseHead)), promise: nil)
             context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
         default:
             let responseHead = HTTPResponseHead(version: requestHead.version, status: .methodNotAllowed)

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -181,6 +181,35 @@ struct CLIParserTests {
         #expect(config.initializeParamsOverride?.clientName == "custom-client")
     }
 
+    @Test func configRejectsLegacyHandshakeProtocolVersion() throws {
+        let configPath = try makeTempConfigFile(
+            """
+            [upstream_handshake]
+            protocolVersion = "2025-03-26"
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let config = ProxyConfig(
+            listenHost: "localhost",
+            listenPort: 0,
+            upstreamCommand: "xcrun",
+            upstreamArgs: ["mcpbridge"],
+            maxBodyBytes: 1_048_576,
+            requestTimeout: 300,
+            configPath: configPath
+        )
+
+        #expect(config.initializeParamsOverride?.protocolVersion == "2025-03-26")
+        do {
+            try config.validateModernProtocolConfiguration()
+            Issue.record("expected legacy protocolVersion to be rejected")
+        } catch let error as CLIError {
+            #expect(error.description.contains("2025-06-18"))
+            #expect(error.description.contains("2025-03-26"))
+        }
+    }
+
     @Test func cliParsesUpstreamProcesses() async throws {
         let config = try CLIParser.parse(
             args: ["xcode-mcp-proxy", "--upstream-processes", "10"],

--- a/Tests/ProxyContractTests/ExternalContractTests.swift
+++ b/Tests/ProxyContractTests/ExternalContractTests.swift
@@ -20,7 +20,7 @@ struct ExternalContractTests {
               xcode-mcp-proxy [options]
 
             Description:
-              STDIO adapter that forwards MCP traffic to a running xcode-mcp-proxy-server (HTTP/SSE).
+              STDIO compatibility adapter that forwards MCP traffic to a running xcode-mcp-proxy-server (Streamable HTTP).
 
             Options:
               --request-timeout seconds  Request timeout (default: 300, 0 disables)
@@ -59,8 +59,8 @@ struct ExternalContractTests {
               -h, --help
 
             Notes:
-              - Starts the HTTP/SSE proxy server (and spawns xcrun mcpbridge as upstream processes).
-              - Use xcode-mcp-proxy as a STDIO adapter for Codex / Claude Code.
+              - Starts the Streamable HTTP proxy server (and spawns xcrun mcpbridge as upstream processes).
+              - HTTP-capable clients should connect directly; xcode-mcp-proxy is the STDIO compatibility adapter.
               - Default listen: localhost:8765 (override via --listen / --host / --port or env LISTEN/HOST/PORT).
               - --auto-approve opt-in enables automatic approval of the Xcode permission dialog.
               - Initialize config path: --config or env MCP_XCODE_CONFIG

--- a/Tests/ProxyHTTPGatewayTests/DisabledToolHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/DisabledToolHTTPTests.swift
@@ -129,7 +129,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-disabled-notification-mixed",
                 payload: [
@@ -148,23 +148,8 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let body: [String: Any]
-            if let object = bodyData as? [String: Any] {
-                body = object
-            } else if let array = bodyData as? [[String: Any]],
-                let first = array.first
-            {
-                body = first
-            } else {
-                Issue.record("expected forwarded allowed tool response payload")
-                return
-            }
-            let result = body["result"] as? [String: Any]
-            let content = result?["content"] as? [[String: Any]]
-            #expect(content?.first?["text"] as? String == "other-tool-result")
-            #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -190,7 +175,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-disabled-batch-no-upstream",
                 payload: [
@@ -214,24 +199,9 @@ extension HTTPHandlerTests {
                     ],
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-
-            let blocked = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 211 }
-            let blockedResult = blocked?["result"] as? [String: Any]
-            let blockedContent = blockedResult?["content"] as? [[String: Any]]
-            #expect((blockedResult?["isError"] as? Bool) == true)
-            #expect(blockedContent?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
-
-            let forwarded = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 212 }
-            let forwardedError = forwarded?["error"] as? [String: Any]
-            #expect((forwardedError?["code"] as? NSNumber)?.intValue == -32001)
-            #expect(forwardedError?["message"] as? String == "upstream unavailable")
-
+            #expect(response.statusCode == 400)
             #expect(sessionManager.sentToolNames().isEmpty)
-            #expect(sessionManager.chooseUpstreamIndexCallCount() == 1)
+            #expect(sessionManager.chooseUpstreamIndexCallCount() == 0)
         } catch {
             try? await server.shutdown()
             throw error
@@ -267,7 +237,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-disabled-batch",
                 payload: [
@@ -299,20 +269,8 @@ extension HTTPHandlerTests {
                     ],
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-            let blocked = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 201 }
-            let blockedResult = blocked?["result"] as? [String: Any]
-            let blockedContent = blockedResult?["content"] as? [[String: Any]]
-            #expect((blockedResult?["isError"] as? Bool) == true)
-            #expect(blockedContent?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
-            let allowed = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 202 }
-            let allowedResult = allowed?["result"] as? [String: Any]
-            let allowedContent = allowedResult?["content"] as? [[String: Any]]
-            #expect(allowedContent?.first?["text"] as? String == "allowed")
-            #expect(sessionManager.sentToolNames() == ["XcodeListWindows"])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -337,7 +295,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-disabled-all-blocked",
                 payload: [
@@ -360,16 +318,7 @@ extension HTTPHandlerTests {
                     ],
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 1)
-            let blocked = bodyArray.first
-            let result = blocked?["result"] as? [String: Any]
-            let content = result?["content"] as? [[String: Any]]
-            #expect((blocked?["id"] as? NSNumber)?.intValue == 301)
-            #expect((result?["isError"] as? Bool) == true)
-            #expect(content?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
+            #expect(response.statusCode == 400)
             #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()

--- a/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
@@ -198,7 +198,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-docs-batch-fallthrough",
                 payload: [
@@ -216,19 +216,8 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 63 }
-            let docsResult = docs?["result"] as? [String: Any]
-            let docsContent = docsResult?["content"] as? [[String: Any]]
-            #expect(docsContent?.first?["text"] as? String == "{\"answer\":\"upstream-docs\"}")
-            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 64 }
-            let otherResult = other?["result"] as? [String: Any]
-            let otherContent = otherResult?["content"] as? [[String: Any]]
-            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
-            #expect(sessionManager.sentToolNames() == ["DocumentationSearch", "OtherAllowedTool"])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -275,7 +264,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-docs-batch",
                 payload: [
@@ -293,23 +282,9 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-
-            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 701 }
-            let docsResult = docs?["result"] as? [String: Any]
-            let structuredContent = docsResult?["structuredContent"] as? [String: Any]
-            #expect(structuredContent?["answer"] as? String == "docs")
-
-            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 702 }
-            let otherResult = other?["result"] as? [String: Any]
-            let otherContent = otherResult?["content"] as? [[String: Any]]
-            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
-
-            #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
-            #expect(documentationRequests.withLockedValue { $0 } == ["UIView animate"])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
+            #expect(documentationRequests.withLockedValue { $0 }.isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -356,7 +331,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-docs-batch-notification",
                 payload: [
@@ -377,20 +352,8 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 1)
-
-            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 703 }
-            let otherResult = other?["result"] as? [String: Any]
-            let otherContent = otherResult?["content"] as? [[String: Any]]
-            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
-
-            #expect(sessionManager.sentToolNames() == [
-                "DocumentationSearch",
-                "OtherAllowedTool",
-            ])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
             #expect(documentationRequests.withLockedValue { $0 }.isEmpty)
         } catch {
             try? await server.shutdown()
@@ -436,53 +399,26 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let postTask = Task {
-                try await postHTTPAnyData(
-                    url: server.url,
-                    sessionID: "session-docs-batch-forwarding-not-blocked",
-                    payload: [
-                        toolsCallPayload(
-                            id: 721,
-                            name: "DocumentationSearch",
-                            arguments: [
-                                "query": "UIView animate",
-                            ]
-                        ),
-                        toolsCallPayload(
-                            id: 722,
-                            name: "OtherAllowedTool",
-                            arguments: [:]
-                        ),
-                    ]
-                )
-            }
-
-            try await documentationStarted.wait(
-                timeout: .seconds(1),
-                description: "waiting for documentation search to start"
+            let rawResponse = try await assertHTTPBatchRejected(
+                url: server.url,
+                sessionID: "session-docs-batch-forwarding-not-blocked",
+                payload: [
+                    toolsCallPayload(
+                        id: 721,
+                        name: "DocumentationSearch",
+                        arguments: [
+                            "query": "UIView animate",
+                        ]
+                    ),
+                    toolsCallPayload(
+                        id: 722,
+                        name: "OtherAllowedTool",
+                        arguments: [:]
+                    ),
+                ]
             )
-            let didForwardOtherTool = await waitUntil(timeout: .seconds(1)) {
-                sessionManager.sentToolNames() == ["OtherAllowedTool"]
-            }
-            #expect(didForwardOtherTool)
-            await releaseDocumentation.signal()
-
-            let rawResponse = try await postTask.value
-            #expect(rawResponse.statusCode == 200)
-            let bodyData = try JSONSerialization.jsonObject(
-                with: rawResponse.bodyData,
-                options: []
-            )
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 721 }
-            let docsResult = docs?["result"] as? [String: Any]
-            let structuredContent = docsResult?["structuredContent"] as? [String: Any]
-            #expect(structuredContent?["answer"] as? String == "docs")
-            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 722 }
-            let otherResult = other?["result"] as? [String: Any]
-            let otherContent = otherResult?["content"] as? [[String: Any]]
-            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
+            #expect(rawResponse.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             await releaseDocumentation.signal()
             try? await server.shutdown()
@@ -528,7 +464,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-tools-list-batch-local",
                 payload: [
@@ -544,23 +480,9 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-
-            let toolsList = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 731 }
-            let toolsResult = toolsList?["result"] as? [String: Any]
-            let tools = try #require(toolsResult?["tools"] as? [[String: Any]])
-            #expect(tools.map { $0["name"] as? String }.contains("DocumentationSearch"))
-
-            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 732 }
-            let otherResult = other?["result"] as? [String: Any]
-            let otherContent = otherResult?["content"] as? [[String: Any]]
-            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
-
-            #expect(sessionManager.sentMethods() == ["tools/call"])
-            #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentMethods().isEmpty)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -622,7 +544,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-tools-list-activates-docs-route",
                 payload: [
@@ -645,28 +567,9 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 3)
-
-            let toolsList = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 741 }
-            let toolsResult = toolsList?["result"] as? [String: Any]
-            let tools = try #require(toolsResult?["tools"] as? [[String: Any]])
-            #expect(tools.map { $0["name"] as? String }.contains("DocumentationSearch"))
-
-            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 742 }
-            let docsResult = docs?["result"] as? [String: Any]
-            let structuredContent = docsResult?["structuredContent"] as? [String: Any]
-            #expect(structuredContent?["answer"] as? String == "docs")
-
-            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 743 }
-            let otherResult = other?["result"] as? [String: Any]
-            let otherContent = otherResult?["content"] as? [[String: Any]]
-            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
-
-            #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
-            #expect(documentationRequests.withLockedValue { $0 } == ["UIView same batch"])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
+            #expect(documentationRequests.withLockedValue { $0 }.isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -714,7 +617,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-tools-list-docs-unavailable",
                 payload: [
@@ -732,23 +635,9 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-
-            let toolsList = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 751 }
-            let toolsResult = toolsList?["result"] as? [String: Any]
-            let tools = try #require(toolsResult?["tools"] as? [[String: Any]])
-            #expect(tools.map { $0["name"] as? String }.contains("DocumentationSearch") == false)
-
-            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 752 }
-            let docsError = try #require(docs?["error"] as? [String: Any])
-            #expect((docsError["code"] as? NSNumber)?.intValue == -32001)
-            #expect(docsError["message"] as? String == DocumentationProviderUnavailableReason.userFacingMessage)
-
+            #expect(response.statusCode == 400)
             #expect(sessionManager.sentToolNames() == [])
-            #expect(localDocumentationRequests.withLockedValue { $0 } == 1)
+            #expect(localDocumentationRequests.withLockedValue { $0 } == 0)
         } catch {
             try? await server.shutdown()
             throw error
@@ -796,7 +685,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-docs-unavailable-before-other-timeout",
                 payload: [
@@ -814,24 +703,9 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-
-            let docs = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 761 }
-            let docsError = try #require(docs?["error"] as? [String: Any])
-            #expect((docsError["code"] as? NSNumber)?.intValue == -32001)
-            #expect(docsError["message"] as? String == DocumentationProviderUnavailableReason.userFacingMessage)
-
-            let other = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 762 }
-            let otherError = other?["error"] as? [String: Any]
-            #expect(otherError?["message"] as? String == "upstream timeout")
-
-            #expect(sessionManager.sentToolRequests() == [
-                "OtherAllowedTool@0",
-            ])
-            #expect(localDocumentationRequests.withLockedValue { $0 } == 1)
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolRequests().isEmpty)
+            #expect(localDocumentationRequests.withLockedValue { $0 } == 0)
         } catch {
             try? await server.shutdown()
             throw error
@@ -870,7 +744,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-docs-batch-deadline",
                 payload: [
@@ -890,19 +764,8 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let bodyArray = try #require(bodyData as? [[String: Any]])
-            #expect(bodyArray.count == 2)
-
-            let first = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 711 }
-            #expect(first?["result"] != nil)
-
-            let second = bodyArray.first { ($0["id"] as? NSNumber)?.intValue == 712 }
-            let secondError = try #require(second?["error"] as? [String: Any])
-            #expect((secondError["code"] as? NSNumber)?.intValue == -32000)
-            #expect(secondError["message"] as? String == "upstream timeout")
-            #expect(documentationRequests.withLockedValue { $0 } == ["first"])
+            #expect(response.statusCode == 400)
+            #expect(documentationRequests.withLockedValue { $0 }.isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -1083,6 +946,7 @@ extension HTTPHandlerTests {
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
+        _ = sessionManager.session(id: "session-1")
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
         let payload: [String: Any] = [
@@ -1094,9 +958,10 @@ extension HTTPHandlerTests {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: "session-1")
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1117,11 +982,12 @@ extension HTTPHandlerTests {
         #expect(resources?.isEmpty == true)
     }
 
-    @Test func httpSingleItemBatchResourcesListReturnsEmptyArray() async throws {
+    @Test func httpSingleItemBatchResourcesListIsRejected() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
+        _ = sessionManager.session(id: "session-batch-resources")
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
         let payload: [[String: Any]] = [[
@@ -1130,28 +996,9 @@ extension HTTPHandlerTests {
             "method": "resources/list",
             "params": [String: Any](),
         ]]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Mcp-Session-Id", value: "session-batch-resources")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try postJSONArray(payload, sessionID: "session-batch-resources", to: channel)
 
         let response = try collectResponse(from: channel)
-        #expect(response.head.status == .ok)
-
-        let responseArray =
-            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
-            as? [[String: Any]]
-        let responseObject = try #require(responseArray?.first)
-        #expect((responseObject["id"] as? NSNumber)?.intValue == 1)
-        let result = responseObject["result"] as? [String: Any]
-        let resources = result?["resources"] as? [Any]
-        #expect(resources?.isEmpty == true)
+        assertBatchRejected(response)
     }
 }

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -803,7 +803,10 @@ private actor EchoUpstreamClient: UpstreamSlotControlling {
         let method = object["method"] as? String
         let result: [String: Any]
         if method == "initialize" {
-            result = ["capabilities": [String: Any]()]
+            result = [
+                "protocolVersion": MCPProtocolVersion.current,
+                "capabilities": [String: Any](),
+            ]
         } else {
             result = [:]
         }

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -586,6 +586,7 @@ struct HTTPConcurrencyTests {
             request.httpMethod = "GET"
             request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
             request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+            request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
             let sseTask = Task<(HTTPURLResponse, String), Error> {
                 try await withTestURLSession { session in
@@ -915,7 +916,7 @@ private actor ControlledUpstreamClient: UpstreamSlotControlling {
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": id,
-            "result": ["capabilities": [String: Any]()],
+            "result": ["protocolVersion": MCPProtocolVersion.current, "capabilities": [String: Any]()],
         ]
         return try! JSONSerialization.data(withJSONObject: response, options: [])
     }
@@ -1065,6 +1066,7 @@ private actor RefreshSensitiveUpstreamClient: UpstreamSlotControlling {
             "jsonrpc": "2.0",
             "id": id,
             "result": [
+                "protocolVersion": MCPProtocolVersion.current,
                 "capabilities": [String: Any]()
             ],
         ]
@@ -1234,6 +1236,7 @@ private actor SingleFlightRefreshUpstreamClient: UpstreamSlotControlling {
             "jsonrpc": "2.0",
             "id": id,
             "result": [
+                "protocolVersion": MCPProtocolVersion.current,
                 "capabilities": [String: Any]()
             ],
         ]
@@ -1341,6 +1344,7 @@ private actor NotifyingUpstreamClient: UpstreamSlotControlling {
             "jsonrpc": "2.0",
             "id": id,
             "result": [
+                "protocolVersion": MCPProtocolVersion.current,
                 "capabilities": [String: Any]()
             ],
         ]
@@ -1354,7 +1358,7 @@ private func initializePayload(id: Int) -> [String: Any] {
         "id": id,
         "method": "initialize",
         "params": [
-            "protocolVersion": "2025-03-26",
+            "protocolVersion": "2025-06-18",
             "capabilities": [String: Any](),
             "clientInfo": [
                 "name": "xcode-mcp-proxy-concurrency-tests",
@@ -1434,12 +1438,13 @@ private func postJSON(
     request.httpMethod = "POST"
     request.httpBody = data
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     if let timeout {
         request.timeoutInterval = timeout
     }
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
     }
 
     return try await withTestURLSession(timeout: timeout ?? 5) { session in
@@ -1465,12 +1470,13 @@ private func postStatusOnly(
     request.httpMethod = "POST"
     request.httpBody = data
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     if let timeout {
         request.timeoutInterval = timeout
     }
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
     }
 
     return try await withTestURLSession(timeout: timeout ?? 5) { session in
@@ -1514,10 +1520,11 @@ private func postEmbeddedJSON(
 ) throws {
     let data = try JSONSerialization.data(withJSONObject: payload, options: [])
     var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Accept", value: "application/json, text/event-stream")
     head.headers.add(name: "Content-Type", value: "application/json")
     if let sessionID {
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
     }
     var body = channel.allocator.buffer(capacity: data.count)
     body.writeBytes(data)

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -99,6 +99,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         var requestSuccessNotifications = 0
         var pendingResponses: [PendingResponse] = []
         var sentRequests: [SentRequest] = []
+        var sentUpstreamPayloads: [Data] = []
         var availableUpstreamIndices: [Int?] = []
         var requeuedLeaseCount = 0
     }
@@ -213,6 +214,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             state.cachedToolsList = nil
             state.pendingResponses.removeAll()
             state.sentRequests.removeAll()
+            state.sentUpstreamPayloads.removeAll()
             state.upstreamIDMapping.removeAll()
         }
     }
@@ -413,6 +415,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         _ = ensureRunning
         state.withLockedValue { state in
             state.upstreamSendCount += 1
+            state.sentUpstreamPayloads.append(data)
         }
 
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
@@ -750,6 +753,10 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     func sentUpstreamCount() -> Int {
         state.withLockedValue { $0.upstreamSendCount }
+    }
+
+    func sentUpstreamPayloads() -> [Data] {
+        state.withLockedValue { $0.sentUpstreamPayloads }
     }
 
     func sentToolNames() -> [String] {

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -102,6 +102,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         var sentUpstreamPayloads: [Data] = []
         var availableUpstreamIndices: [Int?] = []
         var requeuedLeaseCount = 0
+        var serverRequestResponseSendResults: [UpstreamSendResult] = []
     }
 
     private let state = NIOLockedValueBox(State())
@@ -427,6 +428,52 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         }
         if let array = json as? [Any] {
             handleBatchUpstreamRequest(array, upstreamIndex: upstreamIndex)
+        }
+    }
+
+    func forwardServerRequestResponse(
+        responseData: Data,
+        sessionID: String,
+        responseID: RPCID,
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<ServerRequestResponseForwardingResult> {
+        let session = session(id: sessionID)
+        guard let route = session.serverRequestTracker.lookup(clientID: responseID) else {
+            return eventLoop.makeSucceededFuture(.missingRoute)
+        }
+        guard var rewritten = try? JSONSerialization.jsonObject(
+            with: responseData,
+            options: []
+        ) as? [String: Any] else {
+            return eventLoop.makeSucceededFuture(.invalidResponse)
+        }
+        rewritten["id"] = route.upstreamID.value.foundationObject
+        guard JSONSerialization.isValidJSONObject(rewritten),
+            let data = try? JSONSerialization.data(withJSONObject: rewritten, options: [])
+        else {
+            return eventLoop.makeSucceededFuture(.invalidResponse)
+        }
+
+        let sendResult = state.withLockedValue { state -> UpstreamSendResult in
+            state.upstreamSendCount += 1
+            state.sentUpstreamPayloads.append(data)
+            if state.serverRequestResponseSendResults.isEmpty {
+                return .accepted
+            }
+            return state.serverRequestResponseSendResults.removeFirst()
+        }
+        switch sendResult {
+        case .accepted:
+            _ = session.serverRequestTracker.complete(clientID: responseID, route: route)
+            return eventLoop.makeSucceededFuture(.accepted)
+        case .backpressure, .unavailable:
+            return eventLoop.makeSucceededFuture(.upstreamUnavailable)
+        }
+    }
+
+    func setServerRequestResponseSendResults(_ results: [UpstreamSendResult]) {
+        state.withLockedValue { state in
+            state.serverRequestResponseSendResults = results
         }
     }
 

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -173,6 +173,19 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         }
     }
 
+    func uninitializedSession(id: String) -> SessionContext {
+        state.withLockedValue { state in
+            if let existing = state.sessions[id] {
+                state.sessionProtocolVersions.removeValue(forKey: id)
+                return existing
+            }
+            let context = SessionContext(id: id, config: config)
+            state.sessions[id] = context
+            state.sessionProtocolVersions.removeValue(forKey: id)
+            return context
+        }
+    }
+
     func hasSession(id: String) -> Bool {
         state.withLockedValue { state in
             state.sessions[id] != nil

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -8,13 +8,37 @@ import ProxyCore
 import ProxyMCP
 import ProxySession
 import ProxyXcodeFeatures
- import ProxyXcodeSupport
+import ProxyXcodeSupport
 import XcodeMCPTestSupport
 
 @testable import ProxyHTTPGateway
 
 enum HTTPTestError: Error {
     case missingResponseHead
+}
+
+private let httpTestSessionRegistry = NIOLockedValueBox<[String: any RuntimeCoordinating]>([:])
+
+private func registerHTTPTestServer(
+    url: URL,
+    sessionManager: any RuntimeCoordinating
+) {
+    httpTestSessionRegistry.withLockedValue { registry in
+        registry[url.absoluteString] = sessionManager
+    }
+}
+
+private func unregisterHTTPTestServer(url: URL) {
+    _ = httpTestSessionRegistry.withLockedValue { registry in
+        registry.removeValue(forKey: url.absoluteString)
+    }
+}
+
+private func prepareHTTPTestSession(url: URL, sessionID: String) {
+    let sessionManager = httpTestSessionRegistry.withLockedValue { registry in
+        registry[url.absoluteString]
+    }
+    _ = sessionManager?.session(id: sessionID)
 }
 
 struct UpstreamResponsePlan {
@@ -61,6 +85,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         }
 
         var sessions: [String: SessionContext] = [:]
+        var sessionProtocolVersions: [String: String] = [:]
         var nextUpstreamID: Int64 = 1
         var assignUpstreamIDCount = 0
         var initialized = false
@@ -143,6 +168,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             }
             let context = SessionContext(id: id, config: config)
             state.sessions[id] = context
+            state.sessionProtocolVersions[id] = MCPProtocolVersion.current
             return context
         }
     }
@@ -153,9 +179,16 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         }
     }
 
+    func negotiatedProtocolVersion(id: String) -> String? {
+        state.withLockedValue { state in
+            state.sessionProtocolVersions[id]
+        }
+    }
+
     func removeSession(id: String) {
         let context = state.withLockedValue { state in
-            state.sessions.removeValue(forKey: id)
+            state.sessionProtocolVersions.removeValue(forKey: id)
+            return state.sessions.removeValue(forKey: id)
         }
         context?.notificationHub.closeAll()
     }
@@ -163,6 +196,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
     func debugReset() {
         state.withLockedValue { state in
             state.sessions.removeAll()
+            state.sessionProtocolVersions.removeAll()
             state.cachedToolsList = nil
             state.pendingResponses.removeAll()
             state.sentRequests.removeAll()
@@ -200,14 +234,20 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
+        let negotiatedProtocolVersion =
+            ((requestObject["params"] as? [String: Any])?["protocolVersion"] as? String)
+            ?? MCPProtocolVersion.current
+        _ = session(id: sessionID)
         state.withLockedValue { state in
             state.initialized = true
+            state.sessionProtocolVersions[sessionID] = negotiatedProtocolVersion
         }
         _ = chooseUpstreamIndex()
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": originalID.value.foundationObject,
             "result": [
+                "protocolVersion": negotiatedProtocolVersion,
                 "capabilities": [String: Any]()
             ],
         ]
@@ -896,14 +936,41 @@ func postJSON(
 ) throws {
     let data = try JSONSerialization.data(withJSONObject: payload, options: [])
     var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-    head.headers.add(name: "Accept", value: "application/json")
+    head.headers.add(name: "Accept", value: "application/json, text/event-stream")
     head.headers.add(name: "Content-Type", value: "application/json")
     head.headers.add(name: "Mcp-Session-Id", value: sessionID)
+    head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
     var body = channel.allocator.buffer(capacity: data.count)
     body.writeBytes(data)
     try channel.writeInbound(HTTPServerRequestPart.head(head))
     try channel.writeInbound(HTTPServerRequestPart.body(body))
     try channel.writeInbound(HTTPServerRequestPart.end(nil))
+}
+
+func postJSONArray(
+    _ payload: [Any],
+    sessionID: String?,
+    to channel: EmbeddedChannel
+) throws {
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+    var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+    head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+    head.headers.add(name: "Content-Type", value: "application/json")
+    if let sessionID {
+        head.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+    }
+    var body = channel.allocator.buffer(capacity: data.count)
+    body.writeBytes(data)
+    try channel.writeInbound(HTTPServerRequestPart.head(head))
+    try channel.writeInbound(HTTPServerRequestPart.body(body))
+    try channel.writeInbound(HTTPServerRequestPart.end(nil))
+}
+
+func assertBatchRejected(_ response: (head: HTTPResponseHead, body: String)) {
+    #expect(response.head.status == .badRequest)
+    #expect(response.head.headers.first(name: "Content-Type") == "text/plain; charset=utf-8")
+    #expect(response.body == "JSON-RPC batching is not supported")
 }
 
 struct TestHTTPHandlerServer {
@@ -951,6 +1018,7 @@ struct TestHTTPHandlerServer {
         ).wait()
         let port = channel.localAddress?.port ?? 0
         let url = URL(string: "http://\(config.listenHost):\(port)/mcp")!
+        registerHTTPTestServer(url: url, sessionManager: sessionManager)
         return TestHTTPHandlerServer(
             group: group,
             channel: channel,
@@ -961,6 +1029,7 @@ struct TestHTTPHandlerServer {
     }
 
     func shutdown() async throws {
+        unregisterHTTPTestServer(url: url)
         try await shutdownHTTPTestServer(
             listenChannel: channel,
             childChannelTracker: childChannelTracker,
@@ -980,15 +1049,20 @@ struct RawHTTPResponse: Sendable {
 func postHTTPJSON(
     url: URL,
     sessionID: String,
-    payload: [String: Any]
+    payload: [String: Any],
+    prepareSession: Bool = true
 ) async throws -> (HTTPURLResponse, [String: Any]) {
+    if prepareSession {
+        prepareHTTPTestSession(url: url, sessionID: sessionID)
+    }
     let data = try JSONSerialization.data(withJSONObject: payload, options: [])
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.httpBody = data
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+    request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
     return try await withTestURLSession { session in
         let (responseData, response) = try await session.data(for: request)
@@ -1005,15 +1079,20 @@ func postHTTPJSON(
 func postHTTPAnyJSON(
     url: URL,
     sessionID: String,
-    payload: [Any]
+    payload: [Any],
+    prepareSession: Bool = true
 ) async throws -> (HTTPURLResponse, Any) {
+    if prepareSession {
+        prepareHTTPTestSession(url: url, sessionID: sessionID)
+    }
     let data = try JSONSerialization.data(withJSONObject: payload, options: [])
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.httpBody = data
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+    request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
     return try await withTestURLSession { session in
         let (responseData, response) = try await session.data(for: request)
@@ -1028,15 +1107,20 @@ func postHTTPAnyJSON(
 func postHTTPAnyData(
     url: URL,
     sessionID: String,
-    payload: [Any]
+    payload: [Any],
+    prepareSession: Bool = true
 ) async throws -> RawHTTPResponse {
+    if prepareSession {
+        prepareHTTPTestSession(url: url, sessionID: sessionID)
+    }
     let data = try JSONSerialization.data(withJSONObject: payload, options: [])
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.httpBody = data
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+    request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
     return try await withTestURLSession { session in
         let (responseData, response) = try await session.data(for: request)
@@ -1047,18 +1131,40 @@ func postHTTPAnyData(
     }
 }
 
+func assertHTTPBatchRejected(
+    url: URL,
+    sessionID: String,
+    payload: [Any],
+    prepareSession: Bool = true
+) async throws -> RawHTTPResponse {
+    let response = try await postHTTPAnyData(
+        url: url,
+        sessionID: sessionID,
+        payload: payload,
+        prepareSession: prepareSession
+    )
+    #expect(response.statusCode == 400)
+    #expect(String(data: response.bodyData, encoding: .utf8) == "JSON-RPC batching is not supported")
+    return response
+}
+
 func postHTTPData(
     url: URL,
     sessionID: String,
-    payload: [String: Any]
+    payload: [String: Any],
+    prepareSession: Bool = true
 ) async throws -> RawHTTPResponse {
+    if prepareSession {
+        prepareHTTPTestSession(url: url, sessionID: sessionID)
+    }
     let data = try JSONSerialization.data(withJSONObject: payload, options: [])
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
     request.httpBody = data
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+    request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
     return try await withTestURLSession { session in
         let (responseData, response) = try await session.data(for: request)
@@ -1102,7 +1208,7 @@ func initializeHTTPChannel(_ channel: EmbeddedChannel) throws -> String {
     ]
     let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
     var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-    initHead.headers.add(name: "Accept", value: "application/json")
+    initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
     initHead.headers.add(name: "Content-Type", value: "application/json")
     var initBody = channel.allocator.buffer(capacity: initData.count)
     initBody.writeBytes(initData)

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -532,6 +532,38 @@ struct HTTPHandlerTests {
         #expect(sessionManager.isInitialized() == false)
     }
 
+    @Test func httpRejectsOriginHostnameWithLoopbackPrefix() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "Origin", value: "http://127.attacker.example:8765")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .forbidden)
+        #expect(response.body == "origin not allowed")
+        #expect(sessionManager.isInitialized() == false)
+    }
+
     @Test func httpPostRejectsLargeBody() async throws {
         let config = makeConfig(maxBodyBytes: 1)
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -8,7 +8,7 @@ import ProxyCore
 import ProxyMCP
 import ProxySession
 import ProxyXcodeFeatures
- import ProxyXcodeSupport
+import ProxyXcodeSupport
 import XcodeMCPTestSupport
 
 @testable import ProxyHTTPGateway
@@ -314,7 +314,7 @@ struct HTTPHandlerTests {
         #expect(response.head.status == .notAcceptable)
     }
 
-    @Test func httpPostRejectsNonJSONContentType() async throws {
+    @Test func httpPostRequiresJSONAndEventStreamAcceptTypes() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
@@ -323,6 +323,27 @@ struct HTTPHandlerTests {
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
         head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        var body = channel.allocator.buffer(capacity: 2)
+        body.writeString("{}")
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .notAcceptable)
+        #expect(response.body == "client must accept application/json and text/event-stream")
+    }
+
+    @Test func httpPostRejectsNonJSONContentType() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "text/plain")
         var body = channel.allocator.buffer(capacity: 2)
         body.writeString("{}")
@@ -334,6 +355,183 @@ struct HTTPHandlerTests {
         #expect(response.head.status == .unsupportedMediaType)
     }
 
+    @Test func httpPostNonInitializeRequiresSessionHeader() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .badRequest)
+        #expect(response.body == "session id required")
+    }
+
+    @Test func httpPostUnknownSessionReturnsNotFound() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "MCP-Session-Id", value: "missing-session")
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .notFound)
+        #expect(response.body == "session not found")
+    }
+
+    @Test func httpPostRequiresNegotiatedProtocolVersionAfterInitialize() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+        let sessionID = try initializeHTTPChannel(channel)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "MCP-Session-Id", value: sessionID)
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .badRequest)
+        #expect(response.body == "protocol version required")
+    }
+
+    @Test func httpPostRejectsMismatchedProtocolVersionAfterInitialize() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+        let sessionID = try initializeHTTPChannel(channel)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "MCP-Session-Id", value: sessionID)
+        head.headers.add(name: "MCP-Protocol-Version", value: "2025-11-25")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .badRequest)
+        #expect(response.body == "protocol version mismatch")
+    }
+
+    @Test func httpDeleteTerminatesSession() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+        let sessionID = try initializeHTTPChannel(channel)
+
+        var deleteHead = HTTPRequestHead(version: .http1_1, method: .DELETE, uri: "/mcp")
+        deleteHead.headers.add(name: "MCP-Session-Id", value: sessionID)
+        deleteHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        try channel.writeInbound(HTTPServerRequestPart.head(deleteHead))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let deleteResponse = try collectResponse(from: channel)
+        #expect(deleteResponse.head.status == .ok)
+        #expect(sessionManager.hasSession(id: sessionID) == false)
+
+        var sseHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/mcp")
+        sseHead.headers.add(name: "Accept", value: "text/event-stream")
+        sseHead.headers.add(name: "MCP-Session-Id", value: sessionID)
+        sseHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        try channel.writeInbound(HTTPServerRequestPart.head(sseHead))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let afterDeleteResponse = try collectResponse(from: channel)
+        #expect(afterDeleteResponse.head.status == .notFound)
+        #expect(afterDeleteResponse.body == "session not found")
+    }
+
+    @Test func httpRejectsInvalidOrigin() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "Origin", value: "https://example.invalid")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .forbidden)
+        #expect(response.body == "origin not allowed")
+        #expect(sessionManager.isInitialized() == false)
+    }
+
     @Test func httpPostRejectsLargeBody() async throws {
         let config = makeConfig(maxBodyBytes: 1)
         let channel = EmbeddedChannel()
@@ -342,7 +540,7 @@ struct HTTPHandlerTests {
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         var body = channel.allocator.buffer(capacity: 2)
         body.writeString("{}")
@@ -366,7 +564,7 @@ struct HTTPHandlerTests {
             "id": 1,
             "method": "initialize",
             "params": [
-                "protocolVersion": "2025-03-26",
+                "protocolVersion": "2025-06-18",
                 "capabilities": [String: Any](),
                 "clientInfo": [
                     "name": "xcode-mcp-proxy-tests",
@@ -377,7 +575,7 @@ struct HTTPHandlerTests {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
@@ -410,7 +608,7 @@ struct HTTPHandlerTests {
             "id": 1,
             "method": "initialize",
             "params": [
-                "protocolVersion": "2025-03-26",
+                "protocolVersion": "2025-06-18",
                 "capabilities": [String: Any](),
                 "clientInfo": [
                     "name": "xcode-mcp-proxy-tests",
@@ -445,7 +643,7 @@ struct HTTPHandlerTests {
             "jsonrpc": "2.0",
             "method": "initialize",
             "params": [
-                "protocolVersion": "2025-03-26",
+                "protocolVersion": "2025-06-18",
                 "capabilities": [String: Any](),
                 "clientInfo": [
                     "name": "xcode-mcp-proxy-tests",
@@ -455,7 +653,7 @@ struct HTTPHandlerTests {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
@@ -473,7 +671,7 @@ struct HTTPHandlerTests {
         #expect((error?["message"] as? String) == "missing id")
     }
 
-    @Test func httpSingleElementBatchInitializeMissingIDReturnsArrayShape() async throws {
+    @Test func httpJSONArrayBodyIsRejectedBeforeInitializeRouting() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
@@ -485,7 +683,7 @@ struct HTTPHandlerTests {
                 "jsonrpc": "2.0",
                 "method": "initialize",
                 "params": [
-                    "protocolVersion": "2025-03-26",
+                    "protocolVersion": "2025-06-18",
                     "capabilities": [String: Any](),
                     "clientInfo": [
                         "name": "xcode-mcp-proxy-tests",
@@ -494,34 +692,19 @@ struct HTTPHandlerTests {
                 ],
             ]
         ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try postJSONArray(payload, sessionID: nil, to: channel)
 
         let response = try collectResponse(from: channel)
-        #expect(response.head.status == .ok)
-        #expect(response.head.headers.first(name: "Content-Type") == "application/json")
-        let array = try #require(
-            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
-                as? [[String: Any]])
-        #expect(array.count == 1)
-        #expect(array[0]["id"] is NSNull)
-        let error = array[0]["error"] as? [String: Any]
-        #expect((error?["code"] as? NSNumber)?.intValue == -32600)
-        #expect((error?["message"] as? String) == "missing id")
+        assertBatchRejected(response)
+        #expect(sessionManager.isInitialized() == false)
     }
 
-    @Test func httpSingleElementBatchErrorReturnsArrayShape() async throws {
+    @Test func httpJSONArrayBodyIsRejectedBeforeUpstreamRouting() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
+        _ = sessionManager.session(id: "session-batch")
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
         let payload: [[String: Any]] = [
@@ -531,27 +714,11 @@ struct HTTPHandlerTests {
                 "method": "tools/list",
             ]
         ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try postJSONArray(payload, sessionID: "session-batch", to: channel)
 
         let response = try collectResponse(from: channel)
-        #expect(response.head.status == .ok)
-        #expect(response.head.headers.first(name: "Content-Type") == "application/json")
-        let array = try #require(
-            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
-                as? [[String: Any]])
-        #expect(array.count == 1)
-        #expect((array[0]["id"] as? NSNumber)?.intValue == 42)
-        let error = array[0]["error"] as? [String: Any]
-        #expect((error?["code"] as? NSNumber)?.intValue == -32000)
-        #expect((error?["message"] as? String) == "expected initialize request")
+        assertBatchRejected(response)
+        #expect(sessionManager.sentUpstreamCount() == 0)
     }
 
     @Test func httpTimeoutReturnsMCPErrorAndCleansMapping() async throws {
@@ -571,7 +738,7 @@ struct HTTPHandlerTests {
         ]
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -588,9 +755,10 @@ struct HTTPHandlerTests {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -614,7 +782,7 @@ struct HTTPHandlerTests {
         #expect(sessionManager.mappedUpstreamRequestCount() == 0)
     }
 
-    @Test func httpTimeoutReturnsSSEErrorWhenEventStreamIsPreferred() async throws {
+    @Test func httpPostRequiresBothJSONAndEventStreamAcceptTypes() async throws {
         let config = makeConfig(requestTimeout: 0.1)
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
@@ -631,7 +799,7 @@ struct HTTPHandlerTests {
         ]
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -651,22 +819,20 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        advanceEventLoopTime(on: channel, by: .milliseconds(300))
-
         let response = try collectResponse(from: channel)
-        #expect(response.head.status == .ok)
-        #expect(response.head.headers.first(name: "Content-Type") == "text/event-stream")
-        #expect(response.body.contains("data:"))
-        #expect(response.body.contains("\"code\":-32000"))
+        #expect(response.head.status == .notAcceptable)
+        #expect(response.head.headers.first(name: "Content-Type") == "text/plain; charset=utf-8")
+        #expect(response.body == "client must accept application/json and text/event-stream")
     }
 
-    @Test func httpBatchTimeoutCountsHealthPenaltyOnceAndCleansAllMappings() async throws {
+    @Test func httpJSONArrayBodyDoesNotCreateTimeoutMappings() async throws {
         let config = makeConfig(requestTimeout: 0.1)
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
@@ -683,7 +849,7 @@ struct HTTPHandlerTests {
         ]
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -710,32 +876,14 @@ struct HTTPHandlerTests {
                 "method": "tools/list",
             ],
         ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try postJSONArray(payload, sessionID: sessionID, to: channel)
 
-        #expect(sessionManager.mappedUpstreamRequestCount() == 3)
+        #expect(sessionManager.mappedUpstreamRequestCount() == 0)
         advanceEventLoopTime(on: channel, by: .milliseconds(300))
 
         let response = try collectResponse(from: channel)
-        #expect(response.head.status == .ok)
-        let array = try #require(
-            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
-                as? [[String: Any]])
-        #expect(array.count == 3)
-        for object in array {
-            let error = object["error"] as? [String: Any]
-            #expect((error?["code"] as? NSNumber)?.intValue == -32000)
-            #expect((error?["message"] as? String) == "upstream timeout")
-        }
-        #expect(sessionManager.requestTimeoutNotificationCount() == 1)
+        assertBatchRejected(response)
+        #expect(sessionManager.requestTimeoutNotificationCount() == 0)
         #expect(sessionManager.mappedUpstreamRequestCount() == 0)
     }
 
@@ -756,7 +904,7 @@ struct HTTPHandlerTests {
         ]
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -775,9 +923,10 @@ struct HTTPHandlerTests {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -811,7 +960,7 @@ struct HTTPHandlerTests {
         ]
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -825,9 +974,10 @@ struct HTTPHandlerTests {
         let chooseCountBeforeMalformedRequest = sessionManager.chooseUpstreamIndexCallCount()
 
         var malformedHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        malformedHead.headers.add(name: "Accept", value: "application/json")
+        malformedHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         malformedHead.headers.add(name: "Content-Type", value: "application/json")
         malformedHead.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        malformedHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var malformedBody = channel.allocator.buffer(capacity: 20)
         malformedBody.writeString("{\"jsonrpc\":\"2.0\",")
         try channel.writeInbound(HTTPServerRequestPart.head(malformedHead))
@@ -873,7 +1023,7 @@ struct HTTPHandlerTests {
         ]
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -890,9 +1040,10 @@ struct HTTPHandlerTests {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -910,7 +1061,7 @@ struct HTTPHandlerTests {
         #expect(sessionManager.requestSuccessNotificationCount() == 0)
     }
 
-    @Test func httpSessionHeaderAutoCreatesSession() async throws {
+    @Test func httpInitializeIgnoresCallerProvidedSessionHeader() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
@@ -927,9 +1078,10 @@ struct HTTPHandlerTests {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: "missing-session")
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -938,7 +1090,11 @@ struct HTTPHandlerTests {
 
         let response = try collectResponse(from: channel)
         #expect(response.head.status == .ok)
-        #expect(response.head.headers.first(name: "Mcp-Session-Id") == "missing-session")
+        let returnedSessionID = try #require(response.head.headers.first(name: "Mcp-Session-Id"))
+        #expect(returnedSessionID.isEmpty == false)
+        #expect(returnedSessionID != "missing-session")
+        #expect(sessionManager.hasSession(id: returnedSessionID))
+        #expect(sessionManager.hasSession(id: "missing-session") == false)
         #expect(response.body.contains("\"result\""))
     }
 
@@ -953,6 +1109,7 @@ struct HTTPHandlerTests {
         var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/mcp")
         head.headers.add(name: "Accept", value: "text/event-stream")
         head.headers.add(name: "Mcp-Session-Id", value: "session-1")
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
@@ -985,7 +1142,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -1006,9 +1163,10 @@ struct HTTPHandlerTests {
         let toolsData = try JSONSerialization.data(withJSONObject: toolsPayload, options: [])
 
         var toolsHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        toolsHead.headers.add(name: "Accept", value: "application/json")
+        toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1057,7 +1215,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -1081,9 +1239,10 @@ struct HTTPHandlerTests {
         let toolsData = try JSONSerialization.data(withJSONObject: toolsPayload, options: [])
 
         var toolsHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        toolsHead.headers.add(name: "Accept", value: "application/json")
+        toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1109,11 +1268,12 @@ struct HTTPHandlerTests {
         #expect(sessionManager.refreshToolsListCallCount() == 0)
     }
 
-    @Test func httpSingleItemBatchToolsListUsesCachedResult() async throws {
+    @Test func httpSingleItemBatchToolsListIsRejectedBeforeCacheLookup() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
+        _ = sessionManager.session(id: "session-batch-tools-list")
         sessionManager.setInitialized(true)
         sessionManager.setCachedToolsListResult(
             JSONValue(any: ["tools": [Any]()])!,
@@ -1126,33 +1286,14 @@ struct HTTPHandlerTests {
             "id": 2,
             "method": "tools/list",
         ]]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Mcp-Session-Id", value: "session-batch-tools-list")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try postJSONArray(payload, sessionID: "session-batch-tools-list", to: channel)
 
         let response = try collectResponse(from: channel)
-        #expect(response.head.status == .ok)
-
-        let responseArray =
-            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
-            as? [[String: Any]]
-        let responseObject = try #require(responseArray?.first)
-        #expect((responseObject["id"] as? NSNumber)?.intValue == 2)
-        let result = responseObject["result"] as? [String: Any]
-        let tools = result?["tools"] as? [Any]
-        #expect(tools?.isEmpty == true)
+        assertBatchRejected(response)
         #expect(sessionManager.sentUpstreamCount() == 0)
     }
 
-    @Test func httpForwardedSingleItemBatchToolsListRewritesDescription() async throws {
+    @Test func httpForwardedSingleItemBatchToolsListIsRejectedBeforeForwarding() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
@@ -1179,6 +1320,7 @@ struct HTTPHandlerTests {
                 )
             }
         )
+        _ = sessionManager.session(id: "session-forwarded-batch-tools-list")
         sessionManager.setInitialized(true)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
@@ -1187,31 +1329,11 @@ struct HTTPHandlerTests {
             "id": 22,
             "method": "tools/list",
         ]]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Mcp-Session-Id", value: "session-forwarded-batch-tools-list")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try postJSONArray(payload, sessionID: "session-forwarded-batch-tools-list", to: channel)
 
         let response = try collectResponse(from: channel)
-        #expect(response.head.status == .ok)
-
-        let responseArray =
-            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
-            as? [[String: Any]]
-        let responseObject = try #require(responseArray?.first)
-        let result = responseObject["result"] as? [String: Any]
-        let tools = try #require(result?["tools"] as? [[String: Any]])
-        let refreshTool = tools.first { $0["name"] as? String == "XcodeRefreshCodeIssuesInFile" }
-        let description = refreshTool?["description"] as? String
-        #expect(description?.contains("--refresh-code-issues-mode upstream") == true)
-        #expect(sessionManager.sentUpstreamCount() == 1)
+        assertBatchRejected(response)
+        #expect(sessionManager.sentUpstreamCount() == 0)
     }
 
     @Test func httpToolsListCachesResultOnMissWhenParamsArePresent() async throws {
@@ -1243,7 +1365,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -1267,9 +1389,10 @@ struct HTTPHandlerTests {
         let toolsData = try JSONSerialization.data(withJSONObject: toolsPayload, options: [])
 
         var toolsHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        toolsHead.headers.add(name: "Accept", value: "application/json")
+        toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1292,9 +1415,10 @@ struct HTTPHandlerTests {
         ]
         let toolsData2 = try JSONSerialization.data(withJSONObject: toolsPayload2, options: [])
         var toolsHead2 = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        toolsHead2.headers.add(name: "Accept", value: "application/json")
+        toolsHead2.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead2.headers.add(name: "Content-Type", value: "application/json")
         toolsHead2.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        toolsHead2.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var toolsBody2 = channel.allocator.buffer(capacity: toolsData2.count)
         toolsBody2.writeBytes(toolsData2)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead2))
@@ -1340,7 +1464,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -1359,9 +1483,10 @@ struct HTTPHandlerTests {
         let toolsData = try JSONSerialization.data(withJSONObject: toolsPayload, options: [])
 
         var toolsHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        toolsHead.headers.add(name: "Accept", value: "application/json")
+        toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1409,7 +1534,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -1428,9 +1553,10 @@ struct HTTPHandlerTests {
         let toolsData = try JSONSerialization.data(withJSONObject: toolsPayload, options: [])
 
         var toolsHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        toolsHead.headers.add(name: "Accept", value: "application/json")
+        toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1579,7 +1705,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -1602,6 +1728,7 @@ struct HTTPHandlerTests {
         toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1669,7 +1796,7 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
-    @Test func httpForwardedSingleItemBatchResourcesListRewritesUnsupportedResponse() async throws {
+    @Test func httpForwardedSingleItemBatchResourcesListIsRejectedBeforeForwarding() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
@@ -1688,6 +1815,7 @@ struct HTTPHandlerTests {
                 return .immediate(try JSONSerialization.data(withJSONObject: response, options: []))
             }
         )
+        _ = sessionManager.session(id: "session-forwarded-batch-resources-list")
         sessionManager.setInitialized(true)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
@@ -1697,29 +1825,11 @@ struct HTTPHandlerTests {
             "method": "resources/list",
             "params": [String: Any](),
         ]]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Mcp-Session-Id", value: "session-forwarded-batch-resources-list")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try postJSONArray(payload, sessionID: "session-forwarded-batch-resources-list", to: channel)
 
         let response = try collectResponse(from: channel)
-        #expect(response.head.status == .ok)
-
-        let responseArray =
-            try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
-            as? [[String: Any]]
-        let responseObject = try #require(responseArray?.first)
-        let result = responseObject["result"] as? [String: Any]
-        let resources = result?["resources"] as? [Any]
-        #expect(resources?.isEmpty == true)
-        #expect(sessionManager.sentUpstreamCount() == 1)
+        assertBatchRejected(response)
+        #expect(sessionManager.sentUpstreamCount() == 0)
     }
 
     @Test func forwardingServiceSelectsMatchingObjectFromMultiItemBatchResponse() throws {
@@ -1834,6 +1944,7 @@ struct HTTPHandlerTests {
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
+        _ = sessionManager.session(id: "session-1")
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
         let payload: [String: Any] = [
@@ -1845,9 +1956,10 @@ struct HTTPHandlerTests {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: "session-1")
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1898,7 +2010,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -1919,9 +2031,10 @@ struct HTTPHandlerTests {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1975,7 +2088,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -1996,9 +2109,10 @@ struct HTTPHandlerTests {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -2047,7 +2161,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -2068,9 +2182,10 @@ struct HTTPHandlerTests {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -2121,7 +2236,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -2142,9 +2257,10 @@ struct HTTPHandlerTests {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -2199,7 +2315,7 @@ struct HTTPHandlerTests {
         let initData = try JSONSerialization.data(withJSONObject: initPayload, options: [])
 
         var initHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        initHead.headers.add(name: "Accept", value: "application/json")
+        initHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         initHead.headers.add(name: "Content-Type", value: "application/json")
         var initBody = channel.allocator.buffer(capacity: initData.count)
         initBody.writeBytes(initData)
@@ -2220,9 +2336,10 @@ struct HTTPHandlerTests {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -648,6 +648,75 @@ struct HTTPHandlerTests {
         #expect(sessionManager.isInitialized() == false)
     }
 
+    @Test func httpAllowsOriginMatchingHostHeaderWhenBoundToWildcard() async throws {
+        var config = makeConfig()
+        config.listenHost = "0.0.0.0"
+        config.listenPort = 8765
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "Host", value: "192.0.2.10:8765")
+        head.headers.add(name: "Origin", value: "http://192.0.2.10:8765")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .ok)
+        #expect(response.head.headers.first(name: "Mcp-Session-Id") != nil)
+    }
+
+    @Test func httpRejectsOriginMismatchingHostHeaderWhenBoundToWildcard() async throws {
+        var config = makeConfig()
+        config.listenHost = "0.0.0.0"
+        config.listenPort = 8765
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "Host", value: "192.0.2.10:8765")
+        head.headers.add(name: "Origin", value: "http://example.invalid:8765")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .forbidden)
+        #expect(response.body == "origin not allowed")
+        #expect(sessionManager.isInitialized() == false)
+    }
+
     @Test func httpPostRejectsLargeBody() async throws {
         let config = makeConfig(maxBodyBytes: 1)
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -712,7 +712,7 @@ struct HTTPHandlerTests {
         #expect(sessionManager.requestSuccessNotificationCount() == 0)
     }
 
-    @Test func httpJSONRPCResponseIsAcceptedWithoutUpstreamRouting() async throws {
+    @Test func httpJSONRPCResponseIsForwardedAndAcceptedWithoutWaiting() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
@@ -721,6 +721,10 @@ struct HTTPHandlerTests {
 
         let sessionID = try initializeHTTPChannel(channel)
         let chooseCountBeforeResponse = sessionManager.chooseUpstreamIndexCallCount()
+        sessionManager.session(id: sessionID).serverRequestTracker.record(
+            idKey: "99",
+            upstreamIndex: 0
+        )
 
         let payload: [String: Any] = [
             "jsonrpc": "2.0",
@@ -733,7 +737,13 @@ struct HTTPHandlerTests {
         #expect(response.head.status == .accepted)
         #expect(response.body.isEmpty)
         #expect(sessionManager.chooseUpstreamIndexCallCount() == chooseCountBeforeResponse)
-        #expect(sessionManager.sentUpstreamCount() == 0)
+        #expect(sessionManager.sentUpstreamCount() == 1)
+        let sentPayload = try #require(sessionManager.sentUpstreamPayloads().last)
+        let sentObject = try #require(
+            JSONSerialization.jsonObject(with: sentPayload, options: []) as? [String: Any]
+        )
+        #expect((sentObject["id"] as? NSNumber)?.intValue == 99)
+        #expect((sentObject["result"] as? [String: Any])?["ok"] as? Bool == true)
     }
 
     @Test func httpInitializePrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -746,6 +746,32 @@ struct HTTPHandlerTests {
         #expect((sentObject["result"] as? [String: Any])?["ok"] as? Bool == true)
     }
 
+    @Test func httpMalformedJSONRPCObjectWithIDReturnsInvalidRequestError() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let sessionID = try initializeHTTPChannel(channel)
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 123,
+        ]
+        try postJSON(payload, sessionID: sessionID, to: channel)
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .ok)
+        let responseObject = try #require(
+            JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
+                as? [String: Any]
+        )
+        #expect((responseObject["id"] as? NSNumber)?.intValue == 123)
+        let error = try #require(responseObject["error"] as? [String: Any])
+        #expect((error["code"] as? NSNumber)?.intValue == -32600)
+        #expect(sessionManager.sentUpstreamCount() == 0)
+    }
+
     @Test func httpInitializePrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -500,6 +500,24 @@ struct HTTPHandlerTests {
         #expect(afterDeleteResponse.body == "session not found")
     }
 
+    @Test func httpDeleteTerminatesUninitializedSession() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+        _ = sessionManager.uninitializedSession(id: "uninitialized-session")
+
+        var deleteHead = HTTPRequestHead(version: .http1_1, method: .DELETE, uri: "/mcp")
+        deleteHead.headers.add(name: "MCP-Session-Id", value: "uninitialized-session")
+        try channel.writeInbound(HTTPServerRequestPart.head(deleteHead))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let deleteResponse = try collectResponse(from: channel)
+        #expect(deleteResponse.head.status == .ok)
+        #expect(sessionManager.hasSession(id: "uninitialized-session") == false)
+    }
+
     @Test func httpRejectsInvalidOrigin() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -721,14 +721,14 @@ struct HTTPHandlerTests {
 
         let sessionID = try initializeHTTPChannel(channel)
         let chooseCountBeforeResponse = sessionManager.chooseUpstreamIndexCallCount()
-        sessionManager.session(id: sessionID).serverRequestTracker.record(
-            idKey: "99",
+        let clientID = sessionManager.session(id: sessionID).serverRequestTracker.record(
+            upstreamID: RPCID(any: NSNumber(value: 99))!,
             upstreamIndex: 0
         )
 
         let payload: [String: Any] = [
             "jsonrpc": "2.0",
-            "id": 99,
+            "id": clientID.value.foundationObject,
             "result": ["ok": true],
         ]
         try postJSON(payload, sessionID: sessionID, to: channel)

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -712,6 +712,30 @@ struct HTTPHandlerTests {
         #expect(sessionManager.requestSuccessNotificationCount() == 0)
     }
 
+    @Test func httpJSONRPCResponseIsAcceptedWithoutUpstreamRouting() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let sessionID = try initializeHTTPChannel(channel)
+        let chooseCountBeforeResponse = sessionManager.chooseUpstreamIndexCallCount()
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 99,
+            "result": ["ok": true],
+        ]
+        try postJSON(payload, sessionID: sessionID, to: channel)
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .accepted)
+        #expect(response.body.isEmpty)
+        #expect(sessionManager.chooseUpstreamIndexCallCount() == chooseCountBeforeResponse)
+        #expect(sessionManager.sentUpstreamCount() == 0)
+    }
+
     @Test func httpInitializePrefersJSONWhenClientAcceptsJSONAndEventStream() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -335,6 +335,38 @@ struct HTTPHandlerTests {
         #expect(response.body == "client must accept application/json and text/event-stream")
     }
 
+    @Test func httpPostAllowsRequiredAcceptTypesAcrossRepeatedHeaders() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": MCPProtocolVersion.current,
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json")
+        head.headers.add(name: "Accept", value: "text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .ok)
+        #expect(response.head.headers.first(name: "Mcp-Session-Id")?.isEmpty == false)
+    }
+
     @Test func httpPostRejectsNonJSONContentType() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -815,6 +815,61 @@ struct HTTPHandlerTests {
         #expect((sentObject["result"] as? [String: Any])?["ok"] as? Bool == true)
     }
 
+    @Test func httpJSONRPCResponseForwardingFailureKeepsRouteForRetry() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let sessionID = try initializeHTTPChannel(channel)
+        let session = sessionManager.session(id: sessionID)
+        let clientID = session.serverRequestTracker.record(
+            upstreamID: RPCID(any: NSNumber(value: 99))!,
+            upstreamIndex: 0
+        )
+        sessionManager.setServerRequestResponseSendResults([.backpressure, .accepted])
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": clientID.value.foundationObject,
+            "result": ["ok": true],
+        ]
+        try postJSON(payload, sessionID: sessionID, to: channel)
+        let rejected = try collectResponse(from: channel)
+        #expect(rejected.head.status == .serviceUnavailable)
+        #expect(rejected.body == "upstream unavailable")
+        #expect(session.serverRequestTracker.lookup(clientID: clientID) != nil)
+
+        try postJSON(payload, sessionID: sessionID, to: channel)
+        let accepted = try collectResponse(from: channel)
+        #expect(accepted.head.status == .accepted)
+        #expect(accepted.body.isEmpty)
+        #expect(session.serverRequestTracker.lookup(clientID: clientID) == nil)
+        #expect(sessionManager.sentUpstreamCount() == 2)
+    }
+
+    @Test func httpUnknownJSONRPCResponseRouteIsAcknowledgedWithoutForwarding() async throws {
+        let config = makeConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let sessionID = try initializeHTTPChannel(channel)
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": "xcode-mcp-proxy.server-request.999",
+            "result": ["ok": true],
+        ]
+        try postJSON(payload, sessionID: sessionID, to: channel)
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .accepted)
+        #expect(response.body.isEmpty)
+        #expect(sessionManager.sentUpstreamCount() == 0)
+    }
+
     @Test func httpMalformedJSONRPCObjectWithIDReturnsInvalidRequestError() async throws {
         let config = makeConfig()
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -745,12 +745,14 @@ struct HTTPHandlerTests {
 
         let response = try collectResponse(from: channel)
         #expect(response.head.status == .ok)
+        #expect(response.head.headers.first(name: "Mcp-Session-Id") == nil)
         let object =
             try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
             as? [String: Any]
         let error = object?["error"] as? [String: Any]
         #expect((error?["code"] as? NSNumber)?.intValue == -32600)
         #expect((error?["message"] as? String) == "missing id")
+        #expect(sessionManager.isInitialized() == false)
     }
 
     @Test func httpJSONArrayBodyIsRejectedBeforeInitializeRouting() async throws {

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -614,6 +614,40 @@ struct HTTPHandlerTests {
         #expect(sessionManager.isInitialized() == false)
     }
 
+    @Test func httpRejectsOriginWithImplicitDefaultPortMismatch() async throws {
+        var config = makeConfig()
+        config.listenPort = 8765
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "Host", value: "localhost:8765")
+        head.headers.add(name: "Origin", value: "http://localhost")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .forbidden)
+        #expect(response.body == "origin not allowed")
+        #expect(sessionManager.isInitialized() == false)
+    }
+
     @Test func httpPostRejectsLargeBody() async throws {
         let config = makeConfig(maxBodyBytes: 1)
         let channel = EmbeddedChannel()

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -213,7 +213,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-proxy-batch",
                 payload: [
@@ -227,29 +227,8 @@ extension HTTPHandlerTests {
                     )
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let body: [String: Any]
-            if let object = bodyData as? [String: Any] {
-                body = object
-            } else if let array = bodyData as? [[String: Any]],
-                let first = array.first
-            {
-                body = first
-            } else {
-                Issue.record("expected single refresh batch response payload")
-                return
-            }
-            let result = body["result"] as? [String: Any]
-            let structuredContent = result?["structuredContent"] as? [String: Any]
-            let issues = structuredContent?["issues"] as? [[String: Any]]
-            #expect((structuredContent?["totalFound"] as? NSNumber)?.intValue == 1)
-            #expect(issues?.count == 1)
-            #expect(issues?.first?["path"] as? String == target.path)
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeListNavigatorIssues",
-            ])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -343,7 +322,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-proxy-mixed",
                 payload: [
@@ -362,20 +341,8 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let body = try #require(bodyData as? [[String: Any]])
-            #expect(body.count == 2)
-            let refreshResult = try #require(
-                body.first(where: { ($0["id"] as? NSNumber)?.intValue == 230 })?["result"] as? [String: Any]
-            )
-            let structuredContent = refreshResult["structuredContent"] as? [String: Any]
-            #expect((structuredContent?["totalFound"] as? NSNumber)?.intValue == 1)
-            let otherResult = try #require(
-                body.first(where: { ($0["id"] as? NSNumber)?.intValue == 231 })?["result"] as? [String: Any]
-            )
-            let otherContent = otherResult["content"] as? [[String: Any]]
-            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -462,7 +429,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-proxy-scalar-leftover",
                 payload: [
@@ -477,27 +444,8 @@ extension HTTPHandlerTests {
                     NSNull(),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let body = try #require(bodyData as? [[String: Any]])
-            #expect(body.count == 2)
-
-            let refreshResult = try #require(
-                body.first(where: { ($0["id"] as? NSNumber)?.intValue == 330 })?["result"] as? [String: Any]
-            )
-            let structuredContent = refreshResult["structuredContent"] as? [String: Any]
-            #expect((structuredContent?["totalFound"] as? NSNumber)?.intValue == 1)
-
-            let invalidRequest = try #require(
-                body.first(where: { $0["id"] is NSNull })
-            )
-            let error = try #require(invalidRequest["error"] as? [String: Any])
-            #expect((error["code"] as? NSNumber)?.intValue == -32600)
-            #expect(error["message"] as? String == "invalid request")
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeListNavigatorIssues",
-            ])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -586,7 +534,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-proxy-notification-leftover",
                 payload: [
@@ -608,24 +556,8 @@ extension HTTPHandlerTests {
                     NSNull(),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let body = try #require(bodyData as? [[String: Any]])
-            #expect(body.count == 2)
-            #expect(sessionManager.sentMethods().contains("notifications/progress"))
-
-            let refreshResult = try #require(
-                body.first(where: { ($0["id"] as? NSNumber)?.intValue == 340 })?["result"] as? [String: Any]
-            )
-            let structuredContent = refreshResult["structuredContent"] as? [String: Any]
-            #expect((structuredContent?["totalFound"] as? NSNumber)?.intValue == 1)
-
-            let invalidRequest = try #require(
-                body.first(where: { $0["id"] is NSNull })
-            )
-            let error = try #require(invalidRequest["error"] as? [String: Any])
-            #expect((error["code"] as? NSNumber)?.intValue == -32600)
-            #expect(error["message"] as? String == "invalid request")
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentMethods().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -660,7 +592,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-refresh-notification-forwarding",
                 payload: [
@@ -682,15 +614,8 @@ extension HTTPHandlerTests {
                     ],
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let body = try #require(bodyData as? [[String: Any]])
-            #expect(body.count == 1)
-            #expect((body.first?["id"] as? NSNumber)?.intValue == 510)
-            #expect(sessionManager.sentToolNames() == [
-                "RunAllTests",
-                "XcodeRefreshCodeIssuesInFile",
-            ])
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
             throw error
@@ -766,7 +691,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-upstream-mixed-retry",
                 payload: [
@@ -785,22 +710,9 @@ extension HTTPHandlerTests {
                     ),
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let body = try #require(bodyData as? [[String: Any]])
-            #expect(body.count == 2)
-            let refreshResult = try #require(
-                body.first(where: { ($0["id"] as? NSNumber)?.intValue == 232 })?["result"] as? [String: Any]
-            )
-            let refreshContent = refreshResult["content"] as? [[String: Any]]
-            #expect(refreshContent?.first?["text"] as? String == "refresh-ok")
-            let otherResult = try #require(
-                body.first(where: { ($0["id"] as? NSNumber)?.intValue == 233 })?["result"] as? [String: Any]
-            )
-            let otherContent = otherResult["content"] as? [[String: Any]]
-            #expect(otherContent?.first?["text"] as? String == "other-tool-result")
-            #expect(refreshAttempts.withLockedValue { $0 } == 2)
-            #expect(otherAttempts.withLockedValue { $0 } == 1)
+            #expect(response.statusCode == 400)
+            #expect(refreshAttempts.withLockedValue { $0 } == 0)
+            #expect(otherAttempts.withLockedValue { $0 } == 0)
         } catch {
             try? await server.shutdown()
             throw error
@@ -1802,7 +1714,7 @@ extension HTTPHandlerTests {
         )
 
         do {
-            let (response, bodyData) = try await postHTTPAnyJSON(
+            let response = try await assertHTTPBatchRejected(
                 url: server.url,
                 sessionID: "session-retry-batch",
                 payload: [
@@ -1816,22 +1728,9 @@ extension HTTPHandlerTests {
                     )
                 ]
             )
-
-            #expect(response.statusCode == 200)
-            let body: [String: Any]
-            if let object = bodyData as? [String: Any] {
-                body = object
-            } else if let array = bodyData as? [[String: Any]],
-                let first = array.first
-            {
-                body = first
-            } else {
-                Issue.record("expected single refresh batch response payload")
-                return
-            }
-            let result = body["result"] as? [String: Any]
-            #expect((result?["isError"] as? Bool) != true)
-            #expect(sessionManager.sentUpstreamCount() == 2)
+            #expect(response.statusCode == 400)
+            #expect(sessionManager.sentUpstreamCount() == 0)
+            #expect(attempts.withLockedValue { $0 } == 0)
         } catch {
             try? await server.shutdown()
             throw error

--- a/Tests/ProxyIntegrationTests/RequestInspectorTests.swift
+++ b/Tests/ProxyIntegrationTests/RequestInspectorTests.swift
@@ -61,10 +61,42 @@ struct RequestInspectorTests {
         #expect(mapped == false)
     }
 
+    @Test func requestInspectorDoesNotMapJSONRPCResponseIDs() async throws {
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 5,
+            "result": ["ok": true],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        var mapped = false
+        let transform = try RequestInspector.transform(
+            data,
+            sessionID: "s1",
+            mapID: { _, _ in
+                mapped = true
+                return 42
+            }
+        )
+
+        #expect(transform.expectsResponse == false)
+        #expect(transform.idKey == nil)
+        #expect(transform.responseIDs.isEmpty)
+        #expect(transform.method == nil)
+        #expect(mapped == false)
+
+        let upstream =
+            try JSONSerialization.jsonObject(with: transform.upstreamData, options: [])
+            as? [String: Any]
+        let id = (upstream?["id"] as? NSNumber)?.intValue
+        #expect(id == 5)
+    }
+
     @Test func requestInspectorMapsBatchRequests() async throws {
         let payload: [Any] = [
             ["jsonrpc": "2.0", "id": 1, "method": "tools/list"],
             ["jsonrpc": "2.0", "method": "ping"],
+            ["jsonrpc": "2.0", "id": 2, "result": ["ok": true]],
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [])
 
@@ -87,6 +119,9 @@ struct RequestInspectorTests {
         let first = upstream?.first as? [String: Any]
         let id = (first?["id"] as? NSNumber)?.intValue
         #expect(id == 77)
+        let third = upstream?[2] as? [String: Any]
+        let responseID = (third?["id"] as? NSNumber)?.intValue
+        #expect(responseID == 2)
         #expect(mappedCount == 1)
         #expect(transform.cacheableToolsListResponseIDKey == "1")
     }

--- a/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
+++ b/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
@@ -52,7 +52,7 @@ struct LiveMCPBridgeTests {
                 "id": 1,
                 "method": "initialize",
                 "params": [
-                    "protocolVersion": "2025-03-26",
+                    "protocolVersion": "2025-06-18",
                     "clientInfo": [
                         "name": assistantName,
                         "version": "dev",
@@ -151,7 +151,7 @@ struct LiveMCPBridgeTests {
                     "id": 1,
                     "method": "initialize",
                     "params": [
-                        "protocolVersion": "2025-03-26",
+                        "protocolVersion": "2025-06-18",
                         "clientInfo": [
                             "name": "XcodeMCPKitLiveTest",
                             "version": "dev",
@@ -309,9 +309,10 @@ private func postJSON(
     var request = URLRequest(url: url, timeoutInterval: 25)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
     }
     request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 
@@ -325,7 +326,7 @@ private func get(
     urlSession: URLSession
 ) async throws -> Data {
     var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     let (data, response) = try await urlSession.data(for: request)
     _ = try #require(response as? HTTPURLResponse)
     return data

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -426,7 +426,7 @@ extension RuntimeCoordinatorTests {
             ]
         )
         let initializeParams = try jsonValue([
-            "protocolVersion": "2025-03-26",
+            "protocolVersion": "2025-06-18",
             "capabilities": [
                 "roots": [
                     "listChanged": true,
@@ -456,7 +456,7 @@ extension RuntimeCoordinatorTests {
             Issue.record("expected initialize params object")
             return
         }
-        guard case .string("2025-03-26")? = observedObject["protocolVersion"] else {
+        guard case .string("2025-06-18")? = observedObject["protocolVersion"] else {
             Issue.record("expected configured protocol version")
             return
         }

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -920,7 +920,7 @@ func makeInitializeRequest(id: Int) -> [String: Any] {
         "id": id,
         "method": "initialize",
         "params": [
-            "protocolVersion": "2025-03-26",
+            "protocolVersion": "2025-06-18",
             "capabilities": [String: Any](),
             "clientInfo": [
                 "name": "session-manager-tests",
@@ -945,6 +945,7 @@ func makeInitializeResponse(id: Int64) throws -> Data {
 
 func makeInitializeResponse(id: Int64, serverName: String?) throws -> Data {
     var result: [String: Any] = [
+        "protocolVersion": MCPProtocolVersion.current,
         "capabilities": [String: Any]()
     ]
     if let serverName {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -1047,8 +1047,11 @@ func spinUntilSentCount(
     count: Int,
     description: String
 ) async throws {
-    try await spinUntil(description, maxIterations: 1_000) {
-        await upstream.sentCount() >= count
+    guard count > 0 else {
+        return
+    }
+    _ = try await waitWithTimeout(description, timeout: .seconds(5)) {
+        try await upstream.nextSent(at: count - 1)
     }
 }
 
@@ -1057,8 +1060,11 @@ func spinUntilSentCount(
     count: Int,
     description: String
 ) async throws {
-    try await spinUntil(description, maxIterations: 1_000) {
-        await upstream.sentCount() >= count
+    guard count > 0 else {
+        return
+    }
+    _ = try await waitWithTimeout(description, timeout: .seconds(5)) {
+        try await upstream.nextSent(at: count - 1)
     }
 }
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -340,6 +340,215 @@ struct RuntimeCoordinatorTests {
         _ = try await responseFuture.get()
     }
 
+    @Test func sessionManagerRoutesServerRequestFromMixedUpstreamBatchThroughTracker()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-mixed-upstream-batch"
+        let session = manager.session(id: sessionID)
+        let initializeFuture = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let sentInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let initializeUpstreamID = try extractUpstreamID(from: sentInitialize)
+        await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
+        _ = try await initializeFuture.get()
+
+        let originalID = RPCID(any: NSNumber(value: 42))!
+        let responseFuture = session.router.registerRequest(
+            idKey: originalID.key,
+            on: eventLoop
+        )
+        let upstreamID = manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: originalID,
+            upstreamIndex: 0
+        )
+
+        let batch: [[String: Any]] = [
+            [
+                "jsonrpc": "2.0",
+                "id": NSNumber(value: upstreamID),
+                "result": ["ok": true],
+            ],
+            [
+                "jsonrpc": "2.0",
+                "id": "server-request-1",
+                "method": "sampling/createMessage",
+                "params": [String: Any](),
+            ],
+        ]
+        manager.routeUpstreamMessage(
+            try JSONSerialization.data(withJSONObject: batch, options: []),
+            upstreamIndex: 0
+        )
+
+        let response = try decodeJSON(from: try await responseFuture.get())
+        #expect((response["id"] as? NSNumber)?.intValue == 42)
+        #expect((response["result"] as? [String: Any])?["ok"] as? Bool == true)
+
+        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let route = try #require(session.serverRequestTracker.lookup(clientID: clientID))
+        #expect(route.upstreamIndex == 0)
+        #expect(route.upstreamID.key == "server-request-1")
+
+        let clientResponse: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": clientID.value.foundationObject,
+            "result": ["accepted": true],
+        ]
+        let forwardingResult = try await manager.forwardServerRequestResponse(
+            responseData: try JSONSerialization.data(withJSONObject: clientResponse, options: []),
+            sessionID: sessionID,
+            responseID: clientID,
+            on: eventLoop
+        ).get()
+        #expect(forwardingResult == .accepted)
+        #expect(session.serverRequestTracker.lookup(clientID: clientID) == nil)
+
+        let forwarded = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        let forwardedObject = try #require(
+            JSONSerialization.jsonObject(with: forwarded, options: []) as? [String: Any]
+        )
+        #expect(forwardedObject["id"] as? String == "server-request-1")
+        #expect((forwardedObject["result"] as? [String: Any])?["accepted"] as? Bool == true)
+    }
+
+    @Test func sessionManagerCompletesMalformedMappedUpstreamResponseWithError()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-malformed-mapped-response"
+        let session = manager.session(id: sessionID)
+        let initializeFuture = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let sentInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let initializeUpstreamID = try extractUpstreamID(from: sentInitialize)
+        await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
+        _ = try await initializeFuture.get()
+
+        let originalID = RPCID(any: NSNumber(value: 42))!
+        let responseFuture = session.router.registerRequest(
+            idKey: originalID.key,
+            on: eventLoop
+        )
+        let upstreamID = manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: originalID,
+            upstreamIndex: 0
+        )
+        let malformedResponse: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": NSNumber(value: upstreamID),
+        ]
+
+        manager.routeUpstreamMessage(
+            try JSONSerialization.data(withJSONObject: malformedResponse, options: []),
+            upstreamIndex: 0
+        )
+
+        let response = try decodeJSON(from: try await responseFuture.get())
+        #expect((response["id"] as? NSNumber)?.intValue == 42)
+        let error = try #require(response["error"] as? [String: Any])
+        #expect((error["code"] as? NSNumber)?.intValue == -32000)
+        #expect(error["message"] as? String == "invalid upstream response")
+    }
+
+    @Test func sessionManagerPreservesServerRequestRouteUntilForwardingSendAccepted()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = ToggleableOverloadUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-server-response-retry"
+        let session = manager.session(id: sessionID)
+        let initializeFuture = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let sentInitialize = try await upstream.nextSent(at: 0)
+        let initializeUpstreamID = try extractUpstreamID(from: sentInitialize)
+        await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
+        _ = try await initializeFuture.get()
+
+        let serverRequest: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": "server-request-1",
+            "method": "sampling/createMessage",
+            "params": [String: Any](),
+        ]
+        manager.routeUnmappedUpstreamMessage(
+            try JSONSerialization.data(withJSONObject: serverRequest, options: []),
+            upstreamIndex: 0
+        )
+
+        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        #expect(session.serverRequestTracker.lookup(clientID: clientID) != nil)
+
+        let clientResponse: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": clientID.value.foundationObject,
+            "result": ["ok": true],
+        ]
+        let clientResponseData = try JSONSerialization.data(
+            withJSONObject: clientResponse,
+            options: []
+        )
+
+        await upstream.overloadNextSend()
+        let rejectedResult = try await manager.forwardServerRequestResponse(
+            responseData: clientResponseData,
+            sessionID: sessionID,
+            responseID: clientID,
+            on: eventLoop
+        ).get()
+        #expect(rejectedResult == .upstreamUnavailable)
+        #expect(session.serverRequestTracker.lookup(clientID: clientID) != nil)
+
+        let acceptedResult = try await manager.forwardServerRequestResponse(
+            responseData: clientResponseData,
+            sessionID: sessionID,
+            responseID: clientID,
+            on: eventLoop
+        ).get()
+        #expect(acceptedResult == .accepted)
+        #expect(session.serverRequestTracker.lookup(clientID: clientID) == nil)
+
+        let forwarded = try await upstream.nextSent(at: 3)
+        let forwardedObject = try #require(
+            JSONSerialization.jsonObject(with: forwarded, options: []) as? [String: Any]
+        )
+        #expect(forwardedObject["id"] as? String == "server-request-1")
+    }
+
     @Test func serverRequestTrackerPreservesDuplicateUpstreamIDsAcrossUpstreams()
         async throws
     {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -324,7 +324,9 @@ struct RuntimeCoordinatorTests {
         #expect(methodName(from: retriedWarmInitialize) == "initialize")
     }
 
-    @Test func sessionManagerDropsUnmappedNotificationsAfterInitializeCompletes() async throws {
+    @Test func sessionManagerBuffersUnmappedNotificationsAfterInitializeUntilNotificationClientConnects()
+        async throws
+    {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
@@ -358,6 +360,12 @@ struct RuntimeCoordinatorTests {
             options: []
         )
         _ = try await future.get()
+        await upstream.yield(.message(notification))
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        #expect(received.first == notification)
+
+        manager.markNotificationClientConnected(sessionID: sessionID)
         await upstream.yield(.message(notification))
         #expect(
             await staysTrue(for: .milliseconds(200)) {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -358,7 +358,49 @@ struct RuntimeCoordinatorTests {
         #expect(secondRoute.upstreamID.key == "duplicate")
     }
 
-    @Test func sessionManagerRoutesServerInitiatedRequestToSingleSession() async throws {
+    @Test func serverRequestTrackerExpiresUnansweredRoutes() async throws {
+        let tracker = ServerRequestTracker(routeTimeout: .seconds(1))
+        let upstreamID = RPCID(any: "stale")!
+        let now = Date()
+
+        let clientID = tracker.record(
+            upstreamID: upstreamID,
+            upstreamIndex: 0,
+            now: now
+        )
+
+        let expired = tracker.consume(
+            clientID: clientID,
+            now: now.addingTimeInterval(2)
+        )
+        #expect(expired == nil)
+    }
+
+    @Test func serverRequestTrackerEvictsOldestRoutesAtCapacity() async throws {
+        let tracker = ServerRequestTracker(routeTimeout: .seconds(60), maxRoutes: 2)
+        let now = Date()
+        let first = tracker.record(
+            upstreamID: RPCID(any: "first")!,
+            upstreamIndex: 0,
+            now: now
+        )
+        let second = tracker.record(
+            upstreamID: RPCID(any: "second")!,
+            upstreamIndex: 0,
+            now: now
+        )
+        let third = tracker.record(
+            upstreamID: RPCID(any: "third")!,
+            upstreamIndex: 0,
+            now: now
+        )
+
+        #expect(tracker.consume(clientID: first, now: now) == nil)
+        #expect(tracker.consume(clientID: second, now: now)?.upstreamID.key == "second")
+        #expect(tracker.consume(clientID: third, now: now)?.upstreamID.key == "third")
+    }
+
+    @Test func sessionManagerRoutesServerInitiatedRequestToOwningSession() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
@@ -390,6 +432,23 @@ struct RuntimeCoordinatorTests {
         )
         _ = try await secondFuture.get()
 
+        let ownerLeaseID = manager.createRequestLease(
+            descriptor: SessionPipelineRequestDescriptor(
+                sessionID: secondSessionID,
+                label: "tools/call:owner",
+                isBatch: false,
+                expectsResponse: true,
+                isTopLevelClientRequest: true
+            )
+        )
+        manager.activateRequestLease(
+            ownerLeaseID,
+            requestIDKey: "owner",
+            upstreamIndex: 0,
+            timeout: .seconds(5)
+        )
+        defer { manager.completeRequestLease(ownerLeaseID) }
+
         let serverRequest: [String: Any] = [
             "jsonrpc": "2.0",
             "id": "server-request-1",
@@ -403,13 +462,10 @@ struct RuntimeCoordinatorTests {
         manager.routeUnmappedUpstreamMessage(serverRequestData, upstreamIndex: 0)
 
         let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
-        let routes = [
-            firstSession.serverRequestTracker.consume(clientID: clientID),
-            secondSession.serverRequestTracker.consume(clientID: clientID),
-        ].compactMap { $0 }
-        #expect(routes.count == 1)
-        #expect(routes.first?.upstreamIndex == 0)
-        #expect(routes.first?.upstreamID.key == "server-request-1")
+        #expect(firstSession.serverRequestTracker.consume(clientID: clientID) == nil)
+        let route = try #require(secondSession.serverRequestTracker.consume(clientID: clientID))
+        #expect(route.upstreamIndex == 0)
+        #expect(route.upstreamID.key == "server-request-1")
     }
 
     @Test func sessionManagerRestoresPendingInitializeWhenInitializedNotificationOverloads()

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -169,6 +169,91 @@ struct RuntimeCoordinatorTests {
         #expect(manager.chooseUpstreamIndex() == 0)
     }
 
+    @Test func sessionManagerRejectsUnsupportedInitializeProtocolBeforeIssuingSession()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-unsupported-protocol"
+        let future = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let upstreamID = try extractUpstreamID(from: sent)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": upstreamID,
+            "result": [
+                "protocolVersion": "2025-03-26",
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let responseData = try JSONSerialization.data(withJSONObject: response, options: [])
+        await upstream.yield(.message(responseData))
+
+        let responseObject = try decodeJSON(
+            from: try await waitWithTimeout(
+                "waiting for unsupported initialize response",
+                timeout: .seconds(2)
+            ) {
+                try await future.get()
+            }
+        )
+        let error = try #require(responseObject["error"] as? [String: Any])
+        #expect(error["message"] as? String == "unsupported upstream protocol version")
+        #expect(manager.hasSession(id: sessionID) == false)
+        #expect(manager.isInitialized() == false)
+    }
+
+    @Test func sessionManagerRecordsServerInitiatedRequestUpstreamForClientResponses()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-server-request"
+        let session = manager.session(id: sessionID)
+        let future = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let upstreamID = try extractUpstreamID(from: sent)
+        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
+        _ = try await future.get()
+
+        let serverRequest: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": "server-request-1",
+            "method": "sampling/createMessage",
+            "params": [String: Any](),
+        ]
+        let serverRequestData = try JSONSerialization.data(
+            withJSONObject: serverRequest,
+            options: []
+        )
+        manager.routeUnmappedUpstreamMessage(serverRequestData, upstreamIndex: 0)
+
+        #expect(session.serverRequestTracker.consume(idKey: "server-request-1") == 0)
+        #expect(session.serverRequestTracker.consume(idKey: "server-request-1") == nil)
+    }
+
     @Test func sessionManagerRestoresPendingInitializeWhenInitializedNotificationOverloads()
         async throws
     {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -285,6 +285,61 @@ struct RuntimeCoordinatorTests {
         #expect(session.serverRequestTracker.consume(clientID: clientID) == nil)
     }
 
+    @Test func sessionManagerDoesNotTreatServerRequestIDAsPendingResponseID()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-server-request-id-collision"
+        let session = manager.session(id: sessionID)
+        let initializeFuture = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let sentInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let initializeUpstreamID = try extractUpstreamID(from: sentInitialize)
+        await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
+        _ = try await initializeFuture.get()
+
+        let originalID = RPCID(any: NSNumber(value: 42))!
+        let responseFuture = session.router.registerRequest(
+            idKey: originalID.key,
+            on: eventLoop
+        )
+        let upstreamID = manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: originalID,
+            upstreamIndex: 0
+        )
+
+        let serverRequest: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": NSNumber(value: upstreamID),
+            "method": "sampling/createMessage",
+            "params": [String: Any](),
+        ]
+        manager.routeUpstreamMessage(
+            try JSONSerialization.data(withJSONObject: serverRequest, options: []),
+            upstreamIndex: 0
+        )
+
+        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let route = try #require(session.serverRequestTracker.consume(clientID: clientID))
+        #expect(route.upstreamIndex == 0)
+        #expect(route.upstreamID.key == String(upstreamID))
+
+        manager.routeUpstreamMessage(try makeToolListResponse(id: upstreamID), upstreamIndex: 0)
+        _ = try await responseFuture.get()
+    }
+
     @Test func serverRequestTrackerPreservesDuplicateUpstreamIDsAcrossUpstreams()
         async throws
     {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -303,6 +303,60 @@ struct RuntimeCoordinatorTests {
         #expect(secondRoute.upstreamID.key == "duplicate")
     }
 
+    @Test func sessionManagerRoutesServerInitiatedRequestToSingleSession() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let firstSessionID = "session-server-request-a"
+        let firstSession = manager.session(id: firstSessionID)
+        let firstFuture = manager.registerInitialize(
+            sessionID: firstSessionID,
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let upstreamID = try extractUpstreamID(from: sent)
+        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
+        _ = try await firstFuture.get()
+
+        let secondSessionID = "session-server-request-b"
+        let secondSession = manager.session(id: secondSessionID)
+        let secondFuture = manager.registerInitialize(
+            sessionID: secondSessionID,
+            originalID: RPCID(any: NSNumber(value: 2))!,
+            requestObject: makeInitializeRequest(id: 2),
+            on: eventLoop
+        )
+        _ = try await secondFuture.get()
+
+        let serverRequest: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": "server-request-1",
+            "method": "sampling/createMessage",
+            "params": [String: Any](),
+        ]
+        let serverRequestData = try JSONSerialization.data(
+            withJSONObject: serverRequest,
+            options: []
+        )
+        manager.routeUnmappedUpstreamMessage(serverRequestData, upstreamIndex: 0)
+
+        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let routes = [
+            firstSession.serverRequestTracker.consume(clientID: clientID),
+            secondSession.serverRequestTracker.consume(clientID: clientID),
+        ].compactMap { $0 }
+        #expect(routes.count == 1)
+        #expect(routes.first?.upstreamIndex == 0)
+        #expect(routes.first?.upstreamID.key == "server-request-1")
+    }
+
     @Test func sessionManagerRestoresPendingInitializeWhenInitializedNotificationOverloads()
         async throws
     {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -214,6 +214,34 @@ struct RuntimeCoordinatorTests {
         #expect(manager.isInitialized() == false)
     }
 
+    @Test func sessionManagerRemovesPendingInitializeSessionOnFailure() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-failed-initialize"
+        let future = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: RPCID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+
+        manager.failInitPending(error: TimeoutError())
+
+        do {
+            _ = try await future.get()
+            #expect(Bool(false), "initialize future should fail")
+        } catch {
+            #expect(manager.hasSession(id: sessionID) == false)
+        }
+    }
+
     @Test func sessionManagerRecordsServerInitiatedRequestUpstreamForClientResponses()
         async throws
     {
@@ -250,8 +278,29 @@ struct RuntimeCoordinatorTests {
         )
         manager.routeUnmappedUpstreamMessage(serverRequestData, upstreamIndex: 0)
 
-        #expect(session.serverRequestTracker.consume(idKey: "server-request-1") == 0)
-        #expect(session.serverRequestTracker.consume(idKey: "server-request-1") == nil)
+        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let route = try #require(session.serverRequestTracker.consume(clientID: clientID))
+        #expect(route.upstreamIndex == 0)
+        #expect(route.upstreamID.key == "server-request-1")
+        #expect(session.serverRequestTracker.consume(clientID: clientID) == nil)
+    }
+
+    @Test func serverRequestTrackerPreservesDuplicateUpstreamIDsAcrossUpstreams()
+        async throws
+    {
+        let tracker = ServerRequestTracker()
+        let upstreamID = RPCID(any: "duplicate")!
+
+        let firstClientID = tracker.record(upstreamID: upstreamID, upstreamIndex: 0)
+        let secondClientID = tracker.record(upstreamID: upstreamID, upstreamIndex: 1)
+
+        #expect(firstClientID.key != secondClientID.key)
+        let firstRoute = try #require(tracker.consume(clientID: firstClientID))
+        let secondRoute = try #require(tracker.consume(clientID: secondClientID))
+        #expect(firstRoute.upstreamIndex == 0)
+        #expect(secondRoute.upstreamIndex == 1)
+        #expect(firstRoute.upstreamID.key == "duplicate")
+        #expect(secondRoute.upstreamID.key == "duplicate")
     }
 
     @Test func sessionManagerRestoresPendingInitializeWhenInitializedNotificationOverloads()

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -1699,7 +1699,7 @@ struct RuntimeCoordinatorTests {
         let clientInfo = try #require(params["clientInfo"] as? [String: Any])
         let capabilities = try #require(params["capabilities"] as? [String: Any])
 
-        #expect(params["protocolVersion"] as? String == "2025-03-26")
+        #expect(params["protocolVersion"] as? String == "2025-06-18")
         #expect(clientInfo["name"] as? String == "custom-proxy")
         #expect(clientInfo["version"] as? String == InitializeHandshakeParams.defaultProxyClientVersion())
         #expect(capabilities["roots"] as? Bool == true)
@@ -1798,7 +1798,7 @@ struct RuntimeCoordinatorTests {
         let params = try #require(object?["params"] as? [String: Any])
         let clientInfo = try #require(params["clientInfo"] as? [String: Any])
 
-        #expect(params["protocolVersion"] as? String == "2025-03-26")
+        #expect(params["protocolVersion"] as? String == "2025-06-18")
         #expect(clientInfo["name"] as? String == InitializeHandshakeParams.defaultProxyClientName())
         #expect(clientInfo["version"] as? String == InitializeHandshakeParams.defaultProxyClientVersion())
     }
@@ -1868,7 +1868,7 @@ struct RuntimeCoordinatorTests {
 
         let snapshot = manager.testStateSnapshot()
         #expect(snapshot.hasInitResult == false)
-        #expect(params["protocolVersion"] as? String == "2025-03-26")
+        #expect(params["protocolVersion"] as? String == "2025-06-18")
         #expect(clientInfo["name"] as? String == "configured-proxy")
         #expect(clientInfo["version"] as? String == InitializeHandshakeParams.defaultProxyClientVersion())
     }

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -415,7 +415,9 @@ struct RuntimeCoordinatorTests {
         _ = try await future.get()
     }
 
-    @Test func sessionManagerDropsUnmappedNotificationsForCachedInitializeSessions() async throws {
+    @Test func sessionManagerBuffersUnmappedNotificationsForCachedInitializeSessionsUntilClientConnects()
+        async throws
+    {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
@@ -457,6 +459,12 @@ struct RuntimeCoordinatorTests {
         await upstream.yield(.message(notification))
 
         _ = try await cachedFuture.get()
+        let received = try await nextBufferedNotifications(from: session.router)
+        #expect(received.count == 1)
+        #expect(received.first == notification)
+
+        manager.markNotificationClientConnected(sessionID: sessionID)
+        await upstream.yield(.message(notification))
         #expect(
             await staysTrue(for: .milliseconds(200)) {
                 session.router.drainBufferedNotifications().isEmpty
@@ -538,7 +546,9 @@ struct RuntimeCoordinatorTests {
         )
     }
 
-    @Test func sessionManagerDoesNotRouteUnmappedNotificationsToCachedInitializeSessions() async throws {
+    @Test func sessionManagerRoutesUnmappedNotificationsToCachedInitializeSessionsUntilClientConnects()
+        async throws
+    {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
@@ -592,6 +602,25 @@ struct RuntimeCoordinatorTests {
         await upstream0.yield(.message(notification0))
         await upstream1.yield(.message(notification1))
 
+        let received = try await waitWithTimeout(
+            "waiting for cached initialize notifications",
+            timeout: .seconds(5)
+        ) {
+            var notifications: [Data] = []
+            while notifications.count < 2 {
+                notifications.append(contentsOf: session.router.drainBufferedNotifications())
+                if notifications.count >= 2 {
+                    return notifications
+                }
+                await Task.yield()
+            }
+            return notifications
+        }
+        #expect(Set(received) == Set([notification0, notification1]))
+
+        manager.markNotificationClientConnected(sessionID: sessionID)
+        await upstream0.yield(.message(notification0))
+        await upstream1.yield(.message(notification1))
         #expect(
             await staysTrue(for: .milliseconds(200)) {
                 session.router.drainBufferedNotifications().isEmpty

--- a/Tests/ProxySessionTests/SSEHubTests.swift
+++ b/Tests/ProxySessionTests/SSEHubTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import NIO
+import NIOEmbedded
+import NIOHTTP1
+import Testing
+
+@testable import ProxySession
+
+@Suite
+struct SSEHubTests {
+    @Test func sseHubSendsEachBroadcastToOnlyOneClient() throws {
+        let hub = SSEHub()
+        let first = EmbeddedChannel()
+        let second = EmbeddedChannel()
+        defer {
+            _ = try? first.finish()
+            _ = try? second.finish()
+        }
+        try first.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 1)).wait()
+        try second.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 2)).wait()
+
+        hub.add(first)
+        hub.add(second)
+
+        let data = Data(#"{"jsonrpc":"2.0","method":"notifications/test"}"#.utf8)
+        hub.broadcast(data)
+        first.embeddedEventLoop.run()
+        second.embeddedEventLoop.run()
+
+        let firstBodies = try sseBodies(from: first)
+        let secondBodies = try sseBodies(from: second)
+        let allBodies = firstBodies + secondBodies
+        #expect(allBodies.count == 1)
+        #expect(allBodies.first?.contains(String(decoding: data, as: UTF8.self)) == true)
+    }
+
+    private func sseBodies(from channel: EmbeddedChannel) throws -> [String] {
+        var bodies: [String] = []
+        while let part = try channel.readOutbound(as: HTTPServerResponsePart.self) {
+            guard case .body(let body) = part else { continue }
+            guard case .byteBuffer(var buffer) = body else { continue }
+            if let string = buffer.readString(length: buffer.readableBytes) {
+                bodies.append(string)
+            }
+        }
+        return bodies
+    }
+}

--- a/Tests/ProxyStressTests/DocumentationSearchStressTests.swift
+++ b/Tests/ProxyStressTests/DocumentationSearchStressTests.swift
@@ -287,7 +287,7 @@ private actor DocumentationSearchStressUpstreamClient: UpstreamSlotControlling {
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": id,
-            "result": ["capabilities": [String: Any]()],
+            "result": ["protocolVersion": MCPProtocolVersion.current, "capabilities": [String: Any]()],
         ]
         return try! JSONSerialization.data(withJSONObject: response, options: [])
     }
@@ -322,7 +322,7 @@ private func initializePayload(id: Int) -> [String: Any] {
         "id": id,
         "method": "initialize",
         "params": [
-            "protocolVersion": "2025-03-26",
+            "protocolVersion": "2025-06-18",
             "clientInfo": [
                 "name": "XcodeMCPKitStressTest",
                 "version": "dev",
@@ -361,9 +361,10 @@ private func postJSON(
     var request = URLRequest(url: url, timeoutInterval: 60)
     request.httpMethod = "POST"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
+        request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
     }
     request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 


### PR DESCRIPTION
## Purpose
Modernize XcodeMCPKit's MCP transport to strict Streamable HTTP while keeping the stdio compatibility binary supported.

## Changes
- Enforce Streamable HTTP Accept, Content-Type, Origin, session, and protocol-version validation at the HTTP gateway.
- Move the supported upstream protocol target to 2025-06-18, reject legacy 2025-03-26 config overrides, and reject JSON-RPC batch arrays at the HTTP boundary.
- Update the stdio adapter to use server-issued sessions, negotiated protocol versions, modern headers, JSON/SSE POST responses, bounded DELETE shutdown, and preserved post-initialize concurrency.
- Refresh Codex/Claude docs and expand HTTP, stdio, config, and regression tests.

## Testing
- ./scripts/check.sh
- codex-review with base main: clean