### PR TITLE
Refactor proxy support type namespaces

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,6 +52,7 @@ let package = Package(
         .target(
             name: "ProxyMCP",
             dependencies: [
+                "ProxyCore",
                 .product(name: "NIO", package: "swift-nio"),
             ],
             path: "Sources/ProxyMCP",

--- a/Sources/ProxyCLI/Adapter/CLICommandRuntime.swift
+++ b/Sources/ProxyCLI/Adapter/CLICommandRuntime.swift
@@ -3,7 +3,8 @@ import Foundation
 import Logging
 import XcodeMCPProxy
 
-package struct CLICommandRuntime {
+extension XcodeMCPProxyCLICommand {
+    package struct Runtime {
     private let dependencies: XcodeMCPProxyCLICommand.Dependencies
 
     package init(dependencies: XcodeMCPProxyCLICommand.Dependencies) {
@@ -93,7 +94,7 @@ package struct CLICommandRuntime {
     private func logResolvedUpstream(
         config: ProxyConfig,
         upstreamURL: URL,
-        logSink: CLICommandLogSink
+        logSink: XcodeMCPProxyCLICommand.LogSink
     ) {
         let url = upstreamURL.absoluteString
         guard let source = config.stdioUpstreamSource else {
@@ -125,5 +126,6 @@ package struct CLICommandRuntime {
                 ["url": "\(url)"]
             )
         }
+    }
     }
 }

--- a/Sources/ProxyCLI/Adapter/XcodeMCPProxyCLICommand+Parsing.swift
+++ b/Sources/ProxyCLI/Adapter/XcodeMCPProxyCLICommand+Parsing.swift
@@ -3,9 +3,9 @@ import Foundation
 import XcodeMCPProxy
 
 extension XcodeMCPProxyCLICommand {
-    package static func scanInvocation(_ args: [String]) -> CLICommandInvocation {
-        let scan = ProxyCLIInvocationScanner.scanAdapter(args)
-        var invocation = CLICommandInvocation()
+    package static func scanInvocation(_ args: [String]) -> XcodeMCPProxyCLICommand.Invocation {
+        let scan = CLI.InvocationScanner.scanAdapter(args)
+        var invocation = XcodeMCPProxyCLICommand.Invocation()
         invocation.showHelp = scan.showHelp
         invocation.showVersion = scan.showVersion
         invocation.usesRemovedURLHelper = scan.usesRemovedURLHelper
@@ -89,6 +89,6 @@ extension XcodeMCPProxyCLICommand {
     }
 
     static func shouldConsumeRequestTimeoutValue(_ token: String) -> Bool {
-        ProxyCLIInvocationScanner.shouldConsumeRequestTimeoutValue(token)
+        CLI.InvocationScanner.shouldConsumeRequestTimeoutValue(token)
     }
 }

--- a/Sources/ProxyCLI/Adapter/XcodeMCPProxyCLICommand.swift
+++ b/Sources/ProxyCLI/Adapter/XcodeMCPProxyCLICommand.swift
@@ -6,34 +6,34 @@ import XcodeMCPProxy
 
 extension StdioAdapter: CLICommandAdapter {}
 
-package struct CLICommandLogSink {
-    package var error: (String) -> Void
-    package var info: (String, Logger.Metadata) -> Void
-
-    package init(
-        error: @escaping (String) -> Void,
-        info: @escaping (String, Logger.Metadata) -> Void
-    ) {
-        self.error = error
-        self.info = info
-    }
-}
-
-package struct CLICommandInvocation {
-    package var showHelp = false
-    package var showVersion = false
-    package var usesRemovedURLHelper = false
-    package var removedFlagMessage: String?
-    package var hasExplicitURL = false
-    package var hasStdioFlag = false
-    package var serverOnlyFlag: String?
-}
-
 package struct XcodeMCPProxyCLICommand {
+    package struct LogSink {
+        package var error: (String) -> Void
+        package var info: (String, Logger.Metadata) -> Void
+
+        package init(
+            error: @escaping (String) -> Void,
+            info: @escaping (String, Logger.Metadata) -> Void
+        ) {
+            self.error = error
+            self.info = info
+        }
+    }
+
+    package struct Invocation {
+        package var showHelp = false
+        package var showVersion = false
+        package var usesRemovedURLHelper = false
+        package var removedFlagMessage: String?
+        package var hasExplicitURL = false
+        package var hasStdioFlag = false
+        package var serverOnlyFlag: String?
+    }
+
     package struct Dependencies {
         package var bootstrapLogging: ([String: String]) -> Void
         package var stdout: (String) -> Void
-        package var makeLogSink: () -> CLICommandLogSink
+        package var makeLogSink: () -> XcodeMCPProxyCLICommand.LogSink
         package var makeAdapter: (URL, TimeInterval, FileHandle, FileHandle) -> any CLICommandAdapter
         package var input: FileHandle
         package var output: FileHandle
@@ -41,7 +41,7 @@ package struct XcodeMCPProxyCLICommand {
         package init(
             bootstrapLogging: @escaping ([String: String]) -> Void,
             stdout: @escaping (String) -> Void,
-            makeLogSink: @escaping () -> CLICommandLogSink,
+            makeLogSink: @escaping () -> XcodeMCPProxyCLICommand.LogSink,
             makeAdapter: @escaping (URL, TimeInterval, FileHandle, FileHandle) -> any CLICommandAdapter,
             input: FileHandle,
             output: FileHandle
@@ -60,7 +60,7 @@ package struct XcodeMCPProxyCLICommand {
                 stdout: { print($0) },
                 makeLogSink: {
                     let logger = ProxyLogging.make("cli")
-                    return CLICommandLogSink(
+                    return XcodeMCPProxyCLICommand.LogSink(
                         error: { logger.error("\($0)") },
                         info: { message, metadata in
                             logger.info("\(message)", metadata: metadata)
@@ -89,7 +89,7 @@ package struct XcodeMCPProxyCLICommand {
 
     package func run(args: [String], environment: [String: String]) async -> Int32 {
         dependencies.bootstrapLogging(environment)
-        return await CLICommandRuntime(dependencies: dependencies).execute(
+        return await XcodeMCPProxyCLICommand.Runtime(dependencies: dependencies).execute(
             args: args,
             environment: environment
         )

--- a/Sources/ProxyCLI/Common/CLIArgumentCursor.swift
+++ b/Sources/ProxyCLI/Common/CLIArgumentCursor.swift
@@ -1,6 +1,8 @@
 import Foundation
+import ProxyCore
 
-package struct CLIArgumentCursor {
+extension CLI {
+    package struct ArgumentCursor {
     private let args: [String]
     package private(set) var index: Int
 
@@ -43,5 +45,6 @@ package struct CLIArgumentCursor {
         }
         advance(by: 2)
         return value
+    }
     }
 }

--- a/Sources/ProxyCLI/Common/ProxyCLIInvocationScanner.swift
+++ b/Sources/ProxyCLI/Common/ProxyCLIInvocationScanner.swift
@@ -2,7 +2,9 @@ import ProxyCore
 import Foundation
 import XcodeMCPProxy
 
-package struct ProxyCLIAdapterScan {
+extension CLI {
+    package enum InvocationScanner {
+        package struct AdapterScan {
     package var showHelp = false
     package var showVersion = false
     package var usesRemovedURLHelper = false
@@ -10,9 +12,9 @@ package struct ProxyCLIAdapterScan {
     package var hasExplicitURL = false
     package var hasStdioFlag = false
     package var serverOnlyFlag: String?
-}
+        }
 
-package struct ProxyCLIServerScan {
+        package struct ServerScan {
     package var forwardedArgs: [String] = []
     package var showHelp = false
     package var showVersion = false
@@ -24,22 +26,21 @@ package struct ProxyCLIServerScan {
     package var hasRefreshCodeIssuesModeFlag = false
     package var forceRestart = false
     package var dryRun = false
-}
+        }
 
-package struct ProxyCLIInstallScan {
+        package struct InstallScan {
     package var showHelp = false
     package var showVersion = false
-}
+        }
 
-package enum ProxyCLIInvocationScanner {
-    private static let serverOnlyFlags = ProxyCLIFlag.serverOnlyFlagNames
-    private static let serverOnlyValueFlags = ProxyCLIFlag.serverOnlyValueFlagNames
-    private static let serverForwardedValueFlags = ProxyCLIFlag.serverForwardedValueFlagNames
+    private static let serverOnlyFlags = CLI.Flag.serverOnlyFlagNames
+    private static let serverOnlyValueFlags = CLI.Flag.serverOnlyValueFlagNames
+    private static let serverForwardedValueFlags = CLI.Flag.serverForwardedValueFlagNames
 
-    package static func scanAdapter(_ args: [String]) -> ProxyCLIAdapterScan {
-        var scan = ProxyCLIAdapterScan()
+    package static func scanAdapter(_ args: [String]) -> CLI.InvocationScanner.AdapterScan {
+        var scan = CLI.InvocationScanner.AdapterScan()
         scan.showVersion = containsVersionFlag(args)
-        var cursor = CLIArgumentCursor(args: args)
+        var cursor = CLI.ArgumentCursor(args: args)
 
         while let arg = cursor.current {
             switch arg {
@@ -93,10 +94,10 @@ package enum ProxyCLIInvocationScanner {
         return scan
     }
 
-    package static func scanServer(_ args: [String]) throws -> ProxyCLIServerScan {
-        var scan = ProxyCLIServerScan()
+    package static func scanServer(_ args: [String]) throws -> CLI.InvocationScanner.ServerScan {
+        var scan = CLI.InvocationScanner.ServerScan()
         scan.showVersion = containsVersionFlag(args)
-        var cursor = CLIArgumentCursor(args: args)
+        var cursor = CLI.ArgumentCursor(args: args)
 
         while let arg = cursor.current {
             if scan.showVersion {
@@ -135,17 +136,17 @@ package enum ProxyCLIInvocationScanner {
                 cursor.advance()
                 continue
             case "--stdio":
-                throw ProxyServerCommandError.message(
+                throw XcodeMCPProxyServerCommand.Error.message(
                     "--stdio is not supported in server mode (use xcode-mcp-proxy)"
                 )
             case "--url":
-                throw ProxyServerCommandError.message(
+                throw XcodeMCPProxyServerCommand.Error.message(
                     "--url is not supported in server mode (use xcode-mcp-proxy)"
                 )
             case "--xcode-pid":
-                throw ProxyServerCommandError.message(CLIParser.removedXcodePIDMessage)
+                throw XcodeMCPProxyServerCommand.Error.message(CLIParser.removedXcodePIDMessage)
             case "--lazy-init":
-                throw ProxyServerCommandError.message(CLIParser.removedLazyInitMessage)
+                throw XcodeMCPProxyServerCommand.Error.message(CLIParser.removedLazyInitMessage)
             case "--listen":
                 scan.hasListenFlag = true
             case "--host":
@@ -166,7 +167,7 @@ package enum ProxyCLIInvocationScanner {
             if serverForwardedValueFlags.contains(arg) {
                 let value = try cursor.requiredValue(
                     for: arg,
-                    error: { ProxyServerCommandError.message("\($0) requires a value") }
+                    error: { XcodeMCPProxyServerCommand.Error.message("\($0) requires a value") }
                 )
                 scan.forwardedArgs.append(value)
             } else {
@@ -177,10 +178,10 @@ package enum ProxyCLIInvocationScanner {
         return scan
     }
 
-    package static func scanInstall(_ args: [String]) -> ProxyCLIInstallScan {
-        var scan = ProxyCLIInstallScan()
+    package static func scanInstall(_ args: [String]) -> CLI.InvocationScanner.InstallScan {
+        var scan = CLI.InvocationScanner.InstallScan()
         scan.showVersion = containsVersionFlag(args)
-        var cursor = CLIArgumentCursor(args: args)
+        var cursor = CLI.ArgumentCursor(args: args)
 
         while let arg = cursor.current {
             switch arg {
@@ -214,5 +215,6 @@ package enum ProxyCLIInvocationScanner {
 
     private static func containsVersionFlag(_ args: [String]) -> Bool {
         args.dropFirst().contains("--version")
+    }
     }
 }

--- a/Sources/ProxyCLI/Install/InstallBinaryInstaller.swift
+++ b/Sources/ProxyCLI/Install/InstallBinaryInstaller.swift
@@ -3,7 +3,7 @@ import Foundation
 
 package enum InstallBinaryInstaller {
     package static func install(
-        options: InstallOptions,
+        options: XcodeMCPProxyInstallCommand.Options,
         executableURL: URL,
         binaryNames: [String],
         fileManager: FileManager = .default,
@@ -34,7 +34,7 @@ package enum InstallBinaryInstaller {
         for name in binaryNames {
             let sourceURL = baseURL.appendingPathComponent(name)
             guard fileManager.fileExists(atPath: sourceURL.path) else {
-                throw InstallCommandError.message(
+                throw XcodeMCPProxyInstallCommand.Error.message(
                     "\(name) not found next to installer (run with `swift run -c release` from the repo root)"
                 )
             }
@@ -75,7 +75,7 @@ package enum InstallBinaryInstaller {
             try process.run()
             process.waitUntilExit()
             guard process.terminationStatus == 0 else {
-                throw InstallCommandError.message(
+                throw XcodeMCPProxyInstallCommand.Error.message(
                     "swift build failed; run from the repo root and try again"
                 )
             }

--- a/Sources/ProxyCLI/Install/InstallCommandRuntime.swift
+++ b/Sources/ProxyCLI/Install/InstallCommandRuntime.swift
@@ -2,7 +2,8 @@ import ProxyCore
 import Foundation
 import XcodeMCPProxy
 
-package struct InstallCommandRuntime {
+extension XcodeMCPProxyInstallCommand {
+    package struct Runtime {
     private let dependencies: XcodeMCPProxyInstallCommand.Dependencies
 
     package init(dependencies: XcodeMCPProxyInstallCommand.Dependencies) {
@@ -32,7 +33,7 @@ package struct InstallCommandRuntime {
                 return 0
             }
             guard let executableURL = dependencies.executableURL() else {
-                throw InstallCommandError.message("failed to locate installer executable")
+                throw XcodeMCPProxyInstallCommand.Error.message("failed to locate installer executable")
             }
             try XcodeMCPProxyInstallCommand.install(
                 options: options,
@@ -41,7 +42,7 @@ package struct InstallCommandRuntime {
                 stdout: dependencies.stdout
             )
             return 0
-        } catch let error as InstallCommandError {
+        } catch let error as XcodeMCPProxyInstallCommand.Error {
             dependencies.stderr("error: \(error.description)")
             dependencies.stderr("run with --help for usage")
             return 1
@@ -49,5 +50,6 @@ package struct InstallCommandRuntime {
             dependencies.stderr("error: \(error)")
             return 1
         }
+    }
     }
 }

--- a/Sources/ProxyCLI/Install/XcodeMCPProxyInstallCommand+Parsing.swift
+++ b/Sources/ProxyCLI/Install/XcodeMCPProxyInstallCommand+Parsing.swift
@@ -2,9 +2,9 @@ import ProxyCore
 import Foundation
 
 extension XcodeMCPProxyInstallCommand {
-    package static func scanInvocation(_ args: [String]) -> InstallCommandInvocation {
-        let scan = ProxyCLIInvocationScanner.scanInstall(args)
-        var invocation = InstallCommandInvocation()
+    package static func scanInvocation(_ args: [String]) -> XcodeMCPProxyInstallCommand.Invocation {
+        let scan = CLI.InvocationScanner.scanInstall(args)
+        var invocation = XcodeMCPProxyInstallCommand.Invocation()
         invocation.showHelp = scan.showHelp
         invocation.showVersion = scan.showVersion
         return invocation
@@ -38,14 +38,14 @@ extension XcodeMCPProxyInstallCommand {
     package static func parseOptions(
         _ args: [String],
         environment: [String: String]
-    ) throws -> InstallOptions {
-        var options = InstallOptions(
+    ) throws -> XcodeMCPProxyInstallCommand.Options {
+        var options = XcodeMCPProxyInstallCommand.Options(
             prefix: environment["PREFIX"],
             bindir: environment["BINDIR"],
             dryRun: false
         )
 
-        var cursor = CLIArgumentCursor(args: args)
+        var cursor = CLI.ArgumentCursor(args: args)
         while let arg = cursor.current {
             switch arg {
             case "-h", "--help":
@@ -54,18 +54,18 @@ extension XcodeMCPProxyInstallCommand {
             case "--prefix":
                 options.prefix = try cursor.requiredValue(
                     for: arg,
-                    error: { InstallCommandError.message("\($0) requires a value") }
+                    error: { XcodeMCPProxyInstallCommand.Error.message("\($0) requires a value") }
                 )
             case "--bindir":
                 options.bindir = try cursor.requiredValue(
                     for: arg,
-                    error: { InstallCommandError.message("\($0) requires a value") }
+                    error: { XcodeMCPProxyInstallCommand.Error.message("\($0) requires a value") }
                 )
             case "--dry-run":
                 options.dryRun = true
                 cursor.advance()
             default:
-                throw InstallCommandError.message("unknown option: \(arg)")
+                throw XcodeMCPProxyInstallCommand.Error.message("unknown option: \(arg)")
             }
         }
 

--- a/Sources/ProxyCLI/Install/XcodeMCPProxyInstallCommand.swift
+++ b/Sources/ProxyCLI/Install/XcodeMCPProxyInstallCommand.swift
@@ -1,37 +1,37 @@
 import ProxyCore
 import Foundation
 
-package struct InstallOptions {
-    package var prefix: String?
-    package var bindir: String?
-    package var dryRun: Bool
-    package var showHelp: Bool
+package struct XcodeMCPProxyInstallCommand {
+    package struct Options {
+        package var prefix: String?
+        package var bindir: String?
+        package var dryRun: Bool
+        package var showHelp: Bool
 
-    package init(prefix: String?, bindir: String?, dryRun: Bool, showHelp: Bool = false) {
-        self.prefix = prefix
-        self.bindir = bindir
-        self.dryRun = dryRun
-        self.showHelp = showHelp
-    }
-}
-
-package struct InstallCommandInvocation {
-    package var showHelp = false
-    package var showVersion = false
-}
-
-package enum InstallCommandError: Error, CustomStringConvertible {
-    case message(String)
-
-    package var description: String {
-        switch self {
-        case .message(let text):
-            return text
+        package init(prefix: String?, bindir: String?, dryRun: Bool, showHelp: Bool = false) {
+            self.prefix = prefix
+            self.bindir = bindir
+            self.dryRun = dryRun
+            self.showHelp = showHelp
         }
     }
-}
 
-package struct XcodeMCPProxyInstallCommand {
+    package struct Invocation {
+        package var showHelp = false
+        package var showVersion = false
+    }
+
+    package enum Error: Swift.Error, CustomStringConvertible {
+        case message(String)
+
+        package var description: String {
+            switch self {
+            case .message(let text):
+                return text
+            }
+        }
+    }
+
     package struct Dependencies {
         package var stdout: (String) -> Void
         package var stderr: (String) -> Void
@@ -72,13 +72,13 @@ package struct XcodeMCPProxyInstallCommand {
     }
 
     package func run(args: [String], environment: [String: String]) -> Int32 {
-        InstallCommandRuntime(dependencies: dependencies).execute(
+        XcodeMCPProxyInstallCommand.Runtime(dependencies: dependencies).execute(
             args: args,
             environment: environment
         )
     }
     package static func install(
-        options: InstallOptions,
+        options: XcodeMCPProxyInstallCommand.Options,
         executableURL: URL,
         fileManager: FileManager = .default,
         buildProducts: ([String], URL) throws -> Void,

--- a/Sources/ProxyCLI/Server/ProxyServerCommandRuntime.swift
+++ b/Sources/ProxyCLI/Server/ProxyServerCommandRuntime.swift
@@ -2,7 +2,8 @@ import ProxyCore
 import Foundation
 import XcodeMCPProxy
 
-package struct ProxyServerCommandRuntime {
+extension XcodeMCPProxyServerCommand {
+    package struct Runtime {
     private let dependencies: XcodeMCPProxyServerCommand.Dependencies
 
     package init(dependencies: XcodeMCPProxyServerCommand.Dependencies) {
@@ -66,7 +67,7 @@ package struct ProxyServerCommandRuntime {
                 }
                 throw error
             }
-        } catch let error as ProxyServerCommandError {
+        } catch let error as XcodeMCPProxyServerCommand.Error {
             dependencies.stderr("error: \(error.description)")
             dependencies.stderr("run with --help for usage")
             return 1
@@ -78,5 +79,6 @@ package struct ProxyServerCommandRuntime {
             dependencies.stderr("error: \(error)")
             return 1
         }
+    }
     }
 }

--- a/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand+Parsing.swift
+++ b/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand+Parsing.swift
@@ -3,9 +3,9 @@ import Foundation
 import XcodeMCPProxy
 
 extension XcodeMCPProxyServerCommand {
-    package static func parseOptions(args: [String]) throws -> ProxyServerOptions {
-        let scan = try ProxyCLIInvocationScanner.scanServer(args)
-        return ProxyServerOptions(
+    package static func parseOptions(args: [String]) throws -> XcodeMCPProxyServerCommand.Options {
+        let scan = try CLI.InvocationScanner.scanServer(args)
+        return XcodeMCPProxyServerCommand.Options(
             forwardedArgs: scan.forwardedArgs,
             showHelp: scan.showHelp,
             showVersion: scan.showVersion,
@@ -22,7 +22,7 @@ extension XcodeMCPProxyServerCommand {
 
     package static func applyDefaults(
         from environment: [String: String],
-        to options: inout ProxyServerOptions
+        to options: inout XcodeMCPProxyServerCommand.Options
     ) throws {
         if !options.hasListenFlag && !options.hasHostFlag && !options.hasPortFlag {
             if let listen = nonEmpty(environment["LISTEN"]) {
@@ -45,7 +45,7 @@ extension XcodeMCPProxyServerCommand {
         }
 
         if isTruthy(environment["LAZY_INIT"]) {
-            throw ProxyServerCommandError.message(CLIParser.removedLazyInitMessage)
+            throw XcodeMCPProxyServerCommand.Error.message(CLIParser.removedLazyInitMessage)
         }
 
         // MCP_XCODE_CONFIG and MCP_XCODE_REFRESH_CODE_ISSUES_MODE are
@@ -57,7 +57,7 @@ extension XcodeMCPProxyServerCommand {
     /// parser pulled from the environment stay visible even though they
     /// never existed as argv flags.
     package static func dryRunCommandLine(
-        options: ProxyServerOptions,
+        options: XcodeMCPProxyServerCommand.Options,
         config: ProxyConfig
     ) -> String {
         var parts = ["xcode-mcp-proxy-server"] + options.forwardedArgs
@@ -138,7 +138,7 @@ extension XcodeMCPProxyServerCommand {
         return ["1", "true", "yes", "on"].contains(raw.lowercased())
     }
 
-    package static func isAddressAlreadyInUse(_ error: Error) -> Bool {
+    package static func isAddressAlreadyInUse(_ error: Swift.Error) -> Bool {
         let text = String(describing: error)
         if text.localizedCaseInsensitiveContains("Address already in use") {
             return true

--- a/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand.swift
@@ -5,64 +5,64 @@ import XcodeMCPProxy
 
 extension ProxyServer: ProxyServerCommandServer {}
 
-package struct ProxyServerOptions {
-    package var forwardedArgs: [String]
-    package var showHelp: Bool
-    package var showVersion: Bool
-    package var hasListenFlag: Bool
-    package var hasHostFlag: Bool
-    package var hasPortFlag: Bool
-    package var hasConfigFlag: Bool
-    package var hasAutoApproveFlag: Bool
-    package var hasRefreshCodeIssuesModeFlag: Bool
-    package var forceRestart: Bool
-    package var dryRun: Bool
+package struct XcodeMCPProxyServerCommand {
+    package struct Options {
+        package var forwardedArgs: [String]
+        package var showHelp: Bool
+        package var showVersion: Bool
+        package var hasListenFlag: Bool
+        package var hasHostFlag: Bool
+        package var hasPortFlag: Bool
+        package var hasConfigFlag: Bool
+        package var hasAutoApproveFlag: Bool
+        package var hasRefreshCodeIssuesModeFlag: Bool
+        package var forceRestart: Bool
+        package var dryRun: Bool
 
-    package init(
-        forwardedArgs: [String],
-        showHelp: Bool,
-        showVersion: Bool,
-        hasListenFlag: Bool,
-        hasHostFlag: Bool,
-        hasPortFlag: Bool,
-        hasConfigFlag: Bool,
-        hasAutoApproveFlag: Bool,
-        hasRefreshCodeIssuesModeFlag: Bool,
-        forceRestart: Bool,
-        dryRun: Bool
-    ) {
-        self.forwardedArgs = forwardedArgs
-        self.showHelp = showHelp
-        self.showVersion = showVersion
-        self.hasListenFlag = hasListenFlag
-        self.hasHostFlag = hasHostFlag
-        self.hasPortFlag = hasPortFlag
-        self.hasConfigFlag = hasConfigFlag
-        self.hasAutoApproveFlag = hasAutoApproveFlag
-        self.hasRefreshCodeIssuesModeFlag = hasRefreshCodeIssuesModeFlag
-        self.forceRestart = forceRestart
-        self.dryRun = dryRun
-    }
-}
-
-package enum ProxyServerCommandError: Error, CustomStringConvertible {
-    case message(String)
-
-    package var description: String {
-        switch self {
-        case .message(let text):
-            return text
+        package init(
+            forwardedArgs: [String],
+            showHelp: Bool,
+            showVersion: Bool,
+            hasListenFlag: Bool,
+            hasHostFlag: Bool,
+            hasPortFlag: Bool,
+            hasConfigFlag: Bool,
+            hasAutoApproveFlag: Bool,
+            hasRefreshCodeIssuesModeFlag: Bool,
+            forceRestart: Bool,
+            dryRun: Bool
+        ) {
+            self.forwardedArgs = forwardedArgs
+            self.showHelp = showHelp
+            self.showVersion = showVersion
+            self.hasListenFlag = hasListenFlag
+            self.hasHostFlag = hasHostFlag
+            self.hasPortFlag = hasPortFlag
+            self.hasConfigFlag = hasConfigFlag
+            self.hasAutoApproveFlag = hasAutoApproveFlag
+            self.hasRefreshCodeIssuesModeFlag = hasRefreshCodeIssuesModeFlag
+            self.forceRestart = forceRestart
+            self.dryRun = dryRun
         }
     }
-}
 
-package struct XcodeMCPProxyServerCommand {
+    package enum Error: Swift.Error, CustomStringConvertible {
+        case message(String)
+
+        package var description: String {
+            switch self {
+            case .message(let text):
+                return text
+            }
+        }
+    }
+
     package struct Dependencies {
         package var bootstrapLogging: ([String: String]) -> Void
         package var stdout: (String) -> Void
         package var stderr: (String) -> Void
         package var makeServer: (ProxyConfig) -> any ProxyServerCommandServer
-        package var isAddressAlreadyInUse: (Error) -> Bool
+        package var isAddressAlreadyInUse: (Swift.Error) -> Bool
         package var existingProxyServerClient: ExistingProxyServerClient
 
         package init(
@@ -70,7 +70,7 @@ package struct XcodeMCPProxyServerCommand {
             stdout: @escaping (String) -> Void,
             stderr: @escaping (String) -> Void,
             makeServer: @escaping (ProxyConfig) -> any ProxyServerCommandServer,
-            isAddressAlreadyInUse: @escaping (Error) -> Bool,
+            isAddressAlreadyInUse: @escaping (Swift.Error) -> Bool,
             existingProxyServerClient: ExistingProxyServerClient = .liveValue
         ) {
             self.bootstrapLogging = bootstrapLogging
@@ -87,7 +87,7 @@ package struct XcodeMCPProxyServerCommand {
             stderr: @escaping (String) -> Void,
             terminateExistingServer: @escaping @Sendable (String, Int) -> Bool,
             makeServer: @escaping (ProxyConfig) -> any ProxyServerCommandServer,
-            isAddressAlreadyInUse: @escaping (Error) -> Bool,
+            isAddressAlreadyInUse: @escaping (Swift.Error) -> Bool,
             detectExistingProxyServerPIDs: @escaping @Sendable (String, Int) -> [Int]
         ) {
             self.init(
@@ -125,7 +125,7 @@ package struct XcodeMCPProxyServerCommand {
 
     package func run(args: [String], environment: [String: String]) async -> Int32 {
         dependencies.bootstrapLogging(environment)
-        return await ProxyServerCommandRuntime(dependencies: dependencies).execute(
+        return await XcodeMCPProxyServerCommand.Runtime(dependencies: dependencies).execute(
             args: args,
             environment: environment
         )

--- a/Sources/ProxyCore/InitializeHandshakeParams.swift
+++ b/Sources/ProxyCore/InitializeHandshakeParams.swift
@@ -5,7 +5,7 @@ import Foundation
 /// in ProxySession so ProxyCore stays independent of ProxyMCP.
 package enum InitializeHandshakeParams {
     package static func hasExplicitClientVersionOverride(
-        initializeParamsOverride: ProxyInitializeHandshakeOverride?
+        initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride?
     ) -> Bool {
         initializeParamsOverride?.clientVersion != nil
     }

--- a/Sources/ProxyCore/MCPProtocolVersion.swift
+++ b/Sources/ProxyCore/MCPProtocolVersion.swift
@@ -1,7 +1,11 @@
-public enum MCPProtocolVersion {
-    public static let current = "2025-06-18"
+public enum MCP {}
 
-    public static func isSupported(_ version: String) -> Bool {
-        version == current
+extension MCP {
+    public enum ProtocolVersion {
+        public static let current = "2025-06-18"
+
+        public static func isSupported(_ version: String) -> Bool {
+            version == current
+        }
     }
 }

--- a/Sources/ProxyCore/ProxyCLIFlag.swift
+++ b/Sources/ProxyCore/ProxyCLIFlag.swift
@@ -1,80 +1,84 @@
-package enum ProxyCLIFlag: String, CaseIterable, Sendable {
-    case helpShort = "-h"
-    case help = "--help"
-    case version = "--version"
-    case config = "--config"
-    case autoApprove = "--auto-approve"
-    case listen = "--listen"
-    case host = "--host"
-    case port = "--port"
-    case maxBodyBytes = "--max-body-bytes"
-    case requestTimeout = "--request-timeout"
-    case upstreamCommand = "--upstream-command"
-    case upstreamArgs = "--upstream-args"
-    case upstreamArg = "--upstream-arg"
-    case upstreamProcesses = "--upstream-processes"
-    case sessionID = "--session-id"
-    case refreshCodeIssuesMode = "--refresh-code-issues-mode"
-    case stdio = "--stdio"
-    case url = "--url"
-    case printURL = "--print-url"
-    case lazyInit = "--lazy-init"
-    case xcodePID = "--xcode-pid"
-    case dryRun = "--dry-run"
-    case forceRestart = "--force-restart"
-    case prefix = "--prefix"
-    case bindir = "--bindir"
+package enum CLI {}
 
-    package var consumesRequiredValue: Bool {
-        switch self {
-        case .config, .listen, .host, .port, .maxBodyBytes, .requestTimeout,
-             .upstreamCommand, .upstreamArgs, .upstreamArg, .upstreamProcesses,
-             .sessionID, .refreshCodeIssuesMode, .prefix, .bindir:
-            return true
-        case .helpShort, .help, .version, .autoApprove, .stdio, .url, .printURL,
-             .lazyInit, .xcodePID, .dryRun, .forceRestart:
-            return false
+extension CLI {
+    package enum Flag: String, CaseIterable, Sendable {
+        case helpShort = "-h"
+        case help = "--help"
+        case version = "--version"
+        case config = "--config"
+        case autoApprove = "--auto-approve"
+        case listen = "--listen"
+        case host = "--host"
+        case port = "--port"
+        case maxBodyBytes = "--max-body-bytes"
+        case requestTimeout = "--request-timeout"
+        case upstreamCommand = "--upstream-command"
+        case upstreamArgs = "--upstream-args"
+        case upstreamArg = "--upstream-arg"
+        case upstreamProcesses = "--upstream-processes"
+        case sessionID = "--session-id"
+        case refreshCodeIssuesMode = "--refresh-code-issues-mode"
+        case stdio = "--stdio"
+        case url = "--url"
+        case printURL = "--print-url"
+        case lazyInit = "--lazy-init"
+        case xcodePID = "--xcode-pid"
+        case dryRun = "--dry-run"
+        case forceRestart = "--force-restart"
+        case prefix = "--prefix"
+        case bindir = "--bindir"
+
+        package var consumesRequiredValue: Bool {
+            switch self {
+            case .config, .listen, .host, .port, .maxBodyBytes, .requestTimeout,
+                 .upstreamCommand, .upstreamArgs, .upstreamArg, .upstreamProcesses,
+                 .sessionID, .refreshCodeIssuesMode, .prefix, .bindir:
+                return true
+            case .helpShort, .help, .version, .autoApprove, .stdio, .url, .printURL,
+                 .lazyInit, .xcodePID, .dryRun, .forceRestart:
+                return false
+            }
         }
-    }
 
-    package var isServerOnlyForAdapter: Bool {
-        switch self {
-        case .config, .autoApprove, .listen, .host, .port, .maxBodyBytes,
-             .upstreamCommand, .upstreamArgs, .upstreamArg, .upstreamProcesses,
-             .sessionID, .refreshCodeIssuesMode:
-            return true
-        case .helpShort, .help, .version, .requestTimeout, .stdio, .url, .printURL,
-             .lazyInit, .xcodePID, .dryRun, .forceRestart, .prefix, .bindir:
-            return false
+        package var isServerOnlyForAdapter: Bool {
+            switch self {
+            case .config, .autoApprove, .listen, .host, .port, .maxBodyBytes,
+                 .upstreamCommand, .upstreamArgs, .upstreamArg, .upstreamProcesses,
+                 .sessionID, .refreshCodeIssuesMode:
+                return true
+            case .helpShort, .help, .version, .requestTimeout, .stdio, .url, .printURL,
+                 .lazyInit, .xcodePID, .dryRun, .forceRestart, .prefix, .bindir:
+                return false
+            }
         }
-    }
 
-    package var isForwardedByServerCommand: Bool {
-        switch self {
-        case .config, .listen, .host, .port, .upstreamCommand, .upstreamArgs,
-             .upstreamArg, .upstreamProcesses, .sessionID, .maxBodyBytes,
-             .requestTimeout, .refreshCodeIssuesMode:
-            return true
-        case .helpShort, .help, .version, .autoApprove, .stdio, .url, .printURL,
-             .lazyInit, .xcodePID, .dryRun, .forceRestart, .prefix, .bindir:
-            return false
+        package var isForwardedByServerCommand: Bool {
+            switch self {
+            case .config, .listen, .host, .port, .upstreamCommand, .upstreamArgs,
+                 .upstreamArg, .upstreamProcesses, .sessionID, .maxBodyBytes,
+                 .requestTimeout, .refreshCodeIssuesMode:
+                return true
+            case .helpShort, .help, .version, .autoApprove, .stdio, .url, .printURL,
+                 .lazyInit, .xcodePID, .dryRun, .forceRestart, .prefix, .bindir:
+                return false
+            }
         }
+
+        package var isServerForwardedValueFlag: Bool {
+            isForwardedByServerCommand && consumesRequiredValue
+        }
+
+        package static let serverOnlyFlagNames = Set(
+            allCases.filter(\.isServerOnlyForAdapter).map(\.rawValue)
+        )
+
+        package static let serverOnlyValueFlagNames = Set(
+            allCases.filter { $0.isServerOnlyForAdapter && $0.consumesRequiredValue }
+                .map(\.rawValue)
+        )
+
+        package static let serverForwardedValueFlagNames = Set(
+            allCases.filter(\.isServerForwardedValueFlag).map(\.rawValue)
+        )
     }
-
-    package var isServerForwardedValueFlag: Bool {
-        isForwardedByServerCommand && consumesRequiredValue
-    }
-
-    package static let serverOnlyFlagNames = Set(
-        allCases.filter(\.isServerOnlyForAdapter).map(\.rawValue)
-    )
-
-    package static let serverOnlyValueFlagNames = Set(
-        allCases.filter { $0.isServerOnlyForAdapter && $0.consumesRequiredValue }
-            .map(\.rawValue)
-    )
-
-    package static let serverForwardedValueFlagNames = Set(
-        allCases.filter(\.isServerForwardedValueFlag).map(\.rawValue)
-    )
 }

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -1,23 +1,25 @@
 import Foundation
 
-public enum ProxyTransport: String, CaseIterable, Sendable {
-    case http
-    case stdio
-}
-
-public enum StdioUpstreamSource: String, Sendable {
-    case explicit
-    case environment
-    case discovery
-    case fallback
-}
-
-public enum RefreshCodeIssuesMode: String, Sendable {
-    case proxy
-    case upstream
-}
-
 public struct ProxyConfig: Sendable {
+    public enum Transport: String, CaseIterable, Sendable {
+        case http
+        case stdio
+    }
+
+    public enum StdioUpstreamSource: String, Sendable {
+        case explicit
+        case environment
+        case discovery
+        case fallback
+    }
+
+    public enum RefreshCodeIssuesMode: String, Sendable {
+        case proxy
+        case upstream
+    }
+
+    package enum File {}
+
     public var listenHost: String
     public var listenPort: Int
     public var upstreamCommand: String
@@ -27,15 +29,15 @@ public struct ProxyConfig: Sendable {
     public var maxBodyBytes: Int
     public var requestTimeout: TimeInterval
     public var configPath: String?
-    public var transport: ProxyTransport
+    public var transport: ProxyConfig.Transport
     public var stdioUpstreamURL: URL?
-    public var stdioUpstreamSource: StdioUpstreamSource?
+    public var stdioUpstreamSource: ProxyConfig.StdioUpstreamSource?
     public var discoveryFileURL: URL?
     public var prewarmToolsList: Bool
     public var autoApproveXcodeDialog: Bool
-    public var refreshCodeIssuesMode: RefreshCodeIssuesMode
+    public var refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode
     public var disabledToolNames: Set<String>
-    package var initializeParamsOverride: ProxyInitializeHandshakeOverride?
+    package var initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride?
 
     public init(
         listenHost: String,
@@ -47,13 +49,13 @@ public struct ProxyConfig: Sendable {
         maxBodyBytes: Int,
         requestTimeout: TimeInterval,
         configPath: String? = nil,
-        transport: ProxyTransport = .http,
+        transport: ProxyConfig.Transport = .http,
         stdioUpstreamURL: URL? = nil,
-        stdioUpstreamSource: StdioUpstreamSource? = nil,
+        stdioUpstreamSource: ProxyConfig.StdioUpstreamSource? = nil,
         discoveryFileURL: URL? = nil,
         prewarmToolsList: Bool = true,
         autoApproveXcodeDialog: Bool = false,
-        refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy,
+        refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode = .proxy,
         disabledToolNames: Set<String>? = nil
     ) {
         self.listenHost = listenHost
@@ -88,12 +90,12 @@ public struct ProxyConfig: Sendable {
     private mutating func loadFileConfig(preserveDisabledToolNames: Bool) {
         let logger = ProxyLogging.make("config")
         if preserveDisabledToolNames == false {
-            disabledToolNames = ProxyFileConfigLoader.loadDisabledToolNames(
+            disabledToolNames = ProxyConfig.File.Loader.loadDisabledToolNames(
                 configPath: configPath,
                 logger: logger
             )
         }
-        initializeParamsOverride = ProxyFileConfigLoader.loadInitializeParamsOverride(
+        initializeParamsOverride = ProxyConfig.File.Loader.loadInitializeParamsOverride(
             configPath: configPath,
             logger: logger
         )
@@ -103,9 +105,9 @@ public struct ProxyConfig: Sendable {
         guard let protocolVersion = initializeParamsOverride?.protocolVersion else {
             return
         }
-        guard MCPProtocolVersion.isSupported(protocolVersion) else {
+        guard MCP.ProtocolVersion.isSupported(protocolVersion) else {
             throw CLIError.message(
-                "upstream_handshake.protocolVersion must be \(MCPProtocolVersion.current); \(protocolVersion) is not supported"
+                "upstream_handshake.protocolVersion must be \(MCP.ProtocolVersion.current); \(protocolVersion) is not supported"
             )
         }
     }
@@ -157,15 +159,15 @@ public struct CLIParser {
         var requestTimeout: TimeInterval = 300
         var configPath: String?
         var stdioUpstreamURL: URL?
-        var stdioUpstreamSource: StdioUpstreamSource?
+        var stdioUpstreamSource: ProxyConfig.StdioUpstreamSource?
         var autoApproveXcodeDialog = false
-        var refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy
+        var refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode = .proxy
         var hasExplicitRefreshCodeIssuesMode = false
 
         var index = 1
         while index < args.count {
             let arg = args[index]
-            guard let flag = ProxyCLIFlag(rawValue: arg) else {
+            guard let flag = CLI.Flag(rawValue: arg) else {
                 throw CLIError.message("Unknown argument: \(arg)")
             }
             switch flag {
@@ -258,7 +260,7 @@ public struct CLIParser {
                 guard index + 1 < args.count else {
                     throw CLIError.message("--refresh-code-issues-mode requires proxy|upstream")
                 }
-                guard let parsed = RefreshCodeIssuesMode(rawValue: args[index + 1]) else {
+                guard let parsed = ProxyConfig.RefreshCodeIssuesMode(rawValue: args[index + 1]) else {
                     throw CLIError.message("--refresh-code-issues-mode must be proxy or upstream")
                 }
                 refreshCodeIssuesMode = parsed
@@ -296,7 +298,7 @@ public struct CLIParser {
         if let value = nonEmpty(environment[refreshCodeIssuesModeEnv]),
             hasExplicitRefreshCodeIssuesMode == false
         {
-            guard let parsed = RefreshCodeIssuesMode(rawValue: value) else {
+            guard let parsed = ProxyConfig.RefreshCodeIssuesMode(rawValue: value) else {
                 throw CLIError.message(
                     "\(refreshCodeIssuesModeEnv) must be proxy or upstream"
                 )
@@ -306,7 +308,7 @@ public struct CLIParser {
         if configPath == nil, let value = nonEmpty(environment[configPathEnv]) {
             configPath = value
         }
-        let transport: ProxyTransport = stdioUpstreamURL == nil ? .http : .stdio
+        let transport: ProxyConfig.Transport = stdioUpstreamURL == nil ? .http : .stdio
 
         return ProxyConfig(
             listenHost: listenHost,
@@ -353,7 +355,7 @@ public struct CLIParser {
         environment: [String: String],
         discoveryOverrideURL: URL? = nil,
         discoveryClient: DiscoveryClient
-    ) throws -> (url: URL, source: StdioUpstreamSource) {
+    ) throws -> (url: URL, source: ProxyConfig.StdioUpstreamSource) {
         if let raw = nonEmpty(environment[Self.stdioEndpointEnv]) {
             return (try parseHTTPURL(raw, label: Self.stdioEndpointEnv), .environment)
         }

--- a/Sources/ProxyCore/ProxyFileConfig.swift
+++ b/Sources/ProxyCore/ProxyFileConfig.swift
@@ -2,89 +2,91 @@ import Foundation
 import Logging
 import TOMLDecoder
 
-package enum ProxyConfigNumber: Sendable, Equatable {
-    case int(Int64)
-    case double(Double)
-}
-
-package enum ProxyConfigValue: Sendable, Equatable {
-    case object([String: ProxyConfigValue])
-    case array([ProxyConfigValue])
-    case string(String)
-    case number(ProxyConfigNumber)
-    case bool(Bool)
-
-    package init?(any value: Any) {
-        switch value {
-        case let value as Bool:
-            self = .bool(value)
-        case let value as Int:
-            self = .number(.int(Int64(value)))
-        case let value as Int64:
-            self = .number(.int(value))
-        case let value as Double where value.isFinite:
-            self = .number(.double(value))
-        case let value as String:
-            self = .string(value)
-        case let value as [Any]:
-            var array: [ProxyConfigValue] = []
-            array.reserveCapacity(value.count)
-            for item in value {
-                guard let mapped = ProxyConfigValue(any: item) else { return nil }
-                array.append(mapped)
-            }
-            self = .array(array)
-        case let value as [String: Any]:
-            var object: [String: ProxyConfigValue] = [:]
-            object.reserveCapacity(value.count)
-            for (key, item) in value {
-                guard let mapped = ProxyConfigValue(any: item) else { return nil }
-                object[key] = mapped
-            }
-            self = .object(object)
-        default:
-            return nil
-        }
-    }
-}
-
-package struct ProxyInitializeHandshakeOverride: Sendable, Equatable {
-    package let protocolVersion: String?
-    package let clientName: String?
-    package let clientVersion: String?
-    package let capabilities: [String: ProxyConfigValue]?
-
-    package var isEmpty: Bool {
-        protocolVersion == nil
-            && clientName == nil
-            && clientVersion == nil
-            && capabilities == nil
+extension ProxyConfig.File {
+    package enum Number: Sendable, Equatable {
+        case int(Int64)
+        case double(Double)
     }
 
-    fileprivate init(fileConfig: ProxyInitializeHandshakeFileConfig) throws {
-        protocolVersion = fileConfig.protocolVersion
-        clientName = fileConfig.clientName
-        clientVersion = fileConfig.clientVersion
-        if let capabilities = fileConfig.capabilities {
-            self.capabilities = try Self.configValues(from: capabilities)
-        } else {
-            self.capabilities = nil
+    package enum Value: Sendable, Equatable {
+        case object([String: ProxyConfig.File.Value])
+        case array([ProxyConfig.File.Value])
+        case string(String)
+        case number(ProxyConfig.File.Number)
+        case bool(Bool)
+
+        package init?(any value: Any) {
+            switch value {
+            case let value as Bool:
+                self = .bool(value)
+            case let value as Int:
+                self = .number(.int(Int64(value)))
+            case let value as Int64:
+                self = .number(.int(value))
+            case let value as Double where value.isFinite:
+                self = .number(.double(value))
+            case let value as String:
+                self = .string(value)
+            case let value as [Any]:
+                var array: [ProxyConfig.File.Value] = []
+                array.reserveCapacity(value.count)
+                for item in value {
+                    guard let mapped = ProxyConfig.File.Value(any: item) else { return nil }
+                    array.append(mapped)
+                }
+                self = .array(array)
+            case let value as [String: Any]:
+                var object: [String: ProxyConfig.File.Value] = [:]
+                object.reserveCapacity(value.count)
+                for (key, item) in value {
+                    guard let mapped = ProxyConfig.File.Value(any: item) else { return nil }
+                    object[key] = mapped
+                }
+                self = .object(object)
+            default:
+                return nil
+            }
         }
     }
 
-    private static func configValues(
-        from table: TOMLTable
-    ) throws -> [String: ProxyConfigValue] {
-        let object = try Dictionary(table)
-        var values: [String: ProxyConfigValue] = [:]
-        values.reserveCapacity(object.count)
-        for (key, value) in object {
-            guard let mapped = ProxyConfigValue(any: value) else {
-                throw ProxyFileConfigError.nonJSONCompatibleCapabilities
-            }
-            values[key] = mapped
+    package struct InitializeHandshakeOverride: Sendable, Equatable {
+        package let protocolVersion: String?
+        package let clientName: String?
+        package let clientVersion: String?
+        package let capabilities: [String: ProxyConfig.File.Value]?
+
+        package var isEmpty: Bool {
+            protocolVersion == nil
+                && clientName == nil
+                && clientVersion == nil
+                && capabilities == nil
         }
-        return values
+
+        fileprivate init(fileConfig: ProxyInitializeHandshakeFileConfig) throws {
+            protocolVersion = fileConfig.protocolVersion
+            clientName = fileConfig.clientName
+            clientVersion = fileConfig.clientVersion
+            if let capabilities = fileConfig.capabilities {
+                self.capabilities = try Self.configValues(from: capabilities)
+            } else {
+                self.capabilities = nil
+            }
+        }
+
+        private static func configValues(
+            from table: TOMLTable
+        ) throws -> [String: ProxyConfig.File.Value] {
+            let object = try Dictionary(table)
+            var values: [String: ProxyConfig.File.Value] = [:]
+            values.reserveCapacity(object.count)
+            for (key, value) in object {
+                guard let mapped = ProxyConfig.File.Value(any: value) else {
+                    throw ProxyFileConfigError.nonJSONCompatibleCapabilities
+                }
+                values[key] = mapped
+            }
+            return values
+        }
     }
 }
 
@@ -142,43 +144,120 @@ private struct ProxyToolsConfig: Decodable, Sendable, Equatable {
     let disabled: [String]?
 }
 
-package enum ProxyFileConfigLoader {
-    package static func loadInitializeParamsOverride(
-        configPath: String?,
-        logger: Logger
-    ) -> ProxyInitializeHandshakeOverride? {
-        guard let loaded = loadConfig(
-            configPath: configPath,
-            logger: logger,
-            readFailureMessage: "Failed to read proxy config; using built-in initialize params",
-            decodeFailureMessage: "Failed to decode proxy config; using built-in initialize params"
-        ) else {
-            return nil
+extension ProxyConfig.File {
+    package enum Loader {
+        package static func loadInitializeParamsOverride(
+            configPath: String?,
+            logger: Logger
+        ) -> ProxyConfig.File.InitializeHandshakeOverride? {
+            guard let loaded = loadConfig(
+                configPath: configPath,
+                logger: logger,
+                readFailureMessage: "Failed to read proxy config; using built-in initialize params",
+                decodeFailureMessage: "Failed to decode proxy config; using built-in initialize params"
+            ) else {
+                return nil
+            }
+            let expandedPath = loaded.path
+            switch loaded.config.upstreamHandshake {
+            case .missing:
+                logger.warning(
+                    "Proxy config does not define upstream_handshake; using built-in initialize params",
+                    metadata: ["path": .string(expandedPath)]
+                )
+                return nil
+            case .invalid(let error):
+                logger.warning(
+                    "Proxy config upstream_handshake is invalid; using built-in initialize params",
+                    metadata: [
+                        "path": .string(expandedPath),
+                        "error": .string(error),
+                    ]
+                )
+                return nil
+            case .decoded(let fileConfig):
+                let override: ProxyConfig.File.InitializeHandshakeOverride
+                do {
+                    override = try ProxyConfig.File.InitializeHandshakeOverride(fileConfig: fileConfig)
+                } catch {
+                    logger.warning(
+                        "Proxy config capabilities are not JSON-compatible; using built-in initialize params",
+                        metadata: [
+                            "path": .string(expandedPath),
+                            "error": .string(String(describing: error)),
+                        ]
+                    )
+                    return nil
+                }
+                return override.isEmpty ? nil : override
+            }
         }
-        let expandedPath = loaded.path
-        switch loaded.config.upstreamHandshake {
-        case .missing:
-            logger.warning(
-                "Proxy config does not define upstream_handshake; using built-in initialize params",
-                metadata: ["path": .string(expandedPath)]
-            )
-            return nil
-        case .invalid(let error):
-            logger.warning(
-                "Proxy config upstream_handshake is invalid; using built-in initialize params",
-                metadata: [
-                    "path": .string(expandedPath),
-                    "error": .string(error),
-                ]
-            )
-            return nil
-        case .decoded(let fileConfig):
-            let override: ProxyInitializeHandshakeOverride
+
+        package static func loadDisabledToolNames(
+            configPath: String?,
+            logger: Logger
+        ) -> Set<String> {
+            guard let loaded = loadConfig(
+                configPath: configPath,
+                logger: logger,
+                readFailureMessage: "Failed to read proxy config; ignoring disabled tools",
+                decodeFailureMessage: "Failed to decode proxy config; ignoring disabled tools"
+            ) else {
+                return []
+            }
+            let expandedPath = loaded.path
+            switch loaded.config.tools {
+            case .missing:
+                return []
+            case .invalid(let error):
+                logger.warning(
+                    "Proxy config tools is invalid; ignoring disabled tools",
+                    metadata: [
+                        "path": .string(expandedPath),
+                        "error": .string(error),
+                    ]
+                )
+                return []
+            case .decoded(let tools):
+                guard let disabled = tools.disabled else {
+                    return []
+                }
+                var disabledToolNames = Set<String>()
+                for rawName in disabled {
+                    let normalizedName = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard normalizedName.isEmpty == false else {
+                        continue
+                    }
+                    disabledToolNames.insert(normalizedName)
+                }
+                return disabledToolNames
+            }
+        }
+
+        private static func nonEmpty(_ value: String?) -> String? {
+            guard let raw = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !raw.isEmpty else {
+                return nil
+            }
+            return raw
+        }
+
+        private static func loadConfig(
+            configPath: String?,
+            logger: Logger,
+            readFailureMessage: String,
+            decodeFailureMessage: String
+        ) -> (path: String, config: ProxyFileConfig)? {
+            guard let rawPath = nonEmpty(configPath) else { return nil }
+            let expandedPath = NSString(string: rawPath).expandingTildeInPath
+            let url = URL(fileURLWithPath: expandedPath)
+
+            let data: Data
             do {
-                override = try ProxyInitializeHandshakeOverride(fileConfig: fileConfig)
+                data = try Data(contentsOf: url)
             } catch {
                 logger.warning(
-                    "Proxy config capabilities are not JSON-compatible; using built-in initialize params",
+                    "\(readFailureMessage)",
                     metadata: [
                         "path": .string(expandedPath),
                         "error": .string(String(describing: error)),
@@ -186,97 +265,22 @@ package enum ProxyFileConfigLoader {
                 )
                 return nil
             }
-            return override.isEmpty ? nil : override
-        }
-    }
 
-    package static func loadDisabledToolNames(
-        configPath: String?,
-        logger: Logger
-    ) -> Set<String> {
-        guard let loaded = loadConfig(
-            configPath: configPath,
-            logger: logger,
-            readFailureMessage: "Failed to read proxy config; ignoring disabled tools",
-            decodeFailureMessage: "Failed to decode proxy config; ignoring disabled tools"
-        ) else {
-            return []
-        }
-        let expandedPath = loaded.path
-        switch loaded.config.tools {
-        case .missing:
-            return []
-        case .invalid(let error):
-            logger.warning(
-                "Proxy config tools is invalid; ignoring disabled tools",
-                metadata: [
-                    "path": .string(expandedPath),
-                    "error": .string(error),
-                ]
-            )
-            return []
-        case .decoded(let tools):
-            guard let disabled = tools.disabled else {
-                return []
+            let config: ProxyFileConfig
+            do {
+                config = try TOMLDecoder(isLenient: false).decode(ProxyFileConfig.self, from: data)
+            } catch {
+                logger.warning(
+                    "\(decodeFailureMessage)",
+                    metadata: [
+                        "path": .string(expandedPath),
+                        "error": .string(String(describing: error)),
+                    ]
+                )
+                return nil
             }
-            var disabledToolNames = Set<String>()
-            for rawName in disabled {
-                let normalizedName = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard normalizedName.isEmpty == false else {
-                    continue
-                }
-                disabledToolNames.insert(normalizedName)
-            }
-            return disabledToolNames
+
+            return (expandedPath, config)
         }
-    }
-
-    private static func nonEmpty(_ value: String?) -> String? {
-        guard let raw = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !raw.isEmpty else {
-            return nil
-        }
-        return raw
-    }
-
-    private static func loadConfig(
-        configPath: String?,
-        logger: Logger,
-        readFailureMessage: String,
-        decodeFailureMessage: String
-    ) -> (path: String, config: ProxyFileConfig)? {
-        guard let rawPath = nonEmpty(configPath) else { return nil }
-        let expandedPath = NSString(string: rawPath).expandingTildeInPath
-        let url = URL(fileURLWithPath: expandedPath)
-
-        let data: Data
-        do {
-            data = try Data(contentsOf: url)
-        } catch {
-            logger.warning(
-                "\(readFailureMessage)",
-                metadata: [
-                    "path": .string(expandedPath),
-                    "error": .string(String(describing: error)),
-                ]
-            )
-            return nil
-        }
-
-        let config: ProxyFileConfig
-        do {
-            config = try TOMLDecoder(isLenient: false).decode(ProxyFileConfig.self, from: data)
-        } catch {
-            logger.warning(
-                "\(decodeFailureMessage)",
-                metadata: [
-                    "path": .string(expandedPath),
-                    "error": .string(String(describing: error)),
-                ]
-            )
-            return nil
-        }
-
-        return (expandedPath, config)
     }
 }

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
@@ -3,54 +3,54 @@ import NIO
 import ProxyXcodeFeatures
 import ProxySession
 
-package struct HTTPDebugSnapshot: Codable, Sendable {
-    package let generatedAt: Date
-    package let proxyInitialized: Bool
-    package let cachedToolsListAvailable: Bool
-    package let warmupInFlight: Bool
-    package let controlPlane: ProxyControlPlaneDebugSnapshot?
-    package let upstreams: [ProxyUpstreamDebugSnapshot]
-    package let recentTraffic: [ProxyDebugTrafficEvent]
-    package let sessions: [SessionDebugSnapshot]
-    package let leases: [RequestLeaseDebugSnapshot]
-    package let queuedRequestCount: Int
-    package let refreshCodeIssues: RefreshCodeIssuesDebugSnapshot?
-
-    package init(
-        base: ProxyDebugSnapshot,
-        refreshCodeIssues: RefreshCodeIssuesDebugSnapshot?
-    ) {
-        self.generatedAt = base.generatedAt
-        self.proxyInitialized = base.proxyInitialized
-        self.cachedToolsListAvailable = base.cachedToolsListAvailable
-        self.warmupInFlight = base.warmupInFlight
-        self.controlPlane = base.controlPlane
-        self.upstreams = base.upstreams
-        self.recentTraffic = base.recentTraffic
-        self.sessions = base.sessions
-        self.leases = base.leases
-        self.queuedRequestCount = base.queuedRequestCount
-        self.refreshCodeIssues = refreshCodeIssues
-    }
-}
-
-package struct HTTPSSEOpenResult {
-    package let bufferedNotifications: [Data]
-
-    package init(bufferedNotifications: [Data]) {
-        self.bufferedNotifications = bufferedNotifications
-    }
-}
-
 package final class HTTPControlService: Sendable {
+    package struct DebugSnapshot: Codable, Sendable {
+        package let generatedAt: Date
+        package let proxyInitialized: Bool
+        package let cachedToolsListAvailable: Bool
+        package let warmupInFlight: Bool
+        package let controlPlane: ProxyControlPlaneDebugSnapshot?
+        package let upstreams: [ProxyUpstreamDebugSnapshot]
+        package let recentTraffic: [ProxyDebugTrafficEvent]
+        package let sessions: [SessionRequestPipeline.DebugSnapshot]
+        package let leases: [LeaseManager.DebugSnapshot]
+        package let queuedRequestCount: Int
+        package let refreshCodeIssues: RefreshCodeIssues.DebugSnapshot?
+
+        package init(
+            base: ProxyDebugSnapshot,
+            refreshCodeIssues: RefreshCodeIssues.DebugSnapshot?
+        ) {
+            self.generatedAt = base.generatedAt
+            self.proxyInitialized = base.proxyInitialized
+            self.cachedToolsListAvailable = base.cachedToolsListAvailable
+            self.warmupInFlight = base.warmupInFlight
+            self.controlPlane = base.controlPlane
+            self.upstreams = base.upstreams
+            self.recentTraffic = base.recentTraffic
+            self.sessions = base.sessions
+            self.leases = base.leases
+            self.queuedRequestCount = base.queuedRequestCount
+            self.refreshCodeIssues = refreshCodeIssues
+        }
+    }
+
+    package struct SSEOpenResult {
+        package let bufferedNotifications: [Data]
+
+        package init(bufferedNotifications: [Data]) {
+            self.bufferedNotifications = bufferedNotifications
+        }
+    }
+
     private let runtimeCoordinator: any RuntimeCoordinating
-    private let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator?
-    private let refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState?
+    private let refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator?
+    private let refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState?
 
     package init(
         runtimeCoordinator: any RuntimeCoordinating,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
-        refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState? = nil
+        refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
+        refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil
     ) {
         self.runtimeCoordinator = runtimeCoordinator
         self.refreshCodeIssuesCoordinator = refreshCodeIssuesCoordinator
@@ -62,7 +62,7 @@ package final class HTTPControlService: Sendable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         return try? encoder.encode(
-            HTTPDebugSnapshot(
+            HTTPControlService.DebugSnapshot(
                 base: runtimeCoordinator.debugSnapshot(
                     includeSensitiveDebugPayloads: includeSensitiveDebugPayloads
                 ),
@@ -73,13 +73,13 @@ package final class HTTPControlService: Sendable {
         )
     }
 
-    package func openSSE(sessionID: String, channel: Channel) -> HTTPSSEOpenResult {
+    package func openSSE(sessionID: String, channel: Channel) -> HTTPControlService.SSEOpenResult {
         let session = runtimeCoordinator.session(id: sessionID)
         let hadClients = session.notificationHub.hasSseClients
         session.notificationHub.addSse(channel)
         runtimeCoordinator.markNotificationClientConnected(sessionID: sessionID)
         let bufferedNotifications = hadClients ? [] : session.router.drainBufferedNotifications()
-        return HTTPSSEOpenResult(bufferedNotifications: bufferedNotifications)
+        return HTTPControlService.SSEOpenResult(bufferedNotifications: bufferedNotifications)
     }
 
     package func closeSSE(sessionID: String, channel: Channel) {

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler+Responses.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler+Responses.swift
@@ -6,7 +6,7 @@ import ProxyMCP
 
 extension HTTPHandler {
     func sendPostResolution(
-        _ resolution: HTTPPostResolution,
+        _ resolution: HTTPPostService.Resolution,
         on channel: Channel,
         keepAlive: Bool,
         requestLog: RequestLogContext
@@ -152,7 +152,7 @@ extension HTTPHandler {
 
     func sendMCPError(
         on channel: Channel,
-        id: RPCID?,
+        id: JSONRPC.ID?,
         code: Int,
         message: String,
         forceBatchArray: Bool = false,
@@ -176,7 +176,7 @@ extension HTTPHandler {
 
     func sendMCPError(
         on channel: Channel,
-        ids: [RPCID],
+        ids: [JSONRPC.ID],
         code: Int,
         message: String,
         forceBatchArray: Bool = false,

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -26,7 +26,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         package var isSSE = false
         package var sseSessionID: String?
         package var bodyTooLarge = false
-        package var activePostRequestHandles: [String: HTTPPostCancellationHandle] = [:]
+        package var activePostRequestHandles: [String: HTTPPostService.CancellationHandle] = [:]
         package var responseWriteTail: EventLoopFuture<Void>?
     }
 
@@ -40,17 +40,17 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
     package init(
         config: ProxyConfig,
         sessionManager: any RuntimeCoordinating,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
-        refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver(),
-        refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState? = nil,
+        refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
+        refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
+        refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil,
         usesSynchronousLocalResolution: Bool = false
     ) {
         let refreshCoordinator =
             refreshCodeIssuesCoordinator
-            ?? RefreshCodeIssuesCoordinator.makeDefault()
+            ?? RefreshCodeIssues.Coordinator.makeDefault()
         let refreshDebugState =
             refreshCodeIssuesDebugState
-            ?? RefreshCodeIssuesDebugState(
+            ?? RefreshCodeIssues.DebugState(
                 defaultRequestTimeoutSeconds: config.requestTimeout
             )
         self.config = config
@@ -558,7 +558,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         let isInitializeRequest = parsedRequestObject?["method"] as? String == "initialize"
         let hasValidInitializeID: Bool = {
             guard let parsedRequestObject,
-                case .request("initialize", _) = JSONRPCMessageInspector.kind(
+                case .request("initialize", _) = JSONRPC.Message.Inspector.kind(
                     of: parsedRequestObject
                 )
             else {
@@ -700,7 +700,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             )
             return nil
         }
-        guard MCPProtocolVersion.isSupported(protocolVersion),
+        guard MCP.ProtocolVersion.isSupported(protocolVersion),
             protocolVersion == expectedProtocolVersion
         else {
             _ = sendPlain(
@@ -763,7 +763,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             )
             return nil
         }
-        guard MCPProtocolVersion.isSupported(protocolVersion),
+        guard MCP.ProtocolVersion.isSupported(protocolVersion),
             protocolVersion == expectedProtocolVersion
         else {
             _ = sendPlain(

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPResponseWriter.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPResponseWriter.swift
@@ -108,7 +108,7 @@ package struct HTTPResponseWriter: Sendable {
 
     package func sendMCPError(
         on channel: Channel,
-        id: RPCID?,
+        id: JSONRPC.ID?,
         code: Int,
         message: String,
         forceBatchArray: Bool = false,
@@ -144,7 +144,7 @@ package struct HTTPResponseWriter: Sendable {
 
     package func sendMCPError(
         on channel: Channel,
-        ids: [RPCID],
+        ids: [JSONRPC.ID],
         code: Int,
         message: String,
         forceBatchArray: Bool = false,

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -12,17 +12,17 @@ package enum LocalPostHandling {
         future: EventLoopFuture<ByteBuffer>,
         sessionID: String,
         errorSessionID: String?,
-        originalID: RPCID
+        originalID: JSONRPC.ID
     )
     case immediateResponse(data: Data, sessionID: String)
-    case mcpError(id: RPCID?, code: Int, message: String, sessionID: String?)
+    case mcpError(id: JSONRPC.ID?, code: Int, message: String, sessionID: String?)
 }
 
 package struct LocalMCPResponder {
     private struct EmbeddedTestResolutionError: Error {}
 
     private let sessionManager: any RuntimeCoordinating
-    private let refreshCodeIssuesMode: RefreshCodeIssuesMode
+    private let refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode
     private let disabledToolNames: Set<String>
     /// EmbeddedChannel-based tests cannot complete promises from another
     /// thread, so they opt in to a synchronous resolution path explicitly
@@ -32,7 +32,7 @@ package struct LocalMCPResponder {
 
     package init(
         sessionManager: any RuntimeCoordinating,
-        refreshCodeIssuesMode: RefreshCodeIssuesMode,
+        refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode,
         disabledToolNames: Set<String>,
         usesSynchronousLocalResolution: Bool = false,
         logger: Logger
@@ -49,14 +49,14 @@ package struct LocalMCPResponder {
         sessionID: String,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> Data {
-        guard let originalID = JSONRPCMessageInspector.requestID(from: object) else {
+        guard let originalID = JSONRPC.Message.Inspector.requestID(from: object) else {
             throw ControlPlaneError.invalidResponse("missing id")
         }
         let result = try await sessionManager.sharedToolsList(
             sessionID: sessionID,
             requestTimeoutOverride: requestTimeoutOverride
         )
-        let rewrittenResult = RefreshCodeIssuesToolsListRewriter.rewriteResult(
+        let rewrittenResult = RefreshCodeIssues.ToolsListRewriter.rewriteResult(
             result,
             mode: refreshCodeIssuesMode,
             hiddenToolNames: disabledToolNames
@@ -75,12 +75,12 @@ package struct LocalMCPResponder {
         eventLoop: EventLoop,
         requestTimeoutOverride: TimeAmount? = nil
     ) -> LocalPostHandling? {
-        guard let method = JSONRPCMessageInspector.method(from: object) else {
+        guard let method = JSONRPC.Message.Inspector.method(from: object) else {
             return nil
         }
 
         if method == "initialize" {
-            guard let originalID = JSONRPCMessageInspector.requestID(from: object) else {
+            guard let originalID = JSONRPC.Message.Inspector.requestID(from: object) else {
                 return .mcpError(
                     id: nil,
                     code: -32600,
@@ -105,7 +105,7 @@ package struct LocalMCPResponder {
         }
 
         if (method == "resources/list" || method == "resources/templates/list") && sessionManager.isInitialized() == false {
-            guard let originalID = JSONRPCMessageInspector.requestID(from: object) else {
+            guard let originalID = JSONRPC.Message.Inspector.requestID(from: object) else {
                 return .mcpError(
                     id: nil,
                     code: -32600,
@@ -138,7 +138,7 @@ package struct LocalMCPResponder {
         if method == "tools/list",
             let headerSessionID,
             sessionManager.isInitialized(),
-            let originalID = JSONRPCMessageInspector.requestID(from: object)
+            let originalID = JSONRPC.Message.Inspector.requestID(from: object)
         {
             if headerSessionExists == false {
                 _ = sessionManager.session(id: headerSessionID)
@@ -151,7 +151,7 @@ package struct LocalMCPResponder {
                             requestTimeoutOverride: requestTimeoutOverride
                         )
                     }
-                    let rewrittenResult = RefreshCodeIssuesToolsListRewriter.rewriteResult(
+                    let rewrittenResult = RefreshCodeIssues.ToolsListRewriter.rewriteResult(
                         result,
                         mode: refreshCodeIssuesMode,
                         hiddenToolNames: disabledToolNames
@@ -180,7 +180,7 @@ package struct LocalMCPResponder {
                         sessionID: headerSessionID,
                         requestTimeoutOverride: requestTimeoutOverride
                     )
-                    let rewrittenResult = RefreshCodeIssuesToolsListRewriter.rewriteResult(
+                    let rewrittenResult = RefreshCodeIssues.ToolsListRewriter.rewriteResult(
                         result,
                         mode: refreshCodeIssuesMode,
                         hiddenToolNames: disabledToolNames
@@ -216,7 +216,7 @@ package struct LocalMCPResponder {
         if method == "tools/call",
             let headerSessionID,
             sessionManager.isInitialized(),
-            let originalID = JSONRPCMessageInspector.requestID(from: object),
+            let originalID = JSONRPC.Message.Inspector.requestID(from: object),
             let params = object["params"] as? [String: Any],
             let toolName = params["name"] as? String,
             toolName == "XcodeListWindows",
@@ -289,7 +289,7 @@ package struct LocalMCPResponder {
     }
 
     private static func encodeResultBuffer(
-        id: RPCID,
+        id: JSONRPC.ID,
         result: JSONValue
     ) throws -> ByteBuffer {
         struct EncodingError: Error {}
@@ -308,7 +308,7 @@ package struct LocalMCPResponder {
     }
 
     private static func encodeErrorBuffer(
-        id: RPCID,
+        id: JSONRPC.ID,
         error: Error
     ) throws -> ByteBuffer {
         let data = try encodeErrorData(id: id, error: error)
@@ -318,7 +318,7 @@ package struct LocalMCPResponder {
     }
 
     private static func encodeErrorData(
-        id: RPCID,
+        id: JSONRPC.ID,
         error: Error
     ) throws -> Data {
         let mapped = ControlPlaneErrorMapper.jsonRPCError(for: error)
@@ -338,7 +338,7 @@ package struct LocalMCPResponder {
     }
 
     private static func fallbackLocalError(
-        id: RPCID,
+        id: JSONRPC.ID,
         sessionID: String
     ) -> LocalPostHandling {
         .mcpError(

--- a/Sources/ProxyHTTPGateway/MCP/MCPErrorResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/MCPErrorResponder.swift
@@ -4,7 +4,7 @@ import ProxyMCP
 
 enum MCPErrorResponder {
     static func errorResponseData(
-        id: RPCID?,
+        id: JSONRPC.ID?,
         code: Int,
         message: String,
         data: JSONValue? = nil,
@@ -24,7 +24,7 @@ enum MCPErrorResponder {
     }
 
     static func errorResponseData(
-        ids: [RPCID],
+        ids: [JSONRPC.ID],
         code: Int,
         message: String,
         data: JSONValue? = nil,
@@ -62,12 +62,12 @@ enum MCPErrorResponder {
         return try? JSONSerialization.data(withJSONObject: responses, options: [])
     }
 
-    static func requestMetadata(from data: Data) -> (ids: [RPCID], isBatch: Bool) {
+    static func requestMetadata(from data: Data) -> (ids: [JSONRPC.ID], isBatch: Bool) {
         requestMetadata(fromParsed: try? JSONSerialization.jsonObject(with: data, options: []))
     }
 
-    static func requestMetadata(fromParsed json: Any?) -> (ids: [RPCID], isBatch: Bool) {
-        let metadata = JSONRPCMessageInspector.requestMetadata(fromParsed: json)
+    static func requestMetadata(fromParsed json: Any?) -> (ids: [JSONRPC.ID], isBatch: Bool) {
+        let metadata = JSONRPC.Message.Inspector.requestMetadata(fromParsed: json)
         return (metadata.ids, metadata.isBatch)
     }
 

--- a/Sources/ProxyHTTPGateway/MCP/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPGateway/MCP/MCPForwardingService.swift
@@ -71,13 +71,13 @@ package struct MCPForwardingService: Sendable {
         session: SessionContext,
         on eventLoop: EventLoop,
         requestTimeoutOverride: TimeAmount? = nil,
-        leaseID: RequestLeaseID? = nil,
-        cancellationHandle: HTTPPostCancellationHandle? = nil,
+        leaseID: LeaseManager.ID? = nil,
+        cancellationHandle: HTTPPostService.CancellationHandle? = nil,
         onTimeout: (@Sendable () -> Void)? = nil
     ) throws -> StartedRequest {
         let requestTimeout =
             requestTimeoutOverride
-            ?? MCPMethodDispatcher.timeoutForMethod(
+            ?? MCP.MethodDispatcher.timeoutForMethod(
                 prepared.transform.method,
                 defaultSeconds: config.requestTimeout
             )
@@ -204,10 +204,10 @@ package struct MCPForwardingService: Sendable {
         arguments: [String: Any],
         sessionID: String,
         eventLoop: EventLoop,
-        cancellationHandle: HTTPPostCancellationHandle? = nil,
+        cancellationHandle: HTTPPostService.CancellationHandle? = nil,
         upstreamIndexOverride: Int? = nil,
         requestTimeoutOverride: TimeAmount? = nil
-    ) async -> RefreshInternalToolResult {
+    ) async -> RefreshCodeIssues.Workflow.InternalToolResult {
         let requestObject: [String: Any] = [
             "jsonrpc": "2.0",
             "id": "__internal-\(UUID().uuidString)",
@@ -217,7 +217,7 @@ package struct MCPForwardingService: Sendable {
                 "arguments": arguments,
             ],
         ]
-        let internalRequestID = RPCID(any: requestObject["id"]!)!
+        let internalRequestID = JSONRPC.ID(any: requestObject["id"]!)!
 
         guard let bodyData = try? JSONSerialization.data(withJSONObject: requestObject, options: [])
         else {
@@ -227,7 +227,7 @@ package struct MCPForwardingService: Sendable {
             return .unavailable
         }
 
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: sessionID,
             label: "tools/call:\(name)",
             isBatch: false,
@@ -235,7 +235,7 @@ package struct MCPForwardingService: Sendable {
             isTopLevelClientRequest: false
         )
         let leaseID = sessionManager.createRequestLease(descriptor: descriptor)
-        let internalCancellationHandle = HTTPPostCancellationHandle(
+        let internalCancellationHandle = HTTPPostService.CancellationHandle(
             leaseID: leaseID,
             sessionID: sessionID,
             requestIDKeys: []

--- a/Sources/ProxyHTTPGateway/MCP/ToolCallNormalizer.swift
+++ b/Sources/ProxyHTTPGateway/MCP/ToolCallNormalizer.swift
@@ -138,7 +138,7 @@ package struct ToolCallNormalizer: Sendable {
         if let explicitMethod {
             return explicitMethod
         }
-        guard let responseID = JSONRPCMessageInspector.responseID(from: object) else {
+        guard let responseID = JSONRPC.Message.Inspector.responseID(from: object) else {
             return nil
         }
         return responseMethodsByIDKey[responseID.key]
@@ -148,7 +148,7 @@ package struct ToolCallNormalizer: Sendable {
         for object: [String: Any],
         responseToolNamesByIDKey: [String: String]
     ) -> String? {
-        guard let responseID = JSONRPCMessageInspector.responseID(from: object) else {
+        guard let responseID = JSONRPC.Message.Inspector.responseID(from: object) else {
             return nil
         }
         return responseToolNamesByIDKey[responseID.key]

--- a/Sources/ProxyHTTPGateway/MCP/ToolSurface.swift
+++ b/Sources/ProxyHTTPGateway/MCP/ToolSurface.swift
@@ -4,13 +4,13 @@ import ProxyMCP
 import ProxySession
 import ProxyXcodeFeatures
 
-package struct ToolSurfaceRewriteResult: Sendable {
-    package let responseData: Data
-    package let cacheableToolsListResult: JSONValue?
-}
-
 package struct ToolSurface: Sendable {
-    private let refreshCodeIssuesMode: RefreshCodeIssuesMode
+    package struct RewriteResult: Sendable {
+        package let responseData: Data
+        package let cacheableToolsListResult: JSONValue?
+    }
+
+    private let refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode
     private let callNormalizer: ToolCallNormalizer
     private let hiddenToolNames: Set<String>
 
@@ -26,14 +26,14 @@ package struct ToolSurface: Sendable {
     package func rewriteForwardedResponse(
         method: String?,
         toolName: String?,
-        originalID: RPCID?,
+        originalID: JSONRPC.ID?,
         responseMethodsByIDKey: [String: String] = [:],
         responseToolNamesByIDKey: [String: String] = [:],
-        responseOriginalIDsByKey: [String: RPCID] = [:],
+        responseOriginalIDsByKey: [String: JSONRPC.ID] = [:],
         normalizationToolsListResponseIDKey: String? = nil,
         cacheableToolsListResponseIDKey: String? = nil,
         upstreamData: Data
-    ) -> ToolSurfaceRewriteResult {
+    ) -> ToolSurface.RewriteResult {
         let rewrittenResourcesData = rewriteUnsupportedResourcesListResponseIfNeeded(
             method: method,
             originalID: originalID,
@@ -69,7 +69,7 @@ package struct ToolSurface: Sendable {
             responseMethodsByIDKey: responseMethodsByIDKey,
             hiddenToolNames: hiddenToolNames
         )
-        return ToolSurfaceRewriteResult(
+        return ToolSurface.RewriteResult(
             responseData: responseData,
             cacheableToolsListResult: cacheableToolsListResult
         )
@@ -97,9 +97,9 @@ package struct ToolSurface: Sendable {
 
     private func rewriteUnsupportedResourcesListResponseIfNeeded(
         method: String?,
-        originalID: RPCID?,
+        originalID: JSONRPC.ID?,
         responseMethodsByIDKey: [String: String],
-        responseOriginalIDsByKey: [String: RPCID],
+        responseOriginalIDsByKey: [String: JSONRPC.ID],
         upstreamData: Data
     ) -> Data {
         guard let payload = try? JSONSerialization.jsonObject(with: upstreamData, options: []) else {
@@ -107,11 +107,11 @@ package struct ToolSurface: Sendable {
         }
 
         if let object = payload as? [String: Any] {
-            let resolvedRequest: (method: String, originalID: RPCID)? = {
+            let resolvedRequest: (method: String, originalID: JSONRPC.ID)? = {
                 if let method, let originalID {
                     return (method, originalID)
                 }
-                guard let responseID = JSONRPCMessageInspector.responseID(from: object),
+                guard let responseID = JSONRPC.Message.Inspector.responseID(from: object),
                     let method = responseMethodsByIDKey[responseID.key],
                     let originalID = responseOriginalIDsByKey[responseID.key]
                 else {
@@ -143,7 +143,7 @@ package struct ToolSurface: Sendable {
         var rewroteAny = false
         let rewrittenArray = array.map { item -> Any in
             guard let object = item as? [String: Any],
-                let responseID = JSONRPCMessageInspector.responseID(from: object),
+                let responseID = JSONRPC.Message.Inspector.responseID(from: object),
                 let method = responseMethodsByIDKey[responseID.key],
                 let originalID = responseOriginalIDsByKey[responseID.key]
             else {
@@ -176,7 +176,7 @@ package struct ToolSurface: Sendable {
     private func rewriteUnsupportedResourcesListResponseObjectIfNeeded(
         _ object: [String: Any],
         method: String,
-        originalID: RPCID
+        originalID: JSONRPC.ID
     ) -> [String: Any] {
         guard method == "resources/list" || method == "resources/templates/list" else {
             return object
@@ -204,7 +204,7 @@ package struct ToolSurface: Sendable {
         return object
     }
 
-    private func emptyResourcesListResponseObject(method: String, originalID: RPCID) -> [String: Any] {
+    private func emptyResourcesListResponseObject(method: String, originalID: JSONRPC.ID) -> [String: Any] {
         let result: [String: Any] = method == "resources/list"
             ? ["resources": [Any]()]
             : ["resourceTemplates": [Any]()]
@@ -262,7 +262,7 @@ package struct ToolSurface: Sendable {
         responseMethodsByIDKey: [String: String] = [:],
         hiddenToolNames: Set<String> = []
     ) -> Data {
-        RefreshCodeIssuesToolsListRewriter.rewriteResponseDataIfNeeded(
+        RefreshCodeIssues.ToolsListRewriter.rewriteResponseDataIfNeeded(
             responseData,
             method: method,
             responseMethodsByIDKey: responseMethodsByIDKey,
@@ -279,7 +279,7 @@ package struct ToolSurface: Sendable {
             return nil
         }
         if let object = payload as? [String: Any] {
-            guard let responseID = JSONRPCMessageInspector.responseID(from: object),
+            guard let responseID = JSONRPC.Message.Inspector.responseID(from: object),
                 responseID.key == responseIDKey
             else {
                 return nil
@@ -291,7 +291,7 @@ package struct ToolSurface: Sendable {
         }
         for item in array {
             guard let object = item as? [String: Any],
-                let responseID = JSONRPCMessageInspector.responseID(from: object),
+                let responseID = JSONRPC.Message.Inspector.responseID(from: object),
                 responseID.key == responseIDKey
             else {
                 continue

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+ForwardExecutor.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+ForwardExecutor.swift
@@ -19,11 +19,11 @@ extension HTTPPostService {
         prefersEventStream: Bool,
         eventLoop: EventLoop,
         session: SessionContext,
-        leaseID: RequestLeaseID,
+        leaseID: LeaseManager.ID,
         upstreamIndex: Int,
-        cancellationHandle: HTTPPostCancellationHandle?,
+        cancellationHandle: HTTPPostService.CancellationHandle?,
         requestTimeoutOverride: TimeAmount?
-    ) -> EventLoopFuture<HTTPPostResolution> {
+    ) -> EventLoopFuture<HTTPPostService.Resolution> {
         guard let forwardedBodyData = filteredRequest.bodyData
         else {
             return makeImmediateLeaseResolution(
@@ -81,7 +81,7 @@ extension HTTPPostService {
                 refreshRouting.remainingLocalResponseData == nil,
                 let route = refreshRouting.refreshRoutes.first
             {
-                let promise = eventLoop.makePromise(of: HTTPPostResolution.self)
+                let promise = eventLoop.makePromise(of: HTTPPostService.Resolution.self)
                 let refreshTask = Task { [self] in
                     let result = await forwardRefreshCodeIssuesRequest(
                         route.request,
@@ -132,7 +132,7 @@ extension HTTPPostService {
                 return promise.futureResult
             }
 
-            let promise = eventLoop.makePromise(of: HTTPPostResolution.self)
+            let promise = eventLoop.makePromise(of: HTTPPostService.Resolution.self)
             let refreshTask = Task { [self] in
                 var payloads: [Data?] = []
                 let splitDeadline = Self.timeoutDeadline(
@@ -362,7 +362,7 @@ extension HTTPPostService {
                 )
             }
 
-            let promise = eventLoop.makePromise(of: HTTPPostResolution.self)
+            let promise = eventLoop.makePromise(of: HTTPPostService.Resolution.self)
             started.future.whenComplete { result in
                 let resolution = self.forwardingService.resolveResponse(
                     result,

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -16,7 +16,7 @@ extension HTTPPostService {
         prefersEventStream: Bool,
         eventLoop: EventLoop,
         forceBatchArray: Bool
-    ) -> EventLoopFuture<HTTPPostResolution> {
+    ) -> EventLoopFuture<HTTPPostService.Resolution> {
         switch handling {
         case .pendingResponse(let future, let sessionID, let errorSessionID, let originalID):
             return future.map { buffer in
@@ -114,7 +114,7 @@ extension HTTPPostService {
         else {
             return false
         }
-        return JSONRPCMessageInspector.responseID(from: object) != nil
+        return JSONRPC.Message.Inspector.responseID(from: object) != nil
     }
 
     package struct ToolCallRouting {
@@ -243,7 +243,7 @@ extension HTTPPostService {
             requestIDs: routedResponseIDs
         )
         let leaseID = sessionManager.createRequestLease(descriptor: descriptor)
-        let cancellationHandle = HTTPPostCancellationHandle(
+        let cancellationHandle = HTTPPostService.CancellationHandle(
             leaseID: leaseID,
             sessionID: sessionID,
             requestIDKeys: routedResponseIDs.map(\.key)
@@ -369,7 +369,7 @@ extension HTTPPostService {
             guard !Task.isCancelled else {
                 break
             }
-            guard let originalID = JSONRPCMessageInspector.requestID(from: request) else {
+            guard let originalID = JSONRPC.Message.Inspector.requestID(from: request) else {
                 continue
             }
             let requestTimeout = Self.remainingRequestTimeout(until: deadline)
@@ -436,7 +436,7 @@ extension HTTPPostService {
             guard !Task.isCancelled else {
                 break
             }
-            guard let originalID = JSONRPCMessageInspector.requestID(from: request) else {
+            guard let originalID = JSONRPC.Message.Inspector.requestID(from: request) else {
                 continue
             }
             guard JSONSerialization.isValidJSONObject(request),
@@ -511,7 +511,7 @@ extension HTTPPostService {
         guard sessionManager.hasDocumentationProvider() else {
             return false
         }
-        guard case .request("tools/call", _) = JSONRPCMessageInspector.kind(of: object),
+        guard case .request("tools/call", _) = JSONRPC.Message.Inspector.kind(of: object),
             let params = object["params"] as? [String: Any],
             params["name"] as? String == DocumentationToolCatalog.toolName,
             disabledToolNames.contains(DocumentationToolCatalog.toolName) == false else {
@@ -521,8 +521,8 @@ extension HTTPPostService {
     }
 
     private func isToolsListRequest(_ object: [String: Any]) -> Bool {
-        JSONRPCMessageInspector.requestID(from: object) != nil
-            && JSONRPCMessageInspector.method(from: object) == "tools/list"
+        JSONRPC.Message.Inspector.requestID(from: object) != nil
+            && JSONRPC.Message.Inspector.method(from: object) == "tools/list"
             && sessionManager.isInitialized()
     }
 
@@ -538,22 +538,22 @@ extension HTTPPostService {
         return toolName
     }
 
-    package func refreshCodeIssuesRequest(from requestJSON: Any) -> RefreshCodeIssuesRequest? {
-        guard let object = RefreshCodeIssuesRequest.singleRequestObject(from: requestJSON) else {
+    package func refreshCodeIssuesRequest(from requestJSON: Any) -> RefreshCodeIssues.Request? {
+        guard let object = RefreshCodeIssues.Request.singleRequestObject(from: requestJSON) else {
             return nil
         }
-        return RefreshCodeIssuesRequest(requestObject: object)
+        return RefreshCodeIssues.Request(requestObject: object)
     }
 
-    package func refreshRequestRouting(from requestJSON: Any) -> RefreshRequestRouting? {
+    package func refreshRequestRouting(from requestJSON: Any) -> HTTPPostService.RefreshRouting? {
         if let object = requestJSON as? [String: Any],
-            let refreshRequest = RefreshCodeIssuesRequest(requestObject: object),
+            let refreshRequest = RefreshCodeIssues.Request(requestObject: object),
             Self.extractResponseIDs(from: object).isEmpty == false,
             let bodyData = try? JSONSerialization.data(withJSONObject: object, options: [])
         {
-            return RefreshRequestRouting(
+            return HTTPPostService.RefreshRouting(
                 refreshRoutes: [
-                    RefreshRequestRoute(
+                    HTTPPostService.RefreshRoute(
                         request: refreshRequest,
                         bodyData: bodyData,
                         requestIDs: Self.extractResponseIDs(from: object),
@@ -569,7 +569,7 @@ extension HTTPPostService {
         guard let requests = requestJSON as? [Any] else {
             return nil
         }
-        var refreshRoutes: [RefreshRequestRoute] = []
+        var refreshRoutes: [HTTPPostService.RefreshRoute] = []
         var remainingRequestObjects: [[String: Any]] = []
         var remainingInvalidResponseObjects: [[String: Any]] = []
         for item in requests {
@@ -583,7 +583,7 @@ extension HTTPPostService {
                 )
                 continue
             }
-            guard let candidate = RefreshCodeIssuesRequest(requestObject: object) else {
+            guard let candidate = RefreshCodeIssues.Request(requestObject: object) else {
                 remainingRequestObjects.append(object)
                 continue
             }
@@ -597,7 +597,7 @@ extension HTTPPostService {
                 return nil
             }
             refreshRoutes.append(
-                RefreshRequestRoute(
+                HTTPPostService.RefreshRoute(
                     request: candidate,
                     bodyData: bodyData,
                     requestIDs: responseIDs,
@@ -626,7 +626,7 @@ extension HTTPPostService {
             from: remainingInvalidResponseObjects,
             forceBatchArray: remainingInvalidResponseObjects.count > 1
         )
-        return RefreshRequestRouting(
+        return HTTPPostService.RefreshRouting(
             refreshRoutes: refreshRoutes,
             remainingBodyData: remainingBodyData,
             remainingRequestIDs: Self.extractResponseIDs(from: remainingPayload as Any),

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+RefreshSupport.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+RefreshSupport.swift
@@ -14,7 +14,7 @@ extension HTTPPostService {
     package func listXcodeWindows(
         sessionID: String,
         eventLoop: EventLoop,
-        cancellationHandle: HTTPPostCancellationHandle? = nil,
+        cancellationHandle: HTTPPostService.CancellationHandle? = nil,
         upstreamIndexOverride: Int? = nil,
         requestTimeoutOverride: TimeAmount? = nil
     ) async throws -> [XcodeWindowInfo]? {
@@ -43,14 +43,14 @@ extension HTTPPostService {
     package func forwardOnce(
         bodyData: Data,
         sessionID: String,
-        requestIDs: [RPCID],
+        requestIDs: [JSONRPC.ID],
         requestIsBatch: Bool,
         shouldRequeueLeaseOnRetryableFailure: @Sendable () -> Bool,
         eventLoop: EventLoop,
-        leaseID: RequestLeaseID,
-        cancellationHandle: HTTPPostCancellationHandle?,
+        leaseID: LeaseManager.ID,
+        cancellationHandle: HTTPPostService.CancellationHandle?,
         requestTimeoutOverride: TimeAmount? = nil
-    ) async -> RefreshForwardAttemptResult {
+    ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult {
         let parsedRequestJSON: Any
         do {
             parsedRequestJSON = try JSONSerialization.jsonObject(with: bodyData, options: [])
@@ -155,7 +155,7 @@ extension HTTPPostService {
                 // function's job; the terminal lease transition belongs to
                 // the caller that owns the whole refresh request.
                 if allowsLeaseRetry,
-                    RefreshCodeIssuesWorkflow.isRetryableRefreshCodeIssuesFailure(responseData),
+                    RefreshCodeIssues.Workflow.isRetryableRefreshCodeIssuesFailure(responseData),
                     shouldRequeueLeaseOnRetryableFailure()
                 {
                     sessionManager.requeueRequestLease(leaseID)
@@ -186,8 +186,8 @@ extension HTTPPostService {
     /// The single terminal lease transition for a refresh request,
     /// regardless of whether the proxy answered locally or forwarded.
     package func finishRefreshLease(
-        _ leaseID: RequestLeaseID,
-        result: RefreshForwardAttemptResult
+        _ leaseID: LeaseManager.ID,
+        result: RefreshCodeIssues.Workflow.ForwardAttemptResult
     ) {
         switch result {
         case .success:
@@ -235,7 +235,7 @@ extension HTTPPostService {
 
     package static func isRetryScopedRefreshLeaseRequest(_ requestJSON: Any) -> Bool {
         if let object = requestJSON as? [String: Any] {
-            return RefreshCodeIssuesRequest(requestObject: object) != nil
+            return RefreshCodeIssues.Request(requestObject: object) != nil
         }
         guard let array = requestJSON as? [Any],
             array.count == 1,
@@ -243,7 +243,7 @@ extension HTTPPostService {
         else {
             return false
         }
-        return RefreshCodeIssuesRequest(requestObject: object) != nil
+        return RefreshCodeIssues.Request(requestObject: object) != nil
     }
 
 
@@ -251,9 +251,9 @@ extension HTTPPostService {
         sessionID: String,
         parsedRequestJSON: Any,
         requestIsBatch: Bool,
-        requestIDs: [RPCID]
-    ) -> SessionPipelineRequestDescriptor {
-        SessionPipelineRequestDescriptor(
+        requestIDs: [JSONRPC.ID]
+    ) -> SessionRequestPipeline.Descriptor {
+        SessionRequestPipeline.Descriptor(
             sessionID: sessionID,
             label: requestLabel(from: parsedRequestJSON),
             isBatch: requestIsBatch,
@@ -263,16 +263,16 @@ extension HTTPPostService {
     }
 
     package func forwardRefreshCodeIssuesRequest(
-        _ refreshRequest: RefreshCodeIssuesRequest,
+        _ refreshRequest: RefreshCodeIssues.Request,
         bodyData: Data,
         sessionID: String,
-        requestIDs: [RPCID],
+        requestIDs: [JSONRPC.ID],
         requestIsBatch: Bool,
         requestTimeoutOverride: TimeAmount? = nil,
         eventLoop: EventLoop,
-        leaseID: RequestLeaseID,
-        cancellationHandle: HTTPPostCancellationHandle?
-    ) async -> RefreshForwardAttemptResult {
+        leaseID: LeaseManager.ID,
+        cancellationHandle: HTTPPostService.CancellationHandle?
+    ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult {
         await refreshWorkflow.run(
             refreshRequest: refreshRequest,
             bodyData: bodyData,
@@ -328,13 +328,13 @@ extension HTTPPostService {
     /// are no-ops; this performs exactly the lease/cancellation choreography
     /// the re-entry used to produce.
     package func executeRefreshRoute(
-        _ route: RefreshRequestRoute,
+        _ route: HTTPPostService.RefreshRoute,
         sessionID: String,
         prefersEventStream: Bool,
         eventLoop: EventLoop,
         requestTimeoutOverride: TimeAmount?,
-        parentCancellationHandle: HTTPPostCancellationHandle?
-    ) async -> HTTPPostResolution {
+        parentCancellationHandle: HTTPPostService.CancellationHandle?
+    ) async -> HTTPPostService.Resolution {
         let parsedRoutePayload =
             (try? JSONSerialization.jsonObject(with: route.bodyData, options: []))
             ?? [String: Any]()
@@ -345,7 +345,7 @@ extension HTTPPostService {
             requestIDs: route.requestIDs
         )
         let leaseID = sessionManager.createRequestLease(descriptor: descriptor)
-        let cancellationHandle = HTTPPostCancellationHandle(
+        let cancellationHandle = HTTPPostService.CancellationHandle(
             leaseID: leaseID,
             sessionID: sessionID,
             requestIDKeys: route.requestIDs.map(\.key)
@@ -391,10 +391,10 @@ extension HTTPPostService {
     }
 
     package func makeResolution(
-        from result: RefreshForwardAttemptResult,
+        from result: RefreshCodeIssues.Workflow.ForwardAttemptResult,
         sessionID: String,
         prefersEventStream: Bool
-    ) -> HTTPPostResolution {
+    ) -> HTTPPostService.Resolution {
         switch result {
         case .success(let responseData):
             return .responseData(
@@ -459,19 +459,19 @@ extension HTTPPostService {
     }
 
     package func makeImmediateLeaseResolution(
-        _ resolution: HTTPPostResolution,
-        leaseID: RequestLeaseID,
+        _ resolution: HTTPPostService.Resolution,
+        leaseID: LeaseManager.ID,
         eventLoop: EventLoop,
-        cancellationHandle: HTTPPostCancellationHandle?
-    ) -> EventLoopFuture<HTTPPostResolution> {
+        cancellationHandle: HTTPPostService.CancellationHandle?
+    ) -> EventLoopFuture<HTTPPostService.Resolution> {
         cancellationHandle?.markCompleted()
         sessionManager.completeRequestLease(leaseID)
         return eventLoop.makeSucceededFuture(resolution)
     }
 
     package func cancel(
-        _ handle: HTTPPostCancellationHandle,
-        source: HTTPPostCancellationSource = .channelInactive
+        _ handle: HTTPPostService.CancellationHandle,
+        source: HTTPPostService.CancellationSource = .channelInactive
     ) {
         logger.debug(
             "Cancelling top-level upstream request",

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
@@ -15,7 +15,7 @@ extension HTTPPostService {
         method: String?,
         defaultSeconds: TimeInterval
     ) -> TimeAmount? {
-        MCPMethodDispatcher.timeoutForMethod(method, defaultSeconds: defaultSeconds)
+        MCP.MethodDispatcher.timeoutForMethod(method, defaultSeconds: defaultSeconds)
     }
 
     package static func minimumRequestTimeout(
@@ -47,7 +47,7 @@ extension HTTPPostService {
     }
 
     package static func makeRequestTimeoutResponseData(
-        requestIDs: [RPCID],
+        requestIDs: [JSONRPC.ID],
         forceBatchArray: Bool
     ) -> Data? {
         makeJSONRPCErrorResponseData(
@@ -60,11 +60,11 @@ extension HTTPPostService {
 
     package static func makeMissingInitializeResolution(
         parsedRequestJSON: Any,
-        requestIDs: [RPCID],
+        requestIDs: [JSONRPC.ID],
         requestIsBatch: Bool,
         sessionID: String,
         prefersEventStream: Bool
-    ) -> HTTPPostResolution? {
+    ) -> HTTPPostService.Resolution? {
         guard requestRequiresInitialize(parsedRequestJSON) else {
             return nil
         }
@@ -80,12 +80,12 @@ extension HTTPPostService {
     /// keeps any locally-produced responses, a plain request degrades to 503.
     package static func makeUpstreamUnavailableResolution(
         localResponseData: Data?,
-        responseIDs: [RPCID],
+        responseIDs: [JSONRPC.ID],
         forceBatchArray: Bool,
         requestIsBatch: Bool,
         sessionID: String,
         prefersEventStream: Bool
-    ) -> HTTPPostResolution {
+    ) -> HTTPPostService.Resolution {
         if localResponseData != nil {
             return makePartialBatchErrorResolution(
                 localResponseData: localResponseData,
@@ -119,11 +119,11 @@ extension HTTPPostService {
 
     /// The one canonical "expected initialize request" rejection shape.
     package static func makeExpectedInitializeResolution(
-        requestIDs: [RPCID],
+        requestIDs: [JSONRPC.ID],
         requestIsBatch: Bool,
         sessionID: String,
         prefersEventStream: Bool
-    ) -> HTTPPostResolution {
+    ) -> HTTPPostService.Resolution {
         if requestIDs.isEmpty {
             return .plain(
                 status: .unprocessableEntity,
@@ -144,7 +144,7 @@ extension HTTPPostService {
 
     package static func requestRequiresInitialize(_ parsedRequestJSON: Any) -> Bool {
         if let object = parsedRequestJSON as? [String: Any] {
-            if case .request("initialize", _) = JSONRPCMessageInspector.kind(of: object) {
+            if case .request("initialize", _) = JSONRPC.Message.Inspector.kind(of: object) {
                 return false
             }
             return true
@@ -160,7 +160,7 @@ extension HTTPPostService {
         sessionID: String,
         prefersEventStream: Bool,
         emptyStatus: HTTPResponseStatus
-    ) -> HTTPPostResolution {
+    ) -> HTTPPostService.Resolution {
         guard let responseData else {
             return .empty(status: emptyStatus, sessionID: sessionID)
         }
@@ -173,7 +173,7 @@ extension HTTPPostService {
 
     package static func makePartialBatchErrorResolution(
         localResponseData: Data?,
-        responseIDs: [RPCID],
+        responseIDs: [JSONRPC.ID],
         code: Int,
         message: String,
         sessionID: String,
@@ -181,7 +181,7 @@ extension HTTPPostService {
         forceBatchArray: Bool,
         fallbackStatus: HTTPResponseStatus,
         fallbackBody: String
-    ) -> HTTPPostResolution {
+    ) -> HTTPPostService.Resolution {
         guard let localResponseData else {
             if responseIDs.isEmpty {
                 return .plain(
@@ -307,12 +307,12 @@ extension HTTPPostService {
 
     package static func mergeLocalToolResponseData(
         _ localResponseData: Data?,
-        into resolution: HTTPPostResolution,
-        fallbackRequestIDs: [RPCID],
+        into resolution: HTTPPostService.Resolution,
+        fallbackRequestIDs: [JSONRPC.ID],
         forceBatchArray: Bool,
         sessionID: String,
         prefersEventStream: Bool
-    ) -> HTTPPostResolution {
+    ) -> HTTPPostService.Resolution {
         guard localResponseData != nil else {
             return resolution
         }
@@ -363,8 +363,8 @@ extension HTTPPostService {
     }
 
     package static func responseDataForBatchResolution(
-        _ resolution: HTTPPostResolution?,
-        fallbackRequestIDs: [RPCID],
+        _ resolution: HTTPPostService.Resolution?,
+        fallbackRequestIDs: [JSONRPC.ID],
         forceBatchArray: Bool
     ) -> Data? {
         guard let resolution else {
@@ -396,14 +396,14 @@ extension HTTPPostService {
         requestObject: [String: Any],
         toolName: String
     ) -> [[String: Any]] {
-        guard let rpcID = JSONRPCMessageInspector.requestID(from: requestObject) else {
+        guard let rpcID = JSONRPC.Message.Inspector.requestID(from: requestObject) else {
             return []
         }
         return [makeToolResultErrorResponseObject(id: rpcID, toolName: toolName)]
     }
 
     package static func makeToolResultErrorResponseObject(
-        id: RPCID,
+        id: JSONRPC.ID,
         toolName: String
     ) -> [String: Any] {
         [
@@ -422,7 +422,7 @@ extension HTTPPostService {
     }
 
     package static func makeJSONRPCErrorResponseObject(
-        id: RPCID,
+        id: JSONRPC.ID,
         code: Int,
         message: String
     ) -> [String: Any] {
@@ -449,7 +449,7 @@ extension HTTPPostService {
     }
 
     package static func makeJSONRPCErrorResponseData(
-        ids: [RPCID],
+        ids: [JSONRPC.ID],
         code: Int,
         message: String,
         forceBatchArray: Bool
@@ -494,9 +494,9 @@ extension HTTPPostService {
         return []
     }
 
-    package static func extractResponseIDs(from requestJSON: Any) -> [RPCID] {
+    package static func extractResponseIDs(from requestJSON: Any) -> [JSONRPC.ID] {
         if let object = requestJSON as? [String: Any] {
-            guard let rpcID = JSONRPCMessageInspector.requestID(from: object) else {
+            guard let rpcID = JSONRPC.Message.Inspector.requestID(from: object) else {
                 return []
             }
             return [rpcID]
@@ -509,7 +509,7 @@ extension HTTPPostService {
             guard let object = item as? [String: Any] else {
                 return nil
             }
-            return JSONRPCMessageInspector.requestID(from: object)
+            return JSONRPC.Message.Inspector.requestID(from: object)
         }
     }
 }

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -11,7 +11,7 @@ package final class HTTPPostService: Sendable {
     package struct FilteredToolCallRequest: Sendable {
         let bodyData: Data?
         let localResponseData: Data?
-        let forwardedResponseIDs: [RPCID]
+        let forwardedResponseIDs: [JSONRPC.ID]
         let forceBatchArray: Bool
     }
 
@@ -22,13 +22,13 @@ package final class HTTPPostService: Sendable {
 
     private struct LocalToolFallbackForwardingResult {
         let request: FilteredToolCallRequest
-        let resolution: HTTPPostResolution
+        let resolution: HTTPPostService.Resolution
     }
 
     package struct LocalToolFilterOperation {
         let localResponseFuture: EventLoopFuture<LocalToolBatchResult>
         let forwardedRequest: FilteredToolCallRequest
-        let cancellationHandle: HTTPPostCancellationHandle
+        let cancellationHandle: HTTPPostService.CancellationHandle
         let deadline: Date?
     }
 
@@ -37,16 +37,16 @@ package final class HTTPPostService: Sendable {
     package let usesSynchronousLocalResolution: Bool
     package let localResponder: LocalMCPResponder
     package let forwardingService: MCPForwardingService
-    package let refreshWorkflow: RefreshCodeIssuesWorkflow
+    package let refreshWorkflow: RefreshCodeIssues.Workflow
     package let requestTimeoutSeconds: TimeInterval
     package let logger: Logger
 
     package init(
         config: ProxyConfig,
         sessionManager: any RuntimeCoordinating,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator,
-        refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver(),
-        refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState,
+        refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator,
+        refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
+        refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState,
         usesSynchronousLocalResolution: Bool = false,
         logger: Logger = ProxyLogging.make("http")
     ) {
@@ -65,7 +65,7 @@ package final class HTTPPostService: Sendable {
             config: config,
             sessionManager: sessionManager
         )
-        self.refreshWorkflow = RefreshCodeIssuesWorkflow(
+        self.refreshWorkflow = RefreshCodeIssues.Workflow(
             mode: config.refreshCodeIssuesMode,
             requestTimeout: config.requestTimeout,
             coordinator: refreshCodeIssuesCoordinator,
@@ -83,8 +83,8 @@ package final class HTTPPostService: Sendable {
         prefersEventStream: Bool,
         eventLoop: EventLoop,
         requestTimeoutOverride: TimeAmount? = nil,
-        parentCancellationHandle: HTTPPostCancellationHandle? = nil
-    ) -> HTTPPostOperation {
+        parentCancellationHandle: HTTPPostService.CancellationHandle? = nil
+    ) -> HTTPPostService.Operation {
         let parsedRequestJSON = try? JSONSerialization.jsonObject(with: bodyData, options: [])
         let requestMetadata = MCPErrorResponder.requestMetadata(fromParsed: parsedRequestJSON)
         let requestIDs = requestMetadata.ids
@@ -99,7 +99,7 @@ package final class HTTPPostService: Sendable {
                 requestTimeoutOverride: requestTimeoutOverride
             )
         {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: resolveLocalHandling(
                     localHandling,
                     prefersEventStream: prefersEventStream,
@@ -111,7 +111,7 @@ package final class HTTPPostService: Sendable {
         }
 
         guard let sessionID = headerSessionID, sessionID.isEmpty == false else {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     .plain(
                         status: .badRequest,
@@ -124,7 +124,7 @@ package final class HTTPPostService: Sendable {
         }
 
         guard headerSessionExists else {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     .plain(
                         status: .notFound,
@@ -137,9 +137,9 @@ package final class HTTPPostService: Sendable {
         }
 
         if let requestObject = parsedRequestJSON as? [String: Any] {
-            switch JSONRPCMessageInspector.kind(of: requestObject) {
+            switch JSONRPC.Message.Inspector.kind(of: requestObject) {
             case .malformed(let invalidID):
-                return HTTPPostOperation(
+                return HTTPPostService.Operation(
                     future: eventLoop.makeSucceededFuture(
                         .mcpError(
                             id: invalidID,
@@ -166,7 +166,7 @@ package final class HTTPPostService: Sendable {
         }
 
         if sessionManager.isInitialized() == false {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     Self.makeExpectedInitializeResolution(
                         requestIDs: requestIDs,
@@ -180,7 +180,7 @@ package final class HTTPPostService: Sendable {
         }
 
         guard let parsedRequestJSON else {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     .mcpError(
                         id: nil,
@@ -205,7 +205,7 @@ package final class HTTPPostService: Sendable {
                 prefersEventStream: prefersEventStream
             )
         {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(initializeResolution),
                 cancellationHandle: nil
             )
@@ -221,7 +221,7 @@ package final class HTTPPostService: Sendable {
                 requestTimeoutOverride: requestTimeoutOverride
             )
         } catch {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     .mcpError(
                         id: nil,
@@ -242,7 +242,7 @@ package final class HTTPPostService: Sendable {
                 parentCancellationHandle.bindChildHandle(localToolFilter.cancellationHandle) == false
             {
                 localToolFilter.cancellationHandle.cancel(using: sessionManager)
-                return HTTPPostOperation(
+                return HTTPPostService.Operation(
                     future: eventLoop.makeSucceededFuture(
                         .empty(status: .accepted, sessionID: sessionID)
                     ),
@@ -321,7 +321,7 @@ package final class HTTPPostService: Sendable {
                 localToolFilter.cancellationHandle.markCompleted()
                 self.sessionManager.completeRequestLease(localToolFilter.cancellationHandle.leaseID)
             }
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: future,
                 cancellationHandle: localToolFilter.cancellationHandle
             )
@@ -347,8 +347,8 @@ package final class HTTPPostService: Sendable {
         prefersEventStream: Bool,
         eventLoop: EventLoop,
         deadline: Date?,
-        cancellationHandle: HTTPPostCancellationHandle
-    ) -> EventLoopFuture<HTTPPostResolution> {
+        cancellationHandle: HTTPPostService.CancellationHandle
+    ) -> EventLoopFuture<HTTPPostService.Resolution> {
         let forwardingTimeout = Self.remainingRequestTimeout(until: deadline)
         if deadline != nil,
             forwardingTimeout == nil,
@@ -386,10 +386,10 @@ package final class HTTPPostService: Sendable {
         prefersEventStream: Bool,
         eventLoop: EventLoop,
         requestTimeoutOverride: TimeAmount?,
-        parentCancellationHandle: HTTPPostCancellationHandle?
-    ) -> HTTPPostOperation {
+        parentCancellationHandle: HTTPPostService.CancellationHandle?
+    ) -> HTTPPostService.Operation {
         guard let forwardedBodyData = filteredRequest.bodyData else {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     Self.makeLocalResponseResolution(
                         responseData: filteredRequest.localResponseData,
@@ -406,7 +406,7 @@ package final class HTTPPostService: Sendable {
         do {
             forwardedRequestJSON = try JSONSerialization.jsonObject(with: forwardedBodyData, options: [])
         } catch {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     .mcpError(
                         id: nil,
@@ -431,7 +431,7 @@ package final class HTTPPostService: Sendable {
             requestIDs: forwardedRequestIDs
         )
         let leaseID = sessionManager.createRequestLease(descriptor: descriptor)
-        let cancellationHandle = HTTPPostCancellationHandle(
+        let cancellationHandle = HTTPPostService.CancellationHandle(
             leaseID: leaseID,
             sessionID: sessionID,
             requestIDKeys: forwardedRequestIDs.map(\.key)
@@ -440,7 +440,7 @@ package final class HTTPPostService: Sendable {
             parentCancellationHandle.bindChildHandle(cancellationHandle) == false
         {
             cancellationHandle.cancel(using: sessionManager)
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     .empty(status: .accepted, sessionID: sessionID)
                 ),
@@ -460,7 +460,7 @@ package final class HTTPPostService: Sendable {
                         defaultSeconds: requestTimeoutSeconds
                     )
             )
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: makeTopLevelRequestFuture(
                     filteredRequest: filteredRequest,
                     sessionID: sessionID,
@@ -524,7 +524,7 @@ package final class HTTPPostService: Sendable {
                 )
             )
         }
-        return HTTPPostOperation(
+        return HTTPPostService.Operation(
             future: future,
             cancellationHandle: cancellationHandle
         )
@@ -533,13 +533,13 @@ package final class HTTPPostService: Sendable {
     private func makeClientResponseForwardingOperation(
         responseObject: [String: Any],
         sessionID: String,
-        responseID: RPCID,
+        responseID: JSONRPC.ID,
         eventLoop: EventLoop
-    ) -> HTTPPostOperation {
+    ) -> HTTPPostService.Operation {
         guard JSONSerialization.isValidJSONObject(responseObject),
             let responseData = try? JSONSerialization.data(withJSONObject: responseObject, options: [])
         else {
-            return HTTPPostOperation(
+            return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     .plain(
                         status: .badRequest,
@@ -555,7 +555,7 @@ package final class HTTPPostService: Sendable {
             sessionID: sessionID,
             responseID: responseID,
             on: eventLoop
-        ).map { forwardingResult -> HTTPPostResolution in
+        ).map { forwardingResult -> HTTPPostService.Resolution in
             switch forwardingResult {
             case .accepted, .missingRoute:
                 return .empty(status: .accepted, sessionID: sessionID)
@@ -573,7 +573,7 @@ package final class HTTPPostService: Sendable {
                 )
             }
         }
-        return HTTPPostOperation(
+        return HTTPPostService.Operation(
             future: future,
             cancellationHandle: nil
         )

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
@@ -10,15 +10,16 @@ import ProxyXcodeFeatures
 import ProxyXcodeSupport
 import ProxySession
 
-package enum HTTPPostResolution {
+extension HTTPPostService {
+    package enum Resolution {
     case responseData(
         data: Data,
         sessionID: String?,
         prefersEventStream: Bool
     )
     case mcpError(
-        id: RPCID?,
-        ids: [RPCID],
+        id: JSONRPC.ID?,
+        ids: [JSONRPC.ID],
         code: Int,
         message: String,
         forceBatchArray: Bool,
@@ -34,48 +35,48 @@ package enum HTTPPostResolution {
         status: HTTPResponseStatus,
         sessionID: String
     )
-}
+    }
 
-package struct HTTPPostOperation {
-    package let future: EventLoopFuture<HTTPPostResolution>
-    package let cancellationHandle: HTTPPostCancellationHandle?
-}
+    package struct Operation {
+    package let future: EventLoopFuture<HTTPPostService.Resolution>
+    package let cancellationHandle: HTTPPostService.CancellationHandle?
+    }
 
-package struct RefreshRequestRoute: Sendable {
-    let request: RefreshCodeIssuesRequest
+    package struct RefreshRoute: Sendable {
+    let request: RefreshCodeIssues.Request
     let bodyData: Data
-    let requestIDs: [RPCID]
+    let requestIDs: [JSONRPC.ID]
     let requestIsBatch: Bool
-}
+    }
 
-package struct RefreshRequestRouting: Sendable {
-    let refreshRoutes: [RefreshRequestRoute]
+    package struct RefreshRouting: Sendable {
+    let refreshRoutes: [HTTPPostService.RefreshRoute]
     let remainingBodyData: Data?
-    let remainingRequestIDs: [RPCID]
+    let remainingRequestIDs: [JSONRPC.ID]
     let remainingLocalResponseData: Data?
-}
+    }
 
-package enum HTTPPostCancellationSource: String, Sendable {
+    package enum CancellationSource: String, Sendable {
     case channelInactive
     case responseWriteFailure
-}
+    }
 
-package final class HTTPPostCancellationHandle: @unchecked Sendable {
+    package final class CancellationHandle: @unchecked Sendable {
     private struct State: Sendable {
         var requestIDKeys: [String]
         var upstreamIndex: Int?
         var routerPendingToken: UUID?
         var refreshTask: Task<Void, Never>?
-        var childHandles: [HTTPPostCancellationHandle] = []
+        var childHandles: [HTTPPostService.CancellationHandle] = []
         var isTerminal = false
     }
 
-    package let leaseID: RequestLeaseID
+    package let leaseID: LeaseManager.ID
     package let sessionID: String
     private let state: NIOLockedValueBox<State>
 
     package init(
-        leaseID: RequestLeaseID,
+        leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String]
     ) {
@@ -135,7 +136,7 @@ package final class HTTPPostCancellationHandle: @unchecked Sendable {
     }
 
     @discardableResult
-    package func bindChildHandle(_ handle: HTTPPostCancellationHandle) -> Bool {
+    package func bindChildHandle(_ handle: HTTPPostService.CancellationHandle) -> Bool {
         state.withLockedValue { state in
             guard !state.isTerminal else { return false }
             state.childHandles.append(handle)
@@ -145,7 +146,7 @@ package final class HTTPPostCancellationHandle: @unchecked Sendable {
 
     package func cancel(using runtime: any RuntimeCoordinating) {
         let snapshot = state.withLockedValue {
-            state -> (Int?, UUID?, Task<Void, Never>?, [HTTPPostCancellationHandle], [String])? in
+            state -> (Int?, UUID?, Task<Void, Never>?, [HTTPPostService.CancellationHandle], [String])? in
             guard !state.isTerminal else { return nil }
             state.isTerminal = true
             let snapshot = (
@@ -173,5 +174,6 @@ package final class HTTPPostCancellationHandle: @unchecked Sendable {
             requestIDKeys: snapshot.4,
             upstreamIndex: snapshot.0
         )
+    }
     }
 }

--- a/Sources/ProxyMCP/JSONRPCMessageInspector.swift
+++ b/Sources/ProxyMCP/JSONRPCMessageInspector.swift
@@ -1,130 +1,136 @@
 import Foundation
 
-package enum JSONRPCMessageKind: Sendable {
-    case request(method: String, id: RPCID)
-    case notification(method: String)
-    case response(id: RPCID)
-    case malformed(id: RPCID?)
-    case other
+extension JSONRPC {
+    package enum Message {
+        package enum Kind: Sendable {
+            case request(method: String, id: JSONRPC.ID)
+            case notification(method: String)
+            case response(id: JSONRPC.ID)
+            case malformed(id: JSONRPC.ID?)
+            case other
 
-    package var requestID: RPCID? {
-        guard case .request(_, let id) = self else { return nil }
-        return id
-    }
-
-    package var responseID: RPCID? {
-        guard case .response(let id) = self else { return nil }
-        return id
-    }
-
-    package var malformedID: RPCID? {
-        guard case .malformed(let id) = self else { return nil }
-        return id
-    }
-
-    package var responseCorrelationID: RPCID? {
-        switch self {
-        case .response(let id):
-            return id
-        case .malformed(let id):
-            return id
-        case .request, .notification, .other:
-            return nil
-        }
-    }
-
-    package var isServerInitiated: Bool {
-        switch self {
-        case .request, .notification:
-            return true
-        case .response, .malformed, .other:
-            return false
-        }
-    }
-}
-
-package struct JSONRPCRequestMetadata: Sendable {
-    package let ids: [RPCID]
-    package let isBatch: Bool
-}
-
-package enum JSONRPCMessageInspector {
-    package static func kind(of object: [String: Any]) -> JSONRPCMessageKind {
-        let rawID = object["id"]
-        let parsedID = rawID.flatMap { RPCID(any: $0) }
-
-        if let methodValue = object["method"] {
-            guard let method = methodValue as? String else {
-                return .malformed(id: parsedID)
+            package var requestID: JSONRPC.ID? {
+                guard case .request(_, let id) = self else { return nil }
+                return id
             }
-            guard rawID != nil else {
-                return .notification(method: method)
+
+            package var responseID: JSONRPC.ID? {
+                guard case .response(let id) = self else { return nil }
+                return id
             }
-            guard let parsedID else {
-                return .notification(method: method)
+
+            package var malformedID: JSONRPC.ID? {
+                guard case .malformed(let id) = self else { return nil }
+                return id
             }
-            return .request(method: method, id: parsedID)
-        }
 
-        guard let id = parsedID,
-            object["result"] != nil || object["error"] != nil
-        else {
-            if rawID != nil {
-                return .malformed(id: parsedID)
-            }
-            return .other
-        }
-        return .response(id: id)
-    }
-
-    package static func method(from object: [String: Any]) -> String? {
-        switch kind(of: object) {
-        case .request(let method, _), .notification(let method):
-            return method
-        case .response, .malformed, .other:
-            return nil
-        }
-    }
-
-    package static func requestID(from object: [String: Any]) -> RPCID? {
-        kind(of: object).requestID
-    }
-
-    package static func responseID(from object: [String: Any]) -> RPCID? {
-        kind(of: object).responseID
-    }
-
-    package static func responseCorrelationID(from object: [String: Any]) -> RPCID? {
-        kind(of: object).responseCorrelationID
-    }
-
-    package static func invalidMessageID(from object: [String: Any]) -> RPCID? {
-        kind(of: object).malformedID
-    }
-
-    package static func isResponse(_ object: [String: Any]) -> Bool {
-        responseID(from: object) != nil
-    }
-
-    package static func requestMetadata(fromParsed json: Any?) -> JSONRPCRequestMetadata {
-        guard let json else {
-            return JSONRPCRequestMetadata(ids: [], isBatch: false)
-        }
-        if let object = json as? [String: Any] {
-            return JSONRPCRequestMetadata(
-                ids: requestID(from: object).map { [$0] } ?? [],
-                isBatch: false
-            )
-        }
-        if let array = json as? [Any] {
-            let ids = array.compactMap { item -> RPCID? in
-                guard let object = item as? [String: Any] else {
+            package var responseCorrelationID: JSONRPC.ID? {
+                switch self {
+                case .response(let id):
+                    return id
+                case .malformed(let id):
+                    return id
+                case .request, .notification, .other:
                     return nil
                 }
-                return requestID(from: object)
             }
-            return JSONRPCRequestMetadata(ids: ids, isBatch: true)
+
+            package var isServerInitiated: Bool {
+                switch self {
+                case .request, .notification:
+                    return true
+                case .response, .malformed, .other:
+                    return false
+                }
+            }
         }
-        return JSONRPCRequestMetadata(ids: [], isBatch: false)
+
+        package enum Inspector {
+            package static func kind(of object: [String: Any]) -> JSONRPC.Message.Kind {
+                let rawID = object["id"]
+                let parsedID = rawID.flatMap { JSONRPC.ID(any: $0) }
+
+                if let methodValue = object["method"] {
+                    guard let method = methodValue as? String else {
+                        return .malformed(id: parsedID)
+                    }
+                    guard rawID != nil else {
+                        return .notification(method: method)
+                    }
+                    guard let parsedID else {
+                        return .notification(method: method)
+                    }
+                    return .request(method: method, id: parsedID)
+                }
+
+                guard let id = parsedID,
+                    object["result"] != nil || object["error"] != nil
+                else {
+                    if rawID != nil {
+                        return .malformed(id: parsedID)
+                    }
+                    return .other
+                }
+                return .response(id: id)
+            }
+
+            package static func method(from object: [String: Any]) -> String? {
+                switch kind(of: object) {
+                case .request(let method, _), .notification(let method):
+                    return method
+                case .response, .malformed, .other:
+                    return nil
+                }
+            }
+
+            package static func requestID(from object: [String: Any]) -> JSONRPC.ID? {
+                kind(of: object).requestID
+            }
+
+            package static func responseID(from object: [String: Any]) -> JSONRPC.ID? {
+                kind(of: object).responseID
+            }
+
+            package static func responseCorrelationID(from object: [String: Any]) -> JSONRPC.ID? {
+                kind(of: object).responseCorrelationID
+            }
+
+            package static func invalidMessageID(from object: [String: Any]) -> JSONRPC.ID? {
+                kind(of: object).malformedID
+            }
+
+            package static func isResponse(_ object: [String: Any]) -> Bool {
+                responseID(from: object) != nil
+            }
+
+            package static func requestMetadata(fromParsed json: Any?) -> JSONRPC.Request.Metadata {
+                guard let json else {
+                    return JSONRPC.Request.Metadata(ids: [], isBatch: false)
+                }
+                if let object = json as? [String: Any] {
+                    return JSONRPC.Request.Metadata(
+                        ids: requestID(from: object).map { [$0] } ?? [],
+                        isBatch: false
+                    )
+                }
+                if let array = json as? [Any] {
+                    let ids = array.compactMap { item -> JSONRPC.ID? in
+                        guard let object = item as? [String: Any] else {
+                            return nil
+                        }
+                        return requestID(from: object)
+                    }
+                    return JSONRPC.Request.Metadata(ids: ids, isBatch: true)
+                }
+                return JSONRPC.Request.Metadata(ids: [], isBatch: false)
+            }
+        }
+    }
+
+    package enum Request {
+        package struct Metadata: Sendable {
+            package let ids: [JSONRPC.ID]
+            package let isBatch: Bool
+        }
     }
 }

--- a/Sources/ProxyMCP/JSONValue.swift
+++ b/Sources/ProxyMCP/JSONValue.swift
@@ -1,41 +1,43 @@
 import Foundation
 
-package enum JSONNumber: Sendable {
-    case int(Int64)
-    case double(Double)
-
-    package init(_ number: NSNumber) {
-        if CFNumberIsFloatType(number) {
-            self = .double(number.doubleValue)
-        } else {
-            self = .int(number.int64Value)
-        }
-    }
-
-    package var stringValue: String {
-        switch self {
-        case .int(let value):
-            return String(value)
-        case .double(let value):
-            return String(value)
-        }
-    }
-
-    package var foundationObject: NSNumber {
-        switch self {
-        case .int(let value):
-            return NSNumber(value: value)
-        case .double(let value):
-            return NSNumber(value: value)
-        }
-    }
-}
+package enum JSONRPC {}
 
 package enum JSONValue: Sendable {
+    package enum Number: Sendable {
+        case int(Int64)
+        case double(Double)
+
+        package init(_ number: NSNumber) {
+            if CFNumberIsFloatType(number) {
+                self = .double(number.doubleValue)
+            } else {
+                self = .int(number.int64Value)
+            }
+        }
+
+        package var stringValue: String {
+            switch self {
+            case .int(let value):
+                return String(value)
+            case .double(let value):
+                return String(value)
+            }
+        }
+
+        package var foundationObject: NSNumber {
+            switch self {
+            case .int(let value):
+                return NSNumber(value: value)
+            case .double(let value):
+                return NSNumber(value: value)
+            }
+        }
+    }
+
     case object([String: JSONValue])
     case array([JSONValue])
     case string(String)
-    case number(JSONNumber)
+    case number(JSONValue.Number)
     case bool(Bool)
     case null
 
@@ -49,7 +51,7 @@ package enum JSONValue: Sendable {
             if CFGetTypeID(number) == CFBooleanGetTypeID() {
                 self = .bool(number.boolValue)
             } else {
-                self = .number(JSONNumber(number))
+                self = .number(JSONValue.Number(number))
             }
         case let array as [Any]:
             var values: [JSONValue] = []
@@ -90,31 +92,33 @@ package enum JSONValue: Sendable {
     }
 }
 
-package struct RPCID: Sendable {
-    package let key: String
-    package let value: JSONValue
+extension JSONRPC {
+    package struct ID: Sendable {
+        package let key: String
+        package let value: JSONValue
 
-    package init?(any: Any) {
-        guard !(any is NSNull) else { return nil }
+        package init?(any: Any) {
+            guard !(any is NSNull) else { return nil }
 
-        if let string = any as? String {
-            key = string
-            value = .string(string)
-            return
-        }
-
-        if let number = any as? NSNumber {
-            key = number.stringValue
-            if CFGetTypeID(number) == CFBooleanGetTypeID() {
-                value = .bool(number.boolValue)
-            } else {
-                value = .number(JSONNumber(number))
+            if let string = any as? String {
+                key = string
+                value = .string(string)
+                return
             }
-            return
-        }
 
-        let fallbackKey = String(describing: any)
-        key = fallbackKey
-        value = JSONValue(any: any) ?? .string(fallbackKey)
+            if let number = any as? NSNumber {
+                key = number.stringValue
+                if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                    value = .bool(number.boolValue)
+                } else {
+                    value = .number(JSONValue.Number(number))
+                }
+                return
+            }
+
+            let fallbackKey = String(describing: any)
+            key = fallbackKey
+            value = JSONValue(any: any) ?? .string(fallbackKey)
+        }
     }
 }

--- a/Sources/ProxyMCP/MCPMethodDispatcher.swift
+++ b/Sources/ProxyMCP/MCPMethodDispatcher.swift
@@ -1,56 +1,59 @@
 import Foundation
 import NIO
+import ProxyCore
 
-package enum MCPMethodDispatcher {
-    private static let capped20sMethods: Set<String> = [
-        "resources/list",
-        "resources/templates/list",
-    ]
-    private static let initializeFallbackTimeoutSeconds: TimeInterval = 60
+extension MCP {
+    package enum MethodDispatcher {
+        private static let capped20sMethods: Set<String> = [
+            "resources/list",
+            "resources/templates/list",
+        ]
+        private static let initializeFallbackTimeoutSeconds: TimeInterval = 60
 
-    package static func timeoutForInitialize(defaultSeconds: TimeInterval) -> TimeAmount? {
-        let effectiveDefault = defaultSeconds > 0 ? defaultSeconds : initializeFallbackTimeoutSeconds
-        return timeout(defaultSeconds: effectiveDefault, capSeconds: initializeFallbackTimeoutSeconds)
-    }
+        package static func timeoutForInitialize(defaultSeconds: TimeInterval) -> TimeAmount? {
+            let effectiveDefault = defaultSeconds > 0 ? defaultSeconds : initializeFallbackTimeoutSeconds
+            return timeout(defaultSeconds: effectiveDefault, capSeconds: initializeFallbackTimeoutSeconds)
+        }
 
-    package static func timeoutForMethod(
-        _ method: String?,
-        defaultSeconds: TimeInterval
-    ) -> TimeAmount? {
-        guard let method else {
+        package static func timeoutForMethod(
+            _ method: String?,
+            defaultSeconds: TimeInterval
+        ) -> TimeAmount? {
+            guard let method else {
+                return makeRequestTimeout(defaultSeconds)
+            }
+            if method == "initialize" {
+                return timeout(defaultSeconds: defaultSeconds, capSeconds: 60)
+            }
+            if capped20sMethods.contains(method) {
+                return timeout(defaultSeconds: defaultSeconds, capSeconds: 20)
+            }
             return makeRequestTimeout(defaultSeconds)
         }
-        if method == "initialize" {
-            return timeout(defaultSeconds: defaultSeconds, capSeconds: 60)
-        }
-        if capped20sMethods.contains(method) {
-            return timeout(defaultSeconds: defaultSeconds, capSeconds: 20)
-        }
-        return makeRequestTimeout(defaultSeconds)
-    }
 
-    package static func timeoutForControlPlane(
-        defaultSeconds: TimeInterval
-    ) -> TimeAmount? {
-        if defaultSeconds > 0 {
-            return makeRequestTimeout(defaultSeconds)
+        package static func timeoutForControlPlane(
+            defaultSeconds: TimeInterval
+        ) -> TimeAmount? {
+            if defaultSeconds > 0 {
+                return makeRequestTimeout(defaultSeconds)
+            }
+            return .seconds(60)
         }
-        return .seconds(60)
-    }
 
-    private static func timeout(
-        defaultSeconds: TimeInterval,
-        capSeconds: TimeInterval
-    ) -> TimeAmount? {
-        guard defaultSeconds > 0 else { return nil }
-        return makeRequestTimeout(min(defaultSeconds, capSeconds))
-    }
+        private static func timeout(
+            defaultSeconds: TimeInterval,
+            capSeconds: TimeInterval
+        ) -> TimeAmount? {
+            guard defaultSeconds > 0 else { return nil }
+            return makeRequestTimeout(min(defaultSeconds, capSeconds))
+        }
 
-    private static func makeRequestTimeout(_ seconds: TimeInterval) -> TimeAmount? {
-        guard seconds > 0 else { return nil }
-        let whole = Int64(seconds)
-        let fractional = seconds - Double(whole)
-        let nanos = Int64((fractional * 1_000_000_000).rounded())
-        return .seconds(whole) + .nanoseconds(nanos)
+        private static func makeRequestTimeout(_ seconds: TimeInterval) -> TimeAmount? {
+            guard seconds > 0 else { return nil }
+            let whole = Int64(seconds)
+            let fractional = seconds - Double(whole)
+            let nanos = Int64((fractional * 1_000_000_000).rounded())
+            return .seconds(whole) + .nanoseconds(nanos)
+        }
     }
 }

--- a/Sources/ProxyMCP/RequestInspector.swift
+++ b/Sources/ProxyMCP/RequestInspector.swift
@@ -5,13 +5,13 @@ package struct RequestTransform {
     package let expectsResponse: Bool
     package let isBatch: Bool
     package let idKey: String?
-    package let responseIDs: [RPCID]
+    package let responseIDs: [JSONRPC.ID]
     package let responseMethodsByIDKey: [String: String]
     package let responseToolNamesByIDKey: [String: String]
-    package let responseOriginalIDsByKey: [String: RPCID]
+    package let responseOriginalIDsByKey: [String: JSONRPC.ID]
     package let method: String?
     package let toolName: String?
-    package let originalID: RPCID?
+    package let originalID: JSONRPC.ID?
     package let normalizationToolsListResponseIDKey: String?
     package let isCacheableToolsListRequest: Bool
     package let cacheableToolsListResponseIDKey: String?
@@ -22,12 +22,12 @@ package enum RequestInspector {
         _ data: Data,
         parsedJSON: Any? = nil,
         sessionID: String,
-        mapID: (_ sessionID: String, _ originalID: RPCID) -> Int64
+        mapID: (_ sessionID: String, _ originalID: JSONRPC.ID) -> Int64
     ) throws -> RequestTransform {
         let json = try parsedJSON ?? JSONSerialization.jsonObject(with: data, options: [])
         if var object = json as? [String: Any] {
-            let kind = JSONRPCMessageInspector.kind(of: object)
-            let method = JSONRPCMessageInspector.method(from: object)
+            let kind = JSONRPC.Message.Inspector.kind(of: object)
+            let method = JSONRPC.Message.Inspector.method(from: object)
             let toolName = toolName(from: object, method: method)
             // We intentionally treat tools/list as stable and cache it regardless of params.
             // Some clients attach pagination-like params even when they expect the full list.
@@ -77,15 +77,15 @@ package enum RequestInspector {
 
         if let array = json as? [Any] {
             var transformed: [Any] = []
-            var responseIDs: [RPCID] = []
+            var responseIDs: [JSONRPC.ID] = []
             var responseMethodsByIDKey: [String: String] = [:]
             var responseToolNamesByIDKey: [String: String] = [:]
-            var responseOriginalIDsByKey: [String: RPCID] = [:]
+            var responseOriginalIDsByKey: [String: JSONRPC.ID] = [:]
             responseIDs.reserveCapacity(array.count)
             for item in array {
                 if var object = item as? [String: Any] {
                     if case .request(let method, let rpcID) =
-                        JSONRPCMessageInspector.kind(of: object)
+                        JSONRPC.Message.Inspector.kind(of: object)
                     {
                         let upstreamID = mapID(sessionID, rpcID)
                         object["id"] = upstreamID
@@ -105,7 +105,7 @@ package enum RequestInspector {
                 for item in array {
                     guard let object = item as? [String: Any],
                         case .request("tools/list", let rpcID) =
-                            JSONRPCMessageInspector.kind(of: object)
+                            JSONRPC.Message.Inspector.kind(of: object)
                     else {
                         continue
                     }
@@ -120,7 +120,7 @@ package enum RequestInspector {
                 for item in array {
                     guard let object = item as? [String: Any],
                         case .request(let method, _) =
-                            JSONRPCMessageInspector.kind(of: object)
+                            JSONRPC.Message.Inspector.kind(of: object)
                     else {
                         continue
                     }

--- a/Sources/ProxyMCP/StdioFramer.swift
+++ b/Sources/ProxyMCP/StdioFramer.swift
@@ -1,61 +1,61 @@
 import Foundation
 
-package struct StdioFramerProtocolViolation: Sendable {
-    package enum Reason: String, Codable, Sendable {
-        case unexpectedLeadingByte
-        case invalidContentLengthHeader
-        case invalidJSON
-        case bufferLimitExceeded
-    }
-
-    package let reason: Reason
-    package let bufferedByteCount: Int
-    package let preview: String
-    package let previewHex: String
-    package let leadingByteHex: String?
-
-    package init(
-        reason: Reason,
-        bufferedByteCount: Int,
-        preview: String,
-        previewHex: String,
-        leadingByteHex: String?
-    ) {
-        self.reason = reason
-        self.bufferedByteCount = bufferedByteCount
-        self.preview = preview
-        self.previewHex = previewHex
-        self.leadingByteHex = leadingByteHex
-    }
-
-    package init(reason: Reason, bufferedByteCount: Int, preview: String) {
-        self.init(
-            reason: reason,
-            bufferedByteCount: bufferedByteCount,
-            preview: preview,
-            previewHex: "",
-            leadingByteHex: nil
-        )
-    }
-}
-
-package struct StdioFramerAppendResult: Sendable {
-    package let messages: [Data]
-    package let protocolViolation: StdioFramerProtocolViolation?
-    package let bufferedByteCount: Int
-
-    package init(
-        messages: [Data],
-        protocolViolation: StdioFramerProtocolViolation?,
-        bufferedByteCount: Int
-    ) {
-        self.messages = messages
-        self.protocolViolation = protocolViolation
-        self.bufferedByteCount = bufferedByteCount
-    }
-}
-
 package final class StdioFramer {
+    package struct ProtocolViolation: Sendable {
+        package enum Reason: String, Codable, Sendable {
+            case unexpectedLeadingByte
+            case invalidContentLengthHeader
+            case invalidJSON
+            case bufferLimitExceeded
+        }
+
+        package let reason: Reason
+        package let bufferedByteCount: Int
+        package let preview: String
+        package let previewHex: String
+        package let leadingByteHex: String?
+
+        package init(
+            reason: Reason,
+            bufferedByteCount: Int,
+            preview: String,
+            previewHex: String,
+            leadingByteHex: String?
+        ) {
+            self.reason = reason
+            self.bufferedByteCount = bufferedByteCount
+            self.preview = preview
+            self.previewHex = previewHex
+            self.leadingByteHex = leadingByteHex
+        }
+
+        package init(reason: Reason, bufferedByteCount: Int, preview: String) {
+            self.init(
+                reason: reason,
+                bufferedByteCount: bufferedByteCount,
+                preview: preview,
+                previewHex: "",
+                leadingByteHex: nil
+            )
+        }
+    }
+
+    package struct AppendResult: Sendable {
+        package let messages: [Data]
+        package let protocolViolation: StdioFramer.ProtocolViolation?
+        package let bufferedByteCount: Int
+
+        package init(
+            messages: [Data],
+            protocolViolation: StdioFramer.ProtocolViolation?,
+            bufferedByteCount: Int
+        ) {
+            self.messages = messages
+            self.protocolViolation = protocolViolation
+            self.bufferedByteCount = bufferedByteCount
+        }
+    }
+
     private enum JSONPrefixParseResult {
         case complete(Data.Index)
         case incomplete
@@ -69,7 +69,7 @@ package final class StdioFramer {
 
     package init() {}
 
-    package func append(_ data: Data) -> StdioFramerAppendResult {
+    package func append(_ data: Data) -> StdioFramer.AppendResult {
         if !data.isEmpty {
             buffer.append(data)
         }
@@ -88,7 +88,7 @@ package final class StdioFramer {
         }
 
         let protocolViolation = protocolViolationIfNeeded()
-        return StdioFramerAppendResult(
+        return StdioFramer.AppendResult(
             messages: messages,
             protocolViolation: protocolViolation,
             bufferedByteCount: buffer.count
@@ -149,7 +149,7 @@ package final class StdioFramer {
         return message
     }
 
-    private func protocolViolationIfNeeded() -> StdioFramerProtocolViolation? {
+    private func protocolViolationIfNeeded() -> StdioFramer.ProtocolViolation? {
         guard let firstIndex = firstNonWhitespaceIndex(from: buffer.startIndex) else {
             if buffer.count > bufferHardLimit {
                 return makeProtocolViolation(reason: .bufferLimitExceeded)
@@ -210,10 +210,10 @@ package final class StdioFramer {
         }
     }
 
-    private func makeProtocolViolation(reason: StdioFramerProtocolViolation.Reason)
-        -> StdioFramerProtocolViolation
+    private func makeProtocolViolation(reason: StdioFramer.ProtocolViolation.Reason)
+        -> StdioFramer.ProtocolViolation
     {
-        StdioFramerProtocolViolation(
+        StdioFramer.ProtocolViolation(
             reason: reason,
             bufferedByteCount: buffer.count,
             preview: preview(of: buffer),

--- a/Sources/ProxySession/ControlPlane/InitializeManager.swift
+++ b/Sources/ProxySession/ControlPlane/InitializeManager.swift
@@ -40,7 +40,7 @@ package final class InitializeManager: Sendable {
         package let promise: EventLoopPromise<ByteBuffer>
         package let sessionID: String
         package let sessionGeneration: UInt64
-        package let originalID: RPCID
+        package let originalID: JSONRPC.ID
     }
 
     package struct RegisterDecision: Sendable {
@@ -147,7 +147,7 @@ package final class InitializeManager: Sendable {
     package func registerInitialize(
         sessionID: String,
         sessionGeneration: UInt64,
-        originalID: RPCID,
+        originalID: JSONRPC.ID,
         on eventLoop: EventLoop
     ) -> RegisterDecision {
         state.withLockedValue { state in

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -227,11 +227,11 @@ package struct LiveDocumentationProviderSessionFactory: DocumentationProviderSes
 }
 
 private final class DocumentationPendingResponse: @unchecked Sendable {
-    let originalID: RPCID
+    let originalID: JSONRPC.ID
     let continuation: CheckedContinuation<Data, Error>
     var timeoutTask: Task<Void, Never>?
 
-    init(originalID: RPCID, continuation: CheckedContinuation<Data, Error>) {
+    init(originalID: JSONRPC.ID, continuation: CheckedContinuation<Data, Error>) {
         self.originalID = originalID
         self.continuation = continuation
     }
@@ -281,7 +281,7 @@ package actor DocumentationProviderConnection {
     package func call(_ requestData: Data, timeout: TimeAmount?) async throws -> Data {
         guard var object = try JSONSerialization.jsonObject(with: requestData, options: [])
             as? [String: Any],
-            let originalID = JSONRPCMessageInspector.requestID(from: object) else {
+            let originalID = JSONRPC.Message.Inspector.requestID(from: object) else {
             throw ControlPlaneError.invalidResponse("missing DocumentationSearch request id")
         }
 
@@ -335,7 +335,7 @@ package actor DocumentationProviderConnection {
         }
     }
 
-    private func handle(_ event: UpstreamEvent) {
+    private func handle(_ event: Upstream.Event) {
         switch event {
         case .message(let data):
             handleMessage(data)
@@ -348,7 +348,7 @@ package actor DocumentationProviderConnection {
 
     private func handleMessage(_ data: Data) {
         guard var object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-              let responseID = JSONRPCMessageInspector.responseID(from: object),
+              let responseID = JSONRPC.Message.Inspector.responseID(from: object),
               let pending = pendingResponses.removeValue(forKey: responseID.key) else {
             return
         }

--- a/Sources/ProxySession/Runtime/InitializeHandshakeJSON.swift
+++ b/Sources/ProxySession/Runtime/InitializeHandshakeJSON.swift
@@ -4,7 +4,7 @@ import ProxyMCP
 
 package enum InitializeHandshakeJSON {
     package static func resolved(
-        initializeParamsOverride: ProxyInitializeHandshakeOverride?
+        initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride?
     ) -> [String: JSONValue] {
         let mergedParams = mergeJSONObjects(
             defaultParams(),
@@ -20,7 +20,7 @@ package enum InitializeHandshakeJSON {
 
     package static func defaultParams() -> [String: JSONValue] {
         [
-            "protocolVersion": .string(MCPProtocolVersion.current),
+            "protocolVersion": .string(MCP.ProtocolVersion.current),
             "capabilities": .object([:]),
             "clientInfo": .object([
                 "name": .string(InitializeHandshakeParams.defaultProxyClientName()),
@@ -30,7 +30,7 @@ package enum InitializeHandshakeJSON {
     }
 
     private static func jsonObject(
-        from override: ProxyInitializeHandshakeOverride?
+        from override: ProxyConfig.File.InitializeHandshakeOverride?
     ) -> [String: JSONValue]? {
         guard let override else { return nil }
         var params: [String: JSONValue] = [:]
@@ -56,7 +56,7 @@ package enum InitializeHandshakeJSON {
         return params.isEmpty ? nil : params
     }
 
-    private static func jsonValue(from value: ProxyConfigValue) -> JSONValue {
+    private static func jsonValue(from value: ProxyConfig.File.Value) -> JSONValue {
         switch value {
         case .object(let object):
             return .object(object.mapValues(jsonValue(from:)))

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -53,7 +53,7 @@ extension RuntimeCoordinator {
         let startedAt = nowUptimeNanoseconds()
         let effectiveRequestTimeout =
             requestTimeout
-            ?? MCPMethodDispatcher.timeoutForControlPlane(
+            ?? MCP.MethodDispatcher.timeoutForControlPlane(
                 defaultSeconds: config.requestTimeout
             )
         let nowUptimeNs = nowUptimeNanoseconds()
@@ -110,7 +110,7 @@ extension RuntimeCoordinator {
     ) async throws -> JSONValue {
         let effectiveRequestTimeout =
             requestTimeout
-            ?? MCPMethodDispatcher.timeoutForControlPlane(
+            ?? MCP.MethodDispatcher.timeoutForControlPlane(
                 defaultSeconds: config.requestTimeout
             )
         do {
@@ -147,7 +147,7 @@ extension RuntimeCoordinator {
         let internalSessionID = controlPlaneSessionID(for: purpose, route: route)
         let session = session(id: internalSessionID)
         let router = session.router
-        guard let originalID = JSONRPCMessageInspector.requestID(from: requestObject) else {
+        guard let originalID = JSONRPC.Message.Inspector.requestID(from: requestObject) else {
             throw ControlPlaneError.invalidResponse("missing request id")
         }
         let requestTemplate = requestObject.reduce(into: [String: JSONValue]()) { partial, entry in
@@ -156,7 +156,7 @@ extension RuntimeCoordinator {
                 partial[entry.key] = value
             }
         }
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: internalSessionID,
             label: label,
             isBatch: false,

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
@@ -38,7 +38,7 @@ extension RuntimeCoordinator {
         _ = session(id: internalSessionID)
         let probeSession = session(id: internalSessionID)
         let probeTimeout: TimeAmount = .seconds(2)
-        let originalID = RPCID(any: "__probe-\(upstreamIndex)-\(UUID().uuidString)")!
+        let originalID = JSONRPC.ID(any: "__probe-\(upstreamIndex)-\(UUID().uuidString)")!
         let future = probeSession.router.registerRequest(
             idKey: originalID.key,
             on: eventLoop,
@@ -194,7 +194,7 @@ extension RuntimeCoordinator {
 
     func scheduleUpstreamInitTimeout(upstreamIndex: Int, upstreamID: Int64) {
         guard
-            let timeoutAmount = MCPMethodDispatcher.timeoutForInitialize(
+            let timeoutAmount = MCP.MethodDispatcher.timeoutForInitialize(
                 defaultSeconds: config.requestTimeout)
         else {
             return

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -183,7 +183,7 @@ extension RuntimeCoordinator {
         }
     }
 
-    func encodeInitializeResponse(originalID: RPCID, result: JSONValue) -> ByteBuffer? {
+    func encodeInitializeResponse(originalID: JSONRPC.ID, result: JSONValue) -> ByteBuffer? {
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": originalID.value.foundationObject,
@@ -210,7 +210,7 @@ extension RuntimeCoordinator {
 
     static func supportedProtocolVersion(fromInitializeResult result: JSONValue) -> String? {
         guard let version = protocolVersion(fromInitializeResult: result),
-            MCPProtocolVersion.isSupported(version)
+            MCP.ProtocolVersion.isSupported(version)
         else {
             return nil
         }
@@ -224,7 +224,7 @@ extension RuntimeCoordinator {
             "message": "unsupported upstream protocol version",
             "data": [
                 "protocolVersion": version as Any? ?? NSNull(),
-                "supportedProtocolVersions": [MCPProtocolVersion.current],
+                "supportedProtocolVersions": [MCP.ProtocolVersion.current],
             ],
         ]
         if upstreamIndex == 0 {
@@ -239,7 +239,7 @@ extension RuntimeCoordinator {
         }
     }
 
-    func encodeInitializeErrorResponse(originalID: RPCID, errorObject: [String: Any])
+    func encodeInitializeErrorResponse(originalID: JSONRPC.ID, errorObject: [String: Any])
         -> ByteBuffer?
     {
         let response: [String: Any] = [
@@ -352,7 +352,7 @@ extension RuntimeCoordinator {
 
     func scheduleInitTimeout() {
         guard
-            let timeoutAmount = MCPMethodDispatcher.timeoutForInitialize(
+            let timeoutAmount = MCP.MethodDispatcher.timeoutForInitialize(
                 defaultSeconds: config.requestTimeout)
         else {
             return

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -35,7 +35,7 @@ extension RuntimeCoordinator {
             upstreamIndex: Int
         ) -> Data? {
             guard case .request(_, let upstreamID) =
-                JSONRPCMessageInspector.kind(of: object)
+                JSONRPC.Message.Inspector.kind(of: object)
             else {
                 return data
             }
@@ -160,7 +160,7 @@ extension RuntimeCoordinator {
         _ object: [String: Any],
         upstreamIndex: Int
     ) -> MappedResponseRoutingOutcome {
-        guard let responseID = JSONRPCMessageInspector.responseCorrelationID(from: object),
+        guard let responseID = JSONRPC.Message.Inspector.responseCorrelationID(from: object),
             let upstreamID = upstreamID(from: responseID)
         else {
             return .notResponse
@@ -205,9 +205,9 @@ extension RuntimeCoordinator {
 
     private func clientResponseObject(
         from object: [String: Any],
-        originalID: RPCID
+        originalID: JSONRPC.ID
     ) -> [String: Any] {
-        if case .malformed = JSONRPCMessageInspector.kind(of: object) {
+        if case .malformed = JSONRPC.Message.Inspector.kind(of: object) {
             return [
                 "jsonrpc": "2.0",
                 "id": originalID.value.foundationObject,
@@ -336,7 +336,7 @@ extension RuntimeCoordinator {
         }
     }
 
-    package func assignUpstreamID(sessionID: String, originalID: RPCID, upstreamIndex: Int) -> Int64 {
+    package func assignUpstreamID(sessionID: String, originalID: JSONRPC.ID, upstreamIndex: Int) -> Int64 {
         upstreamRouter.assign(
             upstreamIndex: upstreamIndex, sessionID: sessionID, originalID: originalID,
             isInitialize: false)
@@ -401,7 +401,7 @@ extension RuntimeCoordinator {
     package func forwardServerRequestResponse(
         responseData: Data,
         sessionID: String,
-        responseID: RPCID,
+        responseID: JSONRPC.ID,
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ServerRequestResponseForwardingResult> {
         let promise = eventLoop.makePromise(of: ServerRequestResponseForwardingResult.self)
@@ -423,7 +423,7 @@ extension RuntimeCoordinator {
     private func performServerRequestResponseForwarding(
         responseData: Data,
         sessionID: String,
-        responseID: RPCID
+        responseID: JSONRPC.ID
     ) async -> ServerRequestResponseForwardingResult {
         guard let session = sessionRegistry.contextIfPresent(id: sessionID) else {
             return .missingRoute
@@ -466,7 +466,7 @@ extension RuntimeCoordinator {
     private func sendServerRequestResponseUpstream(
         _ data: Data,
         upstreamIndex: Int
-    ) async -> UpstreamSendResult {
+    ) async -> Upstream.SendResult {
         guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
             return .unavailable(.notStarted)
         }
@@ -488,7 +488,7 @@ extension RuntimeCoordinator {
 
     private static func rewriteServerRequestResponse(
         _ responseObject: [String: Any],
-        id: RPCID
+        id: JSONRPC.ID
     ) -> Data? {
         var rewritten = responseObject
         rewritten["id"] = id.value.foundationObject
@@ -528,13 +528,13 @@ extension RuntimeCoordinator {
     }
 
     package func createRequestLease(
-        descriptor: SessionPipelineRequestDescriptor
-    ) -> RequestLeaseID {
+        descriptor: SessionRequestPipeline.Descriptor
+    ) -> LeaseManager.ID {
         leaseManager.createLease(descriptor: descriptor)
     }
 
     package func activateRequestLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
         timeout: TimeAmount?
@@ -550,18 +550,18 @@ extension RuntimeCoordinator {
         )
     }
 
-    package func completeRequestLease(_ leaseID: RequestLeaseID) {
+    package func completeRequestLease(_ leaseID: LeaseManager.ID) {
         releaseLeases([leaseManager.completeLease(leaseID)].compactMap { $0 })
     }
 
-    package func requeueRequestLease(_ leaseID: RequestLeaseID) {
+    package func requeueRequestLease(_ leaseID: LeaseManager.ID) {
         releaseLeases([leaseManager.requeueLease(leaseID)].compactMap { $0 })
     }
 
     package func failRequestLease(
-        _ leaseID: RequestLeaseID,
-        terminalState: RequestLeaseState,
-        reason: RequestLeaseReleaseReason
+        _ leaseID: LeaseManager.ID,
+        terminalState: LeaseManager.State,
+        reason: LeaseManager.ReleaseReason
     ) {
         releaseLeases(
             [leaseManager.failLease(leaseID, terminalState: terminalState, reason: reason)]
@@ -570,7 +570,7 @@ extension RuntimeCoordinator {
     }
 
     package func handleRequestLeaseTimeout(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
         upstreamIndex: Int
@@ -593,7 +593,7 @@ extension RuntimeCoordinator {
     }
 
     package func abandonRequestLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
         upstreamIndex: Int?
@@ -660,7 +660,7 @@ extension RuntimeCoordinator {
 
         let responseAny: Any? = {
             if let object = any as? [String: Any] {
-                guard let id = JSONRPCMessageInspector.requestID(from: object) else { return nil }
+                guard let id = JSONRPC.Message.Inspector.requestID(from: object) else { return nil }
                 return [
                     "jsonrpc": "2.0",
                     "id": id.value.foundationObject,
@@ -670,7 +670,7 @@ extension RuntimeCoordinator {
             if let array = any as? [Any] {
                 let objects = array.compactMap { item -> [String: Any]? in
                     guard let object = item as? [String: Any],
-                        let id = JSONRPCMessageInspector.requestID(from: object)
+                        let id = JSONRPC.Message.Inspector.requestID(from: object)
                     else {
                         return nil
                     }
@@ -708,13 +708,13 @@ extension RuntimeCoordinator {
         return nil
     }
 
-    func upstreamID(from id: RPCID) -> Int64? {
+    func upstreamID(from id: JSONRPC.ID) -> Int64? {
         upstreamID(from: id.value.foundationObject)
     }
 
     func isServerInitiatedMessage(_ value: Any) -> Bool {
         if let object = value as? [String: Any] {
-            switch JSONRPCMessageInspector.kind(of: object) {
+            switch JSONRPC.Message.Inspector.kind(of: object) {
             case .request, .notification:
                 return true
             case .response, .malformed, .other:
@@ -724,7 +724,7 @@ extension RuntimeCoordinator {
         if let array = value as? [Any] {
             return array.contains { item in
                 guard let object = item as? [String: Any] else { return false }
-                switch JSONRPCMessageInspector.kind(of: object) {
+                switch JSONRPC.Message.Inspector.kind(of: object) {
                 case .request, .notification:
                     return true
                 case .response, .malformed, .other:
@@ -781,7 +781,7 @@ extension RuntimeCoordinator {
         else {
             return nil
         }
-        let kind = JSONRPCMessageInspector.kind(of: object)
+        let kind = JSONRPC.Message.Inspector.kind(of: object)
         guard kind.isServerInitiated else {
             return nil
         }
@@ -797,7 +797,7 @@ extension RuntimeCoordinator {
         originalData: Data
     ) -> [ServerInitiatedPayload] {
         if let object = any as? [String: Any] {
-            let kind = JSONRPCMessageInspector.kind(of: object)
+            let kind = JSONRPC.Message.Inspector.kind(of: object)
             guard kind.isServerInitiated else { return [] }
             return [
                 ServerInitiatedPayload(
@@ -991,7 +991,7 @@ extension RuntimeCoordinator {
     }
 
     func handleUpstreamProtocolViolation(
-        _ protocolViolation: StdioFramerProtocolViolation,
+        _ protocolViolation: StdioFramer.ProtocolViolation,
         upstreamIndex: Int
     ) {
         debugRecorder.recordProtocolViolation(protocolViolation, upstreamIndex: upstreamIndex)
@@ -1061,7 +1061,7 @@ extension RuntimeCoordinator {
         )
     }
 
-    private func releaseLeases(_ actions: [RequestLeaseReleaseAction]) {
+    private func releaseLeases(_ actions: [LeaseManager.ReleaseAction]) {
         for action in actions {
             if let upstreamIndex = action.upstreamIndex {
                 upstreamSlotScheduler.releaseUpstreamSlot(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -65,7 +65,7 @@ package protocol RuntimeCoordinating: Sendable {
     func setCachedToolsListResult(_ result: JSONValue, sourceUpstream: Int)
     func registerInitialize(
         sessionID: String,
-        originalID: RPCID,
+        originalID: JSONRPC.ID,
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer>
@@ -84,13 +84,13 @@ package protocol RuntimeCoordinating: Sendable {
     func hasDocumentationProvider() -> Bool
     func chooseUpstreamIndex() -> Int?
     func enqueueOnUpstreamSlot<Output: Sendable>(
-        leaseID: RequestLeaseID,
-        descriptor: SessionPipelineRequestDescriptor,
+        leaseID: LeaseManager.ID,
+        descriptor: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
         preferredUpstreamIndex: Int?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
     ) -> EventLoopFuture<Output>
-    func assignUpstreamID(sessionID: String, originalID: RPCID, upstreamIndex: Int) -> Int64
+    func assignUpstreamID(sessionID: String, originalID: JSONRPC.ID, upstreamIndex: Int) -> Int64
     func removeUpstreamIDMapping(sessionID: String, requestIDKey: String, upstreamIndex: Int)
     func onRequestTimeout(sessionID: String, requestIDKey: String, upstreamIndex: Int)
     func onRequestSucceeded(sessionID: String, requestIDKey: String, upstreamIndex: Int)
@@ -98,33 +98,33 @@ package protocol RuntimeCoordinating: Sendable {
     func forwardServerRequestResponse(
         responseData: Data,
         sessionID: String,
-        responseID: RPCID,
+        responseID: JSONRPC.ID,
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ServerRequestResponseForwardingResult>
     func debugSnapshot() -> ProxyDebugSnapshot
     func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebugSnapshot
-    func createRequestLease(descriptor: SessionPipelineRequestDescriptor) -> RequestLeaseID
+    func createRequestLease(descriptor: SessionRequestPipeline.Descriptor) -> LeaseManager.ID
     func activateRequestLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
         timeout: TimeAmount?
     )
-    func completeRequestLease(_ leaseID: RequestLeaseID)
-    func requeueRequestLease(_ leaseID: RequestLeaseID)
+    func completeRequestLease(_ leaseID: LeaseManager.ID)
+    func requeueRequestLease(_ leaseID: LeaseManager.ID)
     func failRequestLease(
-        _ leaseID: RequestLeaseID,
-        terminalState: RequestLeaseState,
-        reason: RequestLeaseReleaseReason
+        _ leaseID: LeaseManager.ID,
+        terminalState: LeaseManager.State,
+        reason: LeaseManager.ReleaseReason
     )
     func handleRequestLeaseTimeout(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
         upstreamIndex: Int
     )
     func abandonRequestLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
         upstreamIndex: Int?
@@ -151,15 +151,15 @@ extension RuntimeCoordinating {
     package func forwardServerRequestResponse(
         responseData _: Data,
         sessionID _: String,
-        responseID _: RPCID,
+        responseID _: JSONRPC.ID,
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ServerRequestResponseForwardingResult> {
         eventLoop.makeSucceededFuture(.missingRoute)
     }
 
     func enqueueOnUpstreamSlot<Output: Sendable>(
-        leaseID: RequestLeaseID,
-        descriptor: SessionPipelineRequestDescriptor,
+        leaseID: LeaseManager.ID,
+        descriptor: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
     ) -> EventLoopFuture<Output> {
@@ -219,7 +219,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let config: ProxyConfig
     package let logger: Logger = ProxyLogging.make("session")
     package let upstreams: [any UpstreamSlotControlling]
-    package let initializeParamsOverride: ProxyInitializeHandshakeOverride?
+    package let initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride?
     package let canonicalBrokerState: CanonicalBrokerState
     package let controlPlaneDebugMirror = ControlPlaneDebugMirror()
 
@@ -344,7 +344,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             canUseUpstream: { [weak upstreamHealthManager = self.upstreamHealthManager] upstreamIndex in
                 let nowUptimeNs = uptimeProvider()
                 guard let upstreamHealthManager else {
-                    return UpstreamUseEvaluation(isUsable: false, effects: [])
+                    return UpstreamHealthManager.UseEvaluation(isUsable: false, effects: [])
                 }
                 return upstreamHealthManager.evaluateUsableInitialized(
                     index: upstreamIndex,
@@ -356,7 +356,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 return upstreamHealthManager?.chooseBestInitializedUpstream(
                     nowUptimeNs: nowUptimeNs,
                     occupiedUpstreams: occupied
-                ) ?? UpstreamSelectionResult(upstreamIndex: nil, effects: [])
+                ) ?? UpstreamHealthManager.SelectionResult(upstreamIndex: nil, effects: [])
             },
             applyHealthEffects: { [runtimeBox] effects in
                 runtimeBox.value?.applyHealthEffects(effects)
@@ -401,7 +401,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 })
             },
             logger: ProxyLogging.make("control-plane"),
-            controlPlaneDefaultTimeout: MCPMethodDispatcher.timeoutForControlPlane(
+            controlPlaneDefaultTimeout: MCP.MethodDispatcher.timeoutForControlPlane(
                 defaultSeconds: config.requestTimeout
             ),
             clock: runtimeClock
@@ -584,7 +584,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package func refreshToolsListIfNeeded() {
         guard config.prewarmToolsList, isInitialized() else { return }
         let deadline = timeoutDeadline(
-            for: MCPMethodDispatcher.timeoutForControlPlane(
+            for: MCP.MethodDispatcher.timeoutForControlPlane(
                 defaultSeconds: config.requestTimeout
             )
         )
@@ -600,7 +600,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         let timeoutSeconds = config.requestTimeout > 0
             ? min(config.requestTimeout, 30)
             : 30
-        let timeout = MCPMethodDispatcher.timeoutForControlPlane(defaultSeconds: timeoutSeconds)
+        let timeout = MCP.MethodDispatcher.timeoutForControlPlane(defaultSeconds: timeoutSeconds)
         let task = Task { [weak self, documentationProviderManager, logger] in
             guard !Task.isCancelled else { return }
             logger.debug(
@@ -640,7 +640,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         return chosen
     }
 
-    private func applyHealthEffects(_ effects: [UpstreamHealthEffect]) {
+    private func applyHealthEffects(_ effects: [UpstreamHealthManager.Effect]) {
         for effect in effects {
             switch effect {
             case .cancelInitTimeout(let timeout):
@@ -658,7 +658,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
     }
 
-    private func startHealthProbes(_ probes: [HealthProbeRequest]) {
+    private func startHealthProbes(_ probes: [UpstreamHealthManager.ProbeRequest]) {
         for probe in probes {
             probeUpstreamHealth(
                 upstreamIndex: probe.upstreamIndex,
@@ -668,8 +668,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     }
 
     package func enqueueOnUpstreamSlot<Output: Sendable>(
-        leaseID: RequestLeaseID,
-        descriptor: SessionPipelineRequestDescriptor,
+        leaseID: LeaseManager.ID,
+        descriptor: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
         preferredUpstreamIndex: Int? = nil,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
@@ -717,7 +717,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     package func registerInitialize(
         sessionID: String,
-        originalID: RPCID,
+        originalID: JSONRPC.ID,
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
@@ -731,7 +731,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     func registerInitializeWaiter(
         sessionID: String,
-        originalID: RPCID,
+        originalID: JSONRPC.ID,
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
@@ -787,7 +787,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     }
 
     package func registerInitialize(
-        originalID: RPCID,
+        originalID: JSONRPC.ID,
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
@@ -810,7 +810,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         _ = session(id: sessionID)
         let timeout =
             requestTimeoutOverride
-            ?? MCPMethodDispatcher.timeoutForMethod(
+            ?? MCP.MethodDispatcher.timeoutForMethod(
                 "tools/list",
                 defaultSeconds: config.requestTimeout
             )
@@ -858,7 +858,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     ) async throws -> JSONValue {
         let timeout =
             requestTimeoutOverride
-            ?? MCPMethodDispatcher.timeoutForMethod(
+            ?? MCP.MethodDispatcher.timeoutForMethod(
                 "tools/call",
                 defaultSeconds: config.requestTimeout
             )
@@ -880,7 +880,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
         let timeout =
             requestTimeoutOverride
-            ?? MCPMethodDispatcher.timeoutForMethod(
+            ?? MCP.MethodDispatcher.timeoutForMethod(
                 "tools/call",
                 defaultSeconds: config.requestTimeout
             )
@@ -967,7 +967,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     }
 
     func encodeJSONRPCResultBuffer(
-        id: RPCID,
+        id: JSONRPC.ID,
         result: JSONValue
     ) throws -> ByteBuffer {
         let response: [String: Any] = [
@@ -985,7 +985,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     }
 
     func encodeControlPlaneErrorBuffer(
-        id: RPCID,
+        id: JSONRPC.ID,
         error: Error
     ) throws -> ByteBuffer {
         let mapped = ControlPlaneErrorMapper.jsonRPCError(for: error)

--- a/Sources/ProxySession/Session/LeaseManager.swift
+++ b/Sources/ProxySession/Session/LeaseManager.swift
@@ -1,110 +1,110 @@
 import Foundation
 import NIOConcurrencyHelpers
 
-package typealias RequestLeaseID = UUID
-
-package enum RequestLeaseState: String, Codable, Sendable {
-    case queued
-    case active
-    case completed
-    case timedOut
-    case failed
-    case abandoned
-}
-
-package enum RequestLeaseReleaseReason: String, Codable, Sendable {
-    case completed
-    case timedOut
-    case invalidUpstreamResponse
-    case upstreamUnavailable
-    case upstreamExit
-    case upstreamOverloaded
-    case stdoutProtocolViolation
-    case clientDisconnected
-    case lateResponse
-}
-
-package struct RequestLeaseDebugSnapshot: Codable, Sendable {
-    package let leaseID: String
-    package let sessionID: String
-    package let requestIDKey: String?
-    package let upstreamIndex: Int?
-    package let label: String
-    package let state: RequestLeaseState
-    package let startedAt: Date?
-    package let timeoutAt: Date?
-    package let releasedAt: Date?
-    package let releaseReason: String?
-    package let lateResponseCount: Int
-
-    package init(
-        leaseID: String,
-        sessionID: String,
-        requestIDKey: String?,
-        upstreamIndex: Int?,
-        label: String,
-        state: RequestLeaseState,
-        startedAt: Date?,
-        timeoutAt: Date?,
-        releasedAt: Date?,
-        releaseReason: String?,
-        lateResponseCount: Int
-    ) {
-        self.leaseID = leaseID
-        self.sessionID = sessionID
-        self.requestIDKey = requestIDKey
-        self.upstreamIndex = upstreamIndex
-        self.label = label
-        self.state = state
-        self.startedAt = startedAt
-        self.timeoutAt = timeoutAt
-        self.releasedAt = releasedAt
-        self.releaseReason = releaseReason
-        self.lateResponseCount = lateResponseCount
-    }
-}
-
-package struct RequestLeaseReleaseAction: Sendable {
-    package let leaseID: RequestLeaseID
-    package let sessionID: String
-    package let upstreamIndex: Int?
-
-    package init(leaseID: RequestLeaseID, sessionID: String, upstreamIndex: Int?) {
-        self.leaseID = leaseID
-        self.sessionID = sessionID
-        self.upstreamIndex = upstreamIndex
-    }
-}
-
 package final class LeaseManager: Sendable {
+    package typealias ID = UUID
+
+    package enum State: String, Codable, Sendable {
+        case queued
+        case active
+        case completed
+        case timedOut
+        case failed
+        case abandoned
+    }
+
+    package enum ReleaseReason: String, Codable, Sendable {
+        case completed
+        case timedOut
+        case invalidUpstreamResponse
+        case upstreamUnavailable
+        case upstreamExit
+        case upstreamOverloaded
+        case stdoutProtocolViolation
+        case clientDisconnected
+        case lateResponse
+    }
+
+    package struct DebugSnapshot: Codable, Sendable {
+        package let leaseID: String
+        package let sessionID: String
+        package let requestIDKey: String?
+        package let upstreamIndex: Int?
+        package let label: String
+        package let state: LeaseManager.State
+        package let startedAt: Date?
+        package let timeoutAt: Date?
+        package let releasedAt: Date?
+        package let releaseReason: String?
+        package let lateResponseCount: Int
+
+        package init(
+            leaseID: String,
+            sessionID: String,
+            requestIDKey: String?,
+            upstreamIndex: Int?,
+            label: String,
+            state: LeaseManager.State,
+            startedAt: Date?,
+            timeoutAt: Date?,
+            releasedAt: Date?,
+            releaseReason: String?,
+            lateResponseCount: Int
+        ) {
+            self.leaseID = leaseID
+            self.sessionID = sessionID
+            self.requestIDKey = requestIDKey
+            self.upstreamIndex = upstreamIndex
+            self.label = label
+            self.state = state
+            self.startedAt = startedAt
+            self.timeoutAt = timeoutAt
+            self.releasedAt = releasedAt
+            self.releaseReason = releaseReason
+            self.lateResponseCount = lateResponseCount
+        }
+    }
+
+    package struct ReleaseAction: Sendable {
+        package let leaseID: LeaseManager.ID
+        package let sessionID: String
+        package let upstreamIndex: Int?
+
+        package init(leaseID: LeaseManager.ID, sessionID: String, upstreamIndex: Int?) {
+            self.leaseID = leaseID
+            self.sessionID = sessionID
+            self.upstreamIndex = upstreamIndex
+        }
+    }
+
     private struct LeaseRecord: Sendable {
-        let leaseID: RequestLeaseID
-        let descriptor: SessionPipelineRequestDescriptor
+        let leaseID: LeaseManager.ID
+        let descriptor: SessionRequestPipeline.Descriptor
         var requestIDKey: String?
         var upstreamIndex: Int?
         var startedAt: Date?
         var timeoutAt: Date?
-        var state: RequestLeaseState
+        var state: LeaseManager.State
         var releasedAt: Date?
-        var releaseReason: RequestLeaseReleaseReason?
+        var releaseReason: LeaseManager.ReleaseReason?
         var lateResponseCount: Int
     }
 
-    private struct State: Sendable {
-        var leasesByID: [RequestLeaseID: LeaseRecord] = [:]
-        var activeLeaseIDsByUpstream: [Int: Set<RequestLeaseID>] = [:]
-        var releasedLeasesByID: [RequestLeaseID: LeaseRecord] = [:]
-        var releasedLeaseIDsInOrder: [RequestLeaseID] = []
+    private struct Storage: Sendable {
+        var leasesByID: [LeaseManager.ID: LeaseRecord] = [:]
+        var activeLeaseIDsByUpstream: [Int: Set<LeaseManager.ID>] = [:]
+        var releasedLeasesByID: [LeaseManager.ID: LeaseRecord] = [:]
+        var releasedLeaseIDsInOrder: [LeaseManager.ID] = []
     }
 
-    private let state = NIOLockedValueBox(State())
+    private let state = NIOLockedValueBox(Storage())
     private let releasedHistoryLimit: Int
 
     package init(releasedHistoryLimit: Int = 256) {
         self.releasedHistoryLimit = max(0, releasedHistoryLimit)
     }
 
-    package func createLease(descriptor: SessionPipelineRequestDescriptor) -> RequestLeaseID {
+    package func createLease(descriptor: SessionRequestPipeline.Descriptor) -> LeaseManager.ID {
         let leaseID = UUID()
         state.withLockedValue { state in
             state.leasesByID[leaseID] = LeaseRecord(
@@ -124,7 +124,7 @@ package final class LeaseManager: Sendable {
     }
 
     package func activateLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
         timeoutAt: Date?
@@ -149,11 +149,11 @@ package final class LeaseManager: Sendable {
         }
     }
 
-    package func completeLease(_ leaseID: RequestLeaseID) -> RequestLeaseReleaseAction? {
+    package func completeLease(_ leaseID: LeaseManager.ID) -> LeaseManager.ReleaseAction? {
         finishLease(leaseID, terminalState: .completed, reason: .completed)
     }
 
-    package func requeueLease(_ leaseID: RequestLeaseID) -> RequestLeaseReleaseAction? {
+    package func requeueLease(_ leaseID: LeaseManager.ID) -> LeaseManager.ReleaseAction? {
         state.withLockedValue { state in
             guard var record = state.leasesByID[leaseID] else { return nil }
             guard record.state == .active else { return nil }
@@ -172,7 +172,7 @@ package final class LeaseManager: Sendable {
                 }
             }
 
-            return RequestLeaseReleaseAction(
+            return LeaseManager.ReleaseAction(
                 leaseID: leaseID,
                 sessionID: record.descriptor.sessionID,
                 upstreamIndex: upstreamIndex
@@ -180,25 +180,25 @@ package final class LeaseManager: Sendable {
         }
     }
 
-    package func timeoutLease(_ leaseID: RequestLeaseID) -> RequestLeaseReleaseAction? {
+    package func timeoutLease(_ leaseID: LeaseManager.ID) -> LeaseManager.ReleaseAction? {
         finishLease(leaseID, terminalState: .timedOut, reason: .timedOut)
     }
 
     package func failLease(
-        _ leaseID: RequestLeaseID,
-        terminalState: RequestLeaseState = .failed,
-        reason: RequestLeaseReleaseReason
-    ) -> RequestLeaseReleaseAction? {
+        _ leaseID: LeaseManager.ID,
+        terminalState: LeaseManager.State = .failed,
+        reason: LeaseManager.ReleaseReason
+    ) -> LeaseManager.ReleaseAction? {
         finishLease(leaseID, terminalState: terminalState, reason: reason)
     }
 
     package func abandonActiveLeases(
         upstreamIndex: Int,
-        reason: RequestLeaseReleaseReason
-    ) -> [RequestLeaseReleaseAction] {
+        reason: LeaseManager.ReleaseReason
+    ) -> [LeaseManager.ReleaseAction] {
         state.withLockedValue { state in
             let leaseIDs = state.activeLeaseIDsByUpstream.removeValue(forKey: upstreamIndex) ?? []
-            var actions: [RequestLeaseReleaseAction] = []
+            var actions: [LeaseManager.ReleaseAction] = []
             actions.reserveCapacity(leaseIDs.count)
 
             for leaseID in leaseIDs {
@@ -210,7 +210,7 @@ package final class LeaseManager: Sendable {
                 state.leasesByID.removeValue(forKey: leaseID)
                 storeReleasedLease(record, in: &state)
                 actions.append(
-                    RequestLeaseReleaseAction(
+                    LeaseManager.ReleaseAction(
                         leaseID: leaseID,
                         sessionID: record.descriptor.sessionID,
                         upstreamIndex: record.upstreamIndex
@@ -222,14 +222,14 @@ package final class LeaseManager: Sendable {
         }
     }
 
-    package func debugSnapshots() -> [RequestLeaseDebugSnapshot] {
+    package func debugSnapshots() -> [LeaseManager.DebugSnapshot] {
         state.withLockedValue { state in
             let records = Array(state.leasesByID.values) + state.releasedLeaseIDsInOrder.compactMap {
                 state.releasedLeasesByID[$0]
             }
             return records
                 .map { record in
-                    RequestLeaseDebugSnapshot(
+                    LeaseManager.DebugSnapshot(
                         leaseID: record.leaseID.uuidString,
                         sessionID: record.descriptor.sessionID,
                         requestIDKey: record.requestIDKey,
@@ -252,12 +252,12 @@ package final class LeaseManager: Sendable {
         }
     }
 
-    package func resetAll(reason: RequestLeaseReleaseReason) -> [RequestLeaseReleaseAction] {
+    package func resetAll(reason: LeaseManager.ReleaseReason) -> [LeaseManager.ReleaseAction] {
         state.withLockedValue { state in
-            let actions = state.leasesByID.values.compactMap { record -> RequestLeaseReleaseAction? in
+            let actions = state.leasesByID.values.compactMap { record -> LeaseManager.ReleaseAction? in
                 switch record.state {
                 case .queued, .active:
-                    return RequestLeaseReleaseAction(
+                    return LeaseManager.ReleaseAction(
                         leaseID: record.leaseID,
                         sessionID: record.descriptor.sessionID,
                         upstreamIndex: record.upstreamIndex
@@ -274,7 +274,7 @@ package final class LeaseManager: Sendable {
         }
     }
 
-    package func sessionDebugSnapshots(allSessionIDs: [String]) -> [SessionDebugSnapshot] {
+    package func sessionDebugSnapshots(allSessionIDs: [String]) -> [SessionRequestPipeline.DebugSnapshot] {
         state.withLockedValue { state in
             var counts: [String: Int] = [:]
             for record in state.leasesByID.values where record.state == .active {
@@ -282,7 +282,7 @@ package final class LeaseManager: Sendable {
             }
             let sessionIDs = Set(allSessionIDs).union(counts.keys).sorted()
             return sessionIDs.map { sessionID in
-                SessionDebugSnapshot(
+                SessionRequestPipeline.DebugSnapshot(
                     sessionID: sessionID,
                     activeCorrelatedRequestCount: counts[sessionID] ?? 0
                 )
@@ -322,10 +322,10 @@ package final class LeaseManager: Sendable {
     }
 
     private func finishLease(
-        _ leaseID: RequestLeaseID,
-        terminalState: RequestLeaseState,
-        reason: RequestLeaseReleaseReason
-    ) -> RequestLeaseReleaseAction? {
+        _ leaseID: LeaseManager.ID,
+        terminalState: LeaseManager.State,
+        reason: LeaseManager.ReleaseReason
+    ) -> LeaseManager.ReleaseAction? {
         state.withLockedValue { state in
             guard var record = state.leasesByID[leaseID] ?? state.releasedLeasesByID[leaseID] else {
                 return nil
@@ -345,7 +345,7 @@ package final class LeaseManager: Sendable {
                 }
                 state.leasesByID.removeValue(forKey: leaseID)
                 storeReleasedLease(record, in: &state)
-                return RequestLeaseReleaseAction(
+                return LeaseManager.ReleaseAction(
                     leaseID: leaseID,
                     sessionID: record.descriptor.sessionID,
                     upstreamIndex: record.upstreamIndex
@@ -364,7 +364,7 @@ package final class LeaseManager: Sendable {
         }
     }
 
-    private func storeReleasedLease(_ record: LeaseRecord, in state: inout State) {
+    private func storeReleasedLease(_ record: LeaseRecord, in state: inout Storage) {
         if state.releasedLeasesByID[record.leaseID] == nil {
             state.releasedLeaseIDsInOrder.append(record.leaseID)
         }

--- a/Sources/ProxySession/Session/ProxyDebugRecorder.swift
+++ b/Sources/ProxySession/Session/ProxyDebugRecorder.swift
@@ -76,7 +76,7 @@ package final class ProxyDebugRecorder: Sendable {
     }
 
     package func recordProtocolViolation(
-        _ protocolViolation: StdioFramerProtocolViolation,
+        _ protocolViolation: StdioFramer.ProtocolViolation,
         upstreamIndex: Int
     ) {
         state.withLockedValue { state in
@@ -138,8 +138,8 @@ package final class ProxyDebugRecorder: Sendable {
         cachedToolsListAvailable: Bool,
         controlPlane: ProxyControlPlaneDebugSnapshot?,
         upstreamStates: [UpstreamHealthManager.UpstreamState],
-        sessionSnapshots: [SessionDebugSnapshot],
-        leaseSnapshots: [RequestLeaseDebugSnapshot],
+        sessionSnapshots: [SessionRequestPipeline.DebugSnapshot],
+        leaseSnapshots: [LeaseManager.DebugSnapshot],
         queuedRequestCount: Int,
         redactedText: String,
         includeSensitiveDebugPayloads: Bool,

--- a/Sources/ProxySession/Session/ProxyDebugSnapshot.swift
+++ b/Sources/ProxySession/Session/ProxyDebugSnapshot.swift
@@ -113,8 +113,8 @@ package struct ProxyDebugSnapshot: Codable, Sendable {
     package let controlPlane: ProxyControlPlaneDebugSnapshot?
     package let upstreams: [ProxyUpstreamDebugSnapshot]
     package let recentTraffic: [ProxyDebugTrafficEvent]
-    package let sessions: [SessionDebugSnapshot]
-    package let leases: [RequestLeaseDebugSnapshot]
+    package let sessions: [SessionRequestPipeline.DebugSnapshot]
+    package let leases: [LeaseManager.DebugSnapshot]
     package let queuedRequestCount: Int
 
     package init(
@@ -125,8 +125,8 @@ package struct ProxyDebugSnapshot: Codable, Sendable {
         controlPlane: ProxyControlPlaneDebugSnapshot? = nil,
         upstreams: [ProxyUpstreamDebugSnapshot],
         recentTraffic: [ProxyDebugTrafficEvent],
-        sessions: [SessionDebugSnapshot],
-        leases: [RequestLeaseDebugSnapshot],
+        sessions: [SessionRequestPipeline.DebugSnapshot],
+        leases: [LeaseManager.DebugSnapshot],
         queuedRequestCount: Int
     ) {
         self.generatedAt = generatedAt

--- a/Sources/ProxySession/Session/ProxyRouter.swift
+++ b/Sources/ProxySession/Session/ProxyRouter.swift
@@ -249,7 +249,7 @@ package final class ProxyRouter: Sendable {
     }
 
     private static func responseIDKey(from object: [String: Any]) -> String? {
-        JSONRPCMessageInspector.responseCorrelationID(from: object)?.key
+        JSONRPC.Message.Inspector.responseCorrelationID(from: object)?.key
     }
 
     private static func responseIDKeys(from array: [Any]) -> Set<String> {

--- a/Sources/ProxySession/Session/ServerRequestTracker.swift
+++ b/Sources/ProxySession/Session/ServerRequestTracker.swift
@@ -3,14 +3,14 @@ import NIO
 import NIOConcurrencyHelpers
 import ProxyMCP
 
-package struct ServerRequestRoute: Sendable {
-    package let upstreamIndex: Int
-    package let upstreamID: RPCID
-}
-
 package final class ServerRequestTracker: Sendable {
+    package struct Route: Sendable {
+        package let upstreamIndex: Int
+        package let upstreamID: JSONRPC.ID
+    }
+
     private struct StoredRoute: Sendable {
-        let route: ServerRequestRoute
+        let route: ServerRequestTracker.Route
         let expiresAt: Date
     }
 
@@ -33,18 +33,18 @@ package final class ServerRequestTracker: Sendable {
     }
 
     package func record(
-        upstreamID: RPCID,
+        upstreamID: JSONRPC.ID,
         upstreamIndex: Int,
         now: Date = Date()
-    ) -> RPCID {
+    ) -> JSONRPC.ID {
         state.withLockedValue { state in
             Self.removeExpiredRoutes(now: now, state: &state)
             state.nextClientID += 1
-            let clientID = RPCID(
+            let clientID = JSONRPC.ID(
                 any: "xcode-mcp-proxy.server-request.\(state.nextClientID)"
             )!
             state.routesByClientIDKey[clientID.key] = StoredRoute(
-                route: ServerRequestRoute(
+                route: ServerRequestTracker.Route(
                     upstreamIndex: upstreamIndex,
                     upstreamID: upstreamID
                 ),
@@ -56,7 +56,7 @@ package final class ServerRequestTracker: Sendable {
         }
     }
 
-    package func consume(clientID: RPCID, now: Date = Date()) -> ServerRequestRoute? {
+    package func consume(clientID: JSONRPC.ID, now: Date = Date()) -> ServerRequestTracker.Route? {
         state.withLockedValue { state in
             Self.removeExpiredRoutes(now: now, state: &state)
             guard let stored = state.routesByClientIDKey.removeValue(forKey: clientID.key) else {
@@ -67,7 +67,7 @@ package final class ServerRequestTracker: Sendable {
         }
     }
 
-    package func lookup(clientID: RPCID, now: Date = Date()) -> ServerRequestRoute? {
+    package func lookup(clientID: JSONRPC.ID, now: Date = Date()) -> ServerRequestTracker.Route? {
         state.withLockedValue { state in
             Self.removeExpiredRoutes(now: now, state: &state)
             return state.routesByClientIDKey[clientID.key]?.route
@@ -76,8 +76,8 @@ package final class ServerRequestTracker: Sendable {
 
     @discardableResult
     package func complete(
-        clientID: RPCID,
-        route: ServerRequestRoute,
+        clientID: JSONRPC.ID,
+        route: ServerRequestTracker.Route,
         now: Date = Date()
     ) -> Bool {
         state.withLockedValue { state in

--- a/Sources/ProxySession/Session/SessionRequestPipeline.swift
+++ b/Sources/ProxySession/Session/SessionRequestPipeline.swift
@@ -1,44 +1,46 @@
 import Foundation
 import ProxyCore
 
-package struct SessionPipelineRequestDescriptor: Codable, Sendable {
-    package let sessionID: String
-    package let label: String
-    package let isBatch: Bool
-    package let expectsResponse: Bool
-    package let isTopLevelClientRequest: Bool
+package enum SessionRequestPipeline {
+    package struct Descriptor: Codable, Sendable {
+        package let sessionID: String
+        package let label: String
+        package let isBatch: Bool
+        package let expectsResponse: Bool
+        package let isTopLevelClientRequest: Bool
 
-    package init(
-        sessionID: String,
-        label: String,
-        isBatch: Bool,
-        expectsResponse: Bool,
-        isTopLevelClientRequest: Bool
-    ) {
-        self.sessionID = sessionID
-        self.label = label
-        self.isBatch = isBatch
-        self.expectsResponse = expectsResponse
-        self.isTopLevelClientRequest = isTopLevelClientRequest
-    }
-}
-
-package struct SessionDebugSnapshot: Codable, Sendable {
-    package let sessionID: String
-    package let activeCorrelatedRequestCount: Int
-
-    package init(
-        sessionID: String,
-        activeCorrelatedRequestCount: Int
-    ) {
-        self.sessionID = sessionID
-        self.activeCorrelatedRequestCount = activeCorrelatedRequestCount
+        package init(
+            sessionID: String,
+            label: String,
+            isBatch: Bool,
+            expectsResponse: Bool,
+            isTopLevelClientRequest: Bool
+        ) {
+            self.sessionID = sessionID
+            self.label = label
+            self.isBatch = isBatch
+            self.expectsResponse = expectsResponse
+            self.isTopLevelClientRequest = isTopLevelClientRequest
+        }
     }
 
-    package var hasActiveRequest: Bool { activeCorrelatedRequestCount > 0 }
-    package var currentRequestLabel: String? { nil }
-    package var currentRequestStartedAt: Date? { nil }
-    package var pendingRequestCount: Int { 0 }
+    package struct DebugSnapshot: Codable, Sendable {
+        package let sessionID: String
+        package let activeCorrelatedRequestCount: Int
+
+        package init(
+            sessionID: String,
+            activeCorrelatedRequestCount: Int
+        ) {
+            self.sessionID = sessionID
+            self.activeCorrelatedRequestCount = activeCorrelatedRequestCount
+        }
+
+        package var hasActiveRequest: Bool { activeCorrelatedRequestCount > 0 }
+        package var currentRequestLabel: String? { nil }
+        package var currentRequestStartedAt: Date? { nil }
+        package var pendingRequestCount: Int { 0 }
+    }
 }
 
 package enum UpstreamSlotAcquisitionError: Error {

--- a/Sources/ProxySession/Session/UpstreamRouter.swift
+++ b/Sources/ProxySession/Session/UpstreamRouter.swift
@@ -52,7 +52,7 @@ package final class UpstreamRouter: Sendable {
 
     private struct State: Sendable {
         var nextID: Int64 = 1
-        var mappingsByUpstream: [[Int64: UpstreamMapping]] = []
+        var mappingsByUpstream: [[Int64: UpstreamRouter.Mapping]] = []
         var upstreamIDByRequestKeyByUpstream: [[RequestLookupKey: Int64]] = []
         var recentlyReleasedResponseIDsByUpstream: [[Int64]] = []
     }
@@ -68,7 +68,7 @@ package final class UpstreamRouter: Sendable {
         }
     }
 
-    func assign(upstreamIndex: Int, sessionID: String, originalID: RPCID, isInitialize: Bool)
+    func assign(upstreamIndex: Int, sessionID: String, originalID: JSONRPC.ID, isInitialize: Bool)
         -> Int64
     {
         state.withLockedValue { state in
@@ -77,7 +77,7 @@ package final class UpstreamRouter: Sendable {
             }
             let id = state.nextID
             state.nextID += 1
-            state.mappingsByUpstream[upstreamIndex][id] = UpstreamMapping(
+            state.mappingsByUpstream[upstreamIndex][id] = UpstreamRouter.Mapping(
                 sessionID: sessionID,
                 originalID: originalID,
                 isInitialize: isInitialize
@@ -98,7 +98,7 @@ package final class UpstreamRouter: Sendable {
             }
             let id = state.nextID
             state.nextID += 1
-            state.mappingsByUpstream[upstreamIndex][id] = UpstreamMapping(
+            state.mappingsByUpstream[upstreamIndex][id] = UpstreamRouter.Mapping(
                 sessionID: nil,
                 originalID: nil,
                 isInitialize: true
@@ -107,7 +107,7 @@ package final class UpstreamRouter: Sendable {
         }
     }
 
-    func consume(upstreamIndex: Int, upstreamID: Int64) -> UpstreamMapping? {
+    func consume(upstreamIndex: Int, upstreamID: Int64) -> UpstreamRouter.Mapping? {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.mappingsByUpstream.count else {
                 return nil
@@ -233,10 +233,9 @@ package final class UpstreamRouter: Sendable {
             )
         }
     }
-}
-
-package struct UpstreamMapping: Sendable {
-    package let sessionID: String?
-    package let originalID: RPCID?
-    package let isInitialize: Bool
+    package struct Mapping: Sendable {
+        package let sessionID: String?
+        package let originalID: JSONRPC.ID?
+        package let isInitialize: Bool
+    }
 }

--- a/Sources/ProxySession/Upstream/ManagedUpstreamSlot.swift
+++ b/Sources/ProxySession/Upstream/ManagedUpstreamSlot.swift
@@ -18,8 +18,8 @@ package actor ManagedUpstreamSlot: UpstreamSlotControlling {
         }
     }
 
-    package nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    package nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private let factory: any UpstreamSessionFactory
     private var pendingStart: StartAttempt?
     private var current: RunningSessionBox?
@@ -28,7 +28,7 @@ package actor ManagedUpstreamSlot: UpstreamSlotControlling {
     package init(factory: any UpstreamSessionFactory) {
         self.factory = factory
 
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -56,7 +56,7 @@ package actor ManagedUpstreamSlot: UpstreamSlotControlling {
         }
     }
 
-    package func send(_ data: Data) async -> UpstreamSendResult {
+    package func send(_ data: Data) async -> Upstream.SendResult {
         guard !isShutdown else {
             return .unavailable(.shuttingDown)
         }
@@ -146,7 +146,7 @@ package actor ManagedUpstreamSlot: UpstreamSlotControlling {
     }
 
     private func handleSessionEvent(
-        _ event: UpstreamEvent,
+        _ event: Upstream.Event,
         from running: RunningSessionBox
     ) {
         guard current === running else {

--- a/Sources/ProxySession/Upstream/UpstreamClient.swift
+++ b/Sources/ProxySession/Upstream/UpstreamClient.swift
@@ -2,33 +2,37 @@ import Foundation
 import ProxyCore
 import ProxyMCP
 
-package enum UpstreamEvent: Sendable {
-    case message(Data)
-    case stderr(String)
-    case stdoutProtocolViolation(StdioFramerProtocolViolation)
-    case stdoutBufferSize(Int)
-    case exit(Int32)
-}
+package enum Upstream {}
 
-package enum UpstreamUnavailableReason: Sendable, Equatable {
-    case notStarted
-    case startFailed
-    case terminated
-    case shuttingDown
-}
+extension Upstream {
+    package enum Event: Sendable {
+        case message(Data)
+        case stderr(String)
+        case stdoutProtocolViolation(StdioFramer.ProtocolViolation)
+        case stdoutBufferSize(Int)
+        case exit(Int32)
+    }
+
+    package enum UnavailableReason: Sendable, Equatable {
+        case notStarted
+        case startFailed
+        case terminated
+        case shuttingDown
+    }
 
 /// Why a send did not reach the upstream. Backpressure is the only case
 /// that should count against the upstream's health; an unavailable slot is
 /// already handled by the exit/quarantine machinery.
-package enum UpstreamSendResult: Sendable, Equatable {
-    case accepted
-    case backpressure
-    case unavailable(UpstreamUnavailableReason)
+    package enum SendResult: Sendable, Equatable {
+        case accepted
+        case backpressure
+        case unavailable(Upstream.UnavailableReason)
+    }
 }
 
 package protocol UpstreamSession: AnyObject, Sendable {
-    var events: AsyncStream<UpstreamEvent> { get }
-    func send(_ data: Data) async -> UpstreamSendResult
+    var events: AsyncStream<Upstream.Event> { get }
+    func send(_ data: Data) async -> Upstream.SendResult
     func stop() async
 }
 
@@ -37,8 +41,8 @@ package protocol UpstreamSessionFactory: Sendable {
 }
 
 package protocol UpstreamSlotControlling: Sendable {
-    var events: AsyncStream<UpstreamEvent> { get }
+    var events: AsyncStream<Upstream.Event> { get }
     func start() async
     func stop() async
-    func send(_ data: Data) async -> UpstreamSendResult
+    func send(_ data: Data) async -> Upstream.SendResult
 }

--- a/Sources/ProxySession/Upstream/UpstreamHealthManager.swift
+++ b/Sources/ProxySession/Upstream/UpstreamHealthManager.swift
@@ -2,50 +2,50 @@ import Foundation
 import NIO
 import NIOConcurrencyHelpers
 
-package struct HealthProbeRequest: Sendable {
-    package let upstreamIndex: Int
-    package let probeGeneration: UInt64
-}
-
-package enum UpstreamHealthEffect: Sendable {
-    case cancelInitTimeout(RuntimeScheduledTimeout)
-    case startHealthProbe(HealthProbeRequest)
-    case clearPins
-    case failQueuedIfNoRecovery
-}
-
-package struct UpstreamUseEvaluation: Sendable {
-    package let isUsable: Bool
-    package let effects: [UpstreamHealthEffect]
-
-    package init(isUsable: Bool, effects: [UpstreamHealthEffect]) {
-        self.isUsable = isUsable
-        self.effects = effects
-    }
-}
-
-package struct UpstreamSelectionResult: Sendable {
-    package let upstreamIndex: Int?
-    package let effects: [UpstreamHealthEffect]
-
-    package init(upstreamIndex: Int?, effects: [UpstreamHealthEffect]) {
-        self.upstreamIndex = upstreamIndex
-        self.effects = effects
-    }
-}
-
-package struct ProtocolViolationTransition: Sendable {
-    package let quarantineUntil: UInt64
-    package let cancelledInitTimeout: RuntimeScheduledTimeout?
-}
-
-package struct IncompatibilityTransition: Sendable {
-    package let quarantineUntil: UInt64
-    package let cancelledInitTimeout: RuntimeScheduledTimeout?
-    package let initUpstreamID: Int64?
-}
-
 package final class UpstreamHealthManager: Sendable {
+    package struct ProbeRequest: Sendable {
+        package let upstreamIndex: Int
+        package let probeGeneration: UInt64
+    }
+
+    package enum Effect: Sendable {
+        case cancelInitTimeout(RuntimeScheduledTimeout)
+        case startHealthProbe(UpstreamHealthManager.ProbeRequest)
+        case clearPins
+        case failQueuedIfNoRecovery
+    }
+
+    package struct UseEvaluation: Sendable {
+        package let isUsable: Bool
+        package let effects: [UpstreamHealthManager.Effect]
+
+        package init(isUsable: Bool, effects: [UpstreamHealthManager.Effect]) {
+            self.isUsable = isUsable
+            self.effects = effects
+        }
+    }
+
+    package struct SelectionResult: Sendable {
+        package let upstreamIndex: Int?
+        package let effects: [UpstreamHealthManager.Effect]
+
+        package init(upstreamIndex: Int?, effects: [UpstreamHealthManager.Effect]) {
+            self.upstreamIndex = upstreamIndex
+            self.effects = effects
+        }
+    }
+
+    package struct ProtocolViolationTransition: Sendable {
+        package let quarantineUntil: UInt64
+        package let cancelledInitTimeout: RuntimeScheduledTimeout?
+    }
+
+    package struct IncompatibilityTransition: Sendable {
+        package let quarantineUntil: UInt64
+        package let cancelledInitTimeout: RuntimeScheduledTimeout?
+        package let initUpstreamID: Int64?
+    }
+
     package enum InitPhase: Sendable, Equatable {
         case idle
         case initializing(upstreamID: Int64?)
@@ -193,8 +193,8 @@ package final class UpstreamHealthManager: Sendable {
     package func evaluateUsableInitialized(
         index: Int,
         nowUptimeNs: UInt64
-    ) -> UpstreamUseEvaluation {
-        var effects: [UpstreamHealthEffect] = []
+    ) -> UpstreamHealthManager.UseEvaluation {
+        var effects: [UpstreamHealthManager.Effect] = []
         let usable = state.withLockedValue { state in
             guard index >= 0, index < state.upstreamStates.count else { return false }
             let health = Self.classifyHealthAndCollectEffectsIfNeeded(
@@ -212,14 +212,14 @@ package final class UpstreamHealthManager: Sendable {
             }
             return isHealthyEnough && state.upstreamStates[index].isInitialized
         }
-        return UpstreamUseEvaluation(isUsable: usable, effects: effects)
+        return UpstreamHealthManager.UseEvaluation(isUsable: usable, effects: effects)
     }
 
     package func chooseBestInitializedUpstream(
         nowUptimeNs: UInt64,
         occupiedUpstreams: Set<Int>
-    ) -> UpstreamSelectionResult {
-        var effects: [UpstreamHealthEffect] = []
+    ) -> UpstreamHealthManager.SelectionResult {
+        var effects: [UpstreamHealthManager.Effect] = []
         let chosen = state.withLockedValue { state -> Int? in
             let count = state.upstreamStates.count
             guard count > 0 else { return nil }
@@ -258,7 +258,7 @@ package final class UpstreamHealthManager: Sendable {
             }
             return degradedCandidate
         }
-        return UpstreamSelectionResult(upstreamIndex: chosen, effects: effects)
+        return UpstreamHealthManager.SelectionResult(upstreamIndex: chosen, effects: effects)
     }
 
     package func markRequestSucceeded(upstreamIndex: Int) {
@@ -292,7 +292,7 @@ package final class UpstreamHealthManager: Sendable {
     package func markProtocolViolation(
         upstreamIndex: Int,
         nowUptimeNs: UInt64
-    ) -> ProtocolViolationTransition? {
+    ) -> UpstreamHealthManager.ProtocolViolationTransition? {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
             let quarantineUntil = nowUptimeNs &+ 15_000_000_000
@@ -307,7 +307,7 @@ package final class UpstreamHealthManager: Sendable {
             )
             state.upstreamStates[upstreamIndex].healthProbeInFlight = false
             state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
-            return ProtocolViolationTransition(
+            return UpstreamHealthManager.ProtocolViolationTransition(
                 quarantineUntil: quarantineUntil,
                 cancelledInitTimeout: cancelledInitTimeout
             )
@@ -317,7 +317,7 @@ package final class UpstreamHealthManager: Sendable {
     package func quarantineIncompatibleUpstream(
         upstreamIndex: Int,
         nowUptimeNs: UInt64
-    ) -> IncompatibilityTransition? {
+    ) -> UpstreamHealthManager.IncompatibilityTransition? {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
             let quarantineUntil = nowUptimeNs &+ 30_000_000_000
@@ -334,7 +334,7 @@ package final class UpstreamHealthManager: Sendable {
             state.upstreamStates[upstreamIndex].healthProbeInFlight = false
             state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
             state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
-            return IncompatibilityTransition(
+            return UpstreamHealthManager.IncompatibilityTransition(
                 quarantineUntil: quarantineUntil,
                 cancelledInitTimeout: cancelledInitTimeout,
                 initUpstreamID: initUpstreamID
@@ -509,7 +509,7 @@ package final class UpstreamHealthManager: Sendable {
         }
     }
 
-    package func apply(event: Event) -> [UpstreamHealthEffect] {
+    package func apply(event: Event) -> [UpstreamHealthManager.Effect] {
         state.withLockedValue { state in
             switch event {
             case .requestSucceeded(let upstreamIndex):
@@ -570,7 +570,7 @@ package final class UpstreamHealthManager: Sendable {
         upstreamIndex: Int,
         nowUptimeNs: UInt64,
         state: inout State,
-        effects: inout [UpstreamHealthEffect]
+        effects: inout [UpstreamHealthManager.Effect]
     ) -> UpstreamHealthState {
         guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else {
             return .quarantined(untilUptimeNs: nowUptimeNs)
@@ -589,7 +589,7 @@ package final class UpstreamHealthManager: Sendable {
                 state.upstreamStates[upstreamIndex].healthProbeInFlight = true
                 state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
                 effects.append(
-                    .startHealthProbe(HealthProbeRequest(
+                    .startHealthProbe(UpstreamHealthManager.ProbeRequest(
                         upstreamIndex: upstreamIndex,
                         probeGeneration: state.upstreamStates[upstreamIndex].healthProbeGeneration
                     ))

--- a/Sources/ProxySession/Upstream/UpstreamProcess.swift
+++ b/Sources/ProxySession/Upstream/UpstreamProcess.swift
@@ -30,7 +30,7 @@ private final class StdinWriter: @unchecked Sendable {
         self.onComplete = onComplete
     }
 
-    func send(_ payload: Data) -> UpstreamSendResult {
+    func send(_ payload: Data) -> Upstream.SendResult {
         state.lock()
         defer { state.unlock() }
 
@@ -108,8 +108,8 @@ package struct UpstreamProcess: UpstreamSessionFactory {
 }
 
 package actor ProcessBackedUpstreamSession: UpstreamSession {
-    package nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    package nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
 
     private let config: UpstreamProcess.Config
     private let logger: Logger = ProxyLogging.make("upstream")
@@ -146,14 +146,14 @@ package actor ProcessBackedUpstreamSession: UpstreamSession {
     private init(config: UpstreamProcess.Config) {
         self.config = config
 
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
         self.continuation = streamContinuation
     }
 
-    package func send(_ data: Data) async -> UpstreamSendResult {
+    package func send(_ data: Data) async -> Upstream.SendResult {
         if isStopping {
             logger.warning("Upstream send skipped because session is stopping")
             return .unavailable(.shuttingDown)

--- a/Sources/ProxySession/Upstream/UpstreamSlotScheduler.swift
+++ b/Sources/ProxySession/Upstream/UpstreamSlotScheduler.swift
@@ -4,23 +4,23 @@ import NIO
 import NIOConcurrencyHelpers
 import ProxyCore
 
-package struct UpstreamSlotSchedulerDebugSnapshot: Codable, Sendable {
-    package let queuedRequestCount: Int
-    package let activeLeaseCountByUpstream: [Int: Int]
-
-    package init(
-        queuedRequestCount: Int,
-        activeLeaseCountByUpstream: [Int: Int]
-    ) {
-        self.queuedRequestCount = queuedRequestCount
-        self.activeLeaseCountByUpstream = activeLeaseCountByUpstream
-    }
-}
-
 package final class UpstreamSlotScheduler: Sendable {
+    package struct DebugSnapshot: Codable, Sendable {
+        package let queuedRequestCount: Int
+        package let activeLeaseCountByUpstream: [Int: Int]
+
+        package init(
+            queuedRequestCount: Int,
+            activeLeaseCountByUpstream: [Int: Int]
+        ) {
+            self.queuedRequestCount = queuedRequestCount
+            self.activeLeaseCountByUpstream = activeLeaseCountByUpstream
+        }
+    }
+
     private struct PendingRequest: Sendable {
-        let leaseID: RequestLeaseID
-        let descriptor: SessionPipelineRequestDescriptor
+        let leaseID: LeaseManager.ID
+        let descriptor: SessionRequestPipeline.Descriptor
         let eventLoop: EventLoop
         let preferredUpstreamIndex: Int?
         let start: @Sendable (Int) -> Void
@@ -36,22 +36,22 @@ package final class UpstreamSlotScheduler: Sendable {
 
     private struct State: Sendable {
         var pendingRequests: [PendingRequest] = []
-        var activeLeaseIDsByUpstream: [Int: RequestLeaseID] = [:]
-        var activeTopLevelLeaseIDsBySession: [String: RequestLeaseID] = [:]
-        var reservationsByLeaseID: [RequestLeaseID: Reservation] = [:]
+        var activeLeaseIDsByUpstream: [Int: LeaseManager.ID] = [:]
+        var activeTopLevelLeaseIDsBySession: [String: LeaseManager.ID] = [:]
+        var reservationsByLeaseID: [LeaseManager.ID: Reservation] = [:]
     }
 
     private let logger: Logger
     private let state: NIOLockedValueBox<State>
-    private let canUseUpstream: @Sendable (Int) -> UpstreamUseEvaluation
-    private let selectUpstream: @Sendable (Set<Int>) -> UpstreamSelectionResult
-    private let applyHealthEffects: @Sendable ([UpstreamHealthEffect]) -> Void
+    private let canUseUpstream: @Sendable (Int) -> UpstreamHealthManager.UseEvaluation
+    private let selectUpstream: @Sendable (Set<Int>) -> UpstreamHealthManager.SelectionResult
+    private let applyHealthEffects: @Sendable ([UpstreamHealthManager.Effect]) -> Void
 
     package init(
         logger: Logger = ProxyLogging.make("upstream.scheduler"),
-        canUseUpstream: @escaping @Sendable (Int) -> UpstreamUseEvaluation,
-        selectUpstream: @escaping @Sendable (Set<Int>) -> UpstreamSelectionResult,
-        applyHealthEffects: @escaping @Sendable ([UpstreamHealthEffect]) -> Void = { _ in }
+        canUseUpstream: @escaping @Sendable (Int) -> UpstreamHealthManager.UseEvaluation,
+        selectUpstream: @escaping @Sendable (Set<Int>) -> UpstreamHealthManager.SelectionResult,
+        applyHealthEffects: @escaping @Sendable ([UpstreamHealthManager.Effect]) -> Void = { _ in }
     ) {
         self.logger = logger
         self.canUseUpstream = canUseUpstream
@@ -66,8 +66,8 @@ package final class UpstreamSlotScheduler: Sendable {
     }
 
     package func enqueueRequest(
-        leaseID: RequestLeaseID,
-        descriptor: SessionPipelineRequestDescriptor,
+        leaseID: LeaseManager.ID,
+        descriptor: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
         preferredUpstreamIndex: Int? = nil,
         starter: @escaping @Sendable (Int) -> Void,
@@ -90,7 +90,7 @@ package final class UpstreamSlotScheduler: Sendable {
         dispatchQueuedRequestsIfPossible()
     }
 
-    package func releaseUpstreamSlot(upstreamIndex: Int, leaseID: RequestLeaseID) {
+    package func releaseUpstreamSlot(upstreamIndex: Int, leaseID: LeaseManager.ID) {
         let released = state.withLockedValue { state -> Bool in
             guard state.activeLeaseIDsByUpstream[upstreamIndex] == leaseID else { return false }
             state.activeLeaseIDsByUpstream.removeValue(forKey: upstreamIndex)
@@ -159,7 +159,7 @@ package final class UpstreamSlotScheduler: Sendable {
         }
     }
 
-    package func cancelQueuedRequest(leaseID: RequestLeaseID) {
+    package func cancelQueuedRequest(leaseID: LeaseManager.ID) {
         enum CancelledRequest {
             case pending(PendingRequest)
             case reserved(PendingRequest, Int)
@@ -212,9 +212,9 @@ package final class UpstreamSlotScheduler: Sendable {
         }
     }
 
-    package func debugSnapshot() -> UpstreamSlotSchedulerDebugSnapshot {
+    package func debugSnapshot() -> UpstreamSlotScheduler.DebugSnapshot {
         state.withLockedValue { state in
-            UpstreamSlotSchedulerDebugSnapshot(
+            UpstreamSlotScheduler.DebugSnapshot(
                 queuedRequestCount: state.pendingRequests.count,
                 activeLeaseCountByUpstream: state.activeLeaseIDsByUpstream.reduce(into: [:]) { counts, item in
                     counts[item.key] = 1
@@ -261,10 +261,10 @@ package final class UpstreamSlotScheduler: Sendable {
     private func dispatchQueuedRequestsIfPossible() {
         let dispatch = state.withLockedValue { state -> (
             starts: [(PendingRequest, Int)],
-            healthEffects: [UpstreamHealthEffect]
+            healthEffects: [UpstreamHealthManager.Effect]
         ) in
             var ready: [(PendingRequest, Int)] = []
-            var healthEffects: [UpstreamHealthEffect] = []
+            var healthEffects: [UpstreamHealthManager.Effect] = []
 
             while state.pendingRequests.isEmpty == false {
                 let occupied = Set(state.activeLeaseIDsByUpstream.keys)

--- a/Sources/ProxyStdioTransport/StdioAdapter.swift
+++ b/Sources/ProxyStdioTransport/StdioAdapter.swift
@@ -243,7 +243,7 @@ public actor StdioAdapter {
         guard let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
             let result = object["result"] as? [String: Any],
             let protocolVersion = result["protocolVersion"] as? String,
-            MCPProtocolVersion.isSupported(protocolVersion)
+            MCP.ProtocolVersion.isSupported(protocolVersion)
         else {
             return nil
         }
@@ -417,15 +417,15 @@ public actor StdioAdapter {
             return RequestEnvelope(method: nil, ids: [])
         }
         if let object = json as? [String: Any] {
-            let method = JSONRPCMessageInspector.method(from: object)
-            let ids = JSONRPCMessageInspector.requestID(from: object).map { [$0.value] } ?? []
+            let method = JSONRPC.Message.Inspector.method(from: object)
+            let ids = JSONRPC.Message.Inspector.requestID(from: object).map { [$0.value] } ?? []
             return RequestEnvelope(method: method, ids: ids)
         }
         if let array = json as? [Any] {
             var ids: [JSONValue] = []
             for item in array {
                 guard let object = item as? [String: Any] else { continue }
-                if let id = JSONRPCMessageInspector.requestID(from: object) {
+                if let id = JSONRPC.Message.Inspector.requestID(from: object) {
                     ids.append(id.value)
                 }
             }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesCoordinator.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesCoordinator.swift
@@ -1,7 +1,8 @@
 import Foundation
 import NIO
 
-package actor RefreshCodeIssuesCoordinator {
+extension RefreshCodeIssues {
+    package actor Coordinator {
     private enum WaiterState: Sendable {
         case active
         case cancelled
@@ -42,8 +43,8 @@ package actor RefreshCodeIssuesCoordinator {
     private var activeExecutionsByKey: [String: ActiveExecution] = [:]
     private var waitersByKey: [String: [Waiter]] = [:]
 
-    package static func makeDefault() -> RefreshCodeIssuesCoordinator {
-        RefreshCodeIssuesCoordinator()
+    package static func makeDefault() -> RefreshCodeIssues.Coordinator {
+        RefreshCodeIssues.Coordinator()
     }
 
     package init(
@@ -304,5 +305,6 @@ package actor RefreshCodeIssuesCoordinator {
             return .zero
         }
         return .nanoseconds(nanoseconds)
+    }
     }
 }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesDebugState.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesDebugState.swift
@@ -1,7 +1,8 @@
 import Foundation
 import ProxyCore
 
-package struct RefreshCodeIssuesQueueDebugSnapshot: Codable, Sendable {
+extension RefreshCodeIssues {
+    package struct QueueSnapshot: Codable, Sendable {
     package let defaultRequestTimeoutSeconds: Double
     package let activeByQueueKey: [String: Int]
     package let waitingByQueueKey: [String: Int]
@@ -26,7 +27,7 @@ package struct RefreshCodeIssuesQueueDebugSnapshot: Codable, Sendable {
 /// A refresh request's terminal outcome. The diagnostic final state is
 /// derived here, so the outcome-to-state mapping cannot drift between the
 /// workflow and the debug snapshot.
-package enum RefreshCodeIssuesOutcome: String, Sendable {
+package enum Outcome: String, Sendable {
     case success
     case timeout
     case queueWaitTimedOut = "queue_wait_timed_out"
@@ -35,7 +36,7 @@ package enum RefreshCodeIssuesOutcome: String, Sendable {
     case upstreamUnavailable = "upstream_unavailable"
     case invalidUpstreamResponse = "invalid_upstream_response"
 
-    package var finalState: RefreshCodeIssuesDebugRequestState {
+    package var finalState: RefreshCodeIssues.RequestState {
         switch self {
         case .success:
             return .completed
@@ -49,7 +50,7 @@ package enum RefreshCodeIssuesOutcome: String, Sendable {
     }
 }
 
-package enum RefreshCodeIssuesDebugRequestState: String, Sendable {
+package enum RequestState: String, Sendable {
     case waitingForPermit = "waiting_for_permit"
     case running
     case completed
@@ -58,7 +59,7 @@ package enum RefreshCodeIssuesDebugRequestState: String, Sendable {
     case failed
 }
 
-package enum RefreshCodeIssuesDebugStep: Sendable, Equatable {
+package enum Step: Sendable, Equatable {
     case waitingForPermit
     case permitAcquired
     case requestTimeoutExhausted
@@ -147,7 +148,7 @@ package enum RefreshCodeIssuesDebugStep: Sendable, Equatable {
     }
 }
 
-package struct RefreshCodeIssuesRequestDebugSnapshot: Codable, Sendable {
+package struct RequestSnapshot: Codable, Sendable {
     package let id: String
     package let sessionID: String
     package let queueKey: String
@@ -190,7 +191,7 @@ package struct RefreshCodeIssuesRequestDebugSnapshot: Codable, Sendable {
     }
 }
 
-package struct RefreshCodeIssuesCompletedRequestDebugSnapshot: Codable, Sendable {
+package struct CompletedRequestSnapshot: Codable, Sendable {
     package let id: String
     package let sessionID: String
     package let queueKey: String
@@ -236,15 +237,15 @@ package struct RefreshCodeIssuesCompletedRequestDebugSnapshot: Codable, Sendable
     }
 }
 
-package struct RefreshCodeIssuesDebugSnapshot: Codable, Sendable {
-    package let queue: RefreshCodeIssuesQueueDebugSnapshot
-    package let activeRequests: [RefreshCodeIssuesRequestDebugSnapshot]
-    package let recentCompletedRequests: [RefreshCodeIssuesCompletedRequestDebugSnapshot]
+package struct DebugSnapshot: Codable, Sendable {
+    package let queue: RefreshCodeIssues.QueueSnapshot
+    package let activeRequests: [RefreshCodeIssues.RequestSnapshot]
+    package let recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot]
 
     package init(
-        queue: RefreshCodeIssuesQueueDebugSnapshot,
-        activeRequests: [RefreshCodeIssuesRequestDebugSnapshot],
-        recentCompletedRequests: [RefreshCodeIssuesCompletedRequestDebugSnapshot]
+        queue: RefreshCodeIssues.QueueSnapshot,
+        activeRequests: [RefreshCodeIssues.RequestSnapshot],
+        recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot]
     ) {
         self.queue = queue
         self.activeRequests = activeRequests
@@ -252,7 +253,7 @@ package struct RefreshCodeIssuesDebugSnapshot: Codable, Sendable {
     }
 }
 
-package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
+package final class DebugState: @unchecked Sendable {
     private struct RequestRecord: Sendable {
         let id: String
         let sessionID: String
@@ -262,15 +263,15 @@ package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
         let mode: String
         let startedAt: Date
         var lastUpdatedAt: Date
-        var state: RefreshCodeIssuesDebugRequestState
-        var step: RefreshCodeIssuesDebugStep
+        var state: RefreshCodeIssues.RequestState
+        var step: RefreshCodeIssues.Step
         var lastQueuePosition: Int?
         var metadata: [String: String]
     }
 
     private struct State {
         var activeRequests: [String: RequestRecord] = [:]
-        var recentCompletedRequests: [RefreshCodeIssuesCompletedRequestDebugSnapshot] = []
+        var recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot] = []
     }
 
     private let lock = NSLock()
@@ -336,8 +337,8 @@ package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
 
     package func updateStep(
         requestID: String,
-        step: RefreshCodeIssuesDebugStep,
-        state overrideState: RefreshCodeIssuesDebugRequestState? = nil,
+        step: RefreshCodeIssues.Step,
+        state overrideState: RefreshCodeIssues.RequestState? = nil,
         metadata: [String: String] = [:]
     ) {
         updateRequest(requestID: requestID) { record, now in
@@ -354,7 +355,7 @@ package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
 
     package func finishRequest(
         requestID: String,
-        outcome: RefreshCodeIssuesOutcome,
+        outcome: RefreshCodeIssues.Outcome,
         metadata: [String: String] = [:]
     ) {
         let now = clock.now()
@@ -368,7 +369,7 @@ package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
         for (key, value) in metadata {
             record.metadata[key] = value
         }
-        let completed = RefreshCodeIssuesCompletedRequestDebugSnapshot(
+        let completed = RefreshCodeIssues.CompletedRequestSnapshot(
             id: record.id,
             sessionID: record.sessionID,
             queueKey: record.queueKey,
@@ -392,7 +393,7 @@ package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
         lock.unlock()
     }
 
-    package func snapshot() -> RefreshCodeIssuesDebugSnapshot {
+    package func snapshot() -> RefreshCodeIssues.DebugSnapshot {
         lock.lock()
         let activeRecords = Array(state.activeRequests.values)
         let recentCompleted = state.recentCompletedRequests
@@ -416,7 +417,7 @@ package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
                 return lhs.startedAt < rhs.startedAt
             }
             .map { record in
-                RefreshCodeIssuesRequestDebugSnapshot(
+                RefreshCodeIssues.RequestSnapshot(
                     id: record.id,
                     sessionID: record.sessionID,
                     queueKey: record.queueKey,
@@ -431,14 +432,14 @@ package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
                     metadata: record.metadata
                 )
             }
-        let queue = RefreshCodeIssuesQueueDebugSnapshot(
+        let queue = RefreshCodeIssues.QueueSnapshot(
             defaultRequestTimeoutSeconds: defaultRequestTimeoutSeconds,
             activeByQueueKey: activeByQueueKey,
             waitingByQueueKey: waitingByQueueKey,
-            activeRequestCount: activeRequests.filter { $0.state == RefreshCodeIssuesDebugRequestState.running.rawValue }.count,
-            waitingRequestCount: activeRequests.filter { $0.state != RefreshCodeIssuesDebugRequestState.running.rawValue }.count
+            activeRequestCount: activeRequests.filter { $0.state == RefreshCodeIssues.RequestState.running.rawValue }.count,
+            waitingRequestCount: activeRequests.filter { $0.state != RefreshCodeIssues.RequestState.running.rawValue }.count
         )
-        return RefreshCodeIssuesDebugSnapshot(
+        return RefreshCodeIssues.DebugSnapshot(
             queue: queue,
             activeRequests: activeRequests,
             recentCompletedRequests: recentCompleted
@@ -464,5 +465,6 @@ package final class RefreshCodeIssuesDebugState: @unchecked Sendable {
         mutate(&record, now)
         state.activeRequests[requestID] = record
         lock.unlock()
+    }
     }
 }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesPathMatcher.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesPathMatcher.swift
@@ -1,7 +1,8 @@
 import Foundation
 import ProxyCore
 
-package enum RefreshCodeIssuesPathMatcher {
+extension RefreshCodeIssues {
+    package enum PathMatcher {
     package static func matches(
         issuePath: String,
         resolvedFilePath: String,
@@ -99,5 +100,6 @@ package enum RefreshCodeIssuesPathMatcher {
             }
             currentURL = parentURL
         }
+    }
     }
 }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesTargetResolver.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesTargetResolver.swift
@@ -3,21 +3,22 @@ import NIO
 import ProxyCore
 import ProxyXcodeSupport
 
-package struct RefreshCodeIssuesResolvedTarget: Sendable, Equatable {
-    package let workspacePath: String
-    package let workspaceRoot: String
-    package let resolvedFilePath: String
-    package let workspaceRelativePath: String
-}
+extension RefreshCodeIssues {
+    package struct ResolvedTarget: Sendable, Equatable {
+        package let workspacePath: String
+        package let workspaceRoot: String
+        package let resolvedFilePath: String
+        package let workspaceRelativePath: String
+    }
 
-package struct RefreshCodeIssuesTargetResolution: Sendable, Equatable {
-    package let target: RefreshCodeIssuesResolvedTarget?
-    package let workspacePath: String?
-    package let resolvedFilePath: String?
-    package let failureReason: String?
-}
+    package struct TargetResolution: Sendable, Equatable {
+        package let target: RefreshCodeIssues.ResolvedTarget?
+        package let workspacePath: String?
+        package let resolvedFilePath: String?
+        package let failureReason: String?
+    }
 
-package actor RefreshCodeIssuesTargetResolver {
+    package actor TargetResolver {
     package typealias WindowsProvider =
         @Sendable (_ sessionID: String, _ eventLoop: EventLoop) async throws -> [XcodeWindowInfo]?
 
@@ -39,9 +40,9 @@ package actor RefreshCodeIssuesTargetResolver {
         sessionID: String,
         eventLoop: EventLoop,
         windowsProvider: WindowsProvider
-    ) async throws -> RefreshCodeIssuesTargetResolution {
+    ) async throws -> RefreshCodeIssues.TargetResolution {
         guard let tabIdentifier, tabIdentifier.isEmpty == false else {
-            return RefreshCodeIssuesTargetResolution(
+            return RefreshCodeIssues.TargetResolution(
                 target: nil,
                 workspacePath: nil,
                 resolvedFilePath: nil,
@@ -49,7 +50,7 @@ package actor RefreshCodeIssuesTargetResolver {
             )
         }
         guard let filePath, filePath.isEmpty == false else {
-            return RefreshCodeIssuesTargetResolution(
+            return RefreshCodeIssues.TargetResolution(
                 target: nil,
                 workspacePath: nil,
                 resolvedFilePath: nil,
@@ -64,7 +65,7 @@ package actor RefreshCodeIssuesTargetResolver {
             windowsProvider: windowsProvider
         )
         guard let workspacePath else {
-            return RefreshCodeIssuesTargetResolution(
+            return RefreshCodeIssues.TargetResolution(
                 target: nil,
                 workspacePath: nil,
                 resolvedFilePath: nil,
@@ -78,7 +79,7 @@ package actor RefreshCodeIssuesTargetResolver {
             workspaceRoot: workspaceRoot,
             requestedFilePath: filePath
         ) else {
-            return RefreshCodeIssuesTargetResolution(
+            return RefreshCodeIssues.TargetResolution(
                 target: nil,
                 workspacePath: workspacePath,
                 resolvedFilePath: nil,
@@ -89,7 +90,7 @@ package actor RefreshCodeIssuesTargetResolver {
             for: resolvedFilePath,
             within: workspaceRoot
         ) else {
-            return RefreshCodeIssuesTargetResolution(
+            return RefreshCodeIssues.TargetResolution(
                 target: nil,
                 workspacePath: workspacePath,
                 resolvedFilePath: resolvedFilePath,
@@ -97,8 +98,8 @@ package actor RefreshCodeIssuesTargetResolver {
             )
         }
 
-        return RefreshCodeIssuesTargetResolution(
-            target: RefreshCodeIssuesResolvedTarget(
+        return RefreshCodeIssues.TargetResolution(
+            target: RefreshCodeIssues.ResolvedTarget(
                 workspacePath: workspacePath,
                 workspaceRoot: workspaceRoot,
                 resolvedFilePath: resolvedFilePath,
@@ -322,5 +323,6 @@ package actor RefreshCodeIssuesTargetResolver {
             score += 1
         }
         return score
+    }
     }
 }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesToolsListRewriter.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesToolsListRewriter.swift
@@ -2,10 +2,11 @@ import Foundation
 import ProxyCore
 import ProxyMCP
 
-package enum RefreshCodeIssuesToolsListRewriter {
+extension RefreshCodeIssues {
+    package enum ToolsListRewriter {
     package static func rewriteResult(
         _ result: JSONValue,
-        mode: RefreshCodeIssuesMode,
+        mode: ProxyConfig.RefreshCodeIssuesMode,
         hiddenToolNames: Set<String> = []
     ) -> JSONValue {
         guard case .object(var resultObject) = result,
@@ -24,7 +25,7 @@ package enum RefreshCodeIssuesToolsListRewriter {
             guard hiddenToolNames.contains(name) == false else {
                 return nil
             }
-            guard name == RefreshCodeIssuesRequest.toolName else {
+            guard name == RefreshCodeIssues.Request.toolName else {
                 return toolValue
             }
             toolObject["description"] = .string(description(for: mode))
@@ -38,7 +39,7 @@ package enum RefreshCodeIssuesToolsListRewriter {
         _ responseData: Data,
         method: String? = nil,
         responseMethodsByIDKey: [String: String] = [:],
-        mode: RefreshCodeIssuesMode,
+        mode: ProxyConfig.RefreshCodeIssuesMode,
         hiddenToolNames: Set<String> = []
     ) -> Data {
         guard let payload = try? JSONSerialization.jsonObject(with: responseData, options: []) else {
@@ -106,7 +107,7 @@ package enum RefreshCodeIssuesToolsListRewriter {
         if let explicitMethod {
             return explicitMethod
         }
-        guard let responseID = JSONRPCMessageInspector.responseID(from: object) else {
+        guard let responseID = JSONRPC.Message.Inspector.responseID(from: object) else {
             return nil
         }
         return responseMethodsByIDKey[responseID.key]
@@ -114,7 +115,7 @@ package enum RefreshCodeIssuesToolsListRewriter {
 
     private static func rewriteResponseObject(
         _ object: [String: Any],
-        mode: RefreshCodeIssuesMode,
+        mode: ProxyConfig.RefreshCodeIssuesMode,
         hiddenToolNames: Set<String>
     ) -> [String: Any]? {
         guard let result = object["result"],
@@ -137,7 +138,7 @@ package enum RefreshCodeIssuesToolsListRewriter {
         return rewrittenObject
     }
 
-    private static func description(for mode: RefreshCodeIssuesMode) -> String {
+    private static func description(for mode: ProxyConfig.RefreshCodeIssuesMode) -> String {
         switch mode {
         case .proxy:
             return """
@@ -148,5 +149,6 @@ package enum RefreshCodeIssuesToolsListRewriter {
             Returns file-scoped diagnostics for a source file. This proxy is configured to pass through to Xcode's native live diagnostics path.
             """
         }
+    }
     }
 }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesWorkflow+Forwarding.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesWorkflow+Forwarding.swift
@@ -5,13 +5,13 @@ import ProxyCore
 import ProxyMCP
 import ProxyXcodeSupport
 
-extension RefreshCodeIssuesWorkflow {
+extension RefreshCodeIssues.Workflow {
     /// Every proxy-mode bail-out funnels through here: record the debug
     /// step, log the reason, and return nil so the caller falls back to a
     /// plain upstream refresh.
     private func fallBackToUpstream(
         reason: String,
-        state: RefreshCodeIssuesDebugRequestState? = nil,
+        state: RefreshCodeIssues.RequestState? = nil,
         extraMetadata: [String: String] = [:],
         debugRequestID: String,
         logMetadata: Logger.Metadata
@@ -37,9 +37,9 @@ extension RefreshCodeIssuesWorkflow {
     }
 
     package func runProxyRefresh(
-        refreshRequest: RefreshCodeIssuesRequest,
+        refreshRequest: RefreshCodeIssues.Request,
         sessionID: String,
-        requestIDs: [RPCID],
+        requestIDs: [JSONRPC.ID],
         requestIsBatch: Bool,
         eventLoop: EventLoop,
         baseMetadata: Logger.Metadata,
@@ -246,15 +246,15 @@ extension RefreshCodeIssuesWorkflow {
     package func runForwardAttempts(
         bodyData: Data,
         sessionID: String,
-        requestIDs: [RPCID],
+        requestIDs: [JSONRPC.ID],
         requestIsBatch: Bool,
         eventLoop: EventLoop,
         baseMetadata: Logger.Metadata,
         executionBudget: ExecutionBudget,
         debugRequestID: String,
         forwarder: Forwarder
-    ) async -> RefreshForwardAttemptResult {
-        var finalResult: RefreshForwardAttemptResult = .invalidRequest
+    ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult {
+        var finalResult: RefreshCodeIssues.Workflow.ForwardAttemptResult = .invalidRequest
 
         resultLoop: for attemptIndex in 0...Self.retryDelaysNanos.count {
             let attempt = attemptIndex + 1

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesWorkflow+Helpers.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesWorkflow+Helpers.swift
@@ -5,9 +5,9 @@ import ProxyCore
 import ProxyMCP
 import ProxyXcodeSupport
 
-extension RefreshCodeIssuesWorkflow {
+extension RefreshCodeIssues.Workflow {
     package static func makeToolResponseData(
-        id: RPCID,
+        id: JSONRPC.ID,
         result: [String: Any],
         forceBatchArray: Bool
     ) -> Data? {
@@ -39,7 +39,7 @@ extension RefreshCodeIssuesWorkflow {
 
         let filteredIssues = issues.filter { issue in
             guard let path = issue["path"] as? String else { return false }
-            return RefreshCodeIssuesPathMatcher.matches(
+            return RefreshCodeIssues.PathMatcher.matches(
                 issuePath: path,
                 resolvedFilePath: resolvedFilePath
             )
@@ -106,8 +106,8 @@ extension RefreshCodeIssuesWorkflow {
     }
 
     package static func debugOutcome(
-        for result: RefreshForwardAttemptResult
-    ) -> RefreshCodeIssuesOutcome {
+        for result: RefreshCodeIssues.Workflow.ForwardAttemptResult
+    ) -> RefreshCodeIssues.Outcome {
         switch result {
         case .success:
             return .success
@@ -153,7 +153,7 @@ extension RefreshCodeIssuesWorkflow {
     }
 
     package static func throwIfCancelled(
-        debugState: RefreshCodeIssuesDebugState,
+        debugState: RefreshCodeIssues.DebugState,
         requestID: String
     ) throws {
         guard !Task.isCancelled else {

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesWorkflow.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesWorkflow.swift
@@ -5,7 +5,10 @@ import ProxyCore
 import ProxyMCP
 import ProxyXcodeSupport
 
-package struct RefreshCodeIssuesRequest: Sendable {
+package enum RefreshCodeIssues {}
+
+extension RefreshCodeIssues {
+    package struct Request: Sendable {
     package static let toolName = "XcodeRefreshCodeIssuesInFile"
     package static let globalQueueKey = "__global__"
 
@@ -53,25 +56,27 @@ package struct RefreshCodeIssuesRequest: Sendable {
         }
         return tabIdentifier
     }
+    }
 }
 
-package enum RefreshForwardAttemptResult: Sendable {
-    case success(Data)
-    case timeout(responseIDs: [RPCID], isBatch: Bool)
-    case upstreamUnavailable(responseIDs: [RPCID], isBatch: Bool)
-    case cancelled(responseIDs: [RPCID], isBatch: Bool)
-    case invalidRequest
-    case invalidUpstreamResponse
-}
+extension RefreshCodeIssues {
+    package struct Workflow {
+        package enum ForwardAttemptResult: Sendable {
+            case success(Data)
+            case timeout(responseIDs: [JSONRPC.ID], isBatch: Bool)
+            case upstreamUnavailable(responseIDs: [JSONRPC.ID], isBatch: Bool)
+            case cancelled(responseIDs: [JSONRPC.ID], isBatch: Bool)
+            case invalidRequest
+            case invalidUpstreamResponse
+        }
 
-package enum RefreshInternalToolResult {
-    case success([String: Any])
-    case timeout
-    case cancelled
-    case unavailable
-}
+        package enum InternalToolResult {
+            case success([String: Any])
+            case timeout
+            case cancelled
+            case unavailable
+        }
 
-package struct RefreshCodeIssuesWorkflow {
     package typealias WindowsProvider =
         @Sendable (
             _ sessionID: String,
@@ -88,17 +93,17 @@ package struct RefreshCodeIssuesWorkflow {
             _ eventLoop: EventLoop,
             _ upstreamIndexOverride: Int?,
             _ requestTimeoutOverride: TimeAmount?
-        ) async -> RefreshInternalToolResult
+        ) async -> RefreshCodeIssues.Workflow.InternalToolResult
     package typealias Forwarder =
         @Sendable (
             _ bodyData: Data,
             _ sessionID: String,
-            _ requestIDs: [RPCID],
+            _ requestIDs: [JSONRPC.ID],
             _ requestIsBatch: Bool,
             _ shouldRequeueLeaseOnRetryableFailure: @Sendable () -> Bool,
             _ eventLoop: EventLoop,
             _ requestTimeoutOverride: TimeAmount?
-        ) async -> RefreshForwardAttemptResult
+        ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult
 
     package static let retryDelaysNanos: [UInt64] = [
         200_000_000,
@@ -201,22 +206,22 @@ package struct RefreshCodeIssuesWorkflow {
         }
     }
 
-    package let mode: RefreshCodeIssuesMode
+    package let mode: ProxyConfig.RefreshCodeIssuesMode
     package let requestTimeout: TimeInterval
-    package let coordinator: RefreshCodeIssuesCoordinator
-    package let targetResolver: RefreshCodeIssuesTargetResolver
-    package let debugState: RefreshCodeIssuesDebugState
+    package let coordinator: RefreshCodeIssues.Coordinator
+    package let targetResolver: RefreshCodeIssues.TargetResolver
+    package let debugState: RefreshCodeIssues.DebugState
     package let windowLookupTimeoutSeconds: TimeInterval
     package let navigatorIssuesTimeoutSeconds: TimeInterval
     package let clock: ClockClient
     package let logger: Logger
 
     package init(
-        mode: RefreshCodeIssuesMode,
+        mode: ProxyConfig.RefreshCodeIssuesMode,
         requestTimeout: TimeInterval,
-        coordinator: RefreshCodeIssuesCoordinator,
-        targetResolver: RefreshCodeIssuesTargetResolver,
-        debugState: RefreshCodeIssuesDebugState,
+        coordinator: RefreshCodeIssues.Coordinator,
+        targetResolver: RefreshCodeIssues.TargetResolver,
+        debugState: RefreshCodeIssues.DebugState,
         windowLookupTimeout: TimeInterval = 5,
         navigatorIssuesTimeout: TimeInterval = 15,
         clock: ClockClient = .liveValue,
@@ -234,10 +239,10 @@ package struct RefreshCodeIssuesWorkflow {
     }
 
     package func run(
-        refreshRequest: RefreshCodeIssuesRequest,
+        refreshRequest: RefreshCodeIssues.Request,
         bodyData: Data,
         sessionID: String,
-        requestIDs: [RPCID],
+        requestIDs: [JSONRPC.ID],
         requestIsBatch: Bool,
         requestTimeoutOverride: TimeAmount? = nil,
         eventLoop: EventLoop,
@@ -245,7 +250,7 @@ package struct RefreshCodeIssuesWorkflow {
         internalUpstreamChooser: @escaping InternalUpstreamChooser,
         internalToolCaller: @escaping InternalToolCaller,
         forwarder: @escaping Forwarder
-    ) async -> RefreshForwardAttemptResult {
+    ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult {
         let executionBudget = ExecutionBudget(
             requestTimeout: requestTimeout,
             requestTimeoutOverride: requestTimeoutOverride,
@@ -340,7 +345,7 @@ package struct RefreshCodeIssuesWorkflow {
                     ]
                 )
 
-                let result: RefreshForwardAttemptResult
+                let result: RefreshCodeIssues.Workflow.ForwardAttemptResult
                 if mode == .proxy,
                     let proxyResponseData = try await runProxyRefresh(
                         refreshRequest: refreshRequest,
@@ -385,7 +390,7 @@ package struct RefreshCodeIssuesWorkflow {
                 )
                 return result
             }
-        } catch RefreshCodeIssuesCoordinator.AcquireError.queueWaitTimedOut {
+        } catch RefreshCodeIssues.Coordinator.AcquireError.queueWaitTimedOut {
             logger.warning(
                 "Refresh code issues request timed out while waiting for permit",
                 metadata: [
@@ -438,4 +443,5 @@ package struct RefreshCodeIssuesWorkflow {
         }
     }
 
+    }
 }

--- a/Sources/ProxyXcodeSupport/PermissionDialogAXClient.swift
+++ b/Sources/ProxyXcodeSupport/PermissionDialogAXClient.swift
@@ -4,322 +4,323 @@ import Foundation
 import Logging
 import ProxyCore
 
-package protocol XcodePermissionDialogAXAccessing: Sendable {
-    func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialogAccessibilityStatus
-    func runningXcodeProcessIDs() -> [pid_t]
-    func openWindows(for processID: pid_t) throws -> [XcodePermissionDialogAXWindow]
-    func pressDefaultButton(in window: XcodePermissionDialogAXWindow) throws
-}
-
-package final class XcodePermissionDialogAXWindow {
-    package let processID: pid_t
-    package let snapshot: XcodePermissionDialogWindowSnapshot
-    private let defaultButton: AXUIElement
-
-    package init(
-        processID: pid_t,
-        snapshot: XcodePermissionDialogWindowSnapshot,
-        defaultButton: AXUIElement
-    ) {
-        self.processID = processID
-        self.snapshot = snapshot
-        self.defaultButton = defaultButton
+extension XcodePermissionDialog {
+    package protocol AXAccessing: Sendable {
+        func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialog.AccessibilityStatus
+        func runningXcodeProcessIDs() -> [pid_t]
+        func openWindows(for processID: pid_t) throws -> [XcodePermissionDialog.AXWindow]
+        func pressDefaultButton(in window: XcodePermissionDialog.AXWindow) throws
     }
 
-    fileprivate func pressDefaultButton() throws {
-        let error = AXUIElementPerformAction(defaultButton, kAXPressAction as CFString)
-        guard error == .success else {
-            throw XcodePermissionDialogAXError.performActionFailed(error)
+    package final class AXWindow {
+        package let processID: pid_t
+        package let snapshot: XcodePermissionDialog.WindowSnapshot
+        private let defaultButton: AXUIElement
+
+        package init(
+            processID: pid_t,
+            snapshot: XcodePermissionDialog.WindowSnapshot,
+            defaultButton: AXUIElement
+        ) {
+            self.processID = processID
+            self.snapshot = snapshot
+            self.defaultButton = defaultButton
+        }
+
+        fileprivate func pressDefaultButton() throws {
+            let error = AXUIElementPerformAction(defaultButton, kAXPressAction as CFString)
+            guard error == .success else {
+                throw XcodePermissionDialog.AXError.performActionFailed(error)
+            }
         }
     }
-}
 
-package enum XcodePermissionDialogAXError: Error, CustomStringConvertible {
-    case copyAttributeFailed(attribute: String, error: AXError)
-    case performActionFailed(AXError)
+    package enum AXError: Error, CustomStringConvertible {
+        case copyAttributeFailed(attribute: String, error: ApplicationServices.AXError)
+        case performActionFailed(ApplicationServices.AXError)
 
-    package var description: String {
-        switch self {
-        case .copyAttributeFailed(let attribute, let error):
-            return "AX attribute '\(attribute)' failed: \(error.rawValue)"
-        case .performActionFailed(let error):
-            return "AX action failed: \(error.rawValue)"
+        package var description: String {
+            switch self {
+            case .copyAttributeFailed(let attribute, let error):
+                return "AX attribute '\(attribute)' failed: \(error.rawValue)"
+            case .performActionFailed(let error):
+                return "AX action failed: \(error.rawValue)"
+            }
         }
     }
-}
 
-package enum XcodePermissionDialogAXFailureClassifier {
-    private static let externalViewServiceBundleIdentifier = "com.apple.dt.ExternalViewService"
-    private static let windowsAttribute = kAXWindowsAttribute as String
+    package enum AXFailureClassifier {
+        private static let externalViewServiceBundleIdentifier = "com.apple.dt.ExternalViewService"
+        private static let windowsAttribute = kAXWindowsAttribute as String
 
-    package static func isBenignOpenWindowsFailure(
-        _ error: Error,
-        processBundleIdentifier: String?
-    ) -> Bool {
-        guard processBundleIdentifier == externalViewServiceBundleIdentifier else {
-            return false
+        package static func isBenignOpenWindowsFailure(
+            _ error: Error,
+            processBundleIdentifier: String?
+        ) -> Bool {
+            guard processBundleIdentifier == externalViewServiceBundleIdentifier else {
+                return false
+            }
+            guard let error = error as? XcodePermissionDialog.AXError else {
+                return false
+            }
+            guard case .copyAttributeFailed(let attribute, let axError) = error else {
+                return false
+            }
+            return attribute == windowsAttribute && axError == .cannotComplete
         }
-        guard let error = error as? XcodePermissionDialogAXError else {
-            return false
-        }
-        guard case .copyAttributeFailed(let attribute, let axError) = error else {
-            return false
-        }
-        return attribute == windowsAttribute && axError == .cannotComplete
     }
-}
 
-package struct LiveXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessing {
-    private let maxDescendantCount = 128
+    package struct AXClient: XcodePermissionDialog.AXAccessing {
+        private let maxDescendantCount = 128
 
-    package init() {}
+        package init() {}
 
-    package func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialogAccessibilityStatus {
-        if promptIfNeeded {
-            let options: NSDictionary = [
-                "AXTrustedCheckOptionPrompt" as NSString: true
+        package func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialog.AccessibilityStatus {
+            if promptIfNeeded {
+                let options: NSDictionary = [
+                    "AXTrustedCheckOptionPrompt" as NSString: true
+                ]
+                return AXIsProcessTrustedWithOptions(options) ? .trusted : .untrusted
+            }
+            return AXIsProcessTrusted() ? .trusted : .untrusted
+        }
+
+        package func runningXcodeProcessIDs() -> [pid_t] {
+            let bundleIdentifiers: Set<String> = [
+                "com.apple.dt.Xcode",
+                "com.apple.dt.ExternalViewService",
+                "com.apple.dt.Xcode.DeveloperSystemPolicyService",
             ]
-            return AXIsProcessTrustedWithOptions(options) ? .trusted : .untrusted
-        }
-        return AXIsProcessTrusted() ? .trusted : .untrusted
-    }
-
-    package func runningXcodeProcessIDs() -> [pid_t] {
-        let bundleIdentifiers: Set<String> = [
-            "com.apple.dt.Xcode",
-            "com.apple.dt.ExternalViewService",
-            "com.apple.dt.Xcode.DeveloperSystemPolicyService",
-        ]
-        var processIDs = Set(NSWorkspace.shared.runningApplications.compactMap { application -> pid_t? in
-            guard let bundleIdentifier = application.bundleIdentifier else {
-                return nil
-            }
-            guard bundleIdentifiers.contains(bundleIdentifier), application.isTerminated == false else {
-                return nil
-            }
-            return application.processIdentifier
-        })
+            var processIDs = Set(NSWorkspace.shared.runningApplications.compactMap { application -> pid_t? in
+                guard let bundleIdentifier = application.bundleIdentifier else {
+                    return nil
+                }
+                guard bundleIdentifiers.contains(bundleIdentifier), application.isTerminated == false else {
+                    return nil
+                }
+                return application.processIdentifier
+            })
         processIDs.formUnion(ProcessEnumeration.processIDs(named: "Xcode"))
         return processIDs.sorted()
     }
 
-
-    package func openWindows(for processID: pid_t) throws -> [XcodePermissionDialogAXWindow] {
+    package func openWindows(for processID: pid_t) throws -> [XcodePermissionDialog.AXWindow] {
         let app = AXUIElementCreateApplication(processID)
         return try copyElementArray(attribute: kAXWindowsAttribute as CFString, from: app).compactMap { window in
-            try makeWindow(processID: processID, window: window)
-        }
-    }
-
-    package func pressDefaultButton(in window: XcodePermissionDialogAXWindow) throws {
-        try window.pressDefaultButton()
-    }
-
-    private func makeWindow(
-        processID: pid_t,
-        window: AXUIElement
-    ) throws -> XcodePermissionDialogAXWindow? {
-        let role = copyString(attribute: kAXRoleAttribute as CFString, from: window)
-        if let role, role != kAXWindowRole as String {
-            return nil
-        }
-
-        let subrole = copyString(attribute: kAXSubroleAttribute as CFString, from: window)
-        if let subrole,
-           subrole != kAXDialogSubrole as String,
-           subrole != "AXSystemDialog" {
-            return nil
-        }
-
-        let isModal = copyBool(attribute: kAXModalAttribute as CFString, from: window) ?? false
-        guard isModal else {
-            return nil
-        }
-
-        let isMinimized = copyBool(attribute: kAXMinimizedAttribute as CFString, from: window)
-        guard isMinimized != true else {
-            return nil
-        }
-
-        let isMain = copyBool(attribute: kAXMainAttribute as CFString, from: window)
-        let document = copyString(attribute: kAXDocumentAttribute as CFString, from: window)
-        let hasProxy = copyElement(attribute: kAXProxyAttribute as CFString, from: window) != nil
-        if isMain == true && (hasNonEmptyText(document) || hasProxy) {
-            return nil
-        }
-
-        let children = (try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: window)) ?? []
-        guard let defaultButton = copyElement(attribute: kAXDefaultButtonAttribute as CFString, from: window)
-            ?? fallbackAllowButton(in: window)
-        else {
-            return nil
-        }
-        let processBundleIdentifier = NSRunningApplication(processIdentifier: processID)?.bundleIdentifier
-
-        let snapshot = XcodePermissionDialogWindowSnapshot(
-            processBundleIdentifier: processBundleIdentifier,
-            title: copyString(attribute: kAXTitleAttribute as CFString, from: window) ?? "",
-            textValues: collectTextValues(from: window),
-            role: role,
-            subrole: subrole,
-            windowIdentifier: copyString(attribute: kAXIdentifierAttribute as CFString, from: window),
-            isModal: isModal,
-            isMain: isMain,
-            isMinimized: isMinimized,
-            document: document,
-            childCount: children.count,
-            hasProxy: hasProxy,
-            defaultButton: buttonSnapshot(from: defaultButton),
-            cancelButton: copyElement(attribute: kAXCancelButtonAttribute as CFString, from: window)
-                .flatMap(buttonSnapshot(from:))
-        )
-
-        return XcodePermissionDialogAXWindow(
-            processID: processID,
-            snapshot: snapshot,
-            defaultButton: defaultButton
-        )
-    }
-
-    private func fallbackAllowButton(in root: AXUIElement) -> AXUIElement? {
-        var queue: [AXUIElement] = [root]
-        var visited = 0
-
-        while queue.isEmpty == false, visited < maxDescendantCount {
-            let element = queue.removeFirst()
-            visited += 1
-
-            if isAllowButton(element) {
-                return element
+                try makeWindow(processID: processID, window: window)
             }
-            let children = (try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: element)) ?? []
-            queue.append(contentsOf: children)
         }
 
-        return nil
-    }
+        package func pressDefaultButton(in window: XcodePermissionDialog.AXWindow) throws {
+            try window.pressDefaultButton()
+        }
 
-    private func isAllowButton(_ element: AXUIElement) -> Bool {
-        let role = copyString(attribute: kAXRoleAttribute as CFString, from: element)
-        guard role == kAXButtonRole as String else { return false }
-        let title = copyString(attribute: kAXTitleAttribute as CFString, from: element)
-            .flatMap(normalizedButtonText)
-        let identifier = copyString(attribute: kAXIdentifierAttribute as CFString, from: element)
-            .flatMap(normalizedButtonText)
-        return title == "allow"
-            || title == "許可"
-            || identifier == "action-button-1"
-    }
-
-    private func normalizedButtonText(_ value: String) -> String? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.isEmpty == false else { return nil }
-        return trimmed.lowercased()
-    }
-
-    private func hasNonEmptyText(_ value: String?) -> Bool {
-        guard let value else { return false }
-        return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-    }
-
-    private func collectTextValues(from root: AXUIElement) -> [String] {
-        var queue: [AXUIElement] = [root]
-        var values: [String] = []
-        var visited = 0
-
-        while queue.isEmpty == false, visited < maxDescendantCount {
-            let element = queue.removeFirst()
-            visited += 1
-
-            if let title = copyString(attribute: kAXTitleAttribute as CFString, from: element) {
-                values.append(title)
-            }
-            if let value = copyString(attribute: kAXValueAttribute as CFString, from: element) {
-                values.append(value)
-            }
-            if let description = copyString(attribute: kAXDescriptionAttribute as CFString, from: element) {
-                values.append(description)
+        private func makeWindow(
+            processID: pid_t,
+            window: AXUIElement
+        ) throws -> XcodePermissionDialog.AXWindow? {
+            let role = copyString(attribute: kAXRoleAttribute as CFString, from: window)
+            if let role, role != kAXWindowRole as String {
+                return nil
             }
 
-            if let children = try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: element) {
+            let subrole = copyString(attribute: kAXSubroleAttribute as CFString, from: window)
+            if let subrole,
+               subrole != kAXDialogSubrole as String,
+               subrole != "AXSystemDialog" {
+                return nil
+            }
+
+            let isModal = copyBool(attribute: kAXModalAttribute as CFString, from: window) ?? false
+            guard isModal else {
+                return nil
+            }
+
+            let isMinimized = copyBool(attribute: kAXMinimizedAttribute as CFString, from: window)
+            guard isMinimized != true else {
+                return nil
+            }
+
+            let isMain = copyBool(attribute: kAXMainAttribute as CFString, from: window)
+            let document = copyString(attribute: kAXDocumentAttribute as CFString, from: window)
+            let hasProxy = copyElement(attribute: kAXProxyAttribute as CFString, from: window) != nil
+            if isMain == true && (hasNonEmptyText(document) || hasProxy) {
+                return nil
+            }
+
+            let children = (try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: window)) ?? []
+            guard let defaultButton = copyElement(attribute: kAXDefaultButtonAttribute as CFString, from: window)
+                ?? fallbackAllowButton(in: window)
+            else {
+                return nil
+            }
+            let processBundleIdentifier = NSRunningApplication(processIdentifier: processID)?.bundleIdentifier
+
+            let snapshot = XcodePermissionDialog.WindowSnapshot(
+                processBundleIdentifier: processBundleIdentifier,
+                title: copyString(attribute: kAXTitleAttribute as CFString, from: window) ?? "",
+                textValues: collectTextValues(from: window),
+                role: role,
+                subrole: subrole,
+                windowIdentifier: copyString(attribute: kAXIdentifierAttribute as CFString, from: window),
+                isModal: isModal,
+                isMain: isMain,
+                isMinimized: isMinimized,
+                document: document,
+                childCount: children.count,
+                hasProxy: hasProxy,
+                defaultButton: buttonSnapshot(from: defaultButton),
+                cancelButton: copyElement(attribute: kAXCancelButtonAttribute as CFString, from: window)
+                    .flatMap(buttonSnapshot(from:))
+            )
+
+            return XcodePermissionDialog.AXWindow(
+                processID: processID,
+                snapshot: snapshot,
+                defaultButton: defaultButton
+            )
+        }
+
+        private func fallbackAllowButton(in root: AXUIElement) -> AXUIElement? {
+            var queue: [AXUIElement] = [root]
+            var visited = 0
+
+            while queue.isEmpty == false, visited < maxDescendantCount {
+                let element = queue.removeFirst()
+                visited += 1
+
+                if isAllowButton(element) {
+                    return element
+                }
+                let children = (try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: element)) ?? []
                 queue.append(contentsOf: children)
             }
+
+            return nil
         }
 
-        var seen = Set<String>()
-        return values.filter { value in
+        private func isAllowButton(_ element: AXUIElement) -> Bool {
+            let role = copyString(attribute: kAXRoleAttribute as CFString, from: element)
+            guard role == kAXButtonRole as String else { return false }
+            let title = copyString(attribute: kAXTitleAttribute as CFString, from: element)
+                .flatMap(normalizedButtonText)
+            let identifier = copyString(attribute: kAXIdentifierAttribute as CFString, from: element)
+                .flatMap(normalizedButtonText)
+            return title == "allow"
+                || title == "許可"
+                || identifier == "action-button-1"
+        }
+
+        private func normalizedButtonText(_ value: String) -> String? {
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard trimmed.isEmpty == false else {
-                return false
+            guard trimmed.isEmpty == false else { return nil }
+            return trimmed.lowercased()
+        }
+
+        private func hasNonEmptyText(_ value: String?) -> Bool {
+            guard let value else { return false }
+            return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        }
+
+        private func collectTextValues(from root: AXUIElement) -> [String] {
+            var queue: [AXUIElement] = [root]
+            var values: [String] = []
+            var visited = 0
+
+            while queue.isEmpty == false, visited < maxDescendantCount {
+                let element = queue.removeFirst()
+                visited += 1
+
+                if let title = copyString(attribute: kAXTitleAttribute as CFString, from: element) {
+                    values.append(title)
+                }
+                if let value = copyString(attribute: kAXValueAttribute as CFString, from: element) {
+                    values.append(value)
+                }
+                if let description = copyString(attribute: kAXDescriptionAttribute as CFString, from: element) {
+                    values.append(description)
+                }
+
+                if let children = try? copyElementArray(attribute: kAXChildrenAttribute as CFString, from: element) {
+                    queue.append(contentsOf: children)
+                }
             }
-            return seen.insert(trimmed).inserted
-        }
-    }
 
-    private func buttonSnapshot(from element: AXUIElement) -> XcodePermissionDialogButtonSnapshot {
-        XcodePermissionDialogButtonSnapshot(
-            title: copyString(attribute: kAXTitleAttribute as CFString, from: element)
-                ?? copyString(attribute: kAXDescriptionAttribute as CFString, from: element)
-                ?? copyString(attribute: kAXValueAttribute as CFString, from: element),
-            role: copyString(attribute: kAXRoleAttribute as CFString, from: element),
-            subrole: copyString(attribute: kAXSubroleAttribute as CFString, from: element),
-            identifier: copyString(attribute: kAXIdentifierAttribute as CFString, from: element)
-        )
-    }
-
-    private func copyString(attribute: CFString, from element: AXUIElement) -> String? {
-        guard let value = try? copyAttribute(attribute: attribute, from: element) else {
-            return nil
+            var seen = Set<String>()
+            return values.filter { value in
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard trimmed.isEmpty == false else {
+                    return false
+                }
+                return seen.insert(trimmed).inserted
+            }
         }
-        return value as? String
-    }
 
-    private func copyBool(attribute: CFString, from element: AXUIElement) -> Bool? {
-        guard let value = try? copyAttribute(attribute: attribute, from: element) else {
-            return nil
+        private func buttonSnapshot(from element: AXUIElement) -> XcodePermissionDialog.ButtonSnapshot {
+            XcodePermissionDialog.ButtonSnapshot(
+                title: copyString(attribute: kAXTitleAttribute as CFString, from: element)
+                    ?? copyString(attribute: kAXDescriptionAttribute as CFString, from: element)
+                    ?? copyString(attribute: kAXValueAttribute as CFString, from: element),
+                role: copyString(attribute: kAXRoleAttribute as CFString, from: element),
+                subrole: copyString(attribute: kAXSubroleAttribute as CFString, from: element),
+                identifier: copyString(attribute: kAXIdentifierAttribute as CFString, from: element)
+            )
         }
-        return value as? Bool
-    }
 
-    private func copyElement(attribute: CFString, from element: AXUIElement) -> AXUIElement? {
-        guard let value = try? copyAttribute(attribute: attribute, from: element) else {
-            return nil
+        private func copyString(attribute: CFString, from element: AXUIElement) -> String? {
+            guard let value = try? copyAttribute(attribute: attribute, from: element) else {
+                return nil
+            }
+            return value as? String
         }
-        guard CFGetTypeID(value) == AXUIElementGetTypeID() else {
-            return nil
-        }
-        return unsafe unsafeDowncast(value, to: AXUIElement.self)
-    }
 
-    private func copyElementArray(attribute: CFString, from element: AXUIElement) throws -> [AXUIElement] {
-        guard let value = try copyAttribute(attribute: attribute, from: element) else {
+        private func copyBool(attribute: CFString, from element: AXUIElement) -> Bool? {
+            guard let value = try? copyAttribute(attribute: attribute, from: element) else {
+                return nil
+            }
+            return value as? Bool
+        }
+
+        private func copyElement(attribute: CFString, from element: AXUIElement) -> AXUIElement? {
+            guard let value = try? copyAttribute(attribute: attribute, from: element) else {
+                return nil
+            }
+            guard CFGetTypeID(value) == AXUIElementGetTypeID() else {
+                return nil
+            }
+            return unsafe unsafeDowncast(value, to: AXUIElement.self)
+        }
+
+        private func copyElementArray(attribute: CFString, from element: AXUIElement) throws -> [AXUIElement] {
+            guard let value = try copyAttribute(attribute: attribute, from: element) else {
+                return []
+            }
+            if let elements = value as? [AXUIElement] {
+                return elements
+            }
+            if let array = value as? [AnyObject] {
+                return array.compactMap { candidate in
+                    guard CFGetTypeID(candidate) == AXUIElementGetTypeID() else {
+                        return nil
+                    }
+                    return unsafe unsafeDowncast(candidate, to: AXUIElement.self)
+                }
+            }
             return []
         }
-        if let elements = value as? [AXUIElement] {
-            return elements
-        }
-        if let array = value as? [AnyObject] {
-            return array.compactMap { candidate in
-                guard CFGetTypeID(candidate) == AXUIElementGetTypeID() else {
-                    return nil
-                }
-                return unsafe unsafeDowncast(candidate, to: AXUIElement.self)
-            }
-        }
-        return []
-    }
 
-    private func copyAttribute(attribute: CFString, from element: AXUIElement) throws -> CFTypeRef? {
-        var value: CFTypeRef?
-        let error = unsafe AXUIElementCopyAttributeValue(element, attribute, &value)
-        switch error {
-        case .success, .noValue:
-            return value
-        default:
-            throw XcodePermissionDialogAXError.copyAttributeFailed(
-                attribute: attribute as String,
-                error: error
-            )
+        private func copyAttribute(attribute: CFString, from element: AXUIElement) throws -> CFTypeRef? {
+            var value: CFTypeRef?
+            let error = unsafe AXUIElementCopyAttributeValue(element, attribute, &value)
+            switch error {
+            case .success, .noValue:
+                return value
+            default:
+                throw XcodePermissionDialog.AXError.copyAttributeFailed(
+                    attribute: attribute as String,
+                    error: error
+                )
+            }
         }
     }
 }

--- a/Sources/ProxyXcodeSupport/PermissionDialogMatcher.swift
+++ b/Sources/ProxyXcodeSupport/PermissionDialogMatcher.swift
@@ -4,7 +4,8 @@ import Foundation
 import Logging
 import ProxyCore
 
-package enum XcodePermissionDialogMatcher {
+extension XcodePermissionDialog {
+    package enum Matcher {
     private static let allowedProcessBundleIdentifiers = normalizedCandidates([
         "com.apple.dt.Xcode",
         "com.apple.dt.ExternalViewService",
@@ -19,12 +20,12 @@ package enum XcodePermissionDialogMatcher {
     ])
 
     package static func decision(
-        for snapshot: XcodePermissionDialogWindowSnapshot,
+        for snapshot: XcodePermissionDialog.WindowSnapshot,
         processID: pid_t,
         agentPathCandidates: Set<String> = [],
         assistantNameCandidates: Set<String>,
         serverProcessIDCandidates: Set<pid_t> = [ProcessInfo.processInfo.processIdentifier]
-    ) -> XcodePermissionDialogMatchDecision? {
+    ) -> XcodePermissionDialog.MatchDecision? {
         guard passesStructuralChecks(snapshot) else {
             return nil
         }
@@ -44,14 +45,14 @@ package enum XcodePermissionDialogMatcher {
             return nil
         }
 
-        return XcodePermissionDialogMatchDecision(
+        return XcodePermissionDialog.MatchDecision(
             fingerprint: fingerprint(for: snapshot, processID: processID),
             defaultButtonTitle: defaultButtonDescription
         )
     }
 
     package static func fingerprint(
-        for snapshot: XcodePermissionDialogWindowSnapshot,
+        for snapshot: XcodePermissionDialog.WindowSnapshot,
         processID: pid_t
     ) -> String {
         let textFingerprint = normalizedTextNodes(for: snapshot).joined(separator: "\u{1F}")
@@ -68,7 +69,7 @@ package enum XcodePermissionDialogMatcher {
         ].joined(separator: "|")
     }
 
-    package static func passesStructuralChecks(_ snapshot: XcodePermissionDialogWindowSnapshot) -> Bool {
+    package static func passesStructuralChecks(_ snapshot: XcodePermissionDialog.WindowSnapshot) -> Bool {
         guard
             let normalizedBundleIdentifier = normalizedText(snapshot.processBundleIdentifier),
             allowedProcessBundleIdentifiers.contains(normalizedBundleIdentifier)
@@ -98,12 +99,12 @@ package enum XcodePermissionDialogMatcher {
         return true
     }
 
-    private static func looksLikeNormalWorkspaceWindow(_ snapshot: XcodePermissionDialogWindowSnapshot) -> Bool {
+    private static func looksLikeNormalWorkspaceWindow(_ snapshot: XcodePermissionDialog.WindowSnapshot) -> Bool {
         let hasDocument = normalizedText(snapshot.document) != nil
         return snapshot.isMain == true && (hasDocument || snapshot.hasProxy)
     }
 
-    private static func normalizedTextNodes(for snapshot: XcodePermissionDialogWindowSnapshot) -> [String] {
+    private static func normalizedTextNodes(for snapshot: XcodePermissionDialog.WindowSnapshot) -> [String] {
         ([snapshot.title] + snapshot.textValues).compactMap(normalizedText)
     }
 
@@ -192,7 +193,7 @@ package enum XcodePermissionDialogMatcher {
     }
 
     private static func normalizedButtonDescription(
-        _ button: XcodePermissionDialogButtonSnapshot?
+        _ button: XcodePermissionDialog.ButtonSnapshot?
     ) -> String {
         normalizedText(button?.title)
             ?? normalizedText(button?.identifier)
@@ -261,5 +262,6 @@ package enum XcodePermissionDialogMatcher {
             return nil
         }
         return trimmed.lowercased()
+    }
     }
 }

--- a/Sources/ProxyXcodeSupport/PermissionDialogSnapshot.swift
+++ b/Sources/ProxyXcodeSupport/PermissionDialogSnapshot.swift
@@ -4,12 +4,15 @@ import Foundation
 import Logging
 import ProxyCore
 
-package enum XcodePermissionDialogAccessibilityStatus: Sendable {
-    case trusted
-    case untrusted
-}
+package enum XcodePermissionDialog {}
 
-package struct XcodePermissionDialogButtonSnapshot: Equatable, Sendable {
+extension XcodePermissionDialog {
+    package enum AccessibilityStatus: Sendable {
+        case trusted
+        case untrusted
+    }
+
+    package struct ButtonSnapshot: Equatable, Sendable {
     package let title: String?
     package let role: String?
     package let subrole: String?
@@ -26,9 +29,9 @@ package struct XcodePermissionDialogButtonSnapshot: Equatable, Sendable {
         self.subrole = subrole
         self.identifier = identifier
     }
-}
+    }
 
-package struct XcodePermissionDialogWindowSnapshot: Equatable, Sendable {
+    package struct WindowSnapshot: Equatable, Sendable {
     package let processBundleIdentifier: String?
     package let title: String
     package let textValues: [String]
@@ -41,8 +44,8 @@ package struct XcodePermissionDialogWindowSnapshot: Equatable, Sendable {
     package let document: String?
     package let childCount: Int
     package let hasProxy: Bool
-    package let defaultButton: XcodePermissionDialogButtonSnapshot?
-    package let cancelButton: XcodePermissionDialogButtonSnapshot?
+    package let defaultButton: XcodePermissionDialog.ButtonSnapshot?
+    package let cancelButton: XcodePermissionDialog.ButtonSnapshot?
 
     package init(
         processBundleIdentifier: String? = nil,
@@ -57,8 +60,8 @@ package struct XcodePermissionDialogWindowSnapshot: Equatable, Sendable {
         document: String? = nil,
         childCount: Int = 0,
         hasProxy: Bool = false,
-        defaultButton: XcodePermissionDialogButtonSnapshot? = nil,
-        cancelButton: XcodePermissionDialogButtonSnapshot? = nil
+        defaultButton: XcodePermissionDialog.ButtonSnapshot? = nil,
+        cancelButton: XcodePermissionDialog.ButtonSnapshot? = nil
     ) {
         self.processBundleIdentifier = processBundleIdentifier
         self.title = title
@@ -75,14 +78,15 @@ package struct XcodePermissionDialogWindowSnapshot: Equatable, Sendable {
         self.defaultButton = defaultButton
         self.cancelButton = cancelButton
     }
-}
+    }
 
-package struct XcodePermissionDialogMatchDecision: Equatable, Sendable {
+    package struct MatchDecision: Equatable, Sendable {
     package let fingerprint: String
     package let defaultButtonTitle: String
 
     package init(fingerprint: String, defaultButtonTitle: String) {
         self.fingerprint = fingerprint
         self.defaultButtonTitle = defaultButtonTitle
+    }
     }
 }

--- a/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
@@ -4,9 +4,10 @@ import Foundation
 import Logging
 import ProxyCore
 
-package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
+extension XcodePermissionDialog {
+    package final class AutoApprover: @unchecked Sendable {
     package struct Dependencies: DependencyClient {
-        package var axClient: any XcodePermissionDialogAXAccessing
+        package var axClient: any XcodePermissionDialog.AXAccessing
         package var agentPathCandidates: @Sendable () -> Set<String>
         package var assistantNameCandidates: @Sendable () -> Set<String>
         package var serverProcessIDCandidates: @Sendable () -> Set<pid_t>
@@ -15,7 +16,7 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
         package var logger: Logger
 
         package init(
-            axClient: any XcodePermissionDialogAXAccessing,
+            axClient: any XcodePermissionDialog.AXAccessing,
             agentPathCandidates: @escaping @Sendable () -> Set<String>,
             assistantNameCandidates: @escaping @Sendable () -> Set<String>,
             serverProcessIDCandidates: @escaping @Sendable () -> Set<pid_t>,
@@ -34,17 +35,17 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
 
         package static func live(
             agentPathCandidates: @escaping @Sendable () -> Set<String> = {
-                XcodePermissionDialogAutoApprover.defaultAgentPathCandidates()
+                XcodePermissionDialog.AutoApprover.defaultAgentPathCandidates()
             },
             assistantNameCandidates: @escaping @Sendable () -> Set<String> = {
                 ["XcodeMCPKit"]
             },
             serverProcessIDCandidates: @escaping @Sendable () -> Set<pid_t> = {
-                XcodePermissionDialogAutoApprover.defaultServerProcessIDCandidates()
+                XcodePermissionDialog.AutoApprover.defaultServerProcessIDCandidates()
             }
         ) -> Self {
             Self(
-                axClient: LiveXcodePermissionDialogAXClient(),
+                axClient: XcodePermissionDialog.AXClient(),
                 agentPathCandidates: agentPathCandidates,
                 assistantNameCandidates: assistantNameCandidates,
                 serverProcessIDCandidates: serverProcessIDCandidates,
@@ -83,8 +84,8 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
 
     private struct MatchedWindow {
         let processID: pid_t
-        let window: XcodePermissionDialogAXWindow
-        let decision: XcodePermissionDialogMatchDecision
+        let window: XcodePermissionDialog.AXWindow
+        let decision: XcodePermissionDialog.MatchDecision
     }
 
     private let dependencies: Dependencies
@@ -240,11 +241,11 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
 
         for processID in processIDs {
             let processBundleIdentifier = NSRunningApplication(processIdentifier: processID)?.bundleIdentifier
-            let windows: [XcodePermissionDialogAXWindow]
+            let windows: [XcodePermissionDialog.AXWindow]
             do {
                 windows = try dependencies.axClient.openWindows(for: processID)
             } catch {
-                if XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
+                if XcodePermissionDialog.AXFailureClassifier.isBenignOpenWindowsFailure(
                     error,
                     processBundleIdentifier: processBundleIdentifier
                 ) {
@@ -272,8 +273,8 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
                     inspectedWindowTitles.append(trimmedTitle)
                 }
                 let isStructurallyEligible =
-                    XcodePermissionDialogMatcher.passesStructuralChecks(window.snapshot)
-                guard let decision = XcodePermissionDialogMatcher.decision(
+                    XcodePermissionDialog.Matcher.passesStructuralChecks(window.snapshot)
+                guard let decision = XcodePermissionDialog.Matcher.decision(
                     for: window.snapshot,
                     processID: processID,
                     agentPathCandidates: agentPathCandidates,
@@ -378,7 +379,7 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
 
     private func logStructurallyEligibleWindowIfNeeded(
         processID: pid_t,
-        snapshot: XcodePermissionDialogWindowSnapshot,
+        snapshot: XcodePermissionDialog.WindowSnapshot,
         agentPathCandidates: Set<String>,
         assistantNameCandidates: Set<String>,
         dependencies: Dependencies
@@ -429,7 +430,7 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
 
     private func inspectionMetadata(
         processID: pid_t,
-        snapshot: XcodePermissionDialogWindowSnapshot,
+        snapshot: XcodePermissionDialog.WindowSnapshot,
         agentPathCandidates: Set<String>,
         assistantNameCandidates: Set<String>,
         serverProcessIDCandidates: Set<pid_t>
@@ -459,9 +460,9 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
 
     private func inspectionFingerprint(
         processID: pid_t,
-        snapshot: XcodePermissionDialogWindowSnapshot
+        snapshot: XcodePermissionDialog.WindowSnapshot
     ) -> String {
-        "candidate|\(XcodePermissionDialogMatcher.fingerprint(for: snapshot, processID: processID))"
+        "candidate|\(XcodePermissionDialog.Matcher.fingerprint(for: snapshot, processID: processID))"
     }
 
     private static func childProcessIDs(of parentProcessID: pid_t) -> [pid_t] {
@@ -484,10 +485,11 @@ package final class XcodePermissionDialogAutoApprover: @unchecked Sendable {
 
         return childProcessIDs.prefix(Int(copiedCount)).filter { $0 > 0 }
     }
+    }
 }
 
-private struct NoopXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessing {
-    func authorizationStatus(promptIfNeeded _: Bool) -> XcodePermissionDialogAccessibilityStatus {
+private struct NoopXcodePermissionDialogAXClient: XcodePermissionDialog.AXAccessing {
+    func authorizationStatus(promptIfNeeded _: Bool) -> XcodePermissionDialog.AccessibilityStatus {
         .untrusted
     }
 
@@ -495,11 +497,11 @@ private struct NoopXcodePermissionDialogAXClient: XcodePermissionDialogAXAccessi
         []
     }
 
-    func openWindows(for _: pid_t) throws -> [XcodePermissionDialogAXWindow] {
+    func openWindows(for _: pid_t) throws -> [XcodePermissionDialog.AXWindow] {
         []
     }
 
-    func pressDefaultButton(in _: XcodePermissionDialogAXWindow) throws {}
+    func pressDefaultButton(in _: XcodePermissionDialog.AXWindow) throws {}
 }
 
 private extension NSLock {

--- a/Sources/XcodeMCPProxy/ProxyHTTPChildChannelInitializer.swift
+++ b/Sources/XcodeMCPProxy/ProxyHTTPChildChannelInitializer.swift
@@ -9,17 +9,17 @@ import ProxyXcodeFeatures
 final class ProxyHTTPChildChannelInitializer: @unchecked Sendable {
     private let config: ProxyConfig
     private let sessionManager: any RuntimeCoordinating
-    private let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator
-    private let refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver
-    private let refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState
+    private let refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator
+    private let refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver
+    private let refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState
     private let logger: Logger
 
     init(
         config: ProxyConfig,
         sessionManager: any RuntimeCoordinating,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator,
-        refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver,
-        refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState,
+        refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator,
+        refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver,
+        refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState,
         logger: Logger
     ) {
         self.config = config

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -42,10 +42,10 @@ public final class ProxyServer {
                         config: config,
                         executableLookupClient: executableLookupClient
                     )
-                    return XcodePermissionDialogAutoApprover(
+                    return XcodePermissionDialog.AutoApprover(
                         dependencies: .live(
                             agentPathCandidates: {
-                                XcodePermissionDialogAutoApprover.defaultAgentPathCandidates(
+                                XcodePermissionDialog.AutoApprover.defaultAgentPathCandidates(
                                     additionalExecutableCandidates: additionalCandidates
                                 )
                             },
@@ -71,9 +71,9 @@ public final class ProxyServer {
     package let config: ProxyConfig
     package let dependencies: Dependencies
     package let group: EventLoopGroup
-    package let refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator
-    package let refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver
-    package let refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState
+    package let refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator
+    package let refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver
+    package let refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState
     private var channels: [Channel] = []
     package let logger: Logger = ProxyLogging.make("server")
     package let runtimeLock = NSLock()
@@ -90,9 +90,9 @@ public final class ProxyServer {
         self.config = config
         self.dependencies = dependencies
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        self.refreshCodeIssuesCoordinator = RefreshCodeIssuesCoordinator.makeDefault()
-        self.refreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver()
-        self.refreshCodeIssuesDebugState = RefreshCodeIssuesDebugState(
+        self.refreshCodeIssuesCoordinator = RefreshCodeIssues.Coordinator.makeDefault()
+        self.refreshCodeIssuesTargetResolver = RefreshCodeIssues.TargetResolver()
+        self.refreshCodeIssuesDebugState = RefreshCodeIssues.DebugState(
             defaultRequestTimeoutSeconds: config.requestTimeout
         )
     }
@@ -390,7 +390,7 @@ package protocol ProxyServerPermissionDialogAutoApprover: Sendable {
     func stop()
 }
 
-extension XcodePermissionDialogAutoApprover: ProxyServerPermissionDialogAutoApprover {}
+extension XcodePermissionDialog.AutoApprover: ProxyServerPermissionDialogAutoApprover {}
 
 package extension NSLock {
     func withLock<T>(_ body: () throws -> T) rethrows -> T {

--- a/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/CLICommandIntegrationTests.swift
@@ -38,7 +38,7 @@ struct CLICommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -126,7 +126,7 @@ struct CLICommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -201,7 +201,7 @@ struct CLICommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -283,7 +283,7 @@ struct CLICommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -352,7 +352,7 @@ struct CLICommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -409,7 +409,7 @@ struct CLICommandIntegrationTests {
                 }
             )
             #expect(responsePost.sessionID == "server-session")
-            #expect(responsePost.protocolVersion == MCPProtocolVersion.current)
+            #expect(responsePost.protocolVersion == MCP.ProtocolVersion.current)
         } catch {
             try? await server.shutdown()
             throw error
@@ -431,7 +431,7 @@ struct CLICommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -493,7 +493,7 @@ struct CLICommandIntegrationTests {
 
             let delete = try #require(server.recorder.snapshot().first { $0.httpMethod == "DELETE" })
             #expect(delete.sessionID == "server-session")
-            #expect(delete.protocolVersion == MCPProtocolVersion.current)
+            #expect(delete.protocolVersion == MCP.ProtocolVersion.current)
         } catch {
             try? await server.shutdown()
             throw error
@@ -515,7 +515,7 @@ struct CLICommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -585,7 +585,7 @@ struct CLICommandIntegrationTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -649,18 +649,18 @@ struct CLICommandIntegrationTests {
             let toolsPost = try #require(requests.first { $0.bodyMethod == "tools/list" })
             #expect(toolsPost.httpMethod == "POST")
             #expect(toolsPost.sessionID == "server-session")
-            #expect(toolsPost.protocolVersion == MCPProtocolVersion.current)
+            #expect(toolsPost.protocolVersion == MCP.ProtocolVersion.current)
             #expect(toolsPost.accept == "application/json, text/event-stream")
             #expect(toolsPost.contentType == "application/json")
 
             let sseGet = try #require(requests.first { $0.httpMethod == "GET" })
             #expect(sseGet.sessionID == "server-session")
-            #expect(sseGet.protocolVersion == MCPProtocolVersion.current)
+            #expect(sseGet.protocolVersion == MCP.ProtocolVersion.current)
             #expect(sseGet.accept == "text/event-stream")
 
             let delete = try #require(requests.first { $0.httpMethod == "DELETE" })
             #expect(delete.sessionID == "server-session")
-            #expect(delete.protocolVersion == MCPProtocolVersion.current)
+            #expect(delete.protocolVersion == MCP.ProtocolVersion.current)
         } catch {
             try? await server.shutdown()
             throw error
@@ -695,7 +695,7 @@ private struct StubMCPHTTPServer {
         delayedResponseMethod: String? = nil,
         delayedResponseMilliseconds: Int = 250,
         hangingResponseMethod: String? = nil,
-        initializeProtocolVersion: String? = MCPProtocolVersion.current,
+        initializeProtocolVersion: String? = MCP.ProtocolVersion.current,
         hangsDELETE: Bool = false,
         postSSEPreludeEventsByMethod: [String: [[String: Any]]] = [:],
         getSSEEvents: [[String: Any]] = []
@@ -1000,7 +1000,7 @@ private func stubSSEEventData(for object: [String: Any]) -> Data? {
 private func stubIsJSONRPCResponse(_ object: [String: Any]) -> Bool {
     guard object["method"] == nil,
         let id = object["id"],
-        RPCID(any: id) != nil
+        JSONRPC.ID(any: id) != nil
     else {
         return false
     }

--- a/Tests/ProxyCLITests/CLICommandTests.swift
+++ b/Tests/ProxyCLITests/CLICommandTests.swift
@@ -14,7 +14,7 @@ struct CLICommandTests {
                 stdout: { output.append($0) },
                 makeLogSink: {
                     Issue.record("makeLogSink should not be called for --version")
-                    return CLICommandLogSink(
+                    return XcodeMCPProxyCLICommand.LogSink(
                         error: { _ in },
                         info: { _, _ in }
                     )
@@ -44,7 +44,7 @@ struct CLICommandTests {
                 stdout: { output.append($0) },
                 makeLogSink: {
                     Issue.record("makeLogSink should not be called for --version")
-                    return CLICommandLogSink(
+                    return XcodeMCPProxyCLICommand.LogSink(
                         error: { _ in },
                         info: { _, _ in }
                     )
@@ -74,7 +74,7 @@ struct CLICommandTests {
                 stdout: { output.append($0) },
                 makeLogSink: {
                     Issue.record("makeLogSink should not be called for --help")
-                    return CLICommandLogSink(
+                    return XcodeMCPProxyCLICommand.LogSink(
                         error: { _ in },
                         info: { _, _ in }
                     )
@@ -118,7 +118,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { output.append($0) },
                         info: { _, _ in }
                     )
@@ -152,7 +152,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { output.append($0) },
                         info: { _, _ in }
                     )
@@ -182,7 +182,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { output.append($0) },
                         info: { _, _ in }
                     )
@@ -212,7 +212,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { output.append($0) },
                         info: { _, _ in }
                     )
@@ -242,7 +242,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { output.append($0) },
                         info: { _, _ in }
                     )
@@ -269,7 +269,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { output.append($0) },
                         info: { _, _ in }
                     )
@@ -297,7 +297,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { _ in },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { _ in },
                         info: { _, _ in }
                     )
@@ -335,7 +335,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { output.append($0) },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { _ in },
                         info: { _, _ in }
                     )
@@ -366,7 +366,7 @@ struct CLICommandTests {
                 stdout: { _ in },
                 makeLogSink: {
                     order.withValue { $0.append("makeLogSink") }
-                    return CLICommandLogSink(
+                    return XcodeMCPProxyCLICommand.LogSink(
                         error: { output.append($0) },
                         info: { _, _ in }
                     )
@@ -396,7 +396,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { usage.append($0) },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -430,7 +430,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { usage.append($0) },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )
@@ -466,7 +466,7 @@ struct CLICommandTests {
                 bootstrapLogging: { _ in },
                 stdout: { usage.append($0) },
                 makeLogSink: {
-                    CLICommandLogSink(
+                    XcodeMCPProxyCLICommand.LogSink(
                         error: { errors.append($0) },
                         info: { _, _ in }
                     )

--- a/Tests/ProxyCLITests/InstallCommandTests.swift
+++ b/Tests/ProxyCLITests/InstallCommandTests.swift
@@ -130,9 +130,9 @@ struct InstallCommandTests {
 
         let executableURL = tempDir.appendingPathComponent("xcode-mcp-proxy-install")
 
-        #expect(throws: InstallCommandError.self) {
+        #expect(throws: XcodeMCPProxyInstallCommand.Error.self) {
             try XcodeMCPProxyInstallCommand.install(
-                options: InstallOptions(prefix: nil, bindir: tempDir.path, dryRun: false),
+                options: XcodeMCPProxyInstallCommand.Options(prefix: nil, bindir: tempDir.path, dryRun: false),
                 executableURL: executableURL,
                 buildProducts: { _, _ in },
                 stdout: { _ in }

--- a/Tests/ProxyCLITests/ServerCommandTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandTests.swift
@@ -154,7 +154,7 @@ struct ServerCommandTests {
     }
 
     @Test func serverCommandAppliesEnvironmentDefaultsWithoutXcodePID() throws {
-        var options = ProxyServerOptions(
+        var options = XcodeMCPProxyServerCommand.Options(
             forwardedArgs: [],
             showHelp: false,
             showVersion: false,
@@ -184,7 +184,7 @@ struct ServerCommandTests {
     }
 
     @Test func serverCommandExplicitConfigOverridesEnvironment() throws {
-        var options = ProxyServerOptions(
+        var options = XcodeMCPProxyServerCommand.Options(
             forwardedArgs: ["--config", "/tmp/explicit.toml"],
             showHelp: false,
             showVersion: false,
@@ -212,7 +212,7 @@ struct ServerCommandTests {
     }
 
     @Test func serverCommandIgnoresRemovedXcodePIDEnvironment() throws {
-        var options = ProxyServerOptions(
+        var options = XcodeMCPProxyServerCommand.Options(
             forwardedArgs: [],
             showHelp: false,
             showVersion: false,

--- a/Tests/ProxyContractTests/ExternalContractTests.swift
+++ b/Tests/ProxyContractTests/ExternalContractTests.swift
@@ -117,7 +117,7 @@ struct ExternalContractTests {
         ]
         let responseData = try JSONSerialization.data(withJSONObject: responseObject, options: [])
 
-        let rewritten = RefreshCodeIssuesToolsListRewriter.rewriteResponseDataIfNeeded(
+        let rewritten = RefreshCodeIssues.ToolsListRewriter.rewriteResponseDataIfNeeded(
             responseData,
             method: "tools/list",
             mode: .proxy,
@@ -143,7 +143,7 @@ struct ExternalContractTests {
     @Test func errorWireShapeRemainsStable() throws {
         let responseData = try #require(
             MCPErrorResponder.errorResponseData(
-                id: RPCID(any: 9),
+                id: JSONRPC.ID(any: 9),
                 code: -32001,
                 message: "upstream unavailable",
                 data: .object([

--- a/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
@@ -84,7 +84,7 @@ extension HTTPHandlerTests {
                     requests.append(arguments["query"] as? String ?? "")
                 }
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"cold-docs\"}"
@@ -250,7 +250,7 @@ extension HTTPHandlerTests {
                     requests.append(arguments["query"] as? String ?? "")
                 }
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"docs\"}"
@@ -317,7 +317,7 @@ extension HTTPHandlerTests {
                     requests.append(arguments["query"] as? String ?? "")
                 }
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"docs\"}"
@@ -385,7 +385,7 @@ extension HTTPHandlerTests {
                     JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
                 )
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"docs\"}"
@@ -515,7 +515,7 @@ extension HTTPHandlerTests {
                     requests.append(arguments["query"] as? String ?? "")
                 }
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"docs\"}"
@@ -730,7 +730,7 @@ extension HTTPHandlerTests {
                 }
                 try await Task.sleep(for: .milliseconds(200))
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"\(query)\"}"
@@ -787,7 +787,7 @@ extension HTTPHandlerTests {
                     JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
                 )
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"cancelled\"}"
@@ -802,7 +802,7 @@ extension HTTPHandlerTests {
                 config: config,
                 sessionManager: sessionManager,
                 refreshCodeIssuesCoordinator: .makeDefault(),
-                refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState(
+                refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState(
                     defaultRequestTimeoutSeconds: config.requestTimeout
                 )
             )
@@ -872,7 +872,7 @@ extension HTTPHandlerTests {
                     JSONSerialization.jsonObject(with: requestData, options: []) as? [String: Any]
                 )
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"cancelled\"}"
@@ -887,7 +887,7 @@ extension HTTPHandlerTests {
                 config: config,
                 sessionManager: sessionManager,
                 refreshCodeIssuesCoordinator: .makeDefault(),
-                refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState(
+                refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState(
                     defaultRequestTimeoutSeconds: config.requestTimeout
                 )
             )
@@ -961,7 +961,7 @@ extension HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: "session-1")
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -586,7 +586,7 @@ struct HTTPConcurrencyTests {
             request.httpMethod = "GET"
             request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
             request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-            request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+            request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
             let sseTask = Task<(HTTPURLResponse, String), Error> {
                 try await withTestURLSession { session in
@@ -680,7 +680,7 @@ private struct TestHTTPServer {
     let sessionManager: RuntimeCoordinator
     let upstream: any UpstreamSlotControlling
     let childChannelTracker: HTTPTestServerChannelTracker
-    let refreshDebugState: RefreshCodeIssuesDebugState
+    let refreshDebugState: RefreshCodeIssues.DebugState
 
     static func start(
         upstream providedUpstream: (any UpstreamSlotControlling)? = nil,
@@ -705,7 +705,7 @@ private struct TestHTTPServer {
         let upstream = providedUpstream ?? EchoUpstreamClient()
         let sessionManager = RuntimeCoordinator(
             config: config, eventLoop: group.next(), upstreams: [upstream])
-        let refreshDebugState = RefreshCodeIssuesDebugState(
+        let refreshDebugState = RefreshCodeIssues.DebugState(
             defaultRequestTimeoutSeconds: config.requestTimeout
         )
 
@@ -755,11 +755,11 @@ private struct TestHTTPServer {
 }
 
 private actor EchoUpstreamClient: UpstreamSlotControlling {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
 
     init() {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -772,7 +772,7 @@ private actor EchoUpstreamClient: UpstreamSlotControlling {
         continuation.finish()
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
             return .accepted
         }
@@ -804,7 +804,7 @@ private actor EchoUpstreamClient: UpstreamSlotControlling {
         let result: [String: Any]
         if method == "initialize" {
             result = [
-                "protocolVersion": MCPProtocolVersion.current,
+                "protocolVersion": MCP.ProtocolVersion.current,
                 "capabilities": [String: Any](),
             ]
         } else {
@@ -825,13 +825,13 @@ private actor ControlledUpstreamClient: UpstreamSlotControlling {
         let responseData: Data?
     }
 
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private var sentRequests: [SentRequest] = []
     private var requestHistory: [String] = []
 
     init() {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -844,7 +844,7 @@ private actor ControlledUpstreamClient: UpstreamSlotControlling {
         continuation.finish()
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
             return .accepted
         }
@@ -919,7 +919,7 @@ private actor ControlledUpstreamClient: UpstreamSlotControlling {
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": id,
-            "result": ["protocolVersion": MCPProtocolVersion.current, "capabilities": [String: Any]()],
+            "result": ["protocolVersion": MCP.ProtocolVersion.current, "capabilities": [String: Any]()],
         ]
         return try! JSONSerialization.data(withJSONObject: response, options: [])
     }
@@ -962,15 +962,15 @@ private actor ControlledUpstreamClient: UpstreamSlotControlling {
 }
 
 private actor RefreshSensitiveUpstreamClient: UpstreamSlotControlling {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private let refreshStarts = RecordedValues<String>()
     private let releaseResponses = AsyncGate()
     private var activeTabs: Set<String> = []
     private var emittedErrorFive = false
 
     init() {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -996,7 +996,7 @@ private actor RefreshSensitiveUpstreamClient: UpstreamSlotControlling {
         await releaseResponses.signal()
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
             return .accepted
         }
@@ -1069,7 +1069,7 @@ private actor RefreshSensitiveUpstreamClient: UpstreamSlotControlling {
             "jsonrpc": "2.0",
             "id": id,
             "result": [
-                "protocolVersion": MCPProtocolVersion.current,
+                "protocolVersion": MCP.ProtocolVersion.current,
                 "capabilities": [String: Any]()
             ],
         ]
@@ -1137,15 +1137,15 @@ private actor RefreshSensitiveUpstreamClient: UpstreamSlotControlling {
 }
 
 private actor SingleFlightRefreshUpstreamClient: UpstreamSlotControlling {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private let refreshStarts = RecordedValues<Int>()
     private let releaseResponses = AsyncGate()
     private var hasActiveRefresh = false
     private var emittedConcurrentRefreshError = false
 
     init() {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -1171,7 +1171,7 @@ private actor SingleFlightRefreshUpstreamClient: UpstreamSlotControlling {
         await releaseResponses.signal()
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
             return .accepted
         }
@@ -1239,7 +1239,7 @@ private actor SingleFlightRefreshUpstreamClient: UpstreamSlotControlling {
             "jsonrpc": "2.0",
             "id": id,
             "result": [
-                "protocolVersion": MCPProtocolVersion.current,
+                "protocolVersion": MCP.ProtocolVersion.current,
                 "capabilities": [String: Any]()
             ],
         ]
@@ -1306,11 +1306,11 @@ private actor SingleFlightRefreshUpstreamClient: UpstreamSlotControlling {
 }
 
 private actor NotifyingUpstreamClient: UpstreamSlotControlling {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
 
     init() {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -1323,7 +1323,7 @@ private actor NotifyingUpstreamClient: UpstreamSlotControlling {
         continuation.finish()
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         guard
             let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
             let method = object["method"] as? String
@@ -1347,7 +1347,7 @@ private actor NotifyingUpstreamClient: UpstreamSlotControlling {
             "jsonrpc": "2.0",
             "id": id,
             "result": [
-                "protocolVersion": MCPProtocolVersion.current,
+                "protocolVersion": MCP.ProtocolVersion.current,
                 "capabilities": [String: Any]()
             ],
         ]
@@ -1447,7 +1447,7 @@ private func postJSON(
     }
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-        request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+        request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
     }
 
     return try await withTestURLSession(timeout: timeout ?? 5) { session in
@@ -1479,7 +1479,7 @@ private func postStatusOnly(
     }
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-        request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+        request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
     }
 
     return try await withTestURLSession(timeout: timeout ?? 5) { session in
@@ -1527,7 +1527,7 @@ private func postEmbeddedJSON(
     head.headers.add(name: "Content-Type", value: "application/json")
     if let sessionID {
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
     }
     var body = channel.allocator.buffer(capacity: data.count)
     body.writeBytes(data)

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -63,9 +63,9 @@ struct UpstreamResponsePlan {
 }
 
 final class TestRuntimeCoordinator: RuntimeCoordinating {
-    private struct UpstreamMapping: Sendable {
+    private struct UpstreamIDMapping: Sendable {
         let sessionID: String
-        let originalID: RPCID
+        let originalID: JSONRPC.ID
     }
 
     private struct ChooseUpstreamCall: Sendable {
@@ -92,7 +92,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         var cachedToolsList: JSONValue?
         var refreshToolsListCalls = 0
         var upstreamSendCount = 0
-        var upstreamIDMapping: [Int64: UpstreamMapping] = [:]
+        var upstreamIDMapping: [Int64: UpstreamIDMapping] = [:]
         var chooseUpstreamCalls: [ChooseUpstreamCall] = []
         var availableUpstreamIndex: Int? = 0
         var requestTimeoutNotifications = 0
@@ -102,17 +102,17 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         var sentUpstreamPayloads: [Data] = []
         var availableUpstreamIndices: [Int?] = []
         var requeuedLeaseCount = 0
-        var serverRequestResponseSendResults: [UpstreamSendResult] = []
+        var serverRequestResponseSendResults: [Upstream.SendResult] = []
     }
 
     private let state = NIOLockedValueBox(State())
     private let config: ProxyConfig
     private let upstreamRequestResponder:
-        (@Sendable (_ method: String, _ toolName: String?, _ originalID: RPCID) throws -> UpstreamResponsePlan)?
+        (@Sendable (_ method: String, _ toolName: String?, _ originalID: JSONRPC.ID) throws -> UpstreamResponsePlan)?
     private let upstreamResponder:
-        (@Sendable (_ method: String, _ originalID: RPCID) throws -> UpstreamResponsePlan)?
+        (@Sendable (_ method: String, _ originalID: JSONRPC.ID) throws -> UpstreamResponsePlan)?
     private let legacyUpstreamResponder:
-        (@Sendable (_ method: String, _ originalID: RPCID) throws -> Data)?
+        (@Sendable (_ method: String, _ originalID: JSONRPC.ID) throws -> Data)?
     private let documentationSearchResponder:
         (@Sendable (_ requestData: Data) async throws -> Data)?
     private let cancelAfterStartingEnqueueRequest: Bool
@@ -120,7 +120,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     init(
         config: ProxyConfig,
-        upstreamResponder: (@Sendable (_ method: String, _ originalID: RPCID) throws -> Data)? = nil,
+        upstreamResponder: (@Sendable (_ method: String, _ originalID: JSONRPC.ID) throws -> Data)? = nil,
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) async throws -> Data)? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
@@ -135,7 +135,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     init(
         config: ProxyConfig,
-        upstreamPlanResponder: (@Sendable (_ method: String, _ originalID: RPCID) throws -> UpstreamResponsePlan)?,
+        upstreamPlanResponder: (@Sendable (_ method: String, _ originalID: JSONRPC.ID) throws -> UpstreamResponsePlan)?,
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) async throws -> Data)? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
@@ -150,7 +150,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     init(
         config: ProxyConfig,
-        upstreamRequestResponder: (@Sendable (_ method: String, _ toolName: String?, _ originalID: RPCID) throws -> UpstreamResponsePlan)?,
+        upstreamRequestResponder: (@Sendable (_ method: String, _ toolName: String?, _ originalID: JSONRPC.ID) throws -> UpstreamResponsePlan)?,
         documentationSearchResponder:
             (@Sendable (_ requestData: Data) async throws -> Data)? = nil,
         cancelAfterStartingEnqueueRequest: Bool = false
@@ -170,7 +170,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             }
             let context = SessionContext(id: id, config: config)
             state.sessions[id] = context
-            state.sessionProtocolVersions[id] = MCPProtocolVersion.current
+            state.sessionProtocolVersions[id] = MCP.ProtocolVersion.current
             return context
         }
     }
@@ -246,13 +246,13 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     func registerInitialize(
         sessionID: String,
-        originalID: RPCID,
+        originalID: JSONRPC.ID,
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
         let negotiatedProtocolVersion =
             ((requestObject["params"] as? [String: Any])?["protocolVersion"] as? String)
-            ?? MCPProtocolVersion.current
+            ?? MCP.ProtocolVersion.current
         _ = session(id: sessionID)
         state.withLockedValue { state in
             state.initialized = true
@@ -357,8 +357,8 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
     }
 
     func enqueueOnUpstreamSlot<Output: Sendable>(
-        leaseID _: RequestLeaseID,
-        descriptor _: SessionPipelineRequestDescriptor,
+        leaseID _: LeaseManager.ID,
+        descriptor _: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
         preferredUpstreamIndex: Int?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
@@ -376,12 +376,12 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         return starter(upstreamIndex)
     }
 
-    func assignUpstreamID(sessionID: String, originalID: RPCID, upstreamIndex _: Int) -> Int64 {
+    func assignUpstreamID(sessionID: String, originalID: JSONRPC.ID, upstreamIndex _: Int) -> Int64 {
         state.withLockedValue { state in
             state.assignUpstreamIDCount += 1
             let id = state.nextUpstreamID
             state.nextUpstreamID += 1
-            state.upstreamIDMapping[id] = UpstreamMapping(
+            state.upstreamIDMapping[id] = UpstreamIDMapping(
                 sessionID: sessionID, originalID: originalID)
             return id
         }
@@ -434,7 +434,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
     func forwardServerRequestResponse(
         responseData: Data,
         sessionID: String,
-        responseID: RPCID,
+        responseID: JSONRPC.ID,
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ServerRequestResponseForwardingResult> {
         let session = session(id: sessionID)
@@ -454,7 +454,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             return eventLoop.makeSucceededFuture(.invalidResponse)
         }
 
-        let sendResult = state.withLockedValue { state -> UpstreamSendResult in
+        let sendResult = state.withLockedValue { state -> Upstream.SendResult in
             state.upstreamSendCount += 1
             state.sentUpstreamPayloads.append(data)
             if state.serverRequestResponseSendResults.isEmpty {
@@ -471,7 +471,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         }
     }
 
-    func setServerRequestResponseSendResults(_ results: [UpstreamSendResult]) {
+    func setServerRequestResponseSendResults(_ results: [Upstream.SendResult]) {
         state.withLockedValue { state in
             state.serverRequestResponseSendResults = results
         }
@@ -594,7 +594,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
     private func responsePlan(
         method: String,
         toolName: String?,
-        originalID: RPCID
+        originalID: JSONRPC.ID
     ) -> UpstreamResponsePlan {
         if let upstreamRequestResponder,
             let planned = try? upstreamRequestResponder(method, toolName, originalID)
@@ -634,7 +634,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             )
         }
 
-        let originalID = RPCID(any: "__shared-\(method)-\(UUID().uuidString)")!
+        let originalID = JSONRPC.ID(any: "__shared-\(method)-\(UUID().uuidString)")!
         let plan = responsePlan(
             method: method,
             toolName: toolName,
@@ -668,12 +668,12 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         debugSnapshot(includeSensitiveDebugPayloads: false)
     }
 
-    func createRequestLease(descriptor: SessionPipelineRequestDescriptor) -> RequestLeaseID {
+    func createRequestLease(descriptor: SessionRequestPipeline.Descriptor) -> LeaseManager.ID {
         requestLeaseRegistry.createLease(descriptor: descriptor)
     }
 
     func activateRequestLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
         timeout: TimeAmount?
@@ -688,11 +688,11 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         )
     }
 
-    func completeRequestLease(_ leaseID: RequestLeaseID) {
+    func completeRequestLease(_ leaseID: LeaseManager.ID) {
         _ = requestLeaseRegistry.completeLease(leaseID)
     }
 
-    func requeueRequestLease(_ leaseID: RequestLeaseID) {
+    func requeueRequestLease(_ leaseID: LeaseManager.ID) {
         state.withLockedValue { state in
             state.requeuedLeaseCount += 1
         }
@@ -700,9 +700,9 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
     }
 
     func failRequestLease(
-        _ leaseID: RequestLeaseID,
-        terminalState: RequestLeaseState,
-        reason: RequestLeaseReleaseReason
+        _ leaseID: LeaseManager.ID,
+        terminalState: LeaseManager.State,
+        reason: LeaseManager.ReleaseReason
     ) {
         _ = requestLeaseRegistry.failLease(
             leaseID,
@@ -712,7 +712,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
     }
 
     func handleRequestLeaseTimeout(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
         upstreamIndex: Int
@@ -736,7 +736,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
     }
 
     func abandonRequestLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
         upstreamIndex: Int?
@@ -794,7 +794,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         )
     }
 
-    func leaseDebugSnapshots() -> [RequestLeaseDebugSnapshot] {
+    func leaseDebugSnapshots() -> [LeaseManager.DebugSnapshot] {
         requestLeaseRegistry.debugSnapshots()
     }
 
@@ -932,9 +932,9 @@ func addHTTPHandler(
     to channel: EmbeddedChannel,
     config: ProxyConfig,
     sessionManager: any RuntimeCoordinating,
-    refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
-    refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver(),
-    refreshCodeIssuesDebugState: RefreshCodeIssuesDebugState? = nil
+    refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
+    refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
+    refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil
 ) throws {
     let handler = HTTPHandler(
         config: config,
@@ -1006,7 +1006,7 @@ func postJSON(
     head.headers.add(name: "Accept", value: "application/json, text/event-stream")
     head.headers.add(name: "Content-Type", value: "application/json")
     head.headers.add(name: "Mcp-Session-Id", value: sessionID)
-    head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+    head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
     var body = channel.allocator.buffer(capacity: data.count)
     body.writeBytes(data)
     try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1025,7 +1025,7 @@ func postJSONArray(
     head.headers.add(name: "Content-Type", value: "application/json")
     if let sessionID {
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
     }
     var body = channel.allocator.buffer(capacity: data.count)
     body.writeBytes(data)
@@ -1050,15 +1050,15 @@ struct TestHTTPHandlerServer {
     static func start(
         config: ProxyConfig,
         sessionManager: any RuntimeCoordinating,
-        refreshCodeIssuesCoordinator: RefreshCodeIssuesCoordinator? = nil,
-        refreshCodeIssuesTargetResolver: RefreshCodeIssuesTargetResolver = RefreshCodeIssuesTargetResolver()
+        refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
+        refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver()
     ) throws -> TestHTTPHandlerServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let childChannelTracker = HTTPTestServerChannelTracker()
         let refreshCoordinator =
             refreshCodeIssuesCoordinator
-            ?? RefreshCodeIssuesCoordinator.makeDefault()
-        let refreshDebugState = RefreshCodeIssuesDebugState(
+            ?? RefreshCodeIssues.Coordinator.makeDefault()
+        let refreshDebugState = RefreshCodeIssues.DebugState(
             defaultRequestTimeoutSeconds: config.requestTimeout
         )
         let bootstrap = ServerBootstrap(group: group)
@@ -1129,7 +1129,7 @@ func postHTTPJSON(
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-    request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+    request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
     return try await withTestURLSession { session in
         let (responseData, response) = try await session.data(for: request)
@@ -1159,7 +1159,7 @@ func postHTTPAnyJSON(
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-    request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+    request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
     return try await withTestURLSession { session in
         let (responseData, response) = try await session.data(for: request)
@@ -1187,7 +1187,7 @@ func postHTTPAnyData(
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-    request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+    request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
     return try await withTestURLSession { session in
         let (responseData, response) = try await session.data(for: request)
@@ -1231,7 +1231,7 @@ func postHTTPData(
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-    request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+    request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
 
     return try await withTestURLSession { session in
         let (responseData, response) = try await session.data(for: request)
@@ -1287,7 +1287,7 @@ func initializeHTTPChannel(_ channel: EmbeddedChannel) throws -> String {
     return try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 }
 
-func makeToolSuccessResponse(id: RPCID, text: String) throws -> Data {
+func makeToolSuccessResponse(id: JSONRPC.ID, text: String) throws -> Data {
     let response: [String: Any] = [
         "jsonrpc": "2.0",
         "id": id.value.foundationObject,
@@ -1303,7 +1303,7 @@ func makeToolSuccessResponse(id: RPCID, text: String) throws -> Data {
     return try JSONSerialization.data(withJSONObject: response, options: [])
 }
 
-func makeToolResultResponse(id: RPCID, result: [String: Any]) throws -> Data {
+func makeToolResultResponse(id: JSONRPC.ID, result: [String: Any]) throws -> Data {
     let response: [String: Any] = [
         "jsonrpc": "2.0",
         "id": id.value.foundationObject,
@@ -1312,7 +1312,7 @@ func makeToolResultResponse(id: RPCID, result: [String: Any]) throws -> Data {
     return try JSONSerialization.data(withJSONObject: response, options: [])
 }
 
-func makeToolErrorResponse(id: RPCID, text: String) throws -> Data {
+func makeToolErrorResponse(id: JSONRPC.ID, text: String) throws -> Data {
     let response: [String: Any] = [
         "jsonrpc": "2.0",
         "id": id.value.foundationObject,

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -237,14 +237,14 @@ struct HTTPHandlerTests {
 
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            let snapshot = try decoder.decode(HTTPDebugSnapshot.self, from: data)
+            let snapshot = try decoder.decode(HTTPControlService.DebugSnapshot.self, from: data)
             #expect(snapshot.refreshCodeIssues == nil)
 
             let (sensitiveResponse, sensitiveData) = try await getHTTPData(
                 url: makeDebugSnapshotURL(from: server.url, includeSensitive: true)
             )
             #expect(sensitiveResponse.statusCode == 200)
-            let sensitiveSnapshot = try decoder.decode(HTTPDebugSnapshot.self, from: sensitiveData)
+            let sensitiveSnapshot = try decoder.decode(HTTPControlService.DebugSnapshot.self, from: sensitiveData)
             let refreshSnapshot = try #require(sensitiveSnapshot.refreshCodeIssues)
             #expect(refreshSnapshot.queue.activeRequestCount == 1)
             #expect(refreshSnapshot.activeRequests.count == 1)
@@ -266,7 +266,7 @@ struct HTTPHandlerTests {
                 url: makeDebugSnapshotURL(from: server.url, includeSensitive: true)
             )
             #expect(completedResponse.statusCode == 200)
-            let completedSnapshot = try decoder.decode(HTTPDebugSnapshot.self, from: completedData)
+            let completedSnapshot = try decoder.decode(HTTPControlService.DebugSnapshot.self, from: completedData)
             let completedRefreshSnapshot = try #require(completedSnapshot.refreshCodeIssues)
             #expect(completedRefreshSnapshot.queue.activeRequestCount == 0)
             #expect(completedRefreshSnapshot.recentCompletedRequests.first?.finalState == "completed")
@@ -347,7 +347,7 @@ struct HTTPHandlerTests {
             "id": 1,
             "method": "initialize",
             "params": [
-                "protocolVersion": MCPProtocolVersion.current,
+                "protocolVersion": MCP.ProtocolVersion.current,
                 "capabilities": [String: Any](),
             ],
         ]
@@ -431,7 +431,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "MCP-Session-Id", value: "missing-session")
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -512,7 +512,7 @@ struct HTTPHandlerTests {
 
         var deleteHead = HTTPRequestHead(version: .http1_1, method: .DELETE, uri: "/mcp")
         deleteHead.headers.add(name: "MCP-Session-Id", value: sessionID)
-        deleteHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        deleteHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         try channel.writeInbound(HTTPServerRequestPart.head(deleteHead))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
@@ -523,7 +523,7 @@ struct HTTPHandlerTests {
         var sseHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/mcp")
         sseHead.headers.add(name: "Accept", value: "text/event-stream")
         sseHead.headers.add(name: "MCP-Session-Id", value: sessionID)
-        sseHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        sseHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         try channel.writeInbound(HTTPServerRequestPart.head(sseHead))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
@@ -777,7 +777,7 @@ struct HTTPHandlerTests {
         let sessionID = try initializeHTTPChannel(channel)
         let chooseCountBeforeResponse = sessionManager.chooseUpstreamIndexCallCount()
         let clientID = sessionManager.session(id: sessionID).serverRequestTracker.record(
-            upstreamID: RPCID(any: NSNumber(value: 99))!,
+            upstreamID: JSONRPC.ID(any: NSNumber(value: 99))!,
             upstreamIndex: 0
         )
 
@@ -811,7 +811,7 @@ struct HTTPHandlerTests {
         let sessionID = try initializeHTTPChannel(channel)
         let session = sessionManager.session(id: sessionID)
         let clientID = session.serverRequestTracker.record(
-            upstreamID: RPCID(any: NSNumber(value: 99))!,
+            upstreamID: JSONRPC.ID(any: NSNumber(value: 99))!,
             upstreamIndex: 0
         )
         sessionManager.setServerRequestResponseSendResults([.backpressure, .accepted])
@@ -1046,7 +1046,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1107,7 +1107,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1214,7 +1214,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1265,7 +1265,7 @@ struct HTTPHandlerTests {
         malformedHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         malformedHead.headers.add(name: "Content-Type", value: "application/json")
         malformedHead.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        malformedHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        malformedHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var malformedBody = channel.allocator.buffer(capacity: 20)
         malformedBody.writeString("{\"jsonrpc\":\"2.0\",")
         try channel.writeInbound(HTTPServerRequestPart.head(malformedHead))
@@ -1331,7 +1331,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1369,7 +1369,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: "missing-session")
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -1397,7 +1397,7 @@ struct HTTPHandlerTests {
         var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/mcp")
         head.headers.add(name: "Accept", value: "text/event-stream")
         head.headers.add(name: "Mcp-Session-Id", value: "session-1")
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
@@ -1454,7 +1454,7 @@ struct HTTPHandlerTests {
         toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1530,7 +1530,7 @@ struct HTTPHandlerTests {
         toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1680,7 +1680,7 @@ struct HTTPHandlerTests {
         toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1706,7 +1706,7 @@ struct HTTPHandlerTests {
         toolsHead2.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead2.headers.add(name: "Content-Type", value: "application/json")
         toolsHead2.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        toolsHead2.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        toolsHead2.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var toolsBody2 = channel.allocator.buffer(capacity: toolsData2.count)
         toolsBody2.writeBytes(toolsData2)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead2))
@@ -1774,7 +1774,7 @@ struct HTTPHandlerTests {
         toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -1844,7 +1844,7 @@ struct HTTPHandlerTests {
         toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID)
-        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -2016,7 +2016,7 @@ struct HTTPHandlerTests {
         toolsHead.headers.add(name: "Accept", value: "application/json, text/event-stream")
         toolsHead.headers.add(name: "Content-Type", value: "application/json")
         toolsHead.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        toolsHead.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var toolsBody = channel.allocator.buffer(capacity: toolsData.count)
         toolsBody.writeBytes(toolsData)
         try channel.writeInbound(HTTPServerRequestPart.head(toolsHead))
@@ -2043,7 +2043,7 @@ struct HTTPHandlerTests {
                     requests.append(arguments["query"] as? String ?? "")
                 }
                 let originalIDValue = try #require(object["id"])
-                let originalID = try #require(RPCID(any: originalIDValue))
+                let originalID = try #require(JSONRPC.ID(any: originalIDValue))
                 return try makeToolSuccessResponse(
                     id: originalID,
                     text: "{\"answer\":\"ok\"}"
@@ -2247,7 +2247,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: "session-1")
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -2322,7 +2322,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -2400,7 +2400,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -2473,7 +2473,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -2548,7 +2548,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
@@ -2627,7 +2627,7 @@ struct HTTPHandlerTests {
         head.headers.add(name: "Accept", value: "application/json, text/event-stream")
         head.headers.add(name: "Content-Type", value: "application/json")
         head.headers.add(name: "Mcp-Session-Id", value: sessionID!)
-        head.headers.add(name: "MCP-Protocol-Version", value: MCPProtocolVersion.current)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         var body = channel.allocator.buffer(capacity: data.count)
         body.writeBytes(data)
         try channel.writeInbound(HTTPServerRequestPart.head(head))

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesCoordinatorTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesCoordinatorTests.swift
@@ -8,7 +8,7 @@ import XcodeMCPTestSupport
 struct RefreshCodeIssuesCoordinatorTests {
     @Test func refreshCoordinatorSerializesRequestsForSameKey() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssuesCoordinator(waitClock: clock)
+        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
 
@@ -44,7 +44,7 @@ struct RefreshCodeIssuesCoordinatorTests {
     }
 
     @Test func refreshCoordinatorAllowsDifferentKeysToAcquireConcurrently() async throws {
-        let coordinator = RefreshCodeIssuesCoordinator()
+        let coordinator = RefreshCodeIssues.Coordinator()
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
 
@@ -82,7 +82,7 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorAcceptsManyQueuedWaitersForSameKey() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssuesCoordinator(waitClock: clock)
+        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
         let releaseFirst = AsyncGate()
         let completionCount = RecordedValues<String>()
 
@@ -132,7 +132,7 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorTimeoutRemovesQueuedWaiterDeterministically() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssuesCoordinator(waitClock: clock)
+        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
         let outcomes = RecordedValues<String>()
@@ -159,7 +159,7 @@ struct RefreshCodeIssuesCoordinatorTests {
                     await outcomes.append("success")
                 }
                 await outcomes.append("unexpected-success")
-            } catch RefreshCodeIssuesCoordinator.AcquireError.queueWaitTimedOut {
+            } catch RefreshCodeIssues.Coordinator.AcquireError.queueWaitTimedOut {
                 await outcomes.append("timed-out")
             } catch {
                 await outcomes.append("unexpected")
@@ -191,7 +191,7 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorNilRequestTimeoutKeepsQueuedWaiterWaiting() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssuesCoordinator(waitClock: clock)
+        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
         let releaseFirst = AsyncGate()
         let firstAcquired = AsyncGate()
         let outcomes = RecordedValues<String>()
@@ -234,7 +234,7 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorCancellationRemovesQueuedWaiterDeterministically() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssuesCoordinator(waitClock: clock)
+        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
         let outcomes = RecordedValues<String>()
@@ -292,7 +292,7 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorResetCancelsQueuedWaiters() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssuesCoordinator(waitClock: clock)
+        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
         let outcomes = RecordedValues<String>()
@@ -348,7 +348,7 @@ struct RefreshCodeIssuesCoordinatorTests {
     }
 
     @Test func refreshCoordinatorResetCancelsActiveExecution() async throws {
-        let coordinator = RefreshCodeIssuesCoordinator()
+        let coordinator = RefreshCodeIssues.Coordinator()
         let started = TestSignal()
         let releaseActive = AsyncGate()
         let outcomes = RecordedValues<String>()
@@ -383,7 +383,7 @@ struct RefreshCodeIssuesCoordinatorTests {
     @Test func refreshCoordinatorResetKeepsSameKeySerializedUntilCancelledExecutionExits()
         async throws
     {
-        let coordinator = RefreshCodeIssuesCoordinator()
+        let coordinator = RefreshCodeIssues.Coordinator()
         let activeStarted = TestSignal()
         let activeCancellationObserved = TestSignal()
         let releaseActive = AsyncGate()

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -1159,15 +1159,15 @@ extension HTTPHandlerTests {
         )
 
         let config = makeConfig(requestTimeout: 1)
-        let coordinator = RefreshCodeIssuesCoordinator()
-        let debugState = RefreshCodeIssuesDebugState(
+        let coordinator = RefreshCodeIssues.Coordinator()
+        let debugState = RefreshCodeIssues.DebugState(
             defaultRequestTimeoutSeconds: config.requestTimeout
         )
-        let workflow = RefreshCodeIssuesWorkflow(
+        let workflow = RefreshCodeIssues.Workflow(
             mode: .proxy,
             requestTimeout: config.requestTimeout,
             coordinator: coordinator,
-            targetResolver: RefreshCodeIssuesTargetResolver(),
+            targetResolver: RefreshCodeIssues.TargetResolver(),
             debugState: debugState,
             windowLookupTimeout: 0.2,
             navigatorIssuesTimeout: 0.05,
@@ -1176,7 +1176,7 @@ extension HTTPHandlerTests {
         let observedTimeouts = NIOLockedValueBox<[Int64]>([])
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
-        let requestID = RPCID(any: NSNumber(value: 33))!
+        let requestID = JSONRPC.ID(any: NSNumber(value: 33))!
         let requestPayload = toolsCallPayload(
             id: 33,
             name: "XcodeRefreshCodeIssuesInFile",
@@ -1192,7 +1192,7 @@ extension HTTPHandlerTests {
         )
 
         let result = await workflow.run(
-            refreshRequest: RefreshCodeIssuesRequest(
+            refreshRequest: RefreshCodeIssues.Request(
                 tabIdentifier: "windowtab-navigator-timeout",
                 filePath: "App/Sources/App.swift"
             ),
@@ -1259,15 +1259,15 @@ extension HTTPHandlerTests {
         )
 
         let config = makeConfig(requestTimeout: 0)
-        let coordinator = RefreshCodeIssuesCoordinator()
-        let debugState = RefreshCodeIssuesDebugState(
+        let coordinator = RefreshCodeIssues.Coordinator()
+        let debugState = RefreshCodeIssues.DebugState(
             defaultRequestTimeoutSeconds: config.requestTimeout
         )
-        let workflow = RefreshCodeIssuesWorkflow(
+        let workflow = RefreshCodeIssues.Workflow(
             mode: .proxy,
             requestTimeout: config.requestTimeout,
             coordinator: coordinator,
-            targetResolver: RefreshCodeIssuesTargetResolver(),
+            targetResolver: RefreshCodeIssues.TargetResolver(),
             debugState: debugState,
             windowLookupTimeout: 0.2,
             navigatorIssuesTimeout: 0.05,
@@ -1276,7 +1276,7 @@ extension HTTPHandlerTests {
         let observedTimeouts = NIOLockedValueBox<[Int64]>([])
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
-        let requestID = RPCID(any: NSNumber(value: 133))!
+        let requestID = JSONRPC.ID(any: NSNumber(value: 133))!
         let requestPayload = toolsCallPayload(
             id: 133,
             name: "XcodeRefreshCodeIssuesInFile",
@@ -1288,7 +1288,7 @@ extension HTTPHandlerTests {
         let requestData = try JSONSerialization.data(withJSONObject: requestPayload, options: [])
 
         let result = await workflow.run(
-            refreshRequest: RefreshCodeIssuesRequest(
+            refreshRequest: RefreshCodeIssues.Request(
                 tabIdentifier: "windowtab-unbounded-timeout",
                 filePath: "App/Sources/App.swift"
             ),
@@ -1378,15 +1378,15 @@ extension HTTPHandlerTests {
             withIntermediateDirectories: true
         )
 
-        let coordinator = RefreshCodeIssuesCoordinator()
-        let debugState = RefreshCodeIssuesDebugState(
+        let coordinator = RefreshCodeIssues.Coordinator()
+        let debugState = RefreshCodeIssues.DebugState(
             defaultRequestTimeoutSeconds: 2
         )
-        let workflow = RefreshCodeIssuesWorkflow(
+        let workflow = RefreshCodeIssues.Workflow(
             mode: .proxy,
             requestTimeout: 2,
             coordinator: coordinator,
-            targetResolver: RefreshCodeIssuesTargetResolver(),
+            targetResolver: RefreshCodeIssues.TargetResolver(),
             debugState: debugState,
             windowLookupTimeout: 0.2,
             navigatorIssuesTimeout: 0.05,
@@ -1394,7 +1394,7 @@ extension HTTPHandlerTests {
         )
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
-        let requestID = RPCID(any: NSNumber(value: 144))!
+        let requestID = JSONRPC.ID(any: NSNumber(value: 144))!
         let requestPayload = toolsCallPayload(
             id: 144,
             name: "XcodeRefreshCodeIssuesInFile",
@@ -1406,7 +1406,7 @@ extension HTTPHandlerTests {
         let requestData = try JSONSerialization.data(withJSONObject: requestPayload, options: [])
 
         let result = await workflow.run(
-            refreshRequest: RefreshCodeIssuesRequest(
+            refreshRequest: RefreshCodeIssues.Request(
                 tabIdentifier: "windowtab-cancelled-navigator",
                 filePath: "App/Sources/App.swift"
             ),
@@ -1462,22 +1462,22 @@ extension HTTPHandlerTests {
         )
 
         let config = makeConfig(requestTimeout: 1)
-        let coordinator = RefreshCodeIssuesCoordinator()
-        let debugState = RefreshCodeIssuesDebugState(
+        let coordinator = RefreshCodeIssues.Coordinator()
+        let debugState = RefreshCodeIssues.DebugState(
             defaultRequestTimeoutSeconds: config.requestTimeout
         )
-        let workflow = RefreshCodeIssuesWorkflow(
+        let workflow = RefreshCodeIssues.Workflow(
             mode: .proxy,
             requestTimeout: config.requestTimeout,
             coordinator: coordinator,
-            targetResolver: RefreshCodeIssuesTargetResolver(),
+            targetResolver: RefreshCodeIssues.TargetResolver(),
             debugState: debugState,
             logger: ProxyLogging.make("test.refresh")
         )
         let observedGlob = NIOLockedValueBox<String?>(nil)
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
-        let requestID = RPCID(any: NSNumber(value: 233))!
+        let requestID = JSONRPC.ID(any: NSNumber(value: 233))!
         let requestPayload = toolsCallPayload(
             id: 233,
             name: "XcodeRefreshCodeIssuesInFile",
@@ -1489,7 +1489,7 @@ extension HTTPHandlerTests {
         let requestData = try JSONSerialization.data(withJSONObject: requestPayload, options: [])
 
         let result = await workflow.run(
-            refreshRequest: RefreshCodeIssuesRequest(
+            refreshRequest: RefreshCodeIssues.Request(
                 tabIdentifier: "windowtab-backslash",
                 filePath: "Group\\Folder/App.swift"
             ),
@@ -2119,13 +2119,13 @@ extension HTTPHandlerTests {
         async throws
     {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssuesCoordinator(waitClock: clock)
-        let debugState = RefreshCodeIssuesDebugState(defaultRequestTimeoutSeconds: 2)
-        let workflow = RefreshCodeIssuesWorkflow(
+        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
+        let debugState = RefreshCodeIssues.DebugState(defaultRequestTimeoutSeconds: 2)
+        let workflow = RefreshCodeIssues.Workflow(
             mode: .upstream,
             requestTimeout: 2,
             coordinator: coordinator,
-            targetResolver: RefreshCodeIssuesTargetResolver(),
+            targetResolver: RefreshCodeIssues.TargetResolver(),
             debugState: debugState,
             logger: ProxyLogging.make("test.refresh")
         )
@@ -2145,7 +2145,7 @@ extension HTTPHandlerTests {
         }
         try await activeStarted.wait(description: "waiting for active queued-timeout execution")
 
-        let requestID = RPCID(any: NSNumber(value: 25))!
+        let requestID = JSONRPC.ID(any: NSNumber(value: 25))!
         let requestPayload = toolsCallPayload(
             id: 25,
             name: "XcodeRefreshCodeIssuesInFile",
@@ -2158,7 +2158,7 @@ extension HTTPHandlerTests {
 
         let requestTask = Task {
             await workflow.run(
-                refreshRequest: RefreshCodeIssuesRequest(
+                refreshRequest: RefreshCodeIssues.Request(
                     tabIdentifier: "windowtab-timeout",
                     filePath: "B.swift"
                 ),

--- a/Tests/ProxyHTTPGatewayTests/ToolSurfaceTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/ToolSurfaceTests.swift
@@ -50,7 +50,7 @@ struct ToolSurfaceTests {
         let rewritten = surface.rewriteForwardedResponse(
             method: "tools/call",
             toolName: "DocumentationSearch",
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             upstreamData: upstreamData
         )
 
@@ -102,7 +102,7 @@ struct ToolSurfaceTests {
         let rewritten = surface.rewriteForwardedResponse(
             method: "tools/call",
             toolName: "DocumentationSearch",
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             upstreamData: upstreamData
         )
 
@@ -158,7 +158,7 @@ struct ToolSurfaceTests {
         let rewritten = surface.rewriteForwardedResponse(
             method: "tools/call",
             toolName: "GetBuildLog",
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             upstreamData: upstreamData
         )
 
@@ -185,7 +185,7 @@ struct ToolSurfaceTests {
                 "result": [
                     "tools": [
                         [
-                            "name": RefreshCodeIssuesRequest.toolName,
+                            "name": RefreshCodeIssues.Request.toolName,
                             "description": "old",
                         ],
                         [
@@ -215,7 +215,7 @@ struct ToolSurfaceTests {
         let result = try #require(payload["result"] as? [String: Any])
         let tools = try #require(result["tools"] as? [[String: Any]])
         #expect(tools.count == 1)
-        #expect(tools[0]["name"] as? String == RefreshCodeIssuesRequest.toolName)
+        #expect(tools[0]["name"] as? String == RefreshCodeIssues.Request.toolName)
         #expect((tools[0]["description"] as? String)?.contains("navigator issues") == true)
     }
 
@@ -410,7 +410,7 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
 
     func registerInitialize(
         sessionID: String,
-        originalID: RPCID,
+        originalID: JSONRPC.ID,
         requestObject: [String: Any],
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ByteBuffer> {
@@ -437,8 +437,8 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
     func chooseUpstreamIndex() -> Int? { nil }
 
     func enqueueOnUpstreamSlot<Output>(
-        leaseID: RequestLeaseID,
-        descriptor: SessionPipelineRequestDescriptor,
+        leaseID: LeaseManager.ID,
+        descriptor: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
         preferredUpstreamIndex: Int?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
@@ -446,7 +446,7 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
         fatalError("unused in ToolSurfaceTests")
     }
 
-    func assignUpstreamID(sessionID: String, originalID: RPCID, upstreamIndex: Int) -> Int64 {
+    func assignUpstreamID(sessionID: String, originalID: JSONRPC.ID, upstreamIndex: Int) -> Int64 {
         fatalError("unused in ToolSurfaceTests")
     }
 
@@ -459,35 +459,35 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
         fatalError("unused in ToolSurfaceTests")
     }
 
-    func createRequestLease(descriptor: SessionPipelineRequestDescriptor) -> RequestLeaseID {
+    func createRequestLease(descriptor: SessionRequestPipeline.Descriptor) -> LeaseManager.ID {
         fatalError("unused in ToolSurfaceTests")
     }
 
     func activateRequestLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
         timeout: TimeAmount?
     ) {}
 
-    func completeRequestLease(_ leaseID: RequestLeaseID) {}
-    func requeueRequestLease(_ leaseID: RequestLeaseID) {}
+    func completeRequestLease(_ leaseID: LeaseManager.ID) {}
+    func requeueRequestLease(_ leaseID: LeaseManager.ID) {}
 
     func failRequestLease(
-        _ leaseID: RequestLeaseID,
-        terminalState: RequestLeaseState,
-        reason: RequestLeaseReleaseReason
+        _ leaseID: LeaseManager.ID,
+        terminalState: LeaseManager.State,
+        reason: LeaseManager.ReleaseReason
     ) {}
 
     func handleRequestLeaseTimeout(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
         upstreamIndex: Int
     ) {}
 
     func abandonRequestLease(
-        _ leaseID: RequestLeaseID,
+        _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
         upstreamIndex: Int?

--- a/Tests/ProxyIntegrationTests/JSONValueTests.swift
+++ b/Tests/ProxyIntegrationTests/JSONValueTests.swift
@@ -7,13 +7,13 @@ import ProxyMCP
 @Suite
 struct JSONValueTests {
     @Test func rpcIDFromString() async throws {
-        let rpcID = RPCID(any: "abc")
+        let rpcID = JSONRPC.ID(any: "abc")
         #expect(rpcID?.key == "abc")
         #expect(rpcID?.value.foundationObject as? String == "abc")
     }
 
     @Test func rpcIDFromNumber() async throws {
-        let rpcID = RPCID(any: NSNumber(value: 42))
+        let rpcID = JSONRPC.ID(any: NSNumber(value: 42))
         #expect(rpcID?.key == "42")
         #expect((rpcID?.value.foundationObject as? NSNumber)?.intValue == 42)
     }

--- a/Tests/ProxyIntegrationTests/ProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/ProxyServerTests.swift
@@ -161,13 +161,13 @@ private final class RecordingAutoApprover: @unchecked Sendable, ProxyServerPermi
 
 private final class RecordingUpstreamSlot: @unchecked Sendable, UpstreamSlotControlling {
     private let startCountBox = NIOLockedValueBox(0)
-    private let eventStream: AsyncStream<UpstreamEvent>
+    private let eventStream: AsyncStream<Upstream.Event>
 
     var startCount: Int {
         startCountBox.withLockedValue { $0 }
     }
 
-    var events: AsyncStream<UpstreamEvent> {
+    var events: AsyncStream<Upstream.Event> {
         eventStream
     }
 
@@ -181,7 +181,7 @@ private final class RecordingUpstreamSlot: @unchecked Sendable, UpstreamSlotCont
 
     func stop() async {}
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         _ = data
         return .accepted
     }

--- a/Tests/ProxyIntegrationTests/RefreshCodeIssuesPathMatcherTests.swift
+++ b/Tests/ProxyIntegrationTests/RefreshCodeIssuesPathMatcherTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct RefreshCodeIssuesPathMatcherTests {
     @Test func matcherTreatsCaseOnlyDifferencesAsEqualOnCaseInsensitiveFileSystems() {
         #expect(
-            RefreshCodeIssuesPathMatcher.matches(
+            RefreshCodeIssues.PathMatcher.matches(
                 issuePath: "/tmp/Workspace/Foo.swift",
                 resolvedFilePath: "/tmp/workspace/foo.swift",
                 caseSensitiveFileSystemOverride: false
@@ -17,7 +17,7 @@ struct RefreshCodeIssuesPathMatcherTests {
 
     @Test func matcherPreservesCaseSensitivePathDifferences() {
         #expect(
-            RefreshCodeIssuesPathMatcher.matches(
+            RefreshCodeIssues.PathMatcher.matches(
                 issuePath: "/tmp/Workspace/Foo.swift",
                 resolvedFilePath: "/tmp/workspace/foo.swift",
                 caseSensitiveFileSystemOverride: true
@@ -49,7 +49,7 @@ struct RefreshCodeIssuesPathMatcherTests {
         )
 
         #expect(
-            RefreshCodeIssuesPathMatcher.matches(
+            RefreshCodeIssues.PathMatcher.matches(
                 issuePath: symlinkPath.path,
                 resolvedFilePath: target.path
             )

--- a/Tests/ProxyIntegrationTests/RefreshCodeIssuesTargetResolverTests.swift
+++ b/Tests/ProxyIntegrationTests/RefreshCodeIssuesTargetResolverTests.swift
@@ -19,7 +19,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -40,7 +40,7 @@ struct RefreshCodeIssuesTargetResolverTests {
             withIntermediateDirectories: true
         )
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -69,7 +69,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: unrelatedFile, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -91,7 +91,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let first = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -122,7 +122,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -149,7 +149,7 @@ struct RefreshCodeIssuesTargetResolverTests {
             try "".write(to: url, atomically: true, encoding: .utf8)
         }
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -171,7 +171,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: firstCandidate, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let first = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -220,7 +220,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: validFallback, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -260,7 +260,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: validFallback, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -293,7 +293,7 @@ struct RefreshCodeIssuesTargetResolverTests {
             withDestinationPath: target.path
         )
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -315,7 +315,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -341,7 +341,7 @@ struct RefreshCodeIssuesTargetResolverTests {
             .appendingPathComponent("Outside.swift")
         try "".write(to: outsideFile, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -363,7 +363,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -397,7 +397,7 @@ struct RefreshCodeIssuesTargetResolverTests {
             withDestinationPath: target.path
         )
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -428,7 +428,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: unrelatedFile, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -442,7 +442,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         let root = makeTemporaryWorkspaceRoot()
         defer { try? FileManager.default.removeItem(atPath: root) }
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -470,7 +470,7 @@ struct RefreshCodeIssuesTargetResolverTests {
             withDestinationPath: outsideRoot
         )
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -504,7 +504,7 @@ struct RefreshCodeIssuesTargetResolverTests {
             withDestinationPath: outsideFile.path
         )
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolved = await resolver.resolveAbsoluteFilePath(
             workspacePath: root,
             workspaceRoot: root,
@@ -532,7 +532,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolution = try await resolver.resolve(
             tabIdentifier: "windowtab2",
             filePath: "SampleProject/Feature/Scene/PrimaryView.swift",
@@ -578,7 +578,7 @@ struct RefreshCodeIssuesTargetResolverTests {
             withDestinationPath: target.path
         )
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let resolution = try await resolver.resolve(
             tabIdentifier: "windowtab2",
             filePath: "Feature/Scene/PrimaryView.swift",
@@ -614,7 +614,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let relativePath = await resolver.relativePath(
             for: target.path,
             within: rootAlias.path
@@ -653,7 +653,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         try "".write(to: targetA, atomically: true, encoding: .utf8)
         try "".write(to: targetB, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let eventLoop = EmbeddedEventLoop()
 
         let first = try await resolver.resolve(
@@ -696,7 +696,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let eventLoop = EmbeddedEventLoop()
 
         let first = try await resolver.resolve(
@@ -740,7 +740,7 @@ struct RefreshCodeIssuesTargetResolverTests {
         )
         try "".write(to: target, atomically: true, encoding: .utf8)
 
-        let resolver = RefreshCodeIssuesTargetResolver()
+        let resolver = RefreshCodeIssues.TargetResolver()
         let eventLoop = EmbeddedEventLoop()
 
         let first = try await resolver.resolve(

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -17,7 +17,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -37,7 +37,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 500,
             assistantNameCandidates: ["Custom MCP"],
@@ -57,7 +57,7 @@ struct XcodePermissionDialogAutoApproverTests {
             defaultButton: makeButton(title: "許可")
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -74,13 +74,13 @@ struct XcodePermissionDialogAutoApproverTests {
             textValues: [
                 "The agent XcodeMCPKit wants to use Xcode's tools."
             ],
-            defaultButton: XcodePermissionDialogButtonSnapshot(
+            defaultButton: XcodePermissionDialog.ButtonSnapshot(
                 role: "AXButton",
                 identifier: "action-button-1"
             )
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -100,7 +100,7 @@ struct XcodePermissionDialogAutoApproverTests {
             defaultButton: makeButton(title: "許可")
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -120,7 +120,7 @@ struct XcodePermissionDialogAutoApproverTests {
             defaultButton: makeButton(title: "許可")
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
@@ -141,7 +141,7 @@ struct XcodePermissionDialogAutoApproverTests {
             defaultButton: makeButton(title: "OK")
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -160,7 +160,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -180,7 +180,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -203,7 +203,7 @@ struct XcodePermissionDialogAutoApproverTests {
             defaultButton: makeButton(title: "Allow")
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 1036,
             agentPathCandidates: [
@@ -226,7 +226,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -245,7 +245,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -264,7 +264,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
@@ -284,7 +284,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             agentPathCandidates: ["/tmp/xcode-mcp-proxy-server"],
@@ -304,7 +304,7 @@ struct XcodePermissionDialogAutoApproverTests {
             ]
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -327,7 +327,7 @@ struct XcodePermissionDialogAutoApproverTests {
             hasProxy: true
         )
 
-        let decision = XcodePermissionDialogMatcher.decision(
+        let decision = XcodePermissionDialog.Matcher.decision(
             for: snapshot,
             processID: 4317,
             assistantNameCandidates: ["XcodeMCPKit"],
@@ -338,8 +338,8 @@ struct XcodePermissionDialogAutoApproverTests {
     }
 
     @Test func openWindowsFailureClassifierTreatsExternalViewServiceAXWindowsCannotCompleteAsBenign() {
-        let isBenign = XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
-            XcodePermissionDialogAXError.copyAttributeFailed(
+        let isBenign = XcodePermissionDialog.AXFailureClassifier.isBenignOpenWindowsFailure(
+            XcodePermissionDialog.AXError.copyAttributeFailed(
                 attribute: kAXWindowsAttribute as String,
                 error: .cannotComplete
             ),
@@ -350,8 +350,8 @@ struct XcodePermissionDialogAutoApproverTests {
     }
 
     @Test func openWindowsFailureClassifierRejectsXcodeAXWindowsCannotComplete() {
-        let isBenign = XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
-            XcodePermissionDialogAXError.copyAttributeFailed(
+        let isBenign = XcodePermissionDialog.AXFailureClassifier.isBenignOpenWindowsFailure(
+            XcodePermissionDialog.AXError.copyAttributeFailed(
                 attribute: kAXWindowsAttribute as String,
                 error: .cannotComplete
             ),
@@ -362,8 +362,8 @@ struct XcodePermissionDialogAutoApproverTests {
     }
 
     @Test func openWindowsFailureClassifierRejectsExternalViewServiceForDifferentAttribute() {
-        let isBenign = XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
-            XcodePermissionDialogAXError.copyAttributeFailed(
+        let isBenign = XcodePermissionDialog.AXFailureClassifier.isBenignOpenWindowsFailure(
+            XcodePermissionDialog.AXError.copyAttributeFailed(
                 attribute: kAXTitleAttribute as String,
                 error: .cannotComplete
             ),
@@ -374,8 +374,8 @@ struct XcodePermissionDialogAutoApproverTests {
     }
 
     @Test func openWindowsFailureClassifierRejectsExternalViewServiceForDifferentAXError() {
-        let isBenign = XcodePermissionDialogAXFailureClassifier.isBenignOpenWindowsFailure(
-            XcodePermissionDialogAXError.copyAttributeFailed(
+        let isBenign = XcodePermissionDialog.AXFailureClassifier.isBenignOpenWindowsFailure(
+            XcodePermissionDialog.AXError.copyAttributeFailed(
                 attribute: kAXWindowsAttribute as String,
                 error: .attributeUnsupported
             ),
@@ -399,7 +399,7 @@ struct XcodePermissionDialogAutoApproverTests {
         let symlinkExecutable = temporaryDirectory.appendingPathComponent("link-server")
         try fileManager.createSymbolicLink(at: symlinkExecutable, withDestinationURL: realExecutable)
 
-        let candidates = XcodePermissionDialogAutoApprover.defaultAgentPathCandidates(
+        let candidates = XcodePermissionDialog.AutoApprover.defaultAgentPathCandidates(
             arguments: [symlinkExecutable.path],
             executableURL: realExecutable
         )
@@ -410,7 +410,7 @@ struct XcodePermissionDialogAutoApproverTests {
 
     @Test func autoApproverPromptsAccessibilityOnceAndRemainsInactiveWhenUntrusted() async {
         let axClient = RecordingAXClient(status: .untrusted)
-        let approver = XcodePermissionDialogAutoApprover(
+        let approver = XcodePermissionDialog.AutoApprover(
             dependencies: .init(
                 axClient: axClient,
                 agentPathCandidates: { ["/tmp/xcode-mcp-proxy-server"] },
@@ -445,10 +445,10 @@ private func makeSnapshot(
     document: String? = nil,
     childCount: Int = 3,
     hasProxy: Bool = false,
-    defaultButton: XcodePermissionDialogButtonSnapshot? = makeButton(title: "Allow"),
-    cancelButton: XcodePermissionDialogButtonSnapshot? = makeButton(title: "Cancel")
-) -> XcodePermissionDialogWindowSnapshot {
-    XcodePermissionDialogWindowSnapshot(
+    defaultButton: XcodePermissionDialog.ButtonSnapshot? = makeButton(title: "Allow"),
+    cancelButton: XcodePermissionDialog.ButtonSnapshot? = makeButton(title: "Cancel")
+) -> XcodePermissionDialog.WindowSnapshot {
+    XcodePermissionDialog.WindowSnapshot(
         processBundleIdentifier: processBundleIdentifier,
         title: title,
         textValues: textValues,
@@ -471,8 +471,8 @@ private func makeButton(
     role: String = "AXButton",
     subrole: String? = nil,
     identifier: String? = nil
-) -> XcodePermissionDialogButtonSnapshot {
-    XcodePermissionDialogButtonSnapshot(
+) -> XcodePermissionDialog.ButtonSnapshot {
+    XcodePermissionDialog.ButtonSnapshot(
         title: title,
         role: role,
         subrole: subrole,
@@ -480,17 +480,17 @@ private func makeButton(
     )
 }
 
-private final class RecordingAXClient: @unchecked Sendable, XcodePermissionDialogAXAccessing {
-    private let status: XcodePermissionDialogAccessibilityStatus
+private final class RecordingAXClient: @unchecked Sendable, XcodePermissionDialog.AXAccessing {
+    private let status: XcodePermissionDialog.AccessibilityStatus
     private let lock = NSLock()
     private var promptCalls = 0
     private var windowScanCalls = 0
 
-    init(status: XcodePermissionDialogAccessibilityStatus) {
+    init(status: XcodePermissionDialog.AccessibilityStatus) {
         self.status = status
     }
 
-    func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialogAccessibilityStatus {
+    func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialog.AccessibilityStatus {
         lock.withLock {
             if promptIfNeeded {
                 promptCalls += 1
@@ -506,11 +506,11 @@ private final class RecordingAXClient: @unchecked Sendable, XcodePermissionDialo
         }
     }
 
-    func openWindows(for processID: pid_t) throws -> [XcodePermissionDialogAXWindow] {
+    func openWindows(for processID: pid_t) throws -> [XcodePermissionDialog.AXWindow] {
         []
     }
 
-    func pressDefaultButton(in window: XcodePermissionDialogAXWindow) throws {}
+    func pressDefaultButton(in window: XcodePermissionDialog.AXWindow) throws {}
 
     func snapshot() -> (promptCalls: Int, windowScanCalls: Int) {
         lock.withLock {

--- a/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
+++ b/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
@@ -27,10 +27,10 @@ struct LiveMCPBridgeTests {
 
         let assistantName = "XcodeMCPKitLiveDirectTest"
         let directMCPBridgeProcessID = session.processIdentifier
-        let approver = XcodePermissionDialogAutoApprover(
+        let approver = XcodePermissionDialog.AutoApprover(
             dependencies: .live(
                 agentPathCandidates: {
-                    XcodePermissionDialogAutoApprover.defaultAgentPathCandidates(
+                    XcodePermissionDialog.AutoApprover.defaultAgentPathCandidates(
                         additionalExecutableCandidates: [mcpbridgePath]
                     )
                 },
@@ -38,7 +38,7 @@ struct LiveMCPBridgeTests {
                     ["XcodeMCPKit", assistantName]
                 },
                 serverProcessIDCandidates: {
-                    XcodePermissionDialogAutoApprover.defaultServerProcessIDCandidates()
+                    XcodePermissionDialog.AutoApprover.defaultServerProcessIDCandidates()
                         .union([directMCPBridgeProcessID])
                 }
             )
@@ -312,7 +312,7 @@ private func postJSON(
     request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-        request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+        request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
     }
     request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 

--- a/Tests/ProxyProcessTests/UpstreamProcessTests.swift
+++ b/Tests/ProxyProcessTests/UpstreamProcessTests.swift
@@ -335,7 +335,7 @@ struct UpstreamProcessTests {
                     "final stdout should be drained before exit even when the process exits immediately",
                     timeout: .seconds(5)
                 ) {
-                    var observedEvents: [UpstreamEvent] = []
+                    var observedEvents: [Upstream.Event] = []
                     for await event in session.events {
                         observedEvents.append(event)
 
@@ -405,7 +405,7 @@ struct UpstreamProcessTests {
                 "exit should not wait indefinitely for descendant-held pipe descriptors",
                 timeout: .seconds(1)
             ) {
-                var observedEvents: [UpstreamEvent] = []
+                var observedEvents: [Upstream.Event] = []
                 for await event in session.events {
                     observedEvents.append(event)
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -11,9 +11,9 @@ import XcodeMCPTestSupport
 
 func makeTestUpstreamSlotScheduler(upstreamCount: Int) -> UpstreamSlotScheduler {
     UpstreamSlotScheduler(
-        canUseUpstream: { _ in UpstreamUseEvaluation(isUsable: true, effects: []) },
+        canUseUpstream: { _ in UpstreamHealthManager.UseEvaluation(isUsable: true, effects: []) },
         selectUpstream: { occupied in
-            UpstreamSelectionResult(
+            UpstreamHealthManager.SelectionResult(
                 upstreamIndex: (0..<upstreamCount).first { occupied.contains($0) == false },
                 effects: []
             )
@@ -284,8 +284,8 @@ actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
 }
 
 actor ScriptedDocumentationSession: UpstreamSession {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private let processID: pid_t
     private let plan: ScriptedDocumentationSessionPlan
     private let recorder: ScriptedDocumentationSessionFactory
@@ -301,14 +301,14 @@ actor ScriptedDocumentationSession: UpstreamSession {
         self.plan = plan
         self.recorder = recorder
         self.remainingUserCallResponses = plan.userCallResponses
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
         self.continuation = streamContinuation
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         guard let object = try? JSONSerialization.jsonObject(with: data, options: [])
             as? [String: Any],
             let method = object["method"] as? String else {
@@ -596,12 +596,12 @@ func withEnvironmentVariables<T>(
 }
 
 actor AlwaysOverloadedUpstreamClient: UpstreamSlotControlling {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private let sentMessages = RecordedValues<Data>()
 
     init() {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -614,7 +614,7 @@ actor AlwaysOverloadedUpstreamClient: UpstreamSlotControlling {
         continuation.finish()
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         await sentMessages.append(data)
         return .backpressure
     }
@@ -637,15 +637,15 @@ actor AlwaysOverloadedUpstreamClient: UpstreamSlotControlling {
 }
 
 actor ToggleableOverloadUpstreamClient: UpstreamSlotControlling {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private let sentMessages = RecordedValues<Data>()
     private var overloaded = false
     private var overloadBudget = 0
     private var overloadNextInitializedNotification = false
 
     init() {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -670,7 +670,7 @@ actor ToggleableOverloadUpstreamClient: UpstreamSlotControlling {
         overloadNextInitializedNotification = true
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         await sentMessages.append(data)
         if overloadNextInitializedNotification,
             methodName(from: data) == "notifications/initialized"
@@ -685,7 +685,7 @@ actor ToggleableOverloadUpstreamClient: UpstreamSlotControlling {
         return overloaded ? .backpressure : .accepted
     }
 
-    func yield(_ event: UpstreamEvent) async {
+    func yield(_ event: Upstream.Event) async {
         continuation.yield(event)
     }
 
@@ -945,7 +945,7 @@ func makeInitializeResponse(id: Int64) throws -> Data {
 
 func makeInitializeResponse(id: Int64, serverName: String?) throws -> Data {
     var result: [String: Any] = [
-        "protocolVersion": MCPProtocolVersion.current,
+        "protocolVersion": MCP.ProtocolVersion.current,
         "capabilities": [String: Any]()
     ]
     if let serverName {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -106,12 +106,12 @@ struct RuntimeCoordinatorTests {
         let request1 = makeInitializeRequest(id: 1)
         let request2 = makeInitializeRequest(id: 2)
         let future1 = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: request1,
             on: eventLoop
         )
         let future2 = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 2))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
             requestObject: request2,
             on: eventLoop
         )
@@ -157,7 +157,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -183,7 +183,7 @@ struct RuntimeCoordinatorTests {
         let sessionID = "session-unsupported-protocol"
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -226,7 +226,7 @@ struct RuntimeCoordinatorTests {
         let sessionID = "session-failed-initialize"
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -257,7 +257,7 @@ struct RuntimeCoordinatorTests {
         let session = manager.session(id: sessionID)
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -278,7 +278,7 @@ struct RuntimeCoordinatorTests {
         )
         manager.routeUnmappedUpstreamMessage(serverRequestData, upstreamIndex: 0)
 
-        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let clientID = JSONRPC.ID(any: "xcode-mcp-proxy.server-request.1")!
         let route = try #require(session.serverRequestTracker.consume(clientID: clientID))
         #expect(route.upstreamIndex == 0)
         #expect(route.upstreamID.key == "server-request-1")
@@ -300,7 +300,7 @@ struct RuntimeCoordinatorTests {
         let session = manager.session(id: sessionID)
         let initializeFuture = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -309,7 +309,7 @@ struct RuntimeCoordinatorTests {
         await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
         _ = try await initializeFuture.get()
 
-        let originalID = RPCID(any: NSNumber(value: 42))!
+        let originalID = JSONRPC.ID(any: NSNumber(value: 42))!
         let responseFuture = session.router.registerRequest(
             idKey: originalID.key,
             on: eventLoop
@@ -331,7 +331,7 @@ struct RuntimeCoordinatorTests {
             upstreamIndex: 0
         )
 
-        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let clientID = JSONRPC.ID(any: "xcode-mcp-proxy.server-request.1")!
         let route = try #require(session.serverRequestTracker.consume(clientID: clientID))
         #expect(route.upstreamIndex == 0)
         #expect(route.upstreamID.key == String(upstreamID))
@@ -355,7 +355,7 @@ struct RuntimeCoordinatorTests {
         let session = manager.session(id: sessionID)
         let initializeFuture = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -364,7 +364,7 @@ struct RuntimeCoordinatorTests {
         await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
         _ = try await initializeFuture.get()
 
-        let originalID = RPCID(any: NSNumber(value: 42))!
+        let originalID = JSONRPC.ID(any: NSNumber(value: 42))!
         let responseFuture = session.router.registerRequest(
             idKey: originalID.key,
             on: eventLoop
@@ -397,7 +397,7 @@ struct RuntimeCoordinatorTests {
         #expect((response["id"] as? NSNumber)?.intValue == 42)
         #expect((response["result"] as? [String: Any])?["ok"] as? Bool == true)
 
-        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let clientID = JSONRPC.ID(any: "xcode-mcp-proxy.server-request.1")!
         let route = try #require(session.serverRequestTracker.lookup(clientID: clientID))
         #expect(route.upstreamIndex == 0)
         #expect(route.upstreamID.key == "server-request-1")
@@ -439,7 +439,7 @@ struct RuntimeCoordinatorTests {
         let session = manager.session(id: sessionID)
         let initializeFuture = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -448,7 +448,7 @@ struct RuntimeCoordinatorTests {
         await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
         _ = try await initializeFuture.get()
 
-        let originalID = RPCID(any: NSNumber(value: 42))!
+        let originalID = JSONRPC.ID(any: NSNumber(value: 42))!
         let responseFuture = session.router.registerRequest(
             idKey: originalID.key,
             on: eventLoop
@@ -490,7 +490,7 @@ struct RuntimeCoordinatorTests {
         let session = manager.session(id: sessionID)
         let initializeFuture = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -510,7 +510,7 @@ struct RuntimeCoordinatorTests {
             upstreamIndex: 0
         )
 
-        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let clientID = JSONRPC.ID(any: "xcode-mcp-proxy.server-request.1")!
         #expect(session.serverRequestTracker.lookup(clientID: clientID) != nil)
 
         let clientResponse: [String: Any] = [
@@ -553,7 +553,7 @@ struct RuntimeCoordinatorTests {
         async throws
     {
         let tracker = ServerRequestTracker()
-        let upstreamID = RPCID(any: "duplicate")!
+        let upstreamID = JSONRPC.ID(any: "duplicate")!
 
         let firstClientID = tracker.record(upstreamID: upstreamID, upstreamIndex: 0)
         let secondClientID = tracker.record(upstreamID: upstreamID, upstreamIndex: 1)
@@ -569,7 +569,7 @@ struct RuntimeCoordinatorTests {
 
     @Test func serverRequestTrackerExpiresUnansweredRoutes() async throws {
         let tracker = ServerRequestTracker(routeTimeout: .seconds(1))
-        let upstreamID = RPCID(any: "stale")!
+        let upstreamID = JSONRPC.ID(any: "stale")!
         let now = Date()
 
         let clientID = tracker.record(
@@ -589,17 +589,17 @@ struct RuntimeCoordinatorTests {
         let tracker = ServerRequestTracker(routeTimeout: .seconds(60), maxRoutes: 2)
         let now = Date()
         let first = tracker.record(
-            upstreamID: RPCID(any: "first")!,
+            upstreamID: JSONRPC.ID(any: "first")!,
             upstreamIndex: 0,
             now: now
         )
         let second = tracker.record(
-            upstreamID: RPCID(any: "second")!,
+            upstreamID: JSONRPC.ID(any: "second")!,
             upstreamIndex: 0,
             now: now
         )
         let third = tracker.record(
-            upstreamID: RPCID(any: "third")!,
+            upstreamID: JSONRPC.ID(any: "third")!,
             upstreamIndex: 0,
             now: now
         )
@@ -622,7 +622,7 @@ struct RuntimeCoordinatorTests {
         let firstSession = manager.session(id: firstSessionID)
         let firstFuture = manager.registerInitialize(
             sessionID: firstSessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -635,14 +635,14 @@ struct RuntimeCoordinatorTests {
         let secondSession = manager.session(id: secondSessionID)
         let secondFuture = manager.registerInitialize(
             sessionID: secondSessionID,
-            originalID: RPCID(any: NSNumber(value: 2))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
         _ = try await secondFuture.get()
 
         let ownerLeaseID = manager.createRequestLease(
-            descriptor: SessionPipelineRequestDescriptor(
+            descriptor: SessionRequestPipeline.Descriptor(
                 sessionID: secondSessionID,
                 label: "tools/call:owner",
                 isBatch: false,
@@ -670,7 +670,7 @@ struct RuntimeCoordinatorTests {
         )
         manager.routeUnmappedUpstreamMessage(serverRequestData, upstreamIndex: 0)
 
-        let clientID = RPCID(any: "xcode-mcp-proxy.server-request.1")!
+        let clientID = JSONRPC.ID(any: "xcode-mcp-proxy.server-request.1")!
         #expect(firstSession.serverRequestTracker.consume(clientID: clientID) == nil)
         let route = try #require(secondSession.serverRequestTracker.consume(clientID: clientID))
         #expect(route.upstreamIndex == 0)
@@ -689,7 +689,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -726,7 +726,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -771,7 +771,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -811,7 +811,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -849,7 +849,7 @@ struct RuntimeCoordinatorTests {
 
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -897,7 +897,7 @@ struct RuntimeCoordinatorTests {
 
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -936,7 +936,7 @@ struct RuntimeCoordinatorTests {
 
         let firstFuture = manager.registerInitialize(
             sessionID: "session-A",
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -951,7 +951,7 @@ struct RuntimeCoordinatorTests {
         _ = session.router.drainBufferedNotifications()
         let cachedFuture = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 2))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
@@ -993,7 +993,7 @@ struct RuntimeCoordinatorTests {
         _ = manager.session(id: sessionID)
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1022,7 +1022,7 @@ struct RuntimeCoordinatorTests {
         _ = manager.session(id: sessionID)
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1085,7 +1085,7 @@ struct RuntimeCoordinatorTests {
 
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1153,7 +1153,7 @@ struct RuntimeCoordinatorTests {
 
         let request = makeInitializeRequest(id: 1)
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: request,
             on: eventLoop
         )
@@ -1173,7 +1173,7 @@ struct RuntimeCoordinatorTests {
         #expect(manager.testStateSnapshot().initInFlight == false)
 
         _ = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 2))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
@@ -1195,7 +1195,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1223,7 +1223,7 @@ struct RuntimeCoordinatorTests {
         _ = manager.session(id: sessionID)
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1257,7 +1257,7 @@ struct RuntimeCoordinatorTests {
         _ = manager.session(id: sessionID)
         let future = manager.registerInitialize(
             sessionID: sessionID,
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1304,7 +1304,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1361,7 +1361,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1424,7 +1424,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1494,7 +1494,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1541,7 +1541,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1611,7 +1611,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1677,7 +1677,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1733,7 +1733,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1787,7 +1787,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1842,7 +1842,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -1897,7 +1897,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -2046,7 +2046,7 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func initializeTimeoutRemainsBoundedWhenRequestTimeoutIsDisabled() throws {
-        let timeout = MCPMethodDispatcher.timeoutForInitialize(defaultSeconds: 0)
+        let timeout = MCP.MethodDispatcher.timeoutForInitialize(defaultSeconds: 0)
         #expect(timeout?.nanoseconds == TimeAmount.seconds(60).nanoseconds)
     }
 
@@ -2388,7 +2388,7 @@ struct RuntimeCoordinatorTests {
         }
 
         _ = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: [
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -2429,7 +2429,7 @@ struct RuntimeCoordinatorTests {
 
         let request = makeInitializeRequest(id: 1)
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: request,
             on: eventLoop
         )
@@ -2443,7 +2443,7 @@ struct RuntimeCoordinatorTests {
         _ = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
 
         let cached = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 2))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
@@ -2468,7 +2468,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -2481,7 +2481,7 @@ struct RuntimeCoordinatorTests {
         let init1 = try await sentValue(from: upstream1, at: 0, timeout: .seconds(2))
         let init1ID = try extractUpstreamID(from: init1)
 
-        let activeDescriptor = SessionPipelineRequestDescriptor(
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-active",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -2513,7 +2513,7 @@ struct RuntimeCoordinatorTests {
             ],
             options: []
         )
-        let queuedDescriptor = SessionPipelineRequestDescriptor(
+        let queuedDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-queued",
             label: "tools/list",
             isBatch: false,
@@ -2562,7 +2562,7 @@ struct RuntimeCoordinatorTests {
 
         // First init establishes the cached init result.
         let init1 = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -2582,7 +2582,7 @@ struct RuntimeCoordinatorTests {
 
         // A new downstream initialize must trigger a new upstream initialize (no cached response).
         let init2 = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 2))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
@@ -2602,7 +2602,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -2630,7 +2630,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -2640,7 +2640,7 @@ struct RuntimeCoordinatorTests {
         _ = try await initFuture.get()
         try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
-        let activeDescriptor = SessionPipelineRequestDescriptor(
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-active",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -2672,7 +2672,7 @@ struct RuntimeCoordinatorTests {
             ],
             options: []
         )
-        let queuedDescriptor = SessionPipelineRequestDescriptor(
+        let queuedDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-queued",
             label: "tools/list",
             isBatch: false,
@@ -2733,7 +2733,7 @@ struct RuntimeCoordinatorTests {
 
         // First init establishes the cached init result (primary only).
         let init1 = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -2777,7 +2777,7 @@ struct RuntimeCoordinatorTests {
 
         // A new downstream initialize must trigger a new upstream initialize (no cached response).
         let init2 = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 2))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
@@ -2935,8 +2935,8 @@ struct RuntimeCoordinatorTests {
         let sessionA = manager.session(id: sessionIDA)
         let sessionB = manager.session(id: sessionIDB)
 
-        let originalA = RPCID(any: NSNumber(value: 100))!
-        let originalB = RPCID(any: NSNumber(value: 101))!
+        let originalA = JSONRPC.ID(any: NSNumber(value: 100))!
+        let originalB = JSONRPC.ID(any: NSNumber(value: 101))!
 
         let upstreamIndexA = try #require(
             manager.chooseUpstreamIndex())
@@ -3128,7 +3128,7 @@ struct RuntimeCoordinatorTests {
         let session = manager.session(id: sessionID)
         let upstreamIndex = try #require(
             manager.chooseUpstreamIndex())
-        let original = RPCID(any: NSNumber(value: 301))!
+        let original = JSONRPC.ID(any: NSNumber(value: 301))!
         let future = session.router.registerRequest(
             idKey: original.key, on: eventLoop, timeout: .seconds(1))
         let upstreamID = manager.assignUpstreamID(
@@ -3149,7 +3149,7 @@ struct RuntimeCoordinatorTests {
             ))
         await upstream.yield(
             .stdoutProtocolViolation(
-                StdioFramerProtocolViolation(
+                StdioFramer.ProtocolViolation(
                     reason: .invalidJSON,
                     bufferedByteCount: 1024,
                     preview: "...broken"
@@ -3309,7 +3309,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -3332,7 +3332,7 @@ struct RuntimeCoordinatorTests {
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 0, nowUptimeNs: 0)
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 0, nowUptimeNs: 0)
 
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-quarantine-recovery",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -3378,7 +3378,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -3405,7 +3405,7 @@ struct RuntimeCoordinatorTests {
         let warmInitialize = try #require(await upstream1.sentValue(at: 0))
         let warmInitID = try extractUpstreamID(from: warmInitialize)
 
-        let activeDescriptor = SessionPipelineRequestDescriptor(
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-active",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -3450,7 +3450,7 @@ struct RuntimeCoordinatorTests {
             ],
             options: []
         )
-        let queuedDescriptor = SessionPipelineRequestDescriptor(
+        let queuedDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-queued",
             label: "tools/list",
             isBatch: false,
@@ -3526,7 +3526,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -3541,7 +3541,7 @@ struct RuntimeCoordinatorTests {
         await upstream1.yield(.message(try makeInitializeResponse(id: init1ID)))
         try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
 
-        let activeDescriptor = SessionPipelineRequestDescriptor(
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-active",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -3566,7 +3566,7 @@ struct RuntimeCoordinatorTests {
         }
         _ = activeFuture
 
-        let preferredDescriptor = SessionPipelineRequestDescriptor(
+        let preferredDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-preferred",
             label: "tools/call:XcodeListWindows",
             isBatch: false,
@@ -3589,7 +3589,7 @@ struct RuntimeCoordinatorTests {
             manager.debugSnapshot().queuedRequestCount == 1
         }
 
-        let genericDescriptor = SessionPipelineRequestDescriptor(
+        let genericDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-generic",
             label: "tools/call:ExecuteSnippet",
             isBatch: false,
@@ -3737,7 +3737,7 @@ struct RuntimeCoordinatorTests {
         let session = manager.session(id: sessionID)
 
         // Send a request to upstream1, then kill upstream1 before it can respond.
-        let originalA = RPCID(any: NSNumber(value: 200))!
+        let originalA = JSONRPC.ID(any: NSNumber(value: 200))!
         let futureA = session.router.registerRequest(idKey: originalA.key, on: eventLoop)
         let upstreamIDA = manager.assignUpstreamID(
             sessionID: sessionID, originalID: originalA, upstreamIndex: 1)
@@ -3751,7 +3751,7 @@ struct RuntimeCoordinatorTests {
         )
 
         // The proxy should continue serving on upstream0.
-        let originalB = RPCID(any: NSNumber(value: 201))!
+        let originalB = JSONRPC.ID(any: NSNumber(value: 201))!
         let futureB = session.router.registerRequest(idKey: originalB.key, on: eventLoop)
         let upstreamIndexB = try #require(
             manager.chooseUpstreamIndex())
@@ -3788,7 +3788,7 @@ struct RuntimeCoordinatorTests {
 
         let sessionID = "session-overloaded"
         let session = manager.session(id: sessionID)
-        let original = RPCID(any: NSNumber(value: 910))!
+        let original = JSONRPC.ID(any: NSNumber(value: 910))!
         let future = session.router.registerRequest(
             idKey: original.key, on: eventLoop, timeout: .seconds(5))
         let upstreamID = manager.assignUpstreamID(
@@ -3827,7 +3827,7 @@ struct RuntimeCoordinatorTests {
         let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
         defer { manager.shutdownAndWait() }
 
-        let original = RPCID(any: NSNumber(value: 1001))!
+        let original = JSONRPC.ID(any: NSNumber(value: 1001))!
         let future = manager.registerInitialize(
             originalID: original,
             requestObject: makeInitializeRequest(id: 1001),
@@ -3880,7 +3880,7 @@ struct RuntimeCoordinatorTests {
 
         await upstream0.setOverloaded(true)
 
-        let original = RPCID(any: NSNumber(value: 920))!
+        let original = JSONRPC.ID(any: NSNumber(value: 920))!
         let future = session.router.registerRequest(
             idKey: original.key, on: eventLoop, timeout: .seconds(5))
         let upstreamID = manager.assignUpstreamID(
@@ -3903,7 +3903,7 @@ struct RuntimeCoordinatorTests {
             manager.chooseUpstreamIndex())
         #expect(repinned == 1)
 
-        let original2 = RPCID(any: NSNumber(value: 921))!
+        let original2 = JSONRPC.ID(any: NSNumber(value: 921))!
         let future2 = session.router.registerRequest(
             idKey: original2.key, on: eventLoop, timeout: .seconds(5))
         let upstreamID2 = manager.assignUpstreamID(
@@ -4070,7 +4070,7 @@ struct RuntimeCoordinatorTests {
         ]))
         manager.canonicalBrokerState.syncCanonicalInitialize(cachedHandshake, sourceUpstream: 0)
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 77))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 77))!,
             requestObject: makeInitializeRequest(id: 77),
             on: eventLoop
         )
@@ -4223,7 +4223,7 @@ struct RuntimeCoordinatorTests {
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
 
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-recovery-trigger",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -4273,7 +4273,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4283,7 +4283,7 @@ struct RuntimeCoordinatorTests {
         _ = try await initFuture.get()
         try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
-        let activeDescriptor = SessionPipelineRequestDescriptor(
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-active",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -4307,7 +4307,7 @@ struct RuntimeCoordinatorTests {
         }
         _ = activeFuture
 
-        let queuedDescriptor = SessionPipelineRequestDescriptor(
+        let queuedDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-queued",
             label: "tools/call:ExecuteSnippet",
             isBatch: false,
@@ -4351,7 +4351,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let sessionID = "session-disconnect"
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: sessionID,
             label: "tools/call:ExecuteSnippet",
             isBatch: false,
@@ -4359,7 +4359,7 @@ struct RuntimeCoordinatorTests {
             isTopLevelClientRequest: true
         )
         let leaseID = manager.createRequestLease(descriptor: descriptor)
-        let originalID = try #require(RPCID(any: NSNumber(value: 1)))
+        let originalID = try #require(JSONRPC.ID(any: NSNumber(value: 1)))
         let upstreamID = manager.assignUpstreamID(
             sessionID: sessionID,
             originalID: originalID,
@@ -4413,7 +4413,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let leaseID = manager.createRequestLease(
-            descriptor: SessionPipelineRequestDescriptor(
+            descriptor: SessionRequestPipeline.Descriptor(
                 sessionID: "session-terminal-lease",
                 label: "tools/call:DocumentationSearch",
                 isBatch: false,
@@ -4454,7 +4454,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let sessionID = "session-protocol-violation"
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: sessionID,
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -4462,7 +4462,7 @@ struct RuntimeCoordinatorTests {
             isTopLevelClientRequest: true
         )
         let leaseID = manager.createRequestLease(descriptor: descriptor)
-        let originalID = try #require(RPCID(any: NSNumber(value: 41)))
+        let originalID = try #require(JSONRPC.ID(any: NSNumber(value: 41)))
         let upstreamID = manager.assignUpstreamID(
             sessionID: sessionID,
             originalID: originalID,
@@ -4476,7 +4476,7 @@ struct RuntimeCoordinatorTests {
             timeout: .seconds(5)
         )
         manager.handleUpstreamProtocolViolation(
-            StdioFramerProtocolViolation(
+            StdioFramer.ProtocolViolation(
                 reason: .invalidJSON,
                 bufferedByteCount: 128,
                 preview: "{broken"
@@ -4508,7 +4508,7 @@ struct RuntimeCoordinatorTests {
         #expect(lateLease.releaseReason == "stdoutProtocolViolation")
 
         let nextLeaseID = manager.createRequestLease(descriptor: descriptor)
-        let nextOriginalID = try #require(RPCID(any: NSNumber(value: 42)))
+        let nextOriginalID = try #require(JSONRPC.ID(any: NSNumber(value: 42)))
         let nextUpstreamID = manager.assignUpstreamID(
             sessionID: sessionID,
             originalID: nextOriginalID,
@@ -4541,7 +4541,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4552,7 +4552,7 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
         manager.handleUpstreamProtocolViolation(
-            StdioFramerProtocolViolation(
+            StdioFramer.ProtocolViolation(
                 reason: .invalidJSON,
                 bufferedByteCount: 128,
                 preview: "{broken"
@@ -4581,7 +4581,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4611,7 +4611,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4625,7 +4625,7 @@ struct RuntimeCoordinatorTests {
         #expect(manager.cachedToolsListResult() != nil)
 
         manager.handleUpstreamProtocolViolation(
-            StdioFramerProtocolViolation(
+            StdioFramer.ProtocolViolation(
                 reason: .invalidJSON,
                 bufferedByteCount: 64,
                 preview: "{broken"
@@ -4646,7 +4646,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4657,7 +4657,7 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
         manager.handleUpstreamProtocolViolation(
-            StdioFramerProtocolViolation(
+            StdioFramer.ProtocolViolation(
                 reason: .invalidJSON,
                 bufferedByteCount: 128,
                 preview: "{broken"
@@ -4688,7 +4688,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4698,7 +4698,7 @@ struct RuntimeCoordinatorTests {
         _ = try await initFuture.get()
         try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
-        let activeDescriptor = SessionPipelineRequestDescriptor(
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-active",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -4722,7 +4722,7 @@ struct RuntimeCoordinatorTests {
         }
         _ = activeFuture
 
-        let queuedDescriptor = SessionPipelineRequestDescriptor(
+        let queuedDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-queued",
             label: "tools/call:ExecuteSnippet",
             isBatch: false,
@@ -4749,7 +4749,7 @@ struct RuntimeCoordinatorTests {
         }
 
         manager.handleUpstreamProtocolViolation(
-            StdioFramerProtocolViolation(
+            StdioFramer.ProtocolViolation(
                 reason: .invalidJSON,
                 bufferedByteCount: 128,
                 preview: "{broken"
@@ -4773,7 +4773,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4788,7 +4788,7 @@ struct RuntimeCoordinatorTests {
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 0, nowUptimeNs: 0)
         _ = manager.chooseUpstreamIndex()
 
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-probe-failure",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -4835,7 +4835,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4845,7 +4845,7 @@ struct RuntimeCoordinatorTests {
         _ = try await initFuture.get()
         try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
-        let activeDescriptor = SessionPipelineRequestDescriptor(
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-timeout-active",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -4869,7 +4869,7 @@ struct RuntimeCoordinatorTests {
         }
         _ = activeFuture
 
-        let queuedDescriptor = SessionPipelineRequestDescriptor(
+        let queuedDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-timeout-queued",
             label: "tools/call:ExecuteSnippet",
             isBatch: false,
@@ -4930,7 +4930,7 @@ struct RuntimeCoordinatorTests {
         manager.setCachedToolsListResult(.object(["tools": .array([])]), sourceUpstream: 0)
 
         let leaseID = manager.createRequestLease(
-            descriptor: SessionPipelineRequestDescriptor(
+            descriptor: SessionRequestPipeline.Descriptor(
                 sessionID: "session-debug-reset",
                 label: "tools/call:DocumentationSearch",
                 isBatch: false,
@@ -4964,7 +4964,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -4974,7 +4974,7 @@ struct RuntimeCoordinatorTests {
         _ = try await initFuture.get()
         try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
-        let activeDescriptor = SessionPipelineRequestDescriptor(
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-active",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -4998,7 +4998,7 @@ struct RuntimeCoordinatorTests {
         }
         _ = activeFuture
 
-        let queuedDescriptor = SessionPipelineRequestDescriptor(
+        let queuedDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-queued",
             label: "tools/call:ExecuteSnippet",
             isBatch: false,
@@ -5029,7 +5029,7 @@ struct RuntimeCoordinatorTests {
 
     @Test func requestLeaseRegistryKeepsOnlyBoundedReleasedHistory() async throws {
         let registry = LeaseManager(releasedHistoryLimit: 2)
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-bounded-history",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -5061,7 +5061,7 @@ struct RuntimeCoordinatorTests {
         async throws
     {
         let registry = LeaseManager()
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-requeue",
             label: "tools/call:XcodeRefreshCodeIssuesInFile",
             isBatch: false,
@@ -5093,7 +5093,7 @@ struct RuntimeCoordinatorTests {
         async throws
     {
         let registry = LeaseManager(releasedHistoryLimit: 1)
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-abandon-history",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -5135,10 +5135,10 @@ struct RuntimeCoordinatorTests {
     {
         let eventLoop = EmbeddedEventLoop()
         let scheduler = makeTestUpstreamSlotScheduler(upstreamCount: 1)
-        let startedLeaseIDs = NIOLockedValueBox<[RequestLeaseID]>([])
-        let cancelledLeaseIDs = NIOLockedValueBox<[RequestLeaseID]>([])
+        let startedLeaseIDs = NIOLockedValueBox<[LeaseManager.ID]>([])
+        let cancelledLeaseIDs = NIOLockedValueBox<[LeaseManager.ID]>([])
 
-        let firstDescriptor = SessionPipelineRequestDescriptor(
+        let firstDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-race-1",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -5163,7 +5163,7 @@ struct RuntimeCoordinatorTests {
 
         scheduler.cancelQueuedRequest(leaseID: firstLeaseID)
 
-        let secondDescriptor = SessionPipelineRequestDescriptor(
+        let secondDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-race-2",
             label: "tools/call:ExecuteSnippet",
             isBatch: false,
@@ -5198,10 +5198,10 @@ struct RuntimeCoordinatorTests {
     {
         let eventLoop = EmbeddedEventLoop()
         let scheduler = makeTestUpstreamSlotScheduler(upstreamCount: 1)
-        let startedLeaseIDs = NIOLockedValueBox<[RequestLeaseID]>([])
-        let failedLeaseIDs = NIOLockedValueBox<[RequestLeaseID]>([])
+        let startedLeaseIDs = NIOLockedValueBox<[LeaseManager.ID]>([])
+        let failedLeaseIDs = NIOLockedValueBox<[LeaseManager.ID]>([])
 
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-fail-race",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -5237,10 +5237,10 @@ struct RuntimeCoordinatorTests {
     {
         let eventLoop = EmbeddedEventLoop()
         let scheduler = makeTestUpstreamSlotScheduler(upstreamCount: 1)
-        let startedLeaseIDs = NIOLockedValueBox<[RequestLeaseID]>([])
-        let cancelledLeaseIDs = NIOLockedValueBox<[RequestLeaseID]>([])
+        let startedLeaseIDs = NIOLockedValueBox<[LeaseManager.ID]>([])
+        let cancelledLeaseIDs = NIOLockedValueBox<[LeaseManager.ID]>([])
 
-        let descriptor = SessionPipelineRequestDescriptor(
+        let descriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-reset-race",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -5278,7 +5278,7 @@ struct RuntimeCoordinatorTests {
         let scheduler = makeTestUpstreamSlotScheduler(upstreamCount: 2)
         let started = NIOLockedValueBox<[String]>([])
 
-        let firstDescriptor = SessionPipelineRequestDescriptor(
+        let firstDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-a",
             label: "tools/call:DocumentationSearch",
             isBatch: false,
@@ -5302,7 +5302,7 @@ struct RuntimeCoordinatorTests {
         )
         eventLoop.run()
 
-        let secondDescriptor = SessionPipelineRequestDescriptor(
+        let secondDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-a",
             label: "tools/call:ExecuteSnippet",
             isBatch: false,
@@ -5325,7 +5325,7 @@ struct RuntimeCoordinatorTests {
             }
         )
 
-        let thirdDescriptor = SessionPipelineRequestDescriptor(
+        let thirdDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-b",
             label: "tools/call:XcodeListWindows",
             isBatch: false,

--- a/Tests/ProxySessionTests/TestUpstreamClient.swift
+++ b/Tests/ProxySessionTests/TestUpstreamClient.swift
@@ -4,14 +4,14 @@ import XcodeMCPTestSupport
 @testable import ProxySession
 
 actor TestUpstreamClient: UpstreamSlotControlling {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private let sentMessages = RecordedValues<Data>()
     private var startCountValue = 0
     private var stopCountValue = 0
 
     init() {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -27,12 +27,12 @@ actor TestUpstreamClient: UpstreamSlotControlling {
         continuation.finish()
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         await sentMessages.append(data)
         return .accepted
     }
 
-    func yield(_ event: UpstreamEvent) async {
+    func yield(_ event: Upstream.Event) async {
         continuation.yield(event)
     }
 

--- a/Tests/ProxySessionTests/UpstreamReadinessTests.swift
+++ b/Tests/ProxySessionTests/UpstreamReadinessTests.swift
@@ -245,7 +245,7 @@ extension RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -320,7 +320,7 @@ extension RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
 
         let future = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 1))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
@@ -332,7 +332,7 @@ extension RuntimeCoordinatorTests {
         #expect(await upstream.sentCount() == 0)
 
         let retryFuture = manager.registerInitialize(
-            originalID: RPCID(any: NSNumber(value: 2))!,
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )

--- a/Tests/ProxyStressTests/DocumentationSearchStressTests.swift
+++ b/Tests/ProxyStressTests/DocumentationSearchStressTests.swift
@@ -208,12 +208,12 @@ private struct StressHTTPServer {
 }
 
 private actor DocumentationSearchStressUpstreamClient: UpstreamSlotControlling {
-    nonisolated let events: AsyncStream<UpstreamEvent>
-    private let continuation: AsyncStream<UpstreamEvent>.Continuation
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
     private var countsBySessionIndex: [Int]
 
     init(sessionCount: Int) {
-        var streamContinuation: AsyncStream<UpstreamEvent>.Continuation!
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in
             streamContinuation = continuation
         }
@@ -227,7 +227,7 @@ private actor DocumentationSearchStressUpstreamClient: UpstreamSlotControlling {
         continuation.finish()
     }
 
-    func send(_ data: Data) async -> UpstreamSendResult {
+    func send(_ data: Data) async -> Upstream.SendResult {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
             return .accepted
         }
@@ -287,7 +287,7 @@ private actor DocumentationSearchStressUpstreamClient: UpstreamSlotControlling {
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": id,
-            "result": ["protocolVersion": MCPProtocolVersion.current, "capabilities": [String: Any]()],
+            "result": ["protocolVersion": MCP.ProtocolVersion.current, "capabilities": [String: Any]()],
         ]
         return try! JSONSerialization.data(withJSONObject: response, options: [])
     }
@@ -364,7 +364,7 @@ private func postJSON(
     request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
     if let sessionID {
         request.setValue(sessionID, forHTTPHeaderField: "Mcp-Session-Id")
-        request.setValue(MCPProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
+        request.setValue(MCP.ProtocolVersion.current, forHTTPHeaderField: "MCP-Protocol-Version")
     }
     request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 


### PR DESCRIPTION
## Summary
- Nest support types under their owning domains, including `ProxyConfig`, `MCP`, `JSONRPC`, `RefreshCodeIssues`, `Upstream`, `XcodePermissionDialog`, and CLI command owners.
- Preserve CLI flags, TOML keys, HTTP/MCP wire shape, debug snapshot fields, debug strings, and executable product names.
- Add the `ProxyMCP` to `ProxyCore` target dependency needed to share the `MCP` namespace without compatibility typealiases.

## Validation
- `swift build -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter StdioFramerTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter RefreshCodeIssues -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxySessionTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal`
- `swift test -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`

## Review
- Codex review against `main`: clean, 0 findings.