### PR TITLE
Tighten wildcard origin validation

### DIFF
--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -324,8 +324,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         let hostHeader = requestHead.headers.first(name: "Host")
         guard Self.originHostIsAllowed(
             normalizedOriginHost,
-            configuredHost: config.listenHost,
-            hostHeader: hostHeader
+            configuredHost: config.listenHost
         ) else {
             return false
         }
@@ -356,28 +355,21 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     private static func originHostIsAllowed(
         _ originHost: String,
-        configuredHost: String,
-        hostHeader: String?
-    ) -> Bool {
-        if isLoopbackOrConfiguredHost(originHost, configuredHost: configuredHost) {
-            return true
-        }
-        guard isWildcardHost(configuredHost),
-            let requestHost = host(fromHostHeader: hostHeader)
-        else {
-            return false
-        }
-        return originHost == normalizedHost(requestHost)
-    }
-
-    private static func isLoopbackOrConfiguredHost(
-        _ host: String,
         configuredHost: String
     ) -> Bool {
-        let configured = normalizedHost(configuredHost)
-        if host == configured {
+        if isLoopbackHost(originHost) {
             return true
         }
+
+        let configured = normalizedHost(configuredHost)
+        guard isWildcardHost(configured) == false else {
+            return false
+        }
+
+        return originHost == configured
+    }
+
+    private static func isLoopbackHost(_ host: String) -> Bool {
         if host == "localhost" || host == "::1" || host == "0:0:0:0:0:0:0:1" {
             return true
         }
@@ -412,29 +404,6 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             octets.append(value)
         }
         return octets.first == 127
-    }
-
-    private static func host(fromHostHeader hostHeader: String?) -> String? {
-        guard let hostHeader = hostHeader?.trimmingCharacters(in: .whitespacesAndNewlines),
-            hostHeader.isEmpty == false
-        else {
-            return nil
-        }
-        if hostHeader.hasPrefix("["),
-            let closeBracket = hostHeader.firstIndex(of: "]")
-        {
-            return String(hostHeader[hostHeader.index(after: hostHeader.startIndex)..<closeBracket])
-        }
-        let colonCount = hostHeader.reduce(0) { count, character in
-            character == ":" ? count + 1 : count
-        }
-        if colonCount == 1,
-            let colon = hostHeader.lastIndex(of: ":"),
-            Int(hostHeader[hostHeader.index(after: colon)...]) != nil
-        {
-            return String(hostHeader[..<colon])
-        }
-        return hostHeader
     }
 
     private static func port(fromHostHeader hostHeader: String?) -> Int? {

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -557,24 +557,7 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let payload: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": [
-                "capabilities": [String: Any](),
-            ],
-        ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Origin", value: "https://example.invalid")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try writeInitializePost(to: channel, origin: "https://example.invalid")
 
         let response = try collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
@@ -589,24 +572,7 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let payload: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": [
-                "capabilities": [String: Any](),
-            ],
-        ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Origin", value: "http://127.attacker.example:8765")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try writeInitializePost(to: channel, origin: "http://127.attacker.example:8765")
 
         let response = try collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
@@ -622,25 +588,11 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let payload: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": [
-                "capabilities": [String: Any](),
-            ],
-        ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Host", value: "localhost:8765")
-        head.headers.add(name: "Origin", value: "http://localhost")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try writeInitializePost(
+            to: channel,
+            host: "localhost:8765",
+            origin: "http://localhost"
+        )
 
         let response = try collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
@@ -648,7 +600,7 @@ struct HTTPHandlerTests {
         #expect(sessionManager.isInitialized() == false)
     }
 
-    @Test func httpAllowsOriginMatchingHostHeaderWhenBoundToWildcard() async throws {
+    @Test func httpRejectsNonLoopbackOriginMatchingHostHeaderWhenBoundToWildcard() async throws {
         var config = makeConfig()
         config.listenHost = "0.0.0.0"
         config.listenPort = 8765
@@ -657,25 +609,73 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let payload: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": [
-                "capabilities": [String: Any](),
-            ],
-        ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Host", value: "192.0.2.10:8765")
-        head.headers.add(name: "Origin", value: "http://192.0.2.10:8765")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try writeInitializePost(
+            to: channel,
+            host: "192.0.2.10:8765",
+            origin: "http://192.0.2.10:8765"
+        )
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .forbidden)
+        #expect(response.body == "origin not allowed")
+        #expect(sessionManager.isInitialized() == false)
+    }
+
+    @Test func httpRejectsDNSOriginMatchingHostHeaderWhenBoundToWildcard() async throws {
+        var config = makeConfig()
+        config.listenHost = "0.0.0.0"
+        config.listenPort = 8765
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        try writeInitializePost(
+            to: channel,
+            host: "attacker.example:8765",
+            origin: "http://attacker.example:8765"
+        )
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .forbidden)
+        #expect(response.body == "origin not allowed")
+        #expect(sessionManager.isInitialized() == false)
+    }
+
+    @Test func httpAllowsLoopbackOriginWhenBoundToWildcard() async throws {
+        var config = makeConfig()
+        config.listenHost = "0.0.0.0"
+        config.listenPort = 8765
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        try writeInitializePost(
+            to: channel,
+            host: "localhost:8765",
+            origin: "http://localhost:8765"
+        )
+
+        let response = try collectResponse(from: channel)
+        #expect(response.head.status == .ok)
+        #expect(response.head.headers.first(name: "Mcp-Session-Id") != nil)
+    }
+
+    @Test func httpAllowsOriginMatchingExplicitListenHost() async throws {
+        var config = makeConfig()
+        config.listenHost = "192.0.2.10"
+        config.listenPort = 8765
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        try writeInitializePost(
+            to: channel,
+            host: "192.0.2.10:8765",
+            origin: "http://192.0.2.10:8765"
+        )
 
         let response = try collectResponse(from: channel)
         #expect(response.head.status == .ok)
@@ -691,25 +691,11 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let payload: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": [
-                "capabilities": [String: Any](),
-            ],
-        ]
-        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
-        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
-        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
-        head.headers.add(name: "Content-Type", value: "application/json")
-        head.headers.add(name: "Host", value: "192.0.2.10:8765")
-        head.headers.add(name: "Origin", value: "http://example.invalid:8765")
-        var body = channel.allocator.buffer(capacity: data.count)
-        body.writeBytes(data)
-        try channel.writeInbound(HTTPServerRequestPart.head(head))
-        try channel.writeInbound(HTTPServerRequestPart.body(body))
-        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+        try writeInitializePost(
+            to: channel,
+            host: "192.0.2.10:8765",
+            origin: "http://example.invalid:8765"
+        )
 
         let response = try collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
@@ -2658,6 +2644,34 @@ struct HTTPHandlerTests {
         let result = object?["result"] as? [String: Any]
         #expect((result?["isError"] as? Bool) == true)
         #expect(result?["resources"] == nil)
+    }
+
+    private func writeInitializePost(
+        to channel: EmbeddedChannel,
+        host: String? = nil,
+        origin: String
+    ) throws {
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        if let host {
+            head.headers.add(name: "Host", value: host)
+        }
+        head.headers.add(name: "Origin", value: origin)
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
     }
 
 }


### PR DESCRIPTION
## Purpose

Prevent wildcard-bound HTTP servers from accepting browser requests solely because `Origin` and `Host` match, which weakens DNS rebinding protection.

## Changes

- Restrict Origin host validation to loopback hosts or an explicitly configured non-wildcard listen host.
- Keep existing Origin/Host/listen port consistency checks.
- Update Origin tests to reject non-loopback IP and DNS origins on wildcard binds while preserving loopback and explicit-host allow cases.

## Testing

- `swift test --filter ProxyHTTPGatewayTests`
- `swift test`
- `git diff --check`
- `codex-review` found no issues