### PR TITLE
Scope domain support models to owner namespaces

### DIFF
--- a/Docs/maintainer-architecture.md
+++ b/Docs/maintainer-architecture.md
@@ -33,8 +33,8 @@
 ## Dependency Direction
 
 - `ProxyCore` must not depend on gateway/session/Xcode modules.
-  - Current exception: config handshake shaping reuses `ProxyMCP` JSON value types.
-- `ProxyMCP` may depend only on `ProxyCore`-level primitives conceptually; avoid introducing gateway/session/Xcode knowledge.
+- `ProxyMCP` depends on `ProxyCore` for shared protocol primitives and extends the `MCP` namespace for JSON-RPC / MCP helpers.
+  Avoid introducing gateway/session/Xcode knowledge here.
 - `ProxySession` depends on `ProxyCore` and `ProxyMCP`.
 - `ProxyXcodeSupport` depends on `ProxyCore`.
 - `ProxyXcodeFeatures` depends on `ProxyCore`, `ProxyMCP`, and `ProxyXcodeSupport`.

--- a/Sources/ProxyCLI/Common/ProxyCLIInvocationScanner.swift
+++ b/Sources/ProxyCLI/Common/ProxyCLIInvocationScanner.swift
@@ -1,220 +1,224 @@
-import ProxyCore
 import Foundation
+import ProxyCore
 import XcodeMCPProxy
 
 extension CLI {
     package enum InvocationScanner {
         package struct AdapterScan {
-    package var showHelp = false
-    package var showVersion = false
-    package var usesRemovedURLHelper = false
-    package var removedFlagMessage: String?
-    package var hasExplicitURL = false
-    package var hasStdioFlag = false
-    package var serverOnlyFlag: String?
+            package var showHelp = false
+            package var showVersion = false
+            package var usesRemovedURLHelper = false
+            package var removedFlagMessage: String?
+            package var hasExplicitURL = false
+            package var hasStdioFlag = false
+            package var serverOnlyFlag: String?
         }
 
         package struct ServerScan {
-    package var forwardedArgs: [String] = []
-    package var showHelp = false
-    package var showVersion = false
-    package var hasListenFlag = false
-    package var hasHostFlag = false
-    package var hasPortFlag = false
-    package var hasConfigFlag = false
-    package var hasAutoApproveFlag = false
-    package var hasRefreshCodeIssuesModeFlag = false
-    package var forceRestart = false
-    package var dryRun = false
+            package var forwardedArgs: [String] = []
+            package var showHelp = false
+            package var showVersion = false
+            package var hasListenFlag = false
+            package var hasHostFlag = false
+            package var hasPortFlag = false
+            package var hasConfigFlag = false
+            package var hasAutoApproveFlag = false
+            package var hasRefreshCodeIssuesModeFlag = false
+            package var forceRestart = false
+            package var dryRun = false
         }
 
         package struct InstallScan {
-    package var showHelp = false
-    package var showVersion = false
+            package var showHelp = false
+            package var showVersion = false
         }
 
-    private static let serverOnlyFlags = CLI.Flag.serverOnlyFlagNames
-    private static let serverOnlyValueFlags = CLI.Flag.serverOnlyValueFlagNames
-    private static let serverForwardedValueFlags = CLI.Flag.serverForwardedValueFlagNames
+        private static let serverOnlyFlags = CLI.Flag.serverOnlyFlagNames
+        private static let serverOnlyValueFlags = CLI.Flag.serverOnlyValueFlagNames
+        private static let serverForwardedValueFlags = CLI.Flag.serverForwardedValueFlagNames
 
-    package static func scanAdapter(_ args: [String]) -> CLI.InvocationScanner.AdapterScan {
-        var scan = CLI.InvocationScanner.AdapterScan()
-        scan.showVersion = containsVersionFlag(args)
-        var cursor = CLI.ArgumentCursor(args: args)
+        package static func scanAdapter(_ args: [String]) -> CLI.InvocationScanner.AdapterScan {
+            var scan = CLI.InvocationScanner.AdapterScan()
+            scan.showVersion = containsVersionFlag(args)
+            var cursor = CLI.ArgumentCursor(args: args)
 
-        while let arg = cursor.current {
-            switch arg {
-            case "-h", "--help":
-                scan.showHelp = true
-                cursor.advance()
-            case "--version":
-                scan.showVersion = true
-                cursor.advance()
-            case "url" where cursor.index == 1:
-                scan.usesRemovedURLHelper = true
-                cursor.advance()
-            case "--print-url":
-                scan.usesRemovedURLHelper = true
-                cursor.advance()
-            case "--url":
-                scan.hasExplicitURL = true
-                cursor.advancePastCurrentAndOptionalValue(where: { !$0.hasPrefix("-") })
-            case let value where value.hasPrefix("--url="):
-                scan.hasExplicitURL = true
-                cursor.advance()
-            case "--stdio":
-                scan.hasStdioFlag = true
-                cursor.advancePastCurrentAndOptionalValue(where: { !$0.hasPrefix("-") })
-            case "--lazy-init":
-                if scan.removedFlagMessage == nil {
-                    scan.removedFlagMessage = CLIParser.removedLazyInitMessage
-                }
-                cursor.advance()
-            case "--xcode-pid":
-                if scan.removedFlagMessage == nil {
-                    scan.removedFlagMessage = CLIParser.removedXcodePIDMessage
-                }
-                cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
-            case "--request-timeout":
-                cursor.advancePastCurrentAndOptionalValue(where: shouldConsumeRequestTimeoutValue)
-            case let flag where serverOnlyFlags.contains(flag):
-                if scan.serverOnlyFlag == nil {
-                    scan.serverOnlyFlag = flag
-                }
-                if serverOnlyValueFlags.contains(flag) {
+            while let arg = cursor.current {
+                switch arg {
+                case "-h", "--help":
+                    scan.showHelp = true
+                    cursor.advance()
+                case "--version":
+                    scan.showVersion = true
+                    cursor.advance()
+                case "url" where cursor.index == 1:
+                    scan.usesRemovedURLHelper = true
+                    cursor.advance()
+                case "--print-url":
+                    scan.usesRemovedURLHelper = true
+                    cursor.advance()
+                case "--url":
+                    scan.hasExplicitURL = true
+                    cursor.advancePastCurrentAndOptionalValue(where: { !$0.hasPrefix("-") })
+                case let value where value.hasPrefix("--url="):
+                    scan.hasExplicitURL = true
+                    cursor.advance()
+                case "--stdio":
+                    scan.hasStdioFlag = true
+                    cursor.advancePastCurrentAndOptionalValue(where: { !$0.hasPrefix("-") })
+                case "--lazy-init":
+                    if scan.removedFlagMessage == nil {
+                        scan.removedFlagMessage = CLIParser.removedLazyInitMessage
+                    }
+                    cursor.advance()
+                case "--xcode-pid":
+                    if scan.removedFlagMessage == nil {
+                        scan.removedFlagMessage = CLIParser.removedXcodePIDMessage
+                    }
                     cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
-                } else {
+                case "--request-timeout":
+                    cursor.advancePastCurrentAndOptionalValue(
+                        where: shouldConsumeRequestTimeoutValue)
+                case let flag where serverOnlyFlags.contains(flag):
+                    if scan.serverOnlyFlag == nil {
+                        scan.serverOnlyFlag = flag
+                    }
+                    if serverOnlyValueFlags.contains(flag) {
+                        cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
+                    } else {
+                        cursor.advance()
+                    }
+                default:
                     cursor.advance()
                 }
-            default:
-                cursor.advance()
             }
+
+            return scan
         }
 
-        return scan
-    }
+        package static func scanServer(_ args: [String]) throws -> CLI.InvocationScanner.ServerScan
+        {
+            var scan = CLI.InvocationScanner.ServerScan()
+            scan.showVersion = containsVersionFlag(args)
+            var cursor = CLI.ArgumentCursor(args: args)
 
-    package static func scanServer(_ args: [String]) throws -> CLI.InvocationScanner.ServerScan {
-        var scan = CLI.InvocationScanner.ServerScan()
-        scan.showVersion = containsVersionFlag(args)
-        var cursor = CLI.ArgumentCursor(args: args)
+            while let arg = cursor.current {
+                if scan.showVersion {
+                    switch arg {
+                    case "-h", "--help":
+                        scan.showHelp = true
+                        return scan
+                    default:
+                        if serverForwardedValueFlags.contains(arg) {
+                            if arg == "--refresh-code-issues-mode" {
+                                cursor.advance()
+                            } else {
+                                cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
+                            }
+                        } else {
+                            cursor.advance()
+                        }
+                        continue
+                    }
+                }
 
-        while let arg = cursor.current {
-            if scan.showVersion {
                 switch arg {
                 case "-h", "--help":
                     scan.showHelp = true
                     return scan
-                default:
-                    if serverForwardedValueFlags.contains(arg) {
-                        if arg == "--refresh-code-issues-mode" {
-                            cursor.advance()
-                        } else {
-                            cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
-                        }
-                    } else {
-                        cursor.advance()
-                    }
+                case "--version":
+                    scan.showVersion = true
+                    cursor.advance()
                     continue
+                case "--dry-run":
+                    scan.dryRun = true
+                    cursor.advance()
+                    continue
+                case "--force-restart":
+                    scan.forceRestart = true
+                    cursor.advance()
+                    continue
+                case "--stdio":
+                    throw XcodeMCPProxyServerCommand.Error.message(
+                        "--stdio is not supported in server mode (use xcode-mcp-proxy)"
+                    )
+                case "--url":
+                    throw XcodeMCPProxyServerCommand.Error.message(
+                        "--url is not supported in server mode (use xcode-mcp-proxy)"
+                    )
+                case "--xcode-pid":
+                    throw XcodeMCPProxyServerCommand.Error.message(CLIParser.removedXcodePIDMessage)
+                case "--lazy-init":
+                    throw XcodeMCPProxyServerCommand.Error.message(CLIParser.removedLazyInitMessage)
+                case "--listen":
+                    scan.hasListenFlag = true
+                case "--host":
+                    scan.hasHostFlag = true
+                case "--port":
+                    scan.hasPortFlag = true
+                case "--config":
+                    scan.hasConfigFlag = true
+                case "--auto-approve":
+                    scan.hasAutoApproveFlag = true
+                case "--refresh-code-issues-mode":
+                    scan.hasRefreshCodeIssuesModeFlag = true
+                default:
+                    break
+                }
+
+                scan.forwardedArgs.append(arg)
+                if serverForwardedValueFlags.contains(arg) {
+                    let value = try cursor.requiredValue(
+                        for: arg,
+                        error: {
+                            XcodeMCPProxyServerCommand.Error.message("\($0) requires a value")
+                        }
+                    )
+                    scan.forwardedArgs.append(value)
+                } else {
+                    cursor.advance()
                 }
             }
 
-            switch arg {
-            case "-h", "--help":
-                scan.showHelp = true
-                return scan
-            case "--version":
-                scan.showVersion = true
-                cursor.advance()
-                continue
-            case "--dry-run":
-                scan.dryRun = true
-                cursor.advance()
-                continue
-            case "--force-restart":
-                scan.forceRestart = true
-                cursor.advance()
-                continue
-            case "--stdio":
-                throw XcodeMCPProxyServerCommand.Error.message(
-                    "--stdio is not supported in server mode (use xcode-mcp-proxy)"
-                )
-            case "--url":
-                throw XcodeMCPProxyServerCommand.Error.message(
-                    "--url is not supported in server mode (use xcode-mcp-proxy)"
-                )
-            case "--xcode-pid":
-                throw XcodeMCPProxyServerCommand.Error.message(CLIParser.removedXcodePIDMessage)
-            case "--lazy-init":
-                throw XcodeMCPProxyServerCommand.Error.message(CLIParser.removedLazyInitMessage)
-            case "--listen":
-                scan.hasListenFlag = true
-            case "--host":
-                scan.hasHostFlag = true
-            case "--port":
-                scan.hasPortFlag = true
-            case "--config":
-                scan.hasConfigFlag = true
-            case "--auto-approve":
-                scan.hasAutoApproveFlag = true
-            case "--refresh-code-issues-mode":
-                scan.hasRefreshCodeIssuesModeFlag = true
-            default:
-                break
+            return scan
+        }
+
+        package static func scanInstall(_ args: [String]) -> CLI.InvocationScanner.InstallScan {
+            var scan = CLI.InvocationScanner.InstallScan()
+            scan.showVersion = containsVersionFlag(args)
+            var cursor = CLI.ArgumentCursor(args: args)
+
+            while let arg = cursor.current {
+                switch arg {
+                case "-h", "--help":
+                    scan.showHelp = true
+                    cursor.advance()
+                case "--version":
+                    scan.showVersion = true
+                    cursor.advance()
+                case "--prefix", "--bindir":
+                    cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
+                case "--dry-run":
+                    cursor.advance()
+                default:
+                    cursor.advance()
+                }
             }
 
-            scan.forwardedArgs.append(arg)
-            if serverForwardedValueFlags.contains(arg) {
-                let value = try cursor.requiredValue(
-                    for: arg,
-                    error: { XcodeMCPProxyServerCommand.Error.message("\($0) requires a value") }
-                )
-                scan.forwardedArgs.append(value)
-            } else {
-                cursor.advance()
+            return scan
+        }
+
+        package static func shouldConsumeRequestTimeoutValue(_ token: String) -> Bool {
+            if token == "-h" || token == "--help" {
+                return true
             }
-        }
-
-        return scan
-    }
-
-    package static func scanInstall(_ args: [String]) -> CLI.InvocationScanner.InstallScan {
-        var scan = CLI.InvocationScanner.InstallScan()
-        scan.showVersion = containsVersionFlag(args)
-        var cursor = CLI.ArgumentCursor(args: args)
-
-        while let arg = cursor.current {
-            switch arg {
-            case "-h", "--help":
-                scan.showHelp = true
-                cursor.advance()
-            case "--version":
-                scan.showVersion = true
-                cursor.advance()
-            case "--prefix", "--bindir":
-                cursor.advancePastCurrentAndOptionalValue(where: { _ in true })
-            case "--dry-run":
-                cursor.advance()
-            default:
-                cursor.advance()
+            if Double(token) != nil {
+                return true
             }
+            return !token.hasPrefix("-")
         }
 
-        return scan
-    }
-
-    package static func shouldConsumeRequestTimeoutValue(_ token: String) -> Bool {
-        if token == "-h" || token == "--help" {
-            return true
+        private static func containsVersionFlag(_ args: [String]) -> Bool {
+            args.dropFirst().contains("--version")
         }
-        if Double(token) != nil {
-            return true
-        }
-        return !token.hasPrefix("-")
-    }
-
-    private static func containsVersionFlag(_ args: [String]) -> Bool {
-        args.dropFirst().contains("--version")
-    }
     }
 }

--- a/Sources/ProxyCLI/Server/ProxyServerCommandRuntime.swift
+++ b/Sources/ProxyCLI/Server/ProxyServerCommandRuntime.swift
@@ -75,6 +75,10 @@ extension XcodeMCPProxyServerCommand {
             dependencies.stderr(error.description)
             dependencies.stderr(XcodeMCPProxyServerCommand.serverUsage())
             return 1
+        } catch let error as ProxyConfig.ValidationError {
+            dependencies.stderr(error.description)
+            dependencies.stderr(XcodeMCPProxyServerCommand.serverUsage())
+            return 1
         } catch {
             dependencies.stderr("error: \(error)")
             return 1

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -18,6 +18,17 @@ public struct ProxyConfig: Sendable {
         case upstream
     }
 
+    public enum ValidationError: Error, CustomStringConvertible {
+        case unsupportedProtocolVersion(String)
+
+        public var description: String {
+            switch self {
+            case .unsupportedProtocolVersion(let protocolVersion):
+                return "upstream_handshake.protocolVersion must be \(MCP.ProtocolVersion.current); \(protocolVersion) is not supported"
+            }
+        }
+    }
+
     package enum File {}
 
     public var listenHost: String
@@ -106,9 +117,7 @@ public struct ProxyConfig: Sendable {
             return
         }
         guard MCP.ProtocolVersion.isSupported(protocolVersion) else {
-            throw CLIError.message(
-                "upstream_handshake.protocolVersion must be \(MCP.ProtocolVersion.current); \(protocolVersion) is not supported"
-            )
+            throw ValidationError.unsupportedProtocolVersion(protocolVersion)
         }
     }
 }

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
@@ -9,16 +9,16 @@ package final class HTTPControlService: Sendable {
         package let proxyInitialized: Bool
         package let cachedToolsListAvailable: Bool
         package let warmupInFlight: Bool
-        package let controlPlane: ProxyControlPlaneDebugSnapshot?
-        package let upstreams: [ProxyUpstreamDebugSnapshot]
-        package let recentTraffic: [ProxyDebugTrafficEvent]
+        package let controlPlane: ControlPlane.DebugSnapshot?
+        package let upstreams: [ProxyDebug.UpstreamSnapshot]
+        package let recentTraffic: [ProxyDebug.TrafficEvent]
         package let sessions: [SessionRequestPipeline.DebugSnapshot]
         package let leases: [LeaseManager.DebugSnapshot]
         package let queuedRequestCount: Int
         package let refreshCodeIssues: RefreshCodeIssues.DebugSnapshot?
 
         package init(
-            base: ProxyDebugSnapshot,
+            base: ProxyDebug.Snapshot,
             refreshCodeIssues: RefreshCodeIssues.DebugSnapshot?
         ) {
             self.generatedAt = base.generatedAt

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -50,7 +50,7 @@ package struct LocalMCPResponder {
         requestTimeoutOverride: TimeAmount?
     ) async throws -> Data {
         guard let originalID = JSONRPC.Message.Inspector.requestID(from: object) else {
-            throw ControlPlaneError.invalidResponse("missing id")
+            throw ControlPlane.Error.invalidResponse("missing id")
         }
         let result = try await sessionManager.sharedToolsList(
             sessionID: sessionID,
@@ -321,7 +321,7 @@ package struct LocalMCPResponder {
         id: JSONRPC.ID,
         error: Error
     ) throws -> Data {
-        let mapped = ControlPlaneErrorMapper.jsonRPCError(for: error)
+        let mapped = ControlPlane.ErrorMapper.jsonRPCError(for: error)
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": id.value.foundationObject,

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -395,7 +395,7 @@ extension HTTPPostService {
                     contentsOf: Self.responseObjects(from: responseData)
                 )
             } catch {
-                let mapped = ControlPlaneErrorMapper.jsonRPCError(for: error)
+                let mapped = ControlPlane.ErrorMapper.jsonRPCError(for: error)
                 if let responseData = Self.responseDataForBatchResolution(
                     .mcpError(
                         id: originalID,
@@ -471,7 +471,7 @@ extension HTTPPostService {
                 case .handled(let responseData):
                     let normalizedData = normalizer.normalizeResponseDataIfNeeded(
                         method: "tools/call",
-                        toolName: DocumentationToolCatalog.toolName,
+                        toolName: DocumentationProvider.ToolCatalog.toolName,
                         upstreamData: responseData
                     )
                     responseObjects.append(
@@ -487,7 +487,7 @@ extension HTTPPostService {
                     )
                 }
             } catch {
-                let mapped = ControlPlaneErrorMapper.jsonRPCError(for: error)
+                let mapped = ControlPlane.ErrorMapper.jsonRPCError(for: error)
                 responseObjects.append(
                     Self.makeJSONRPCErrorResponseObject(
                         id: originalID,
@@ -513,8 +513,8 @@ extension HTTPPostService {
         }
         guard case .request("tools/call", _) = JSONRPC.Message.Inspector.kind(of: object),
             let params = object["params"] as? [String: Any],
-            params["name"] as? String == DocumentationToolCatalog.toolName,
-            disabledToolNames.contains(DocumentationToolCatalog.toolName) == false else {
+            params["name"] as? String == DocumentationProvider.ToolCatalog.toolName,
+            disabledToolNames.contains(DocumentationProvider.ToolCatalog.toolName) == false else {
             return false
         }
         return true

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+RefreshSupport.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+RefreshSupport.swift
@@ -22,7 +22,7 @@ extension HTTPPostService {
         _ = eventLoop
         _ = cancellationHandle
         let windowQueryService = XcodeWindowQueryService()
-        let route: ControlPlaneRoute = if let upstreamIndexOverride {
+        let route: ControlPlane.Route = if let upstreamIndexOverride {
             .pinnedUpstream(upstreamIndexOverride)
         } else {
             .anyHealthy

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
@@ -6,174 +6,177 @@ import NIOFoundationCompat
 import NIOHTTP1
 import ProxyCore
 import ProxyMCP
+import ProxySession
 import ProxyXcodeFeatures
 import ProxyXcodeSupport
-import ProxySession
 
 extension HTTPPostService {
     package enum Resolution {
-    case responseData(
-        data: Data,
-        sessionID: String?,
-        prefersEventStream: Bool
-    )
-    case mcpError(
-        id: JSONRPC.ID?,
-        ids: [JSONRPC.ID],
-        code: Int,
-        message: String,
-        forceBatchArray: Bool,
-        sessionID: String?,
-        prefersEventStream: Bool
-    )
-    case plain(
-        status: HTTPResponseStatus,
-        body: String,
-        sessionID: String?
-    )
-    case empty(
-        status: HTTPResponseStatus,
-        sessionID: String
-    )
+        case responseData(
+            data: Data,
+            sessionID: String?,
+            prefersEventStream: Bool
+        )
+        case mcpError(
+            id: JSONRPC.ID?,
+            ids: [JSONRPC.ID],
+            code: Int,
+            message: String,
+            forceBatchArray: Bool,
+            sessionID: String?,
+            prefersEventStream: Bool
+        )
+        case plain(
+            status: HTTPResponseStatus,
+            body: String,
+            sessionID: String?
+        )
+        case empty(
+            status: HTTPResponseStatus,
+            sessionID: String
+        )
     }
 
     package struct Operation {
-    package let future: EventLoopFuture<HTTPPostService.Resolution>
-    package let cancellationHandle: HTTPPostService.CancellationHandle?
+        package let future: EventLoopFuture<HTTPPostService.Resolution>
+        package let cancellationHandle: HTTPPostService.CancellationHandle?
     }
 
     package struct RefreshRoute: Sendable {
-    let request: RefreshCodeIssues.Request
-    let bodyData: Data
-    let requestIDs: [JSONRPC.ID]
-    let requestIsBatch: Bool
+        let request: RefreshCodeIssues.Request
+        let bodyData: Data
+        let requestIDs: [JSONRPC.ID]
+        let requestIsBatch: Bool
     }
 
     package struct RefreshRouting: Sendable {
-    let refreshRoutes: [HTTPPostService.RefreshRoute]
-    let remainingBodyData: Data?
-    let remainingRequestIDs: [JSONRPC.ID]
-    let remainingLocalResponseData: Data?
+        let refreshRoutes: [HTTPPostService.RefreshRoute]
+        let remainingBodyData: Data?
+        let remainingRequestIDs: [JSONRPC.ID]
+        let remainingLocalResponseData: Data?
     }
 
     package enum CancellationSource: String, Sendable {
-    case channelInactive
-    case responseWriteFailure
+        case channelInactive
+        case responseWriteFailure
     }
 
     package final class CancellationHandle: @unchecked Sendable {
-    private struct State: Sendable {
-        var requestIDKeys: [String]
-        var upstreamIndex: Int?
-        var routerPendingToken: UUID?
-        var refreshTask: Task<Void, Never>?
-        var childHandles: [HTTPPostService.CancellationHandle] = []
-        var isTerminal = false
-    }
-
-    package let leaseID: LeaseManager.ID
-    package let sessionID: String
-    private let state: NIOLockedValueBox<State>
-
-    package init(
-        leaseID: LeaseManager.ID,
-        sessionID: String,
-        requestIDKeys: [String]
-    ) {
-        self.leaseID = leaseID
-        self.sessionID = sessionID
-        self.state = NIOLockedValueBox(
-            State(requestIDKeys: requestIDKeys)
-        )
-    }
-
-    package var requestIDKeys: [String] {
-        state.withLockedValue { $0.requestIDKeys }
-    }
-
-    package var isCancelled: Bool {
-        state.withLockedValue { $0.isTerminal }
-    }
-
-    package func activate(upstreamIndex: Int) {
-        state.withLockedValue { state in
-            guard !state.isTerminal else { return }
-            state.upstreamIndex = upstreamIndex
+        private struct State: Sendable {
+            var requestIDKeys: [String]
+            var upstreamIndex: Int?
+            var routerPendingToken: UUID?
+            var refreshTask: Task<Void, Never>?
+            var childHandles: [HTTPPostService.CancellationHandle] = []
+            var isTerminal = false
         }
-    }
 
-    package func bindRouterPendingToken(_ token: UUID) {
-        state.withLockedValue { state in
-            guard !state.isTerminal else { return }
-            state.routerPendingToken = token
-        }
-    }
+        package let leaseID: LeaseManager.ID
+        package let sessionID: String
+        private let state: NIOLockedValueBox<State>
 
-    package func bindRequestIDKeys(_ requestIDKeys: [String]) {
-        state.withLockedValue { state in
-            guard !state.isTerminal else { return }
-            state.requestIDKeys = requestIDKeys
-        }
-    }
-
-    package func markCompleted() {
-        state.withLockedValue { state in
-            state.isTerminal = true
-            state.refreshTask = nil
-            state.childHandles.removeAll()
-        }
-    }
-
-    package func bindRefreshTask(_ task: Task<Void, Never>) {
-        let shouldCancel = state.withLockedValue { state -> Bool in
-            guard !state.isTerminal else { return true }
-            state.refreshTask = task
-            return false
-        }
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    @discardableResult
-    package func bindChildHandle(_ handle: HTTPPostService.CancellationHandle) -> Bool {
-        state.withLockedValue { state in
-            guard !state.isTerminal else { return false }
-            state.childHandles.append(handle)
-            return true
-        }
-    }
-
-    package func cancel(using runtime: any RuntimeCoordinating) {
-        let snapshot = state.withLockedValue {
-            state -> (Int?, UUID?, Task<Void, Never>?, [HTTPPostService.CancellationHandle], [String])? in
-            guard !state.isTerminal else { return nil }
-            state.isTerminal = true
-            let snapshot = (
-                state.upstreamIndex,
-                state.routerPendingToken,
-                state.refreshTask,
-                state.childHandles,
-                state.requestIDKeys
+        package init(
+            leaseID: LeaseManager.ID,
+            sessionID: String,
+            requestIDKeys: [String]
+        ) {
+            self.leaseID = leaseID
+            self.sessionID = sessionID
+            self.state = NIOLockedValueBox(
+                State(requestIDKeys: requestIDKeys)
             )
-            state.refreshTask = nil
-            state.childHandles = []
-            return snapshot
         }
-        guard let snapshot else { return }
-        snapshot.2?.cancel()
-        for childHandle in snapshot.3 {
-            childHandle.cancel(using: runtime)
+
+        package var requestIDKeys: [String] {
+            state.withLockedValue { $0.requestIDKeys }
         }
-        if let routerPendingToken = snapshot.1, runtime.hasSession(id: sessionID) {
-            _ = runtime.session(id: sessionID).router.cancelPending(token: routerPendingToken)
+
+        package var isCancelled: Bool {
+            state.withLockedValue { $0.isTerminal }
         }
-        runtime.abandonRequestLease(
-            leaseID,
-            sessionID: sessionID,
-            requestIDKeys: snapshot.4,
-            upstreamIndex: snapshot.0
-        )
-    }
+
+        package func activate(upstreamIndex: Int) {
+            state.withLockedValue { state in
+                guard !state.isTerminal else { return }
+                state.upstreamIndex = upstreamIndex
+            }
+        }
+
+        package func bindRouterPendingToken(_ token: UUID) {
+            state.withLockedValue { state in
+                guard !state.isTerminal else { return }
+                state.routerPendingToken = token
+            }
+        }
+
+        package func bindRequestIDKeys(_ requestIDKeys: [String]) {
+            state.withLockedValue { state in
+                guard !state.isTerminal else { return }
+                state.requestIDKeys = requestIDKeys
+            }
+        }
+
+        package func markCompleted() {
+            state.withLockedValue { state in
+                state.isTerminal = true
+                state.refreshTask = nil
+                state.childHandles.removeAll()
+            }
+        }
+
+        package func bindRefreshTask(_ task: Task<Void, Never>) {
+            let shouldCancel = state.withLockedValue { state -> Bool in
+                guard !state.isTerminal else { return true }
+                state.refreshTask = task
+                return false
+            }
+            if shouldCancel {
+                task.cancel()
+            }
+        }
+
+        @discardableResult
+        package func bindChildHandle(_ handle: HTTPPostService.CancellationHandle) -> Bool {
+            state.withLockedValue { state in
+                guard !state.isTerminal else { return false }
+                state.childHandles.append(handle)
+                return true
+            }
+        }
+
+        package func cancel(using runtime: any RuntimeCoordinating) {
+            let snapshot = state.withLockedValue {
+                state -> (
+                    Int?, UUID?, Task<Void, Never>?, [HTTPPostService.CancellationHandle], [String]
+                )?
+                in
+                guard !state.isTerminal else { return nil }
+                state.isTerminal = true
+                let snapshot = (
+                    state.upstreamIndex,
+                    state.routerPendingToken,
+                    state.refreshTask,
+                    state.childHandles,
+                    state.requestIDKeys
+                )
+                state.refreshTask = nil
+                state.childHandles = []
+                return snapshot
+            }
+            guard let snapshot else { return }
+            snapshot.2?.cancel()
+            for childHandle in snapshot.3 {
+                childHandle.cancel(using: runtime)
+            }
+            if let routerPendingToken = snapshot.1, runtime.hasSession(id: sessionID) {
+                _ = runtime.session(id: sessionID).router.cancelPending(token: routerPendingToken)
+            }
+            runtime.abandonRequestLease(
+                leaseID,
+                sessionID: sessionID,
+                requestIDKeys: snapshot.4,
+                upstreamIndex: snapshot.0
+            )
+        }
     }
 }

--- a/Sources/ProxySession/ControlPlane/CanonicalBrokerState.swift
+++ b/Sources/ProxySession/ControlPlane/CanonicalBrokerState.swift
@@ -2,58 +2,58 @@ import Foundation
 import NIOConcurrencyHelpers
 import ProxyMCP
 
-package struct CanonicalBrokerIncompatibility: Codable, Sendable {
-    package let upstreamIndex: Int
-    package let kind: String
-    package let reason: String
-    package let observedAt: Date
-
-    package init(
-        upstreamIndex: Int,
-        kind: String,
-        reason: String,
-        observedAt: Date = Date()
-    ) {
-        self.upstreamIndex = upstreamIndex
-        self.kind = kind
-        self.reason = reason
-        self.observedAt = observedAt
-    }
-}
-
-package struct CanonicalBrokerSnapshot: Sendable {
-    package let initializeResult: JSONValue?
-    package let initializeSourceUpstream: Int?
-    package let toolsCatalogRaw: JSONValue?
-    package let toolsSourceUpstream: Int?
-    package let lastIncompatibility: CanonicalBrokerIncompatibility?
-
-    package init(
-        initializeResult: JSONValue?,
-        initializeSourceUpstream: Int?,
-        toolsCatalogRaw: JSONValue?,
-        toolsSourceUpstream: Int?,
-        lastIncompatibility: CanonicalBrokerIncompatibility?
-    ) {
-        self.initializeResult = initializeResult
-        self.initializeSourceUpstream = initializeSourceUpstream
-        self.toolsCatalogRaw = toolsCatalogRaw
-        self.toolsSourceUpstream = toolsSourceUpstream
-        self.lastIncompatibility = lastIncompatibility
-    }
-
-    package var canonicalReady: Bool {
-        initializeResult != nil && toolsCatalogRaw != nil
-    }
-}
-
 package final class CanonicalBrokerState: Sendable {
+    package struct Incompatibility: Codable, Sendable {
+        package let upstreamIndex: Int
+        package let kind: String
+        package let reason: String
+        package let observedAt: Date
+
+        package init(
+            upstreamIndex: Int,
+            kind: String,
+            reason: String,
+            observedAt: Date = Date()
+        ) {
+            self.upstreamIndex = upstreamIndex
+            self.kind = kind
+            self.reason = reason
+            self.observedAt = observedAt
+        }
+    }
+
+    package struct Snapshot: Sendable {
+        package let initializeResult: JSONValue?
+        package let initializeSourceUpstream: Int?
+        package let toolsCatalogRaw: JSONValue?
+        package let toolsSourceUpstream: Int?
+        package let lastIncompatibility: CanonicalBrokerState.Incompatibility?
+
+        package init(
+            initializeResult: JSONValue?,
+            initializeSourceUpstream: Int?,
+            toolsCatalogRaw: JSONValue?,
+            toolsSourceUpstream: Int?,
+            lastIncompatibility: CanonicalBrokerState.Incompatibility?
+        ) {
+            self.initializeResult = initializeResult
+            self.initializeSourceUpstream = initializeSourceUpstream
+            self.toolsCatalogRaw = toolsCatalogRaw
+            self.toolsSourceUpstream = toolsSourceUpstream
+            self.lastIncompatibility = lastIncompatibility
+        }
+
+        package var canonicalReady: Bool {
+            initializeResult != nil && toolsCatalogRaw != nil
+        }
+    }
+
     private struct State: Sendable {
         var initializeResult: JSONValue?
         var initializeSourceUpstream: Int?
         var toolsCatalogRaw: JSONValue?
         var toolsSourceUpstream: Int?
-        var lastIncompatibility: CanonicalBrokerIncompatibility?
+        var lastIncompatibility: CanonicalBrokerState.Incompatibility?
         /// Bumped on every clear/reset. Asynchronous load completions
         /// captured under an older generation must not write back, which
         /// is what allows invalidation to clear synchronously without
@@ -65,9 +65,9 @@ package final class CanonicalBrokerState: Sendable {
 
     package init() {}
 
-    package func snapshot() -> CanonicalBrokerSnapshot {
+    package func snapshot() -> CanonicalBrokerState.Snapshot {
         state.withLockedValue { state in
-            CanonicalBrokerSnapshot(
+            CanonicalBrokerState.Snapshot(
                 initializeResult: state.initializeResult,
                 initializeSourceUpstream: state.initializeSourceUpstream,
                 toolsCatalogRaw: state.toolsCatalogRaw,
@@ -154,7 +154,7 @@ package final class CanonicalBrokerState: Sendable {
         reason: String
     ) {
         state.withLockedValue { state in
-            state.lastIncompatibility = CanonicalBrokerIncompatibility(
+            state.lastIncompatibility = CanonicalBrokerState.Incompatibility(
                 upstreamIndex: upstreamIndex,
                 kind: kind,
                 reason: reason

--- a/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator+LoadPromotion.swift
+++ b/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator+LoadPromotion.swift
@@ -29,7 +29,7 @@ extension ControlPlaneCoordinator {
     }
 
     func replaceWindowLoad(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         current: WindowLoadState,
         requestTimeout: TimeAmount?
     ) -> UUID {
@@ -96,7 +96,7 @@ extension ControlPlaneCoordinator {
     }
 
     func attachWindowWaiters(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         loadID: UUID,
         waiters: [(WaiterID, WindowWaiterRecord)]
     ) {
@@ -129,14 +129,14 @@ extension ControlPlaneCoordinator {
         return .idle
     }
 
-    func currentWaiterCounts() -> ControlPlaneWaiterCounts {
+    func currentWaiterCounts() -> ControlPlane.WaiterCounts {
         let toolsCount =
             (toolsCatalogLoad?.foregroundWaiterCount ?? 0)
             + (prewarmToolsCatalogLoad?.foregroundWaiterCount ?? 0)
         let windowsCount = windowLoads.values.reduce(into: 0) { partial, load in
             partial += load.waiters.count
         }
-        return ControlPlaneWaiterCounts(
+        return ControlPlane.WaiterCounts(
             initialize: 0,
             toolsCatalog: toolsCount,
             windows: windowsCount
@@ -159,7 +159,7 @@ extension ControlPlaneCoordinator {
 
     func syncDebug() {
         let brokerSnapshot = brokerState.snapshot()
-        let snapshot = ProxyControlPlaneDebugSnapshot(
+        let snapshot = ControlPlane.DebugSnapshot(
             phase: currentPhase().rawValue,
             canonicalInitializeSourceUpstream: brokerSnapshot.initializeSourceUpstream,
             canonicalToolsSourceUpstream: brokerSnapshot.toolsSourceUpstream,

--- a/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator.swift
+++ b/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator.swift
@@ -6,13 +6,13 @@ import ProxyMCP
 
 package actor ControlPlaneCoordinator {
     package typealias ToolsCatalogLoader =
-        @Sendable (_ requestTimeout: TimeAmount?, _ rpcHandle: ControlPlaneRPCHandle) async throws
+        @Sendable (_ requestTimeout: TimeAmount?, _ rpcHandle: ControlPlane.RPCHandle) async throws
             -> CanonicalToolsCatalogLoadResult
     package typealias WindowsLoader =
         @Sendable (
-            _ route: ControlPlaneRoute,
+            _ route: ControlPlane.Route,
             _ requestTimeout: TimeAmount?,
-            _ rpcHandle: ControlPlaneRPCHandle
+            _ rpcHandle: ControlPlane.RPCHandle
         ) async throws -> JSONValue
     package typealias UpstreamHandshakeStatesProvider = @Sendable () -> [String: String]
 
@@ -52,7 +52,7 @@ package actor ControlPlaneCoordinator {
         let origin: ToolsCatalogLoadOrigin
         let requestTimeout: TimeAmount?
         let requestDeadlineUptimeNs: UInt64?
-        let rpcHandle: ControlPlaneRPCHandle
+        let rpcHandle: ControlPlane.RPCHandle
         let task: Task<CanonicalToolsCatalogLoadResult, Error>
         let startGeneration: UInt64
         var waiters: [WaiterID: ToolsCatalogWaiterRecord] = [:]
@@ -61,17 +61,17 @@ package actor ControlPlaneCoordinator {
 
     struct WindowLoadState {
         let loadID: UUID
-        let route: ControlPlaneRoute
+        let route: ControlPlane.Route
         let requestTimeout: TimeAmount?
         let requestDeadlineUptimeNs: UInt64?
-        let rpcHandle: ControlPlaneRPCHandle
+        let rpcHandle: ControlPlane.RPCHandle
         let task: Task<JSONValue, Error>
         let startGeneration: UInt64
         var waiters: [WaiterID: WindowWaiterRecord] = [:]
     }
 
     let brokerState: CanonicalBrokerState
-    let debugMirror: ControlPlaneDebugMirror
+    let debugMirror: ControlPlane.DebugMirror
     let toolsCatalogLoader: ToolsCatalogLoader
     let windowsLoader: WindowsLoader
     let upstreamHandshakeStates: UpstreamHandshakeStatesProvider
@@ -81,11 +81,11 @@ package actor ControlPlaneCoordinator {
 
     var toolsCatalogLoad: ToolsCatalogLoadState?
     var prewarmToolsCatalogLoad: ToolsCatalogLoadState?
-    var windowLoads: [ControlPlaneRoute: WindowLoadState] = [:]
+    var windowLoads: [ControlPlane.Route: WindowLoadState] = [:]
 
     package init(
         brokerState: CanonicalBrokerState,
-        debugMirror: ControlPlaneDebugMirror,
+        debugMirror: ControlPlane.DebugMirror,
         toolsCatalogLoader: @escaping ToolsCatalogLoader,
         windowsLoader: @escaping WindowsLoader,
         upstreamHandshakeStates: @escaping UpstreamHandshakeStatesProvider,
@@ -137,7 +137,7 @@ package actor ControlPlaneCoordinator {
     }
 
     package func listWindows(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         deadlineUptimeNs: UInt64?
     ) async throws -> JSONValue {
         cancelInvalidatedLoads()
@@ -245,7 +245,7 @@ package actor ControlPlaneCoordinator {
         requestTimeout: TimeAmount?
     ) -> UUID {
         let loadID = UUID()
-        let rpcHandle = ControlPlaneRPCHandle()
+        let rpcHandle = ControlPlane.RPCHandle()
         let requestDeadlineUptimeNs = requestDeadline(for: requestTimeout)
         let task = Task.detached {
             try await self.toolsCatalogLoader(requestTimeout, rpcHandle)
@@ -279,11 +279,11 @@ package actor ControlPlaneCoordinator {
     }
 
     func startWindowLoad(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         requestTimeout: TimeAmount?
     ) -> UUID {
         let loadID = UUID()
-        let rpcHandle = ControlPlaneRPCHandle()
+        let rpcHandle = ControlPlane.RPCHandle()
         let requestDeadlineUptimeNs = requestDeadline(for: requestTimeout)
         let task = Task.detached {
             try await self.windowsLoader(route, requestTimeout, rpcHandle)
@@ -336,7 +336,7 @@ package actor ControlPlaneCoordinator {
     }
 
     func ensureWindowLoad(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         requestTimeout: TimeAmount?,
         requestedPromotionDeadlineUptimeNs: UInt64?
     ) -> UUID {
@@ -388,7 +388,7 @@ package actor ControlPlaneCoordinator {
     }
 
     func registerWindowWaiter(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         loadID: UUID,
         waiterID: WaiterID,
         deadlineUptimeNs: UInt64?,
@@ -455,7 +455,7 @@ package actor ControlPlaneCoordinator {
     }
 
     func timeoutWindowWaiter(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         loadID: UUID,
         waiterID: WaiterID
     ) {
@@ -463,7 +463,7 @@ package actor ControlPlaneCoordinator {
     }
 
     func cancelWindowWaiter(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         loadID: UUID,
         waiterID: WaiterID
     ) {
@@ -476,7 +476,7 @@ package actor ControlPlaneCoordinator {
     }
 
     private func removeWindowWaiter(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         loadID: UUID,
         waiterID: WaiterID,
         failingWith error: any Error
@@ -495,7 +495,7 @@ package actor ControlPlaneCoordinator {
     }
 
     func cancelWindowWaiter(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         waiterID: WaiterID
     ) {
         guard let load = windowLoads[route], load.waiters[waiterID] != nil else { return }
@@ -531,7 +531,7 @@ package actor ControlPlaneCoordinator {
     }
 
     func completeWindowLoad(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         loadID: UUID,
         result: Result<JSONValue, Error>
     ) {

--- a/Sources/ProxySession/ControlPlane/ControlPlaneSupport.swift
+++ b/Sources/ProxySession/ControlPlane/ControlPlaneSupport.swift
@@ -2,16 +2,20 @@ import Foundation
 import NIOConcurrencyHelpers
 import ProxyMCP
 
-package enum ControlPlaneRoute: Hashable, Sendable {
-    case anyHealthy
-    case pinnedUpstream(Int)
+package enum ControlPlane {}
 
-    package var debugLabel: String {
-        switch self {
-        case .anyHealthy:
-            return "any_healthy"
-        case .pinnedUpstream(let upstreamIndex):
-            return "pinned_\(upstreamIndex)"
+extension ControlPlane {
+    package enum Route: Hashable, Sendable {
+        case anyHealthy
+        case pinnedUpstream(Int)
+
+        package var debugLabel: String {
+            switch self {
+            case .anyHealthy:
+                return "any_healthy"
+            case .pinnedUpstream(let upstreamIndex):
+                return "pinned_\(upstreamIndex)"
+            }
         }
     }
 }
@@ -22,183 +26,197 @@ package struct CanonicalToolsCatalogLoadResult: Sendable {
     package let durationMilliseconds: Int
 }
 
-package struct ControlPlaneWaiterCounts: Codable, Sendable {
-    package let initialize: Int
-    package let toolsCatalog: Int
-    package let windows: Int
-}
-
-package struct ProxyControlPlaneDebugSnapshot: Codable, Sendable {
-    package let phase: String
-    package let canonicalInitializeSourceUpstream: Int?
-    package let canonicalToolsSourceUpstream: Int?
-    package let canonicalReady: Bool
-    package let upstreamHandshakeStates: [String: String]
-    package let waiterCounts: ControlPlaneWaiterCounts
-    package let inFlightControlPlaneRequests: [String]
-    package let lastIncompatibility: CanonicalBrokerIncompatibility?
-}
-
-package final class ControlPlaneDebugMirror: Sendable {
-    private let state = NIOLockedValueBox<ProxyControlPlaneDebugSnapshot?>(nil)
-
-    package init() {}
-
-    package func snapshot() -> ProxyControlPlaneDebugSnapshot? {
-        state.withLockedValue { $0 }
+extension ControlPlane {
+    package struct WaiterCounts: Codable, Sendable {
+        package let initialize: Int
+        package let toolsCatalog: Int
+        package let windows: Int
     }
+}
 
-    package func overwrite(_ snapshot: ProxyControlPlaneDebugSnapshot?) {
-        state.withLockedValue { state in
-            state = snapshot
+extension ControlPlane {
+    package struct DebugSnapshot: Codable, Sendable {
+        package let phase: String
+        package let canonicalInitializeSourceUpstream: Int?
+        package let canonicalToolsSourceUpstream: Int?
+        package let canonicalReady: Bool
+        package let upstreamHandshakeStates: [String: String]
+        package let waiterCounts: ControlPlane.WaiterCounts
+        package let inFlightControlPlaneRequests: [String]
+        package let lastIncompatibility: CanonicalBrokerState.Incompatibility?
+    }
+}
+
+extension ControlPlane {
+    package final class DebugMirror: Sendable {
+        private let state = NIOLockedValueBox<ControlPlane.DebugSnapshot?>(nil)
+
+        package init() {}
+
+        package func snapshot() -> ControlPlane.DebugSnapshot? {
+            state.withLockedValue { $0 }
         }
-    }
-}
 
-package struct ControlPlaneRPCCancelSnapshot: Sendable {
-    package let registrationToken: UUID?
-    package let upstreamIndex: Int?
-    package let requestIDKey: String?
-
-    package init(
-        registrationToken: UUID?,
-        upstreamIndex: Int?,
-        requestIDKey: String?
-    ) {
-        self.registrationToken = registrationToken
-        self.upstreamIndex = upstreamIndex
-        self.requestIDKey = requestIDKey
-    }
-}
-
-package final class ControlPlaneRPCHandle: Sendable {
-    package enum State: Sendable {
-        case queued
-        case registered(registrationToken: UUID, upstreamIndex: Int)
-        case assigned(registrationToken: UUID, upstreamIndex: Int, requestIDKey: String)
-        case finished
-        case cancelled(ControlPlaneRPCCancelSnapshot)
-    }
-
-    private struct HandleState: Sendable {
-        var state: State = .queued
-        var onCancel: (@Sendable (ControlPlaneRPCCancelSnapshot) -> Void)?
-    }
-
-    private let state = NIOLockedValueBox(HandleState())
-
-    package init() {}
-
-    package func installCancel(
-        _ onCancel: @escaping @Sendable (ControlPlaneRPCCancelSnapshot) -> Void
-    ) {
-        let snapshot = state.withLockedValue { state -> ControlPlaneRPCCancelSnapshot? in
-            state.onCancel = onCancel
-            if case .cancelled(let snapshot) = state.state {
-                return snapshot
-            }
-            return nil
-        }
-        if let snapshot {
-            onCancel(snapshot)
-        }
-    }
-
-    package func markRegistered(
-        registrationToken: UUID,
-        upstreamIndex: Int
-    ) -> Bool {
-        state.withLockedValue { state in
-            switch state.state {
-            case .queued:
-                state.state = .registered(
-                    registrationToken: registrationToken,
-                    upstreamIndex: upstreamIndex
-                )
-                return true
-            case .cancelled, .finished, .registered, .assigned:
-                return false
+        package func overwrite(_ snapshot: ControlPlane.DebugSnapshot?) {
+            state.withLockedValue { state in
+                state = snapshot
             }
         }
     }
+}
 
-    package func markAssigned(
-        registrationToken: UUID,
-        upstreamIndex: Int,
-        requestIDKey: String
-    ) -> Bool {
-        state.withLockedValue { state in
-            switch state.state {
-            case .registered(let token, let registeredUpstreamIndex):
-                guard token == registrationToken, registeredUpstreamIndex == upstreamIndex else {
+extension ControlPlane {
+    package struct RPCCancelSnapshot: Sendable {
+        package let registrationToken: UUID?
+        package let upstreamIndex: Int?
+        package let requestIDKey: String?
+
+        package init(
+            registrationToken: UUID?,
+            upstreamIndex: Int?,
+            requestIDKey: String?
+        ) {
+            self.registrationToken = registrationToken
+            self.upstreamIndex = upstreamIndex
+            self.requestIDKey = requestIDKey
+        }
+    }
+}
+
+extension ControlPlane {
+    package final class RPCHandle: Sendable {
+        package enum State: Sendable {
+            case queued
+            case registered(registrationToken: UUID, upstreamIndex: Int)
+            case assigned(registrationToken: UUID, upstreamIndex: Int, requestIDKey: String)
+            case finished
+            case cancelled(ControlPlane.RPCCancelSnapshot)
+        }
+
+        private struct HandleState: Sendable {
+            var state: State = .queued
+            var onCancel: (@Sendable (ControlPlane.RPCCancelSnapshot) -> Void)?
+        }
+
+        private let state = NIOLockedValueBox(HandleState())
+
+        package init() {}
+
+        package func installCancel(
+            _ onCancel: @escaping @Sendable (ControlPlane.RPCCancelSnapshot) -> Void
+        ) {
+            let snapshot = state.withLockedValue { state -> ControlPlane.RPCCancelSnapshot? in
+                state.onCancel = onCancel
+                if case .cancelled(let snapshot) = state.state {
+                    return snapshot
+                }
+                return nil
+            }
+            if let snapshot {
+                onCancel(snapshot)
+            }
+        }
+
+        package func markRegistered(
+            registrationToken: UUID,
+            upstreamIndex: Int
+        ) -> Bool {
+            state.withLockedValue { state in
+                switch state.state {
+                case .queued:
+                    state.state = .registered(
+                        registrationToken: registrationToken,
+                        upstreamIndex: upstreamIndex
+                    )
+                    return true
+                case .cancelled, .finished, .registered, .assigned:
                     return false
                 }
-                state.state = .assigned(
-                    registrationToken: registrationToken,
-                    upstreamIndex: upstreamIndex,
-                    requestIDKey: requestIDKey
-                )
-                return true
-            case .queued, .assigned, .cancelled, .finished:
+            }
+        }
+
+        package func markAssigned(
+            registrationToken: UUID,
+            upstreamIndex: Int,
+            requestIDKey: String
+        ) -> Bool {
+            state.withLockedValue { state in
+                switch state.state {
+                case .registered(let token, let registeredUpstreamIndex):
+                    guard token == registrationToken, registeredUpstreamIndex == upstreamIndex
+                    else {
+                        return false
+                    }
+                    state.state = .assigned(
+                        registrationToken: registrationToken,
+                        upstreamIndex: upstreamIndex,
+                        requestIDKey: requestIDKey
+                    )
+                    return true
+                case .queued, .assigned, .cancelled, .finished:
+                    return false
+                }
+            }
+        }
+
+        package func markFinished() {
+            state.withLockedValue { state in
+                switch state.state {
+                case .queued, .registered, .assigned:
+                    state.state = .finished
+                case .finished, .cancelled:
+                    return
+                }
+            }
+        }
+
+        package func cancel() {
+            let cancellation = state.withLockedValue {
+                state -> (
+                    (@Sendable (ControlPlane.RPCCancelSnapshot) -> Void),
+                    ControlPlane.RPCCancelSnapshot
+                )? in
+                let snapshot: ControlPlane.RPCCancelSnapshot
+                switch state.state {
+                case .finished, .cancelled:
+                    return nil
+                case .queued:
+                    snapshot = ControlPlane.RPCCancelSnapshot(
+                        registrationToken: nil,
+                        upstreamIndex: nil,
+                        requestIDKey: nil
+                    )
+                case .registered(let registrationToken, let upstreamIndex):
+                    snapshot = ControlPlane.RPCCancelSnapshot(
+                        registrationToken: registrationToken,
+                        upstreamIndex: upstreamIndex,
+                        requestIDKey: nil
+                    )
+                case .assigned(let registrationToken, let upstreamIndex, let requestIDKey):
+                    snapshot = ControlPlane.RPCCancelSnapshot(
+                        registrationToken: registrationToken,
+                        upstreamIndex: upstreamIndex,
+                        requestIDKey: requestIDKey
+                    )
+                }
+                state.state = .cancelled(snapshot)
+                guard let onCancel = state.onCancel else {
+                    return nil
+                }
+                return (onCancel, snapshot)
+            }
+            if let (onCancel, snapshot) = cancellation {
+                onCancel(snapshot)
+            }
+        }
+
+        package func isCancelled() -> Bool {
+            state.withLockedValue { state in
+                if case .cancelled = state.state {
+                    return true
+                }
                 return false
             }
-        }
-    }
-
-    package func markFinished() {
-        state.withLockedValue { state in
-            switch state.state {
-            case .queued, .registered, .assigned:
-                state.state = .finished
-            case .finished, .cancelled:
-                return
-            }
-        }
-    }
-
-    package func cancel() {
-        let cancellation = state.withLockedValue {
-            state -> ((@Sendable (ControlPlaneRPCCancelSnapshot) -> Void), ControlPlaneRPCCancelSnapshot)? in
-            let snapshot: ControlPlaneRPCCancelSnapshot
-            switch state.state {
-            case .finished, .cancelled:
-                return nil
-            case .queued:
-                snapshot = ControlPlaneRPCCancelSnapshot(
-                    registrationToken: nil,
-                    upstreamIndex: nil,
-                    requestIDKey: nil
-                )
-            case .registered(let registrationToken, let upstreamIndex):
-                snapshot = ControlPlaneRPCCancelSnapshot(
-                    registrationToken: registrationToken,
-                    upstreamIndex: upstreamIndex,
-                    requestIDKey: nil
-                )
-            case .assigned(let registrationToken, let upstreamIndex, let requestIDKey):
-                snapshot = ControlPlaneRPCCancelSnapshot(
-                    registrationToken: registrationToken,
-                    upstreamIndex: upstreamIndex,
-                    requestIDKey: requestIDKey
-                )
-            }
-            state.state = .cancelled(snapshot)
-            guard let onCancel = state.onCancel else {
-                return nil
-            }
-            return (onCancel, snapshot)
-        }
-        if let (onCancel, snapshot) = cancellation {
-            onCancel(snapshot)
-        }
-    }
-
-    package func isCancelled() -> Bool {
-        state.withLockedValue { state in
-            if case .cancelled = state.state {
-                return true
-            }
-            return false
         }
     }
 }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -4,198 +4,218 @@ import NIO
 import ProxyCore
 import ProxyMCP
 
-package enum DocumentationToolListUpdate: Sendable {
-    case unchanged
-    case unavailable
-    case available(JSONValue)
+package enum DocumentationProvider {}
 
-    package var debugLabel: String {
-        switch self {
-        case .unchanged:
-            "unchanged"
-        case .unavailable:
-            "unavailable"
-        case .available:
-            "available"
+extension DocumentationProvider {
+    package enum ToolListUpdate: Sendable {
+        case unchanged
+        case unavailable
+        case available(JSONValue)
+
+        package var debugLabel: String {
+            switch self {
+            case .unchanged:
+                "unchanged"
+            case .unavailable:
+                "unavailable"
+            case .available:
+                "available"
+            }
         }
     }
 }
 
-package enum DocumentationProviderUnavailableReason: Sendable, Error, CustomStringConvertible {
-    case noAvailableProvider
+extension DocumentationProvider {
+    package enum UnavailableReason: Sendable, Error, CustomStringConvertible {
+        case noAvailableProvider
 
-    package static let userFacingMessage =
-        "DocumentationSearch is unavailable from the running Xcode documentation provider. Try restarting Xcode if the problem persists."
+        package static let userFacingMessage =
+            "DocumentationSearch is unavailable from the running Xcode documentation provider. Try restarting Xcode if the problem persists."
 
-    package var message: String {
-        switch self {
-        case .noAvailableProvider:
-            Self.userFacingMessage
+        package var message: String {
+            switch self {
+            case .noAvailableProvider:
+                Self.userFacingMessage
+            }
         }
-    }
 
-    package var description: String {
-        message
+        package var description: String {
+            message
+        }
     }
 }
 
 /// The manager's classification of one DocumentationSearch attempt.
 /// When the manager is enabled, DocumentationSearch is owned by the
 /// documentation provider and does not fall back to the regular upstream.
-package enum DocumentationProviderCallOutcome: Sendable {
-    case handled(Data, invalidatedProvider: Bool)
-    case unavailable(DocumentationProviderUnavailableReason)
-    case failed(any Error, invalidatedProvider: Bool)
+extension DocumentationProvider {
+    package enum CallOutcome: Sendable {
+        case handled(Data, invalidatedProvider: Bool)
+        case unavailable(DocumentationProvider.UnavailableReason)
+        case failed(any Error, invalidatedProvider: Bool)
+    }
 }
 
 package protocol DocumentationProviderManaging: Sendable {
-    func prewarm(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate
-    func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate
+    func prewarm(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate
+    func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate
     func callDocumentationSearch(
         requestData: Data,
         requestTimeoutOverride: TimeAmount?
-    ) async throws -> DocumentationProviderCallOutcome
+    ) async throws -> DocumentationProvider.CallOutcome
     func invalidate(reason: String) async
     func shutdown() async
 }
 
-package enum DocumentationToolCatalog {
-    package static let toolName = "DocumentationSearch"
+extension DocumentationProvider {
+    package enum ToolCatalog {
+        package static let toolName = "DocumentationSearch"
 
-    package static func applying(
-        _ update: DocumentationToolListUpdate,
-        to result: JSONValue
-    ) -> JSONValue {
-        switch update {
-        case .unchanged:
-            return result
-        case .unavailable:
-            return removingDocumentationSearch(from: result)
-        case .available(let descriptor):
-            return replacingDocumentationSearch(in: result, with: descriptor)
-        }
-    }
-
-    package static func descriptor(in result: JSONValue) -> JSONValue? {
-        guard case .object(let object) = result,
-              case .array(let tools)? = object["tools"] else {
-            return nil
-        }
-        return tools.first { value in
-            guard case .object(let toolObject) = value,
-                  case .string(let name)? = toolObject["name"] else {
-                return false
+        package static func applying(
+            _ update: DocumentationProvider.ToolListUpdate,
+            to result: JSONValue
+        ) -> JSONValue {
+            switch update {
+            case .unchanged:
+                return result
+            case .unavailable:
+                return removingDocumentationSearch(from: result)
+            case .available(let descriptor):
+                return replacingDocumentationSearch(in: result, with: descriptor)
             }
-            return name == toolName
         }
-    }
 
-    package static func responseIsDocumentationNotEnabled(_ data: Data) -> Bool {
-        responseErrorTexts(in: data).contains { text in
-            let normalized = text.lowercased()
-            return normalized.contains("documentationsearch")
-                && normalized.contains("not enabled")
+        package static func descriptor(in result: JSONValue) -> JSONValue? {
+            guard case .object(let object) = result,
+                case .array(let tools)? = object["tools"]
+            else {
+                return nil
+            }
+            return tools.first { value in
+                guard case .object(let toolObject) = value,
+                    case .string(let name)? = toolObject["name"]
+                else {
+                    return false
+                }
+                return name == toolName
+            }
         }
-    }
 
-    package static func responseIsToolError(_ data: Data) -> Bool {
-        responseErrorObjects(in: data).isEmpty == false || responseResultObjects(in: data).contains { object in
-            object["isError"] as? Bool == true
+        package static func responseIsDocumentationNotEnabled(_ data: Data) -> Bool {
+            responseErrorTexts(in: data).contains { text in
+                let normalized = text.lowercased()
+                return normalized.contains("documentationsearch")
+                    && normalized.contains("not enabled")
+            }
         }
-    }
 
-    private static func replacingDocumentationSearch(
-        in result: JSONValue,
-        with descriptor: JSONValue
-    ) -> JSONValue {
-        guard case .object(var object) = result,
-              case .array(let tools)? = object["tools"] else {
-            return result
+        package static func responseIsToolError(_ data: Data) -> Bool {
+            responseErrorObjects(in: data).isEmpty == false
+                || responseResultObjects(in: data).contains { object in
+                    object["isError"] as? Bool == true
+                }
         }
-        var replaced = false
-        var rewritten: [JSONValue] = []
-        rewritten.reserveCapacity(tools.count + 1)
-        for tool in tools {
-            guard case .object(let toolObject) = tool,
-                  case .string(let name)? = toolObject["name"],
-                  name == toolName else {
-                rewritten.append(tool)
-                continue
+
+        private static func replacingDocumentationSearch(
+            in result: JSONValue,
+            with descriptor: JSONValue
+        ) -> JSONValue {
+            guard case .object(var object) = result,
+                case .array(let tools)? = object["tools"]
+            else {
+                return result
+            }
+            var replaced = false
+            var rewritten: [JSONValue] = []
+            rewritten.reserveCapacity(tools.count + 1)
+            for tool in tools {
+                guard case .object(let toolObject) = tool,
+                    case .string(let name)? = toolObject["name"],
+                    name == toolName
+                else {
+                    rewritten.append(tool)
+                    continue
+                }
+                if !replaced {
+                    rewritten.append(descriptor)
+                    replaced = true
+                }
             }
             if !replaced {
                 rewritten.append(descriptor)
-                replaced = true
             }
+            object["tools"] = .array(rewritten)
+            return .object(object)
         }
-        if !replaced {
-            rewritten.append(descriptor)
-        }
-        object["tools"] = .array(rewritten)
-        return .object(object)
-    }
 
-    private static func removingDocumentationSearch(from result: JSONValue) -> JSONValue {
-        guard case .object(var object) = result,
-              case .array(let tools)? = object["tools"] else {
-            return result
-        }
-        object["tools"] = .array(tools.filter { tool in
-            guard case .object(let toolObject) = tool,
-                  case .string(let name)? = toolObject["name"] else {
-                return true
+        private static func removingDocumentationSearch(from result: JSONValue) -> JSONValue {
+            guard case .object(var object) = result,
+                case .array(let tools)? = object["tools"]
+            else {
+                return result
             }
-            return name != toolName
-        })
-        return .object(object)
-    }
-
-    private static func responseErrorTexts(in data: Data) -> [String] {
-        var texts = responseErrorObjects(in: data).compactMap { object in
-            object["message"] as? String
+            object["tools"] = .array(
+                tools.filter { tool in
+                    guard case .object(let toolObject) = tool,
+                        case .string(let name)? = toolObject["name"]
+                    else {
+                        return true
+                    }
+                    return name != toolName
+                })
+            return .object(object)
         }
-        texts += responseResultObjects(in: data).flatMap { object -> [String] in
-            guard object["isError"] as? Bool == true else {
+
+        private static func responseErrorTexts(in data: Data) -> [String] {
+            var texts = responseErrorObjects(in: data).compactMap { object in
+                object["message"] as? String
+            }
+            texts += responseResultObjects(in: data).flatMap { object -> [String] in
+                guard object["isError"] as? Bool == true else {
+                    return []
+                }
+                guard let content = object["content"] as? [[String: Any]] else {
+                    return []
+                }
+                return content.compactMap { $0["text"] as? String }
+            }
+            return texts
+        }
+
+        private static func responseErrorObjects(in data: Data) -> [[String: Any]] {
+            guard let payload = try? JSONSerialization.jsonObject(with: data, options: []) else {
                 return []
             }
-            guard let content = object["content"] as? [[String: Any]] else {
+            if let object = payload as? [String: Any],
+                let error = object["error"] as? [String: Any]
+            {
+                return [error]
+            }
+            guard let array = payload as? [Any] else {
                 return []
             }
-            return content.compactMap { $0["text"] as? String }
+            return array.compactMap { item in
+                guard let object = item as? [String: Any] else { return nil }
+                return object["error"] as? [String: Any]
+            }
         }
-        return texts
-    }
 
-    private static func responseErrorObjects(in data: Data) -> [[String: Any]] {
-        guard let payload = try? JSONSerialization.jsonObject(with: data, options: []) else {
-            return []
-        }
-        if let object = payload as? [String: Any],
-           let error = object["error"] as? [String: Any] {
-            return [error]
-        }
-        guard let array = payload as? [Any] else {
-            return []
-        }
-        return array.compactMap { item in
-            guard let object = item as? [String: Any] else { return nil }
-            return object["error"] as? [String: Any]
-        }
-    }
-
-    private static func responseResultObjects(in data: Data) -> [[String: Any]] {
-        guard let payload = try? JSONSerialization.jsonObject(with: data, options: []) else {
-            return []
-        }
-        if let object = payload as? [String: Any],
-           let result = object["result"] as? [String: Any] {
-            return [result]
-        }
-        guard let array = payload as? [Any] else {
-            return []
-        }
-        return array.compactMap { item in
-            guard let object = item as? [String: Any] else { return nil }
-            return object["result"] as? [String: Any]
+        private static func responseResultObjects(in data: Data) -> [[String: Any]] {
+            guard let payload = try? JSONSerialization.jsonObject(with: data, options: []) else {
+                return []
+            }
+            if let object = payload as? [String: Any],
+                let result = object["result"] as? [String: Any]
+            {
+                return [result]
+            }
+            guard let array = payload as? [Any] else {
+                return []
+            }
+            return array.compactMap { item in
+                guard let object = item as? [String: Any] else { return nil }
+                return object["result"] as? [String: Any]
+            }
         }
     }
 }
@@ -211,7 +231,9 @@ package struct LiveDocumentationProviderSessionFactory: DocumentationProviderSes
         self.baseEnvironment = baseEnvironment
     }
 
-    package func startSession(for target: DocumentationProviderTarget) async throws -> any UpstreamSession {
+    package func startSession(for target: DocumentationProviderTarget) async throws
+        -> any UpstreamSession
+    {
         var environment = baseEnvironment
         environment.removeValue(forKey: "XCODE_PID")
         environment["MCP_XCODE_PID"] = String(target.processID)
@@ -256,7 +278,7 @@ package actor DocumentationProviderConnection {
             for await event in session.events {
                 await self?.handle(event)
             }
-            await self?.failAll(UpstreamSlotAcquisitionError.unavailable)
+            await self?.failAll(UpstreamSlotScheduler.AcquisitionError.unavailable)
         }
     }
 
@@ -269,20 +291,22 @@ package actor DocumentationProviderConnection {
 
     package func sendNotification(_ object: [String: Any]) async throws {
         guard JSONSerialization.isValidJSONObject(object) else {
-            throw ControlPlaneError.invalidResponse("invalid notification")
+            throw ControlPlane.Error.invalidResponse("invalid notification")
         }
         let data = try JSONSerialization.data(withJSONObject: object, options: [])
         let result = await session.send(data)
         guard result == .accepted else {
-            throw UpstreamSlotAcquisitionError.unavailable
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
     }
 
     package func call(_ requestData: Data, timeout: TimeAmount?) async throws -> Data {
-        guard var object = try JSONSerialization.jsonObject(with: requestData, options: [])
-            as? [String: Any],
-            let originalID = JSONRPC.Message.Inspector.requestID(from: object) else {
-            throw ControlPlaneError.invalidResponse("missing DocumentationSearch request id")
+        guard
+            var object = try JSONSerialization.jsonObject(with: requestData, options: [])
+                as? [String: Any],
+            let originalID = JSONRPC.Message.Inspector.requestID(from: object)
+        else {
+            throw ControlPlane.Error.invalidResponse("missing DocumentationSearch request id")
         }
 
         let upstreamID = nextID
@@ -290,7 +314,7 @@ package actor DocumentationProviderConnection {
         nextID += 1
         object["id"] = upstreamID
         guard JSONSerialization.isValidJSONObject(object) else {
-            throw ControlPlaneError.invalidResponse("invalid DocumentationSearch request")
+            throw ControlPlane.Error.invalidResponse("invalid DocumentationSearch request")
         }
         let upstreamData = try JSONSerialization.data(withJSONObject: object, options: [])
 
@@ -306,7 +330,9 @@ package actor DocumentationProviderConnection {
                 Task { [weak self, session] in
                     let sendResult = await session.send(upstreamData)
                     guard sendResult == .accepted else {
-                        await self?.failPending(id: upstreamIDKey, error: UpstreamSlotAcquisitionError.unavailable)
+                        await self?.failPending(
+                            id: upstreamIDKey,
+                            error: UpstreamSlotScheduler.AcquisitionError.unavailable)
                         return
                     }
                 }
@@ -340,24 +366,30 @@ package actor DocumentationProviderConnection {
         case .message(let data):
             handleMessage(data)
         case .exit, .stdoutProtocolViolation:
-            failAll(UpstreamSlotAcquisitionError.unavailable)
+            failAll(UpstreamSlotScheduler.AcquisitionError.unavailable)
         case .stderr, .stdoutBufferSize:
             break
         }
     }
 
     private func handleMessage(_ data: Data) {
-        guard var object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-              let responseID = JSONRPC.Message.Inspector.responseID(from: object),
-              let pending = pendingResponses.removeValue(forKey: responseID.key) else {
+        guard
+            var object = try? JSONSerialization.jsonObject(with: data, options: [])
+                as? [String: Any],
+            let responseID = JSONRPC.Message.Inspector.responseID(from: object),
+            let pending = pendingResponses.removeValue(forKey: responseID.key)
+        else {
             return
         }
 
         pending.timeoutTask?.cancel()
         object["id"] = pending.originalID.value.foundationObject
         guard JSONSerialization.isValidJSONObject(object),
-              let rewrittenData = try? JSONSerialization.data(withJSONObject: object, options: []) else {
-            pending.continuation.resume(throwing: ControlPlaneError.invalidResponse("invalid DocumentationSearch response"))
+            let rewrittenData = try? JSONSerialization.data(withJSONObject: object, options: [])
+        else {
+            pending.continuation.resume(
+                throwing: ControlPlane.Error.invalidResponse("invalid DocumentationSearch response")
+            )
             return
         }
         pending.continuation.resume(returning: rewrittenData)
@@ -410,7 +442,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         private var continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>?
         private var resolvedResult: ProviderSelectionWaitResult?
 
-        func setContinuation(_ continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>) {
+        func setContinuation(
+            _ continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>
+        ) {
             lock.lock()
             if let resolvedResult {
                 lock.unlock()
@@ -448,7 +482,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
 
     package init(
         discovery: any XcodeTargetDiscovering,
-        sessionFactory: any DocumentationProviderSessionMaking = LiveDocumentationProviderSessionFactory(),
+        sessionFactory: any DocumentationProviderSessionMaking =
+            LiveDocumentationProviderSessionFactory(),
         providerSelectionTimeout: TimeAmount? = .seconds(30),
         pinnedProcessID: pid_t? = nil,
         initializeParams: [String: JSONValue] = InitializeHandshakeJSON.defaultParams(),
@@ -464,12 +499,15 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         self.logger = logger
     }
 
-    package func prewarm(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
+    package func prewarm(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate
+    {
         guard !isShutdown else { return .unavailable }
         return await toolListUpdate(requestTimeout: requestTimeout)
     }
 
-    package func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
+    package func toolListUpdate(requestTimeout: TimeAmount?) async
+        -> DocumentationProvider.ToolListUpdate
+    {
         guard !isShutdown else {
             return .unavailable
         }
@@ -488,7 +526,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     package func callDocumentationSearch(
         requestData: Data,
         requestTimeoutOverride: TimeAmount?
-    ) async throws -> DocumentationProviderCallOutcome {
+    ) async throws -> DocumentationProvider.CallOutcome {
         guard !isShutdown else {
             return .unavailable(.noAvailableProvider)
         }
@@ -500,10 +538,12 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             if let deadline, deadline.hasExpired {
                 return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
             }
-            guard let provider = await providerIfAvailable(
-                requestTimeout: deadline?.remaining(),
-                excluding: rejectedProcessIDs
-            ) else {
+            guard
+                let provider = await providerIfAvailable(
+                    requestTimeout: deadline?.remaining(),
+                    excluding: rejectedProcessIDs
+                )
+            else {
                 try Task.checkCancellation()
                 if let deadline, deadline.hasExpired {
                     return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
@@ -518,7 +558,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     requestData,
                     timeout: deadline?.remaining()
                 )
-                guard DocumentationToolCatalog.responseIsDocumentationNotEnabled(response) else {
+                guard DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(response)
+                else {
                     return .handled(response, invalidatedProvider: invalidatedProvider)
                 }
                 await invalidate(provider, reason: "documentation_search_not_enabled")
@@ -547,7 +588,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let provider = activeProvider
         activeProvider = nil
         if let selected = await selection?.task.value,
-           selected.id != provider?.profile.id {
+            selected.id != provider?.profile.id
+        {
             await selected.connection.stop()
         }
         await provider?.profile.connection.stop()
@@ -696,7 +738,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let targets: [DocumentationProviderTarget]
         if let pinnedProcessID {
             targets = discoveredTargets.filter {
-                $0.processID == pinnedProcessID && excludedProcessIDs.contains($0.processID) == false
+                $0.processID == pinnedProcessID
+                    && excludedProcessIDs.contains($0.processID) == false
             }
         } else {
             targets = discoveredTargets.filter {
@@ -710,7 +753,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 "discovered_candidate_count": .string("\(discoveredTargets.count)"),
                 "excluded_candidate_count": .string("\(excludedProcessIDs.count)"),
                 "pinned_pid": .string(pinnedProcessID.map(String.init) ?? ""),
-                "candidates": .string(targets.map { "\($0.processID):\($0.appPath)" }.joined(separator: ",")),
+                "candidates": .string(
+                    targets.map { "\($0.processID):\($0.appPath)" }.joined(separator: ",")),
             ]
         )
         var profiles: [CandidateProfile] = []
@@ -726,7 +770,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 break
             }
             do {
-                let profile = try await boundedProbe(target: target, requestTimeout: candidateTimeout)
+                let profile = try await boundedProbe(
+                    target: target, requestTimeout: candidateTimeout)
                 guard !Task.isCancelled, !isShutdown else {
                     await profile.connection.stop()
                     break
@@ -754,12 +799,15 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             return nil
         }
 
-        guard let selected = profiles.max(by: { lhs, rhs in
-            if lhs.toolCount != rhs.toolCount {
-                return lhs.toolCount < rhs.toolCount
-            }
-            return Self.compareVersion(lhs.serverVersion, rhs.serverVersion) == .orderedAscending
-        }) else {
+        guard
+            let selected = profiles.max(by: { lhs, rhs in
+                if lhs.toolCount != rhs.toolCount {
+                    return lhs.toolCount < rhs.toolCount
+                }
+                return Self.compareVersion(lhs.serverVersion, rhs.serverVersion)
+                    == .orderedAscending
+            })
+        else {
             return nil
         }
 
@@ -797,7 +845,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             }
             do {
                 guard let result = try await group.next() else {
-                    throw UpstreamSlotAcquisitionError.unavailable
+                    throw UpstreamSlotScheduler.AcquisitionError.unavailable
                 }
                 group.cancelAll()
                 return result
@@ -842,8 +890,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 timeout: toolsListTimeout
             )
             let toolsResult = try Self.resultValue(from: toolsList)
-            guard let descriptor = DocumentationToolCatalog.descriptor(in: toolsResult) else {
-                throw UpstreamSlotAcquisitionError.unavailable
+            guard let descriptor = DocumentationProvider.ToolCatalog.descriptor(in: toolsResult)
+            else {
+                throw UpstreamSlotScheduler.AcquisitionError.unavailable
             }
             let documentationProbeTimeout = remainingTimeout(until: probeDeadline)
             guard documentationProbeTimeout?.nanoseconds != 0 else {
@@ -853,9 +902,11 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 try Self.makeDocumentationProbeRequestData(),
                 timeout: documentationProbeTimeout
             )
-            guard !DocumentationToolCatalog.responseIsDocumentationNotEnabled(probeResponse),
-                  !DocumentationToolCatalog.responseIsToolError(probeResponse) else {
-                throw UpstreamSlotAcquisitionError.unavailable
+            guard
+                !DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(probeResponse),
+                !DocumentationProvider.ToolCatalog.responseIsToolError(probeResponse)
+            else {
+                throw UpstreamSlotScheduler.AcquisitionError.unavailable
             }
             return CandidateProfile(
                 id: UUID(),
@@ -901,9 +952,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 "id": "documentation-probe",
                 "method": "tools/call",
                 "params": [
-                    "name": DocumentationToolCatalog.toolName,
+                    "name": DocumentationProvider.ToolCatalog.toolName,
                     "arguments": [
-                        "query": "UIView animate withDuration animations completion",
+                        "query": "UIView animate withDuration animations completion"
                     ],
                 ],
             ],
@@ -912,28 +963,33 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     }
 
     private static func resultValue(from responseData: Data) throws -> JSONValue {
-        guard let object = try JSONSerialization.jsonObject(with: responseData, options: [])
-            as? [String: Any],
+        guard
+            let object = try JSONSerialization.jsonObject(with: responseData, options: [])
+                as? [String: Any],
             let result = object["result"],
-            let value = JSONValue(any: result) else {
-            throw ControlPlaneError.invalidResponse("invalid documentation provider response")
+            let value = JSONValue(any: result)
+        else {
+            throw ControlPlane.Error.invalidResponse("invalid documentation provider response")
         }
         return value
     }
 
     private static func toolCount(in result: JSONValue) -> Int {
         guard case .object(let object) = result,
-              case .array(let tools)? = object["tools"] else {
+            case .array(let tools)? = object["tools"]
+        else {
             return 0
         }
         return tools.count
     }
 
     private static func serverVersion(fromInitializeResponse data: Data) -> String? {
-        guard let object = try? JSONSerialization.jsonObject(with: data, options: [])
-            as? [String: Any],
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data, options: [])
+                as? [String: Any],
             let result = object["result"] as? [String: Any],
-            let serverInfo = result["serverInfo"] as? [String: Any] else {
+            let serverInfo = result["serverInfo"] as? [String: Any]
+        else {
             return nil
         }
         return serverInfo["version"] as? String

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -4,51 +4,59 @@ import NIOConcurrencyHelpers
 import ProxyCore
 import ProxyMCP
 
-package enum ControlPlaneError: Error, Sendable {
-    case invalidResponse(String)
-    case upstreamRPC(code: Int, message: String)
+extension ControlPlane {
+    package enum Error: Swift.Error, Sendable {
+        case invalidResponse(String)
+        case upstreamRPC(code: Int, message: String)
+    }
 }
 
-package struct ControlPlaneRequestError: Error, Sendable {
-    package let route: ControlPlaneRoute
-    package let upstreamIndex: Int?
-    package let underlying: any Error
+extension ControlPlane {
+    package struct RequestError: Swift.Error, Sendable {
+        package let route: ControlPlane.Route
+        package let upstreamIndex: Int?
+        package let underlying: any Swift.Error
+    }
 }
 
-package struct ControlPlaneRPCResponse: Sendable {
-    package let responseData: Data
-    package let upstreamIndex: Int
+extension ControlPlane {
+    package struct RPCResponse: Sendable {
+        package let responseData: Data
+        package let upstreamIndex: Int
+    }
 }
 
 /// The one place that decides which JSON-RPC error a control-plane or
 /// upstream-acquisition failure surfaces as.
-package enum ControlPlaneErrorMapper {
-    package static func jsonRPCError(for error: Error) -> (code: Int, message: String) {
-        if let error = error as? DocumentationProviderUnavailableReason {
-            return (-32001, error.message)
-        }
-        if error is UpstreamSlotAcquisitionError {
-            return (-32001, "upstream unavailable")
-        }
-        if let error = error as? ControlPlaneRequestError {
-            return jsonRPCError(for: error.underlying)
-        }
-        if let error = error as? ControlPlaneError {
-            switch error {
-            case .invalidResponse:
-                return (-32000, "upstream timeout")
-            case .upstreamRPC(let code, let message):
-                return (code, message)
+extension ControlPlane {
+    package enum ErrorMapper {
+        package static func jsonRPCError(for error: Swift.Error) -> (code: Int, message: String) {
+            if let error = error as? DocumentationProvider.UnavailableReason {
+                return (-32001, error.message)
             }
+            if error is UpstreamSlotScheduler.AcquisitionError {
+                return (-32001, "upstream unavailable")
+            }
+            if let error = error as? ControlPlane.RequestError {
+                return jsonRPCError(for: error.underlying)
+            }
+            if let error = error as? ControlPlane.Error {
+                switch error {
+                case .invalidResponse:
+                    return (-32000, "upstream timeout")
+                case .upstreamRPC(let code, let message):
+                    return (code, message)
+                }
+            }
+            return (-32000, "upstream timeout")
         }
-        return (-32000, "upstream timeout")
     }
 }
 
 extension RuntimeCoordinator {
     func loadCanonicalToolsCatalog(
         requestTimeout: TimeAmount?,
-        rpcHandle: ControlPlaneRPCHandle
+        rpcHandle: ControlPlane.RPCHandle
     ) async throws -> CanonicalToolsCatalogLoadResult {
         let startedAt = nowUptimeNanoseconds()
         let effectiveRequestTimeout =
@@ -77,7 +85,7 @@ extension RuntimeCoordinator {
                     nowUptimeNs: nowUptimeNs,
                     reason: "invalid_response"
                 )
-                throw ControlPlaneError.invalidResponse("invalid tools/list result")
+                throw ControlPlane.Error.invalidResponse("invalid tools/list result")
             }
             markToolsListRefreshSucceeded(
                 upstreamIndex: response.upstreamIndex,
@@ -88,7 +96,7 @@ extension RuntimeCoordinator {
                 sourceUpstream: response.upstreamIndex,
                 durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt)
             )
-        } catch let error as ControlPlaneRequestError {
+        } catch let error as ControlPlane.RequestError {
             if error.underlying is CancellationError {
                 throw error.underlying
             }
@@ -104,9 +112,9 @@ extension RuntimeCoordinator {
     }
 
     func loadLiveXcodeListWindows(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         requestTimeout: TimeAmount?,
-        rpcHandle: ControlPlaneRPCHandle
+        rpcHandle: ControlPlane.RPCHandle
     ) async throws -> JSONValue {
         let effectiveRequestTimeout =
             requestTimeout
@@ -131,24 +139,24 @@ extension RuntimeCoordinator {
                 rpcHandle: rpcHandle
             )
             return try extractJSONRPCResult(from: response.responseData)
-        } catch let error as ControlPlaneRequestError {
+        } catch let error as ControlPlane.RequestError {
             throw error.underlying
         }
     }
 
     func performControlPlaneRPC(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         purpose: String,
         label: String,
         requestObject: [String: Any],
         requestTimeout: TimeAmount?,
-        rpcHandle: ControlPlaneRPCHandle? = nil
-    ) async throws -> ControlPlaneRPCResponse {
+        rpcHandle: ControlPlane.RPCHandle? = nil
+    ) async throws -> ControlPlane.RPCResponse {
         let internalSessionID = controlPlaneSessionID(for: purpose, route: route)
         let session = session(id: internalSessionID)
         let router = session.router
         guard let originalID = JSONRPC.Message.Inspector.requestID(from: requestObject) else {
-            throw ControlPlaneError.invalidResponse("missing request id")
+            throw ControlPlane.Error.invalidResponse("missing request id")
         }
         let requestTemplate = requestObject.reduce(into: [String: JSONValue]()) { partial, entry in
             if entry.key == "id" { return }
@@ -164,12 +172,13 @@ extension RuntimeCoordinator {
             isTopLevelClientRequest: false
         )
         let leaseID = createRequestLease(descriptor: descriptor)
-        let preferredUpstreamIndex: Int? = switch route {
-        case .anyHealthy:
-            nil
-        case .pinnedUpstream(let upstreamIndex):
-            upstreamIndex
-        }
+        let preferredUpstreamIndex: Int? =
+            switch route {
+            case .anyHealthy:
+                nil
+            case .pinnedUpstream(let upstreamIndex):
+                upstreamIndex
+            }
         rpcHandle?.installCancel { [self, router] snapshot in
             if let registrationToken = snapshot.registrationToken {
                 _ = router.cancelPending(token: registrationToken)
@@ -195,7 +204,7 @@ extension RuntimeCoordinator {
         }
 
         do {
-            let future: EventLoopFuture<ControlPlaneRPCResponse> = enqueueOnUpstreamSlot(
+            let future: EventLoopFuture<ControlPlane.RPCResponse> = enqueueOnUpstreamSlot(
                 leaseID: leaseID,
                 descriptor: descriptor,
                 on: eventLoop,
@@ -274,10 +283,10 @@ extension RuntimeCoordinator {
                         reason: .invalidUpstreamResponse
                     )
                     return self.eventLoop.makeFailedFuture(
-                        ControlPlaneRequestError(
+                        ControlPlane.RequestError(
                             route: route,
                             upstreamIndex: selectedUpstreamIndex,
-                            underlying: ControlPlaneError.invalidResponse(
+                            underlying: ControlPlane.Error.invalidResponse(
                                 "invalid control-plane request"
                             )
                         )
@@ -307,14 +316,14 @@ extension RuntimeCoordinator {
                 return registration.future.flatMapThrowing { buffer in
                     var buffer = buffer
                     guard let responseData = buffer.readData(length: buffer.readableBytes) else {
-                        throw ControlPlaneError.invalidResponse("missing response data")
+                        throw ControlPlane.Error.invalidResponse("missing response data")
                     }
-                    return ControlPlaneRPCResponse(
+                    return ControlPlane.RPCResponse(
                         responseData: responseData,
                         upstreamIndex: selectedUpstreamIndex
                     )
                 }.flatMapErrorThrowing { error in
-                    throw ControlPlaneRequestError(
+                    throw ControlPlane.RequestError(
                         route: route,
                         upstreamIndex: selectedUpstreamIndex,
                         underlying: error
@@ -333,12 +342,13 @@ extension RuntimeCoordinator {
                     terminalState: .failed,
                     reason: .invalidUpstreamResponse
                 )
-                throw ControlPlaneRequestError(
+                throw ControlPlane.RequestError(
                     route: route,
                     upstreamIndex: response.upstreamIndex,
-                    underlying: ControlPlaneError.upstreamRPC(
+                    underlying: ControlPlane.Error.upstreamRPC(
                         code: extractJSONRPCErrorCode(from: responseObject) ?? -32000,
-                        message: extractJSONRPCErrorMessage(from: responseObject) ?? "upstream error"
+                        message: extractJSONRPCErrorMessage(from: responseObject)
+                            ?? "upstream error"
                     )
                 )
             }
@@ -350,7 +360,7 @@ extension RuntimeCoordinator {
             throw CancellationError()
         } catch is TimeoutError {
             throw TimeoutError()
-        } catch let error as UpstreamSlotAcquisitionError {
+        } catch let error as UpstreamSlotScheduler.AcquisitionError {
             failRequestLease(
                 leaseID,
                 terminalState: .failed,
@@ -369,7 +379,7 @@ extension RuntimeCoordinator {
 
     func controlPlaneSessionID(
         for purpose: String,
-        route: ControlPlaneRoute?
+        route: ControlPlane.Route?
     ) -> String {
         let suffix: String
         switch route {
@@ -384,7 +394,7 @@ extension RuntimeCoordinator {
     func extractJSONRPCResult(from responseData: Data) throws -> JSONValue {
         let object = try extractJSONRPCResponseObject(from: responseData)
         if let errorObject = object["error"] as? [String: Any] {
-            throw ControlPlaneError.upstreamRPC(
+            throw ControlPlane.Error.upstreamRPC(
                 code: (errorObject["code"] as? NSNumber)?.intValue ?? -32000,
                 message: errorObject["message"] as? String ?? "upstream error"
             )
@@ -392,17 +402,19 @@ extension RuntimeCoordinator {
         guard let resultAny = object["result"],
             let result = JSONValue(any: resultAny)
         else {
-            throw ControlPlaneError.invalidResponse("missing result")
+            throw ControlPlane.Error.invalidResponse("missing result")
         }
         return result
     }
 
     func extractJSONRPCResponseObject(from responseData: Data) throws -> [String: Any] {
-        guard let responseObject = try JSONSerialization.jsonObject(
-            with: responseData,
-            options: []
-        ) as? [String: Any] else {
-            throw ControlPlaneError.invalidResponse("response was not an object")
+        guard
+            let responseObject = try JSONSerialization.jsonObject(
+                with: responseData,
+                options: []
+            ) as? [String: Any]
+        else {
+            throw ControlPlane.Error.invalidResponse("response was not an object")
         }
         return responseObject
     }
@@ -419,7 +431,7 @@ extension RuntimeCoordinator {
         if error is TimeoutError {
             return "timeout"
         }
-        if let error = error as? ControlPlaneError {
+        if let error = error as? ControlPlane.Error {
             switch error {
             case .invalidResponse(let reason):
                 return reason

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -498,11 +498,11 @@ extension RuntimeCoordinator {
         return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
     }
 
-    package func debugSnapshot() -> ProxyDebugSnapshot {
+    package func debugSnapshot() -> ProxyDebug.Snapshot {
         debugSnapshot(includeSensitiveDebugPayloads: false)
     }
 
-    package func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebugSnapshot {
+    package func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebug.Snapshot {
         let initSnapshot = initializeManager.snapshot()
         let brokerSnapshot = canonicalBrokerState.snapshot()
         let controlPlaneSnapshot = controlPlaneDebugMirror.snapshot()

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -1,8 +1,8 @@
 import Foundation
 import Logging
 import NIO
-import NIOFoundationCompat
 import NIOConcurrencyHelpers
+import NIOFoundationCompat
 import ProxyCore
 import ProxyMCP
 
@@ -41,7 +41,7 @@ package final class WeakRuntimeCoordinatorBox: @unchecked Sendable {
 /// DocumentationSearch is unavailable.
 package enum DocumentationSearchOutcome: Sendable {
     case handled(Data)
-    case unavailable(DocumentationProviderUnavailableReason)
+    case unavailable(DocumentationProvider.UnavailableReason)
 }
 
 package enum ServerRequestResponseForwardingResult: Sendable, Equatable {
@@ -74,7 +74,7 @@ package protocol RuntimeCoordinating: Sendable {
         requestTimeoutOverride: TimeAmount?
     ) async throws -> JSONValue
     func liveXcodeListWindowsResult(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> JSONValue
     func callDocumentationSearch(
@@ -101,8 +101,8 @@ package protocol RuntimeCoordinating: Sendable {
         responseID: JSONRPC.ID,
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ServerRequestResponseForwardingResult>
-    func debugSnapshot() -> ProxyDebugSnapshot
-    func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebugSnapshot
+    func debugSnapshot() -> ProxyDebug.Snapshot
+    func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebug.Snapshot
     func createRequestLease(descriptor: SessionRequestPipeline.Descriptor) -> LeaseManager.ID
     func activateRequestLease(
         _ leaseID: LeaseManager.ID,
@@ -172,7 +172,7 @@ extension RuntimeCoordinating {
         )
     }
 
-    func debugSnapshot() -> ProxyDebugSnapshot {
+    func debugSnapshot() -> ProxyDebug.Snapshot {
         debugSnapshot(includeSensitiveDebugPayloads: false)
     }
 
@@ -191,7 +191,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         struct Upstream: Sendable {
             let isInitialized: Bool
             let initInFlight: Bool
-            let healthState: UpstreamHealthState
+            let healthState: ProxySession.Upstream.HealthState
         }
 
         struct Session: Sendable {
@@ -221,7 +221,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let upstreams: [any UpstreamSlotControlling]
     package let initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride?
     package let canonicalBrokerState: CanonicalBrokerState
-    package let controlPlaneDebugMirror = ControlPlaneDebugMirror()
+    package let controlPlaneDebugMirror = ControlPlane.DebugMirror()
 
     package let upstreamHealthManager: UpstreamHealthManager
     package let upstreamSlotScheduler: UpstreamSlotScheduler
@@ -229,8 +229,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let upstreamReadinessCoordinator: UpstreamReadinessCoordinator
     package let clock: ClockClient
     package let nowUptimeNanoseconds: @Sendable () -> UInt64
-    package let scheduleRuntimeTimeout: @Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
-        RuntimeScheduledTimeout
+    package let scheduleRuntimeTimeout:
+        @Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
+            RuntimeScheduledTimeout
     package let controlPlaneCoordinator: ControlPlaneCoordinator
     package let documentationProviderManager: (any DocumentationProviderManaging)?
     package let prewarmDocumentationProviderOnStartup: Bool
@@ -269,7 +270,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         config: ProxyConfig,
         discovery: any XcodeTargetDiscovering
     ) -> (any DocumentationProviderManaging)? {
-        guard config.disabledToolNames.contains(DocumentationToolCatalog.toolName) == false else {
+        guard config.disabledToolNames.contains(DocumentationProvider.ToolCatalog.toolName) == false
+        else {
             return nil
         }
         guard XcrunArguments.isDefaultMCPBridgeInvocation(config: config) else {
@@ -294,8 +296,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         clock: ClockClient = .liveValue,
         upstreamReadinessGate: UpstreamReadinessGate? = nil,
         nowUptimeNanoseconds: (@Sendable () -> UInt64)? = nil,
-        scheduleRuntimeTimeout: (@Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
-            RuntimeScheduledTimeout)? = nil,
+        scheduleRuntimeTimeout: (
+            @Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
+                RuntimeScheduledTimeout
+        )? = nil,
         documentationProviderManager: (any DocumentationProviderManaging)? = nil,
         prewarmDocumentationProviderOnStartup: Bool = false,
         startImmediately: Bool = true
@@ -309,7 +313,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             sleep: clock.sleep,
             sleepForTimeInterval: clock.sleepForTimeInterval
         )
-        let timeoutScheduler = scheduleRuntimeTimeout
+        let timeoutScheduler =
+            scheduleRuntimeTimeout
             ?? { delay, operation in
                 RuntimeScheduledTimeout.schedule(
                     on: eventLoop,
@@ -333,7 +338,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.scheduleRuntimeTimeout = timeoutScheduler
         self.documentationProviderManager = documentationProviderManager
         self.prewarmDocumentationProviderOnStartup = prewarmDocumentationProviderOnStartup
-        let resolvedReadinessGate = upstreamReadinessGate
+        let resolvedReadinessGate =
+            upstreamReadinessGate
             ?? .alwaysReady(uptimeNanoseconds: runtimeClock.uptimeNanoseconds)
         self.upstreamReadinessGate = resolvedReadinessGate
         self.upstreamReadinessCoordinator = UpstreamReadinessCoordinator(
@@ -341,7 +347,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             logger: ProxyLogging.make("upstream.readiness")
         )
         self.upstreamSlotScheduler = UpstreamSlotScheduler(
-            canUseUpstream: { [weak upstreamHealthManager = self.upstreamHealthManager] upstreamIndex in
+            canUseUpstream: {
+                [weak upstreamHealthManager = self.upstreamHealthManager] upstreamIndex in
                 let nowUptimeNs = uptimeProvider()
                 guard let upstreamHealthManager else {
                     return UpstreamHealthManager.UseEvaluation(isUsable: false, effects: [])
@@ -388,17 +395,18 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             upstreamHandshakeStates: { [weak upstreamHealthManager = self.upstreamHealthManager] in
                 guard let upstreamHealthManager else { return [:] }
                 let states = upstreamHealthManager.statesSnapshot()
-                return Dictionary(uniqueKeysWithValues: states.enumerated().map { index, state in
-                    let summary: String
-                    if state.initInFlight {
-                        summary = "initializing"
-                    } else if state.isInitialized {
-                        summary = "initialized"
-                    } else {
-                        summary = "idle"
-                    }
-                    return ("\(index)", summary)
-                })
+                return Dictionary(
+                    uniqueKeysWithValues: states.enumerated().map { index, state in
+                        let summary: String
+                        if state.initInFlight {
+                            summary = "initializing"
+                        } else if state.isInitialized {
+                            summary = "initialized"
+                        } else {
+                            summary = "idle"
+                        }
+                        return ("\(index)", summary)
+                    })
             },
             logger: ProxyLogging.make("control-plane"),
             controlPlaneDefaultTimeout: MCP.MethodDispatcher.timeoutForControlPlane(
@@ -597,7 +605,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     package func prewarmDocumentationProvider() {
         guard let documentationProviderManager else { return }
-        let timeoutSeconds = config.requestTimeout > 0
+        let timeoutSeconds =
+            config.requestTimeout > 0
             ? min(config.requestTimeout, 30)
             : 30
         let timeout = MCP.MethodDispatcher.timeoutForControlPlane(defaultSeconds: timeoutSeconds)
@@ -606,7 +615,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             logger.debug(
                 "Prewarming documentation provider",
                 metadata: [
-                    "timeout_seconds": .string("\(timeoutSeconds)"),
+                    "timeout_seconds": .string("\(timeoutSeconds)")
                 ]
             )
             let update = await documentationProviderManager.prewarm(requestTimeout: timeout)
@@ -684,7 +693,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
         guard hasHealthyUpstream || recoveryInFlight else {
             _ = chooseUpstreamIndex()
-            return eventLoop.makeFailedFuture(UpstreamSlotAcquisitionError.unavailable)
+            return eventLoop.makeFailedFuture(UpstreamSlotScheduler.AcquisitionError.unavailable)
         }
         let promise = eventLoop.makePromise(of: Output.self)
         upstreamSlotScheduler.enqueueRequest(
@@ -696,7 +705,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 starter(upstreamIndex).cascade(to: promise)
             },
             failUnavailable: {
-                promise.fail(UpstreamSlotAcquisitionError.unavailable)
+                promise.fail(UpstreamSlotScheduler.AcquisitionError.unavailable)
             },
             failCancelled: {
                 promise.fail(CancellationError())
@@ -849,11 +858,11 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 "update": .string(update.debugLabel),
             ]
         )
-        return DocumentationToolCatalog.applying(update, to: baseResult)
+        return DocumentationProvider.ToolCatalog.applying(update, to: baseResult)
     }
 
     package func liveXcodeListWindowsResult(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> JSONValue {
         let timeout =
@@ -908,7 +917,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         documentationProviderManager != nil
     }
 
-    private func recordDocumentationToolListUpdate(_ update: DocumentationToolListUpdate) {
+    private func recordDocumentationToolListUpdate(_ update: DocumentationProvider.ToolListUpdate) {
         logger.debug(
             "Documentation provider tools/list update observed",
             metadata: ["update": .string(update.debugLabel)]
@@ -932,7 +941,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     private func documentationToolListUpdate(
         manager: any DocumentationProviderManaging,
         requestTimeout: TimeAmount?
-    ) async -> DocumentationToolListUpdate {
+    ) async -> DocumentationProvider.ToolListUpdate {
         guard requestTimeout?.nanoseconds != 0 else {
             return .unavailable
         }
@@ -940,7 +949,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             return await manager.toolListUpdate(requestTimeout: requestTimeout)
         }
         do {
-            return try await withThrowingTaskGroup(of: DocumentationToolListUpdate.self) { group in
+            return try await withThrowingTaskGroup(of: DocumentationProvider.ToolListUpdate.self) {
+                group in
                 group.addTask {
                     await manager.toolListUpdate(requestTimeout: requestTimeout)
                 }
@@ -988,7 +998,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         id: JSONRPC.ID,
         error: Error
     ) throws -> ByteBuffer {
-        let mapped = ControlPlaneErrorMapper.jsonRPCError(for: error)
+        let mapped = ControlPlane.ErrorMapper.jsonRPCError(for: error)
         let response: [String: Any] = [
             "jsonrpc": "2.0",
             "id": id.value.foundationObject,

--- a/Sources/ProxySession/Session/ProxyDebugRecorder.swift
+++ b/Sources/ProxySession/Session/ProxyDebugRecorder.swift
@@ -5,9 +5,9 @@ import ProxyMCP
 
 package final class ProxyDebugRecorder: Sendable {
     private struct DebugUpstreamState: Sendable {
-        var recentStderr: [ProxyDebugEvent] = []
-        var lastDecodeError: ProxyDebugEvent?
-        var lastBridgeError: ProxyDebugEvent?
+        var recentStderr: [ProxyDebug.Event] = []
+        var lastDecodeError: ProxyDebug.Event?
+        var lastBridgeError: ProxyDebug.Event?
         var protocolViolationCount = 0
         var lastProtocolViolationAt: Date?
         var lastProtocolViolationReason: String?
@@ -22,7 +22,7 @@ package final class ProxyDebugRecorder: Sendable {
 
     private struct State: Sendable {
         var upstreams: [DebugUpstreamState] = []
-        var recentTraffic: [ProxyDebugTrafficEvent] = []
+        var recentTraffic: [ProxyDebug.TrafficEvent] = []
     }
 
     private let state = NIOLockedValueBox(State())
@@ -57,7 +57,7 @@ package final class ProxyDebugRecorder: Sendable {
     }
 
     package func recordStderr(_ message: String, upstreamIndex: Int) {
-        let event = ProxyDebugEvent(timestamp: Date(), message: message)
+        let event = ProxyDebug.Event(timestamp: Date(), message: message)
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreams.count else { return }
             state.upstreams[upstreamIndex].recentStderr.append(event)
@@ -117,8 +117,10 @@ package final class ProxyDebugRecorder: Sendable {
         }
     }
 
-    package func recordTraffic(upstreamIndex: Int, direction: String, data: Data, redactedText: String) {
-        let event = ProxyDebugTrafficEvent(
+    package func recordTraffic(
+        upstreamIndex: Int, direction: String, data: Data, redactedText: String
+    ) {
+        let event = ProxyDebug.TrafficEvent(
             timestamp: Date(),
             upstreamIndex: upstreamIndex,
             direction: direction,
@@ -136,15 +138,15 @@ package final class ProxyDebugRecorder: Sendable {
     package func snapshot(
         proxyInitialized: Bool,
         cachedToolsListAvailable: Bool,
-        controlPlane: ProxyControlPlaneDebugSnapshot?,
+        controlPlane: ControlPlane.DebugSnapshot?,
         upstreamStates: [UpstreamHealthManager.UpstreamState],
         sessionSnapshots: [SessionRequestPipeline.DebugSnapshot],
         leaseSnapshots: [LeaseManager.DebugSnapshot],
         queuedRequestCount: Int,
         redactedText: String,
         includeSensitiveDebugPayloads: Bool,
-        healthFormatter: (UpstreamHealthState) -> String
-    ) -> ProxyDebugSnapshot {
+        healthFormatter: (Upstream.HealthState) -> String
+    ) -> ProxyDebug.Snapshot {
         let recordedState = state.withLockedValue { state in
             (upstreams: state.upstreams, recentTraffic: state.recentTraffic)
         }
@@ -154,8 +156,10 @@ package final class ProxyDebugRecorder: Sendable {
         }
 
         let upstreamSnapshots = upstreamStates.enumerated().map { index, upstream in
-            let debug = index < recordedState.upstreams.count ? recordedState.upstreams[index] : DebugUpstreamState()
-            return ProxyUpstreamDebugSnapshot(
+            let debug =
+                index < recordedState.upstreams.count
+                ? recordedState.upstreams[index] : DebugUpstreamState()
+            return ProxyDebug.UpstreamSnapshot(
                 upstreamIndex: index,
                 isInitialized: upstream.isInitialized,
                 initInFlight: upstream.initInFlight,
@@ -165,13 +169,13 @@ package final class ProxyDebugRecorder: Sendable {
                 consecutiveToolsListFailures: upstream.consecutiveToolsListFailures,
                 lastToolsListSuccessUptimeNs: upstream.lastToolsListSuccessUptimeNs,
                 recentStderr: debug.recentStderr.map { event in
-                    ProxyDebugEvent(timestamp: event.timestamp, message: redactedText)
+                    ProxyDebug.Event(timestamp: event.timestamp, message: redactedText)
                 },
                 lastDecodeError: debug.lastDecodeError.map {
-                    ProxyDebugEvent(timestamp: $0.timestamp, message: redactedText)
+                    ProxyDebug.Event(timestamp: $0.timestamp, message: redactedText)
                 },
                 lastBridgeError: debug.lastBridgeError.map {
-                    ProxyDebugEvent(timestamp: $0.timestamp, message: redactedText)
+                    ProxyDebug.Event(timestamp: $0.timestamp, message: redactedText)
                 },
                 protocolViolationCount: debug.protocolViolationCount,
                 lastProtocolViolationAt: debug.lastProtocolViolationAt,
@@ -195,7 +199,7 @@ package final class ProxyDebugRecorder: Sendable {
             )
         }
 
-        return ProxyDebugSnapshot(
+        return ProxyDebug.Snapshot(
             generatedAt: Date(),
             proxyInitialized: proxyInitialized,
             cachedToolsListAvailable: cachedToolsListAvailable,
@@ -203,7 +207,7 @@ package final class ProxyDebugRecorder: Sendable {
             controlPlane: controlPlane,
             upstreams: upstreamSnapshots,
             recentTraffic: recordedState.recentTraffic.map {
-                ProxyDebugTrafficEvent(
+                ProxyDebug.TrafficEvent(
                     timestamp: $0.timestamp,
                     upstreamIndex: $0.upstreamIndex,
                     direction: $0.direction,

--- a/Sources/ProxySession/Session/ProxyDebugSnapshot.swift
+++ b/Sources/ProxySession/Session/ProxyDebugSnapshot.swift
@@ -1,143 +1,155 @@
 import Foundation
 
-package struct ProxyDebugEvent: Codable, Sendable {
-    package let timestamp: Date
-    package let message: String
+package enum ProxyDebug {}
 
-    package init(timestamp: Date, message: String) {
-        self.timestamp = timestamp
-        self.message = message
+extension ProxyDebug {
+    package struct Event: Codable, Sendable {
+        package let timestamp: Date
+        package let message: String
+
+        package init(timestamp: Date, message: String) {
+            self.timestamp = timestamp
+            self.message = message
+        }
     }
 }
 
-package struct ProxyDebugTrafficEvent: Codable, Sendable {
-    package let timestamp: Date
-    package let upstreamIndex: Int
-    package let direction: String
-    package let bytes: Int
-    package let preview: String
+extension ProxyDebug {
+    package struct TrafficEvent: Codable, Sendable {
+        package let timestamp: Date
+        package let upstreamIndex: Int
+        package let direction: String
+        package let bytes: Int
+        package let preview: String
 
-    package init(timestamp: Date, upstreamIndex: Int, direction: String, bytes: Int, preview: String) {
-        self.timestamp = timestamp
-        self.upstreamIndex = upstreamIndex
-        self.direction = direction
-        self.bytes = bytes
-        self.preview = preview
+        package init(
+            timestamp: Date, upstreamIndex: Int, direction: String, bytes: Int, preview: String
+        ) {
+            self.timestamp = timestamp
+            self.upstreamIndex = upstreamIndex
+            self.direction = direction
+            self.bytes = bytes
+            self.preview = preview
+        }
     }
 }
 
-package struct ProxyUpstreamDebugSnapshot: Codable, Sendable {
-    package let upstreamIndex: Int
-    package let isInitialized: Bool
-    package let initInFlight: Bool
-    package let didSendInitialized: Bool
-    package let healthState: String
-    package let consecutiveRequestTimeouts: Int
-    package let consecutiveToolsListFailures: Int
-    package let lastToolsListSuccessUptimeNs: UInt64?
-    package let recentStderr: [ProxyDebugEvent]
-    package let lastDecodeError: ProxyDebugEvent?
-    package let lastBridgeError: ProxyDebugEvent?
-    package let protocolViolationCount: Int
-    package let lastProtocolViolationAt: Date?
-    package let lastProtocolViolationReason: String?
-    package let lastProtocolViolationBufferedBytes: Int?
-    package let lastProtocolViolationPreview: String?
-    package let lastProtocolViolationPreviewHex: String?
-    package let lastProtocolViolationLeadingByteHex: String?
-    package let bufferedStdoutBytes: Int
-    package let capacity: Int
-    package let requestPickCount: Int
-    package let activeCorrelatedRequestCount: Int
-    package let droppedUnmappedNotificationCount: Int
-    package let lateResponseDropCount: Int
+extension ProxyDebug {
+    package struct UpstreamSnapshot: Codable, Sendable {
+        package let upstreamIndex: Int
+        package let isInitialized: Bool
+        package let initInFlight: Bool
+        package let didSendInitialized: Bool
+        package let healthState: String
+        package let consecutiveRequestTimeouts: Int
+        package let consecutiveToolsListFailures: Int
+        package let lastToolsListSuccessUptimeNs: UInt64?
+        package let recentStderr: [ProxyDebug.Event]
+        package let lastDecodeError: ProxyDebug.Event?
+        package let lastBridgeError: ProxyDebug.Event?
+        package let protocolViolationCount: Int
+        package let lastProtocolViolationAt: Date?
+        package let lastProtocolViolationReason: String?
+        package let lastProtocolViolationBufferedBytes: Int?
+        package let lastProtocolViolationPreview: String?
+        package let lastProtocolViolationPreviewHex: String?
+        package let lastProtocolViolationLeadingByteHex: String?
+        package let bufferedStdoutBytes: Int
+        package let capacity: Int
+        package let requestPickCount: Int
+        package let activeCorrelatedRequestCount: Int
+        package let droppedUnmappedNotificationCount: Int
+        package let lateResponseDropCount: Int
 
-    package init(
-        upstreamIndex: Int,
-        isInitialized: Bool,
-        initInFlight: Bool,
-        didSendInitialized: Bool,
-        healthState: String,
-        consecutiveRequestTimeouts: Int,
-        consecutiveToolsListFailures: Int,
-        lastToolsListSuccessUptimeNs: UInt64?,
-        recentStderr: [ProxyDebugEvent],
-        lastDecodeError: ProxyDebugEvent?,
-        lastBridgeError: ProxyDebugEvent?,
-        protocolViolationCount: Int,
-        lastProtocolViolationAt: Date?,
-        lastProtocolViolationReason: String?,
-        lastProtocolViolationBufferedBytes: Int?,
-        lastProtocolViolationPreview: String?,
-        lastProtocolViolationPreviewHex: String?,
-        lastProtocolViolationLeadingByteHex: String?,
-        bufferedStdoutBytes: Int,
-        capacity: Int = 1,
-        requestPickCount: Int = 0,
-        activeCorrelatedRequestCount: Int = 0,
-        droppedUnmappedNotificationCount: Int = 0,
-        lateResponseDropCount: Int = 0
-    ) {
-        self.upstreamIndex = upstreamIndex
-        self.isInitialized = isInitialized
-        self.initInFlight = initInFlight
-        self.didSendInitialized = didSendInitialized
-        self.healthState = healthState
-        self.consecutiveRequestTimeouts = consecutiveRequestTimeouts
-        self.consecutiveToolsListFailures = consecutiveToolsListFailures
-        self.lastToolsListSuccessUptimeNs = lastToolsListSuccessUptimeNs
-        self.recentStderr = recentStderr
-        self.lastDecodeError = lastDecodeError
-        self.lastBridgeError = lastBridgeError
-        self.protocolViolationCount = protocolViolationCount
-        self.lastProtocolViolationAt = lastProtocolViolationAt
-        self.lastProtocolViolationReason = lastProtocolViolationReason
-        self.lastProtocolViolationBufferedBytes = lastProtocolViolationBufferedBytes
-        self.lastProtocolViolationPreview = lastProtocolViolationPreview
-        self.lastProtocolViolationPreviewHex = lastProtocolViolationPreviewHex
-        self.lastProtocolViolationLeadingByteHex = lastProtocolViolationLeadingByteHex
-        self.bufferedStdoutBytes = bufferedStdoutBytes
-        self.capacity = capacity
-        self.requestPickCount = requestPickCount
-        self.activeCorrelatedRequestCount = activeCorrelatedRequestCount
-        self.droppedUnmappedNotificationCount = droppedUnmappedNotificationCount
-        self.lateResponseDropCount = lateResponseDropCount
+        package init(
+            upstreamIndex: Int,
+            isInitialized: Bool,
+            initInFlight: Bool,
+            didSendInitialized: Bool,
+            healthState: String,
+            consecutiveRequestTimeouts: Int,
+            consecutiveToolsListFailures: Int,
+            lastToolsListSuccessUptimeNs: UInt64?,
+            recentStderr: [ProxyDebug.Event],
+            lastDecodeError: ProxyDebug.Event?,
+            lastBridgeError: ProxyDebug.Event?,
+            protocolViolationCount: Int,
+            lastProtocolViolationAt: Date?,
+            lastProtocolViolationReason: String?,
+            lastProtocolViolationBufferedBytes: Int?,
+            lastProtocolViolationPreview: String?,
+            lastProtocolViolationPreviewHex: String?,
+            lastProtocolViolationLeadingByteHex: String?,
+            bufferedStdoutBytes: Int,
+            capacity: Int = 1,
+            requestPickCount: Int = 0,
+            activeCorrelatedRequestCount: Int = 0,
+            droppedUnmappedNotificationCount: Int = 0,
+            lateResponseDropCount: Int = 0
+        ) {
+            self.upstreamIndex = upstreamIndex
+            self.isInitialized = isInitialized
+            self.initInFlight = initInFlight
+            self.didSendInitialized = didSendInitialized
+            self.healthState = healthState
+            self.consecutiveRequestTimeouts = consecutiveRequestTimeouts
+            self.consecutiveToolsListFailures = consecutiveToolsListFailures
+            self.lastToolsListSuccessUptimeNs = lastToolsListSuccessUptimeNs
+            self.recentStderr = recentStderr
+            self.lastDecodeError = lastDecodeError
+            self.lastBridgeError = lastBridgeError
+            self.protocolViolationCount = protocolViolationCount
+            self.lastProtocolViolationAt = lastProtocolViolationAt
+            self.lastProtocolViolationReason = lastProtocolViolationReason
+            self.lastProtocolViolationBufferedBytes = lastProtocolViolationBufferedBytes
+            self.lastProtocolViolationPreview = lastProtocolViolationPreview
+            self.lastProtocolViolationPreviewHex = lastProtocolViolationPreviewHex
+            self.lastProtocolViolationLeadingByteHex = lastProtocolViolationLeadingByteHex
+            self.bufferedStdoutBytes = bufferedStdoutBytes
+            self.capacity = capacity
+            self.requestPickCount = requestPickCount
+            self.activeCorrelatedRequestCount = activeCorrelatedRequestCount
+            self.droppedUnmappedNotificationCount = droppedUnmappedNotificationCount
+            self.lateResponseDropCount = lateResponseDropCount
+        }
     }
 }
 
-package struct ProxyDebugSnapshot: Codable, Sendable {
-    package let generatedAt: Date
-    package let proxyInitialized: Bool
-    package let cachedToolsListAvailable: Bool
-    package let warmupInFlight: Bool
-    package let controlPlane: ProxyControlPlaneDebugSnapshot?
-    package let upstreams: [ProxyUpstreamDebugSnapshot]
-    package let recentTraffic: [ProxyDebugTrafficEvent]
-    package let sessions: [SessionRequestPipeline.DebugSnapshot]
-    package let leases: [LeaseManager.DebugSnapshot]
-    package let queuedRequestCount: Int
+extension ProxyDebug {
+    package struct Snapshot: Codable, Sendable {
+        package let generatedAt: Date
+        package let proxyInitialized: Bool
+        package let cachedToolsListAvailable: Bool
+        package let warmupInFlight: Bool
+        package let controlPlane: ControlPlane.DebugSnapshot?
+        package let upstreams: [ProxyDebug.UpstreamSnapshot]
+        package let recentTraffic: [ProxyDebug.TrafficEvent]
+        package let sessions: [SessionRequestPipeline.DebugSnapshot]
+        package let leases: [LeaseManager.DebugSnapshot]
+        package let queuedRequestCount: Int
 
-    package init(
-        generatedAt: Date,
-        proxyInitialized: Bool,
-        cachedToolsListAvailable: Bool,
-        warmupInFlight: Bool,
-        controlPlane: ProxyControlPlaneDebugSnapshot? = nil,
-        upstreams: [ProxyUpstreamDebugSnapshot],
-        recentTraffic: [ProxyDebugTrafficEvent],
-        sessions: [SessionRequestPipeline.DebugSnapshot],
-        leases: [LeaseManager.DebugSnapshot],
-        queuedRequestCount: Int
-    ) {
-        self.generatedAt = generatedAt
-        self.proxyInitialized = proxyInitialized
-        self.cachedToolsListAvailable = cachedToolsListAvailable
-        self.warmupInFlight = warmupInFlight
-        self.controlPlane = controlPlane
-        self.upstreams = upstreams
-        self.recentTraffic = recentTraffic
-        self.sessions = sessions
-        self.leases = leases
-        self.queuedRequestCount = queuedRequestCount
+        package init(
+            generatedAt: Date,
+            proxyInitialized: Bool,
+            cachedToolsListAvailable: Bool,
+            warmupInFlight: Bool,
+            controlPlane: ControlPlane.DebugSnapshot? = nil,
+            upstreams: [ProxyDebug.UpstreamSnapshot],
+            recentTraffic: [ProxyDebug.TrafficEvent],
+            sessions: [SessionRequestPipeline.DebugSnapshot],
+            leases: [LeaseManager.DebugSnapshot],
+            queuedRequestCount: Int
+        ) {
+            self.generatedAt = generatedAt
+            self.proxyInitialized = proxyInitialized
+            self.cachedToolsListAvailable = cachedToolsListAvailable
+            self.warmupInFlight = warmupInFlight
+            self.controlPlane = controlPlane
+            self.upstreams = upstreams
+            self.recentTraffic = recentTraffic
+            self.sessions = sessions
+            self.leases = leases
+            self.queuedRequestCount = queuedRequestCount
+        }
     }
 }

--- a/Sources/ProxySession/Session/SessionRequestPipeline.swift
+++ b/Sources/ProxySession/Session/SessionRequestPipeline.swift
@@ -42,7 +42,3 @@ package enum SessionRequestPipeline {
         package var pendingRequestCount: Int { 0 }
     }
 }
-
-package enum UpstreamSlotAcquisitionError: Error {
-    case unavailable
-}

--- a/Sources/ProxySession/Upstream/UpstreamHealthManager.swift
+++ b/Sources/ProxySession/Upstream/UpstreamHealthManager.swift
@@ -83,7 +83,7 @@ package final class UpstreamHealthManager: Sendable {
         package var initPhase: InitPhase = .idle
         package var initTimeout: RuntimeScheduledTimeout?
         package var didSendInitialized = false
-        package var healthState: UpstreamHealthState = .healthy
+        package var healthState: Upstream.HealthState = .healthy
         package var consecutiveRequestTimeouts = 0
         package var healthProbeInFlight = false
         package var healthProbeGeneration: UInt64 = 0
@@ -498,7 +498,7 @@ package final class UpstreamHealthManager: Sendable {
         }
     }
 
-    package func debugHealthStateString(_ state: UpstreamHealthState) -> String {
+    package func debugHealthStateString(_ state: Upstream.HealthState) -> String {
         switch state {
         case .healthy:
             return "healthy"
@@ -571,7 +571,7 @@ package final class UpstreamHealthManager: Sendable {
         nowUptimeNs: UInt64,
         state: inout State,
         effects: inout [UpstreamHealthManager.Effect]
-    ) -> UpstreamHealthState {
+    ) -> Upstream.HealthState {
         guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else {
             return .quarantined(untilUptimeNs: nowUptimeNs)
         }

--- a/Sources/ProxySession/Upstream/UpstreamHealthState.swift
+++ b/Sources/ProxySession/Upstream/UpstreamHealthState.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-package enum UpstreamHealthState: Sendable {
-    case healthy
-    case degraded
-    case quarantined(untilUptimeNs: UInt64)
+extension Upstream {
+    package enum HealthState: Sendable {
+        case healthy
+        case degraded
+        case quarantined(untilUptimeNs: UInt64)
+    }
 }

--- a/Sources/ProxySession/Upstream/UpstreamSlotScheduler.swift
+++ b/Sources/ProxySession/Upstream/UpstreamSlotScheduler.swift
@@ -5,6 +5,10 @@ import NIOConcurrencyHelpers
 import ProxyCore
 
 package final class UpstreamSlotScheduler: Sendable {
+    package enum AcquisitionError: Error {
+        case unavailable
+    }
+
     package struct DebugSnapshot: Codable, Sendable {
         package let queuedRequestCount: Int
         package let activeLeaseCountByUpstream: [Int: Int]
@@ -124,8 +128,11 @@ package final class UpstreamSlotScheduler: Sendable {
                 .filter { $0.hasStarted == false }
                 .map(\.request)
 
-            for reservation in state.reservationsByLeaseID.values where reservation.hasStarted == false {
-                if state.activeLeaseIDsByUpstream[reservation.upstreamIndex] == reservation.request.leaseID {
+            for reservation in state.reservationsByLeaseID.values
+            where reservation.hasStarted == false {
+                if state.activeLeaseIDsByUpstream[reservation.upstreamIndex]
+                    == reservation.request.leaseID
+                {
                     state.activeLeaseIDsByUpstream.removeValue(forKey: reservation.upstreamIndex)
                 }
                 if reservation.request.descriptor.isTopLevelClientRequest,
@@ -166,8 +173,10 @@ package final class UpstreamSlotScheduler: Sendable {
         }
 
         let removed = state.withLockedValue { state -> CancelledRequest? in
-            guard let index = state.pendingRequests.firstIndex(where: { $0.leaseID == leaseID }) else {
-                guard let reservation = state.reservationsByLeaseID[leaseID], reservation.hasStarted == false
+            guard let index = state.pendingRequests.firstIndex(where: { $0.leaseID == leaseID })
+            else {
+                guard let reservation = state.reservationsByLeaseID[leaseID],
+                    reservation.hasStarted == false
                 else {
                     return nil
                 }
@@ -201,7 +210,7 @@ package final class UpstreamSlotScheduler: Sendable {
         logger.debug(
             "Cancelled queued request before upstream dispatch",
             metadata: [
-                "lease_id": .string(leaseID.uuidString),
+                "lease_id": .string(leaseID.uuidString)
             ]
         )
         request.eventLoop.execute {
@@ -216,7 +225,8 @@ package final class UpstreamSlotScheduler: Sendable {
         state.withLockedValue { state in
             UpstreamSlotScheduler.DebugSnapshot(
                 queuedRequestCount: state.pendingRequests.count,
-                activeLeaseCountByUpstream: state.activeLeaseIDsByUpstream.reduce(into: [:]) { counts, item in
+                activeLeaseCountByUpstream: state.activeLeaseIDsByUpstream.reduce(into: [:]) {
+                    counts, item in
                     counts[item.key] = 1
                 }
             )
@@ -259,10 +269,11 @@ package final class UpstreamSlotScheduler: Sendable {
     }
 
     private func dispatchQueuedRequestsIfPossible() {
-        let dispatch = state.withLockedValue { state -> (
-            starts: [(PendingRequest, Int)],
-            healthEffects: [UpstreamHealthManager.Effect]
-        ) in
+        let dispatch = state.withLockedValue {
+            state -> (
+                starts: [(PendingRequest, Int)],
+                healthEffects: [UpstreamHealthManager.Effect]
+            ) in
             var ready: [(PendingRequest, Int)] = []
             var healthEffects: [UpstreamHealthManager.Effect] = []
 

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesDebugState.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesDebugState.swift
@@ -3,468 +3,473 @@ import ProxyCore
 
 extension RefreshCodeIssues {
     package struct QueueSnapshot: Codable, Sendable {
-    package let defaultRequestTimeoutSeconds: Double
-    package let activeByQueueKey: [String: Int]
-    package let waitingByQueueKey: [String: Int]
-    package let activeRequestCount: Int
-    package let waitingRequestCount: Int
+        package let defaultRequestTimeoutSeconds: Double
+        package let activeByQueueKey: [String: Int]
+        package let waitingByQueueKey: [String: Int]
+        package let activeRequestCount: Int
+        package let waitingRequestCount: Int
 
-    package init(
-        defaultRequestTimeoutSeconds: Double,
-        activeByQueueKey: [String: Int],
-        waitingByQueueKey: [String: Int],
-        activeRequestCount: Int,
-        waitingRequestCount: Int
-    ) {
-        self.defaultRequestTimeoutSeconds = defaultRequestTimeoutSeconds
-        self.activeByQueueKey = activeByQueueKey
-        self.waitingByQueueKey = waitingByQueueKey
-        self.activeRequestCount = activeRequestCount
-        self.waitingRequestCount = waitingRequestCount
-    }
-}
-
-/// A refresh request's terminal outcome. The diagnostic final state is
-/// derived here, so the outcome-to-state mapping cannot drift between the
-/// workflow and the debug snapshot.
-package enum Outcome: String, Sendable {
-    case success
-    case timeout
-    case queueWaitTimedOut = "queue_wait_timed_out"
-    case cancelled
-    case invalidRequest = "invalid_request"
-    case upstreamUnavailable = "upstream_unavailable"
-    case invalidUpstreamResponse = "invalid_upstream_response"
-
-    package var finalState: RefreshCodeIssues.RequestState {
-        switch self {
-        case .success:
-            return .completed
-        case .timeout, .queueWaitTimedOut:
-            return .timedOut
-        case .cancelled:
-            return .cancelled
-        case .invalidRequest, .upstreamUnavailable, .invalidUpstreamResponse:
-            return .failed
-        }
-    }
-}
-
-package enum RequestState: String, Sendable {
-    case waitingForPermit = "waiting_for_permit"
-    case running
-    case completed
-    case timedOut = "timed_out"
-    case cancelled
-    case failed
-}
-
-package enum Step: Sendable, Equatable {
-    case waitingForPermit
-    case permitAcquired
-    case requestTimeoutExhausted
-    case queueWaitTimedOut
-    case executionBudgetStarted
-    case invalidRequest
-    case cancelled
-    case proxyFallbackToUpstream
-    case proxySelectInternalUpstream
-    case proxyExecutionBudgetExhausted
-    case proxyReservedUpstreamBudget
-    case proxyListWindows
-    case proxyListNavigatorIssues
-    case proxyFilterNavigatorIssues
-    case proxyEncodeResponse
-    case proxySuccess
-    case proxyCompleted
-    case upstreamExecutionBudgetExhausted
-    case upstreamAttempt(Int)
-    case upstreamRetryBudgetExhausted
-    case upstreamRetryDelay
-    case upstreamRetryExhausted
-    case upstreamSuccess
-    case upstreamTimeout
-    case upstreamUnavailable
-    case upstreamInvalidRequest
-    case upstreamInvalidResponse
-
-    package var rawValue: String {
-        switch self {
-        case .waitingForPermit:
-            return "waiting_for_permit"
-        case .permitAcquired:
-            return "permit_acquired"
-        case .requestTimeoutExhausted:
-            return "request_timeout_exhausted"
-        case .queueWaitTimedOut:
-            return "queue_wait_timed_out"
-        case .executionBudgetStarted:
-            return "execution_budget_started"
-        case .invalidRequest:
-            return "invalid_request"
-        case .cancelled:
-            return "cancelled"
-        case .proxyFallbackToUpstream:
-            return "proxy.fallback_to_upstream"
-        case .proxySelectInternalUpstream:
-            return "proxy.select_internal_upstream"
-        case .proxyExecutionBudgetExhausted:
-            return "proxy.execution_budget_exhausted"
-        case .proxyReservedUpstreamBudget:
-            return "proxy.reserved_upstream_budget"
-        case .proxyListWindows:
-            return "proxy.list_windows"
-        case .proxyListNavigatorIssues:
-            return "proxy.list_navigator_issues"
-        case .proxyFilterNavigatorIssues:
-            return "proxy.filter_navigator_issues"
-        case .proxyEncodeResponse:
-            return "proxy.encode_response"
-        case .proxySuccess:
-            return "proxy.success"
-        case .proxyCompleted:
-            return "proxy.completed"
-        case .upstreamExecutionBudgetExhausted:
-            return "upstream.execution_budget_exhausted"
-        case .upstreamAttempt(let attempt):
-            return "upstream.attempt_\(attempt)"
-        case .upstreamRetryBudgetExhausted:
-            return "upstream.retry_budget_exhausted"
-        case .upstreamRetryDelay:
-            return "upstream.retry_delay"
-        case .upstreamRetryExhausted:
-            return "upstream.retry_exhausted"
-        case .upstreamSuccess:
-            return "upstream.success"
-        case .upstreamTimeout:
-            return "upstream.timeout"
-        case .upstreamUnavailable:
-            return "upstream.unavailable"
-        case .upstreamInvalidRequest:
-            return "upstream.invalid_request"
-        case .upstreamInvalidResponse:
-            return "upstream.invalid_response"
-        }
-    }
-}
-
-package struct RequestSnapshot: Codable, Sendable {
-    package let id: String
-    package let sessionID: String
-    package let queueKey: String
-    package let tabIdentifier: String?
-    package let filePath: String?
-    package let mode: String
-    package let state: String
-    package let step: String
-    package let startedAt: Date
-    package let lastUpdatedAt: Date
-    package let lastQueuePosition: Int?
-    package let metadata: [String: String]
-
-    package init(
-        id: String,
-        sessionID: String,
-        queueKey: String,
-        tabIdentifier: String?,
-        filePath: String?,
-        mode: String,
-        state: String,
-        step: String,
-        startedAt: Date,
-        lastUpdatedAt: Date,
-        lastQueuePosition: Int?,
-        metadata: [String: String]
-    ) {
-        self.id = id
-        self.sessionID = sessionID
-        self.queueKey = queueKey
-        self.tabIdentifier = tabIdentifier
-        self.filePath = filePath
-        self.mode = mode
-        self.state = state
-        self.step = step
-        self.startedAt = startedAt
-        self.lastUpdatedAt = lastUpdatedAt
-        self.lastQueuePosition = lastQueuePosition
-        self.metadata = metadata
-    }
-}
-
-package struct CompletedRequestSnapshot: Codable, Sendable {
-    package let id: String
-    package let sessionID: String
-    package let queueKey: String
-    package let tabIdentifier: String?
-    package let filePath: String?
-    package let mode: String
-    package let finalState: String
-    package let finalStep: String
-    package let startedAt: Date
-    package let completedAt: Date
-    package let lastQueuePosition: Int?
-    package let outcome: String
-    package let metadata: [String: String]
-
-    package init(
-        id: String,
-        sessionID: String,
-        queueKey: String,
-        tabIdentifier: String?,
-        filePath: String?,
-        mode: String,
-        finalState: String,
-        finalStep: String,
-        startedAt: Date,
-        completedAt: Date,
-        lastQueuePosition: Int?,
-        outcome: String,
-        metadata: [String: String]
-    ) {
-        self.id = id
-        self.sessionID = sessionID
-        self.queueKey = queueKey
-        self.tabIdentifier = tabIdentifier
-        self.filePath = filePath
-        self.mode = mode
-        self.finalState = finalState
-        self.finalStep = finalStep
-        self.startedAt = startedAt
-        self.completedAt = completedAt
-        self.lastQueuePosition = lastQueuePosition
-        self.outcome = outcome
-        self.metadata = metadata
-    }
-}
-
-package struct DebugSnapshot: Codable, Sendable {
-    package let queue: RefreshCodeIssues.QueueSnapshot
-    package let activeRequests: [RefreshCodeIssues.RequestSnapshot]
-    package let recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot]
-
-    package init(
-        queue: RefreshCodeIssues.QueueSnapshot,
-        activeRequests: [RefreshCodeIssues.RequestSnapshot],
-        recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot]
-    ) {
-        self.queue = queue
-        self.activeRequests = activeRequests
-        self.recentCompletedRequests = recentCompletedRequests
-    }
-}
-
-package final class DebugState: @unchecked Sendable {
-    private struct RequestRecord: Sendable {
-        let id: String
-        let sessionID: String
-        let queueKey: String
-        let tabIdentifier: String?
-        let filePath: String?
-        let mode: String
-        let startedAt: Date
-        var lastUpdatedAt: Date
-        var state: RefreshCodeIssues.RequestState
-        var step: RefreshCodeIssues.Step
-        var lastQueuePosition: Int?
-        var metadata: [String: String]
-    }
-
-    private struct State {
-        var activeRequests: [String: RequestRecord] = [:]
-        var recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot] = []
-    }
-
-    private let lock = NSLock()
-    private var state = State()
-    private let defaultRequestTimeoutSeconds: Double
-    private let recentCompletedLimit: Int
-    private let clock: ClockClient
-
-    package init(
-        defaultRequestTimeoutSeconds: Double,
-        recentCompletedLimit: Int = 20,
-        clock: ClockClient = .liveValue
-    ) {
-        self.defaultRequestTimeoutSeconds = defaultRequestTimeoutSeconds
-        self.recentCompletedLimit = recentCompletedLimit
-        self.clock = clock
-    }
-
-    package func beginRequest(
-        sessionID: String,
-        queueKey: String,
-        tabIdentifier: String?,
-        filePath: String?,
-        mode: String
-    ) -> String {
-        let now = clock.now()
-        let requestID = UUID().uuidString
-        let record = RequestRecord(
-            id: requestID,
-            sessionID: sessionID,
-            queueKey: queueKey,
-            tabIdentifier: tabIdentifier,
-            filePath: filePath,
-            mode: mode,
-            startedAt: now,
-            lastUpdatedAt: now,
-            state: .waitingForPermit,
-            step: .waitingForPermit,
-            lastQueuePosition: nil,
-            metadata: [:]
-        )
-        lock.lock()
-        state.activeRequests[requestID] = record
-        lock.unlock()
-        return requestID
-    }
-
-    package func markPermitAcquired(
-        requestID: String,
-        queuePosition: Int,
-        pendingForKey: Int,
-        pendingTotal: Int
-    ) {
-        updateRequest(requestID: requestID) { record, now in
-            record.state = .running
-            record.step = .permitAcquired
-            record.lastQueuePosition = queuePosition
-            record.lastUpdatedAt = now
-            record.metadata["pending_for_key"] = "\(pendingForKey)"
-            record.metadata["pending_total"] = "\(pendingTotal)"
+        package init(
+            defaultRequestTimeoutSeconds: Double,
+            activeByQueueKey: [String: Int],
+            waitingByQueueKey: [String: Int],
+            activeRequestCount: Int,
+            waitingRequestCount: Int
+        ) {
+            self.defaultRequestTimeoutSeconds = defaultRequestTimeoutSeconds
+            self.activeByQueueKey = activeByQueueKey
+            self.waitingByQueueKey = waitingByQueueKey
+            self.activeRequestCount = activeRequestCount
+            self.waitingRequestCount = waitingRequestCount
         }
     }
 
-    package func updateStep(
-        requestID: String,
-        step: RefreshCodeIssues.Step,
-        state overrideState: RefreshCodeIssues.RequestState? = nil,
-        metadata: [String: String] = [:]
-    ) {
-        updateRequest(requestID: requestID) { record, now in
-            if let overrideState {
-                record.state = overrideState
+    /// A refresh request's terminal outcome. The diagnostic final state is
+    /// derived here, so the outcome-to-state mapping cannot drift between the
+    /// workflow and the debug snapshot.
+    package enum Outcome: String, Sendable {
+        case success
+        case timeout
+        case queueWaitTimedOut = "queue_wait_timed_out"
+        case cancelled
+        case invalidRequest = "invalid_request"
+        case upstreamUnavailable = "upstream_unavailable"
+        case invalidUpstreamResponse = "invalid_upstream_response"
+
+        package var finalState: RefreshCodeIssues.RequestState {
+            switch self {
+            case .success:
+                return .completed
+            case .timeout, .queueWaitTimedOut:
+                return .timedOut
+            case .cancelled:
+                return .cancelled
+            case .invalidRequest, .upstreamUnavailable, .invalidUpstreamResponse:
+                return .failed
             }
-            record.step = step
+        }
+    }
+
+    package enum RequestState: String, Sendable {
+        case waitingForPermit = "waiting_for_permit"
+        case running
+        case completed
+        case timedOut = "timed_out"
+        case cancelled
+        case failed
+    }
+
+    package enum Step: Sendable, Equatable {
+        case waitingForPermit
+        case permitAcquired
+        case requestTimeoutExhausted
+        case queueWaitTimedOut
+        case executionBudgetStarted
+        case invalidRequest
+        case cancelled
+        case proxyFallbackToUpstream
+        case proxySelectInternalUpstream
+        case proxyExecutionBudgetExhausted
+        case proxyReservedUpstreamBudget
+        case proxyListWindows
+        case proxyListNavigatorIssues
+        case proxyFilterNavigatorIssues
+        case proxyEncodeResponse
+        case proxySuccess
+        case proxyCompleted
+        case upstreamExecutionBudgetExhausted
+        case upstreamAttempt(Int)
+        case upstreamRetryBudgetExhausted
+        case upstreamRetryDelay
+        case upstreamRetryExhausted
+        case upstreamSuccess
+        case upstreamTimeout
+        case upstreamUnavailable
+        case upstreamInvalidRequest
+        case upstreamInvalidResponse
+
+        package var rawValue: String {
+            switch self {
+            case .waitingForPermit:
+                return "waiting_for_permit"
+            case .permitAcquired:
+                return "permit_acquired"
+            case .requestTimeoutExhausted:
+                return "request_timeout_exhausted"
+            case .queueWaitTimedOut:
+                return "queue_wait_timed_out"
+            case .executionBudgetStarted:
+                return "execution_budget_started"
+            case .invalidRequest:
+                return "invalid_request"
+            case .cancelled:
+                return "cancelled"
+            case .proxyFallbackToUpstream:
+                return "proxy.fallback_to_upstream"
+            case .proxySelectInternalUpstream:
+                return "proxy.select_internal_upstream"
+            case .proxyExecutionBudgetExhausted:
+                return "proxy.execution_budget_exhausted"
+            case .proxyReservedUpstreamBudget:
+                return "proxy.reserved_upstream_budget"
+            case .proxyListWindows:
+                return "proxy.list_windows"
+            case .proxyListNavigatorIssues:
+                return "proxy.list_navigator_issues"
+            case .proxyFilterNavigatorIssues:
+                return "proxy.filter_navigator_issues"
+            case .proxyEncodeResponse:
+                return "proxy.encode_response"
+            case .proxySuccess:
+                return "proxy.success"
+            case .proxyCompleted:
+                return "proxy.completed"
+            case .upstreamExecutionBudgetExhausted:
+                return "upstream.execution_budget_exhausted"
+            case .upstreamAttempt(let attempt):
+                return "upstream.attempt_\(attempt)"
+            case .upstreamRetryBudgetExhausted:
+                return "upstream.retry_budget_exhausted"
+            case .upstreamRetryDelay:
+                return "upstream.retry_delay"
+            case .upstreamRetryExhausted:
+                return "upstream.retry_exhausted"
+            case .upstreamSuccess:
+                return "upstream.success"
+            case .upstreamTimeout:
+                return "upstream.timeout"
+            case .upstreamUnavailable:
+                return "upstream.unavailable"
+            case .upstreamInvalidRequest:
+                return "upstream.invalid_request"
+            case .upstreamInvalidResponse:
+                return "upstream.invalid_response"
+            }
+        }
+    }
+
+    package struct RequestSnapshot: Codable, Sendable {
+        package let id: String
+        package let sessionID: String
+        package let queueKey: String
+        package let tabIdentifier: String?
+        package let filePath: String?
+        package let mode: String
+        package let state: String
+        package let step: String
+        package let startedAt: Date
+        package let lastUpdatedAt: Date
+        package let lastQueuePosition: Int?
+        package let metadata: [String: String]
+
+        package init(
+            id: String,
+            sessionID: String,
+            queueKey: String,
+            tabIdentifier: String?,
+            filePath: String?,
+            mode: String,
+            state: String,
+            step: String,
+            startedAt: Date,
+            lastUpdatedAt: Date,
+            lastQueuePosition: Int?,
+            metadata: [String: String]
+        ) {
+            self.id = id
+            self.sessionID = sessionID
+            self.queueKey = queueKey
+            self.tabIdentifier = tabIdentifier
+            self.filePath = filePath
+            self.mode = mode
+            self.state = state
+            self.step = step
+            self.startedAt = startedAt
+            self.lastUpdatedAt = lastUpdatedAt
+            self.lastQueuePosition = lastQueuePosition
+            self.metadata = metadata
+        }
+    }
+
+    package struct CompletedRequestSnapshot: Codable, Sendable {
+        package let id: String
+        package let sessionID: String
+        package let queueKey: String
+        package let tabIdentifier: String?
+        package let filePath: String?
+        package let mode: String
+        package let finalState: String
+        package let finalStep: String
+        package let startedAt: Date
+        package let completedAt: Date
+        package let lastQueuePosition: Int?
+        package let outcome: String
+        package let metadata: [String: String]
+
+        package init(
+            id: String,
+            sessionID: String,
+            queueKey: String,
+            tabIdentifier: String?,
+            filePath: String?,
+            mode: String,
+            finalState: String,
+            finalStep: String,
+            startedAt: Date,
+            completedAt: Date,
+            lastQueuePosition: Int?,
+            outcome: String,
+            metadata: [String: String]
+        ) {
+            self.id = id
+            self.sessionID = sessionID
+            self.queueKey = queueKey
+            self.tabIdentifier = tabIdentifier
+            self.filePath = filePath
+            self.mode = mode
+            self.finalState = finalState
+            self.finalStep = finalStep
+            self.startedAt = startedAt
+            self.completedAt = completedAt
+            self.lastQueuePosition = lastQueuePosition
+            self.outcome = outcome
+            self.metadata = metadata
+        }
+    }
+
+    package struct DebugSnapshot: Codable, Sendable {
+        package let queue: RefreshCodeIssues.QueueSnapshot
+        package let activeRequests: [RefreshCodeIssues.RequestSnapshot]
+        package let recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot]
+
+        package init(
+            queue: RefreshCodeIssues.QueueSnapshot,
+            activeRequests: [RefreshCodeIssues.RequestSnapshot],
+            recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot]
+        ) {
+            self.queue = queue
+            self.activeRequests = activeRequests
+            self.recentCompletedRequests = recentCompletedRequests
+        }
+    }
+
+    package final class DebugState: @unchecked Sendable {
+        private struct RequestRecord: Sendable {
+            let id: String
+            let sessionID: String
+            let queueKey: String
+            let tabIdentifier: String?
+            let filePath: String?
+            let mode: String
+            let startedAt: Date
+            var lastUpdatedAt: Date
+            var state: RefreshCodeIssues.RequestState
+            var step: RefreshCodeIssues.Step
+            var lastQueuePosition: Int?
+            var metadata: [String: String]
+        }
+
+        private struct State {
+            var activeRequests: [String: RequestRecord] = [:]
+            var recentCompletedRequests: [RefreshCodeIssues.CompletedRequestSnapshot] = []
+        }
+
+        private let lock = NSLock()
+        private var state = State()
+        private let defaultRequestTimeoutSeconds: Double
+        private let recentCompletedLimit: Int
+        private let clock: ClockClient
+
+        package init(
+            defaultRequestTimeoutSeconds: Double,
+            recentCompletedLimit: Int = 20,
+            clock: ClockClient = .liveValue
+        ) {
+            self.defaultRequestTimeoutSeconds = defaultRequestTimeoutSeconds
+            self.recentCompletedLimit = recentCompletedLimit
+            self.clock = clock
+        }
+
+        package func beginRequest(
+            sessionID: String,
+            queueKey: String,
+            tabIdentifier: String?,
+            filePath: String?,
+            mode: String
+        ) -> String {
+            let now = clock.now()
+            let requestID = UUID().uuidString
+            let record = RequestRecord(
+                id: requestID,
+                sessionID: sessionID,
+                queueKey: queueKey,
+                tabIdentifier: tabIdentifier,
+                filePath: filePath,
+                mode: mode,
+                startedAt: now,
+                lastUpdatedAt: now,
+                state: .waitingForPermit,
+                step: .waitingForPermit,
+                lastQueuePosition: nil,
+                metadata: [:]
+            )
+            lock.lock()
+            state.activeRequests[requestID] = record
+            lock.unlock()
+            return requestID
+        }
+
+        package func markPermitAcquired(
+            requestID: String,
+            queuePosition: Int,
+            pendingForKey: Int,
+            pendingTotal: Int
+        ) {
+            updateRequest(requestID: requestID) { record, now in
+                record.state = .running
+                record.step = .permitAcquired
+                record.lastQueuePosition = queuePosition
+                record.lastUpdatedAt = now
+                record.metadata["pending_for_key"] = "\(pendingForKey)"
+                record.metadata["pending_total"] = "\(pendingTotal)"
+            }
+        }
+
+        package func updateStep(
+            requestID: String,
+            step: RefreshCodeIssues.Step,
+            state overrideState: RefreshCodeIssues.RequestState? = nil,
+            metadata: [String: String] = [:]
+        ) {
+            updateRequest(requestID: requestID) { record, now in
+                if let overrideState {
+                    record.state = overrideState
+                }
+                record.step = step
+                record.lastUpdatedAt = now
+                for (key, value) in metadata {
+                    record.metadata[key] = value
+                }
+            }
+        }
+
+        package func finishRequest(
+            requestID: String,
+            outcome: RefreshCodeIssues.Outcome,
+            metadata: [String: String] = [:]
+        ) {
+            let now = clock.now()
+            lock.lock()
+            guard var record = state.activeRequests.removeValue(forKey: requestID) else {
+                lock.unlock()
+                return
+            }
             record.lastUpdatedAt = now
+            record.state = outcome.finalState
             for (key, value) in metadata {
                 record.metadata[key] = value
             }
-        }
-    }
-
-    package func finishRequest(
-        requestID: String,
-        outcome: RefreshCodeIssues.Outcome,
-        metadata: [String: String] = [:]
-    ) {
-        let now = clock.now()
-        lock.lock()
-        guard var record = state.activeRequests.removeValue(forKey: requestID) else {
-            lock.unlock()
-            return
-        }
-        record.lastUpdatedAt = now
-        record.state = outcome.finalState
-        for (key, value) in metadata {
-            record.metadata[key] = value
-        }
-        let completed = RefreshCodeIssues.CompletedRequestSnapshot(
-            id: record.id,
-            sessionID: record.sessionID,
-            queueKey: record.queueKey,
-            tabIdentifier: record.tabIdentifier,
-            filePath: record.filePath,
-            mode: record.mode,
-            finalState: record.state.rawValue,
-            finalStep: record.step.rawValue,
-            startedAt: record.startedAt,
-            completedAt: now,
-            lastQueuePosition: record.lastQueuePosition,
-            outcome: outcome.rawValue,
-            metadata: record.metadata
-        )
-        state.recentCompletedRequests.append(completed)
-        if state.recentCompletedRequests.count > recentCompletedLimit {
-            state.recentCompletedRequests.removeFirst(
-                state.recentCompletedRequests.count - recentCompletedLimit
+            let completed = RefreshCodeIssues.CompletedRequestSnapshot(
+                id: record.id,
+                sessionID: record.sessionID,
+                queueKey: record.queueKey,
+                tabIdentifier: record.tabIdentifier,
+                filePath: record.filePath,
+                mode: record.mode,
+                finalState: record.state.rawValue,
+                finalStep: record.step.rawValue,
+                startedAt: record.startedAt,
+                completedAt: now,
+                lastQueuePosition: record.lastQueuePosition,
+                outcome: outcome.rawValue,
+                metadata: record.metadata
             )
-        }
-        lock.unlock()
-    }
-
-    package func snapshot() -> RefreshCodeIssues.DebugSnapshot {
-        lock.lock()
-        let activeRecords = Array(state.activeRequests.values)
-        let recentCompleted = state.recentCompletedRequests
-        lock.unlock()
-
-        var activeByQueueKey: [String: Int] = [:]
-        var waitingByQueueKey: [String: Int] = [:]
-        for record in activeRecords {
-            if record.state == .running {
-                activeByQueueKey[record.queueKey, default: 0] += 1
-            } else {
-                waitingByQueueKey[record.queueKey, default: 0] += 1
-            }
-        }
-
-        let activeRequests = activeRecords
-            .sorted { lhs, rhs in
-                if lhs.startedAt == rhs.startedAt {
-                    return lhs.id < rhs.id
-                }
-                return lhs.startedAt < rhs.startedAt
-            }
-            .map { record in
-                RefreshCodeIssues.RequestSnapshot(
-                    id: record.id,
-                    sessionID: record.sessionID,
-                    queueKey: record.queueKey,
-                    tabIdentifier: record.tabIdentifier,
-                    filePath: record.filePath,
-                    mode: record.mode,
-                    state: record.state.rawValue,
-                    step: record.step.rawValue,
-                    startedAt: record.startedAt,
-                    lastUpdatedAt: record.lastUpdatedAt,
-                    lastQueuePosition: record.lastQueuePosition,
-                    metadata: record.metadata
+            state.recentCompletedRequests.append(completed)
+            if state.recentCompletedRequests.count > recentCompletedLimit {
+                state.recentCompletedRequests.removeFirst(
+                    state.recentCompletedRequests.count - recentCompletedLimit
                 )
             }
-        let queue = RefreshCodeIssues.QueueSnapshot(
-            defaultRequestTimeoutSeconds: defaultRequestTimeoutSeconds,
-            activeByQueueKey: activeByQueueKey,
-            waitingByQueueKey: waitingByQueueKey,
-            activeRequestCount: activeRequests.filter { $0.state == RefreshCodeIssues.RequestState.running.rawValue }.count,
-            waitingRequestCount: activeRequests.filter { $0.state != RefreshCodeIssues.RequestState.running.rawValue }.count
-        )
-        return RefreshCodeIssues.DebugSnapshot(
-            queue: queue,
-            activeRequests: activeRequests,
-            recentCompletedRequests: recentCompleted
-        )
-    }
-
-    package func reset() {
-        lock.lock()
-        state = State()
-        lock.unlock()
-    }
-
-    private func updateRequest(
-        requestID: String,
-        mutate: (inout RequestRecord, Date) -> Void
-    ) {
-        let now = clock.now()
-        lock.lock()
-        guard var record = state.activeRequests[requestID] else {
             lock.unlock()
-            return
         }
-        mutate(&record, now)
-        state.activeRequests[requestID] = record
-        lock.unlock()
-    }
+
+        package func snapshot() -> RefreshCodeIssues.DebugSnapshot {
+            lock.lock()
+            let activeRecords = Array(state.activeRequests.values)
+            let recentCompleted = state.recentCompletedRequests
+            lock.unlock()
+
+            var activeByQueueKey: [String: Int] = [:]
+            var waitingByQueueKey: [String: Int] = [:]
+            for record in activeRecords {
+                if record.state == .running {
+                    activeByQueueKey[record.queueKey, default: 0] += 1
+                } else {
+                    waitingByQueueKey[record.queueKey, default: 0] += 1
+                }
+            }
+
+            let activeRequests =
+                activeRecords
+                .sorted { lhs, rhs in
+                    if lhs.startedAt == rhs.startedAt {
+                        return lhs.id < rhs.id
+                    }
+                    return lhs.startedAt < rhs.startedAt
+                }
+                .map { record in
+                    RefreshCodeIssues.RequestSnapshot(
+                        id: record.id,
+                        sessionID: record.sessionID,
+                        queueKey: record.queueKey,
+                        tabIdentifier: record.tabIdentifier,
+                        filePath: record.filePath,
+                        mode: record.mode,
+                        state: record.state.rawValue,
+                        step: record.step.rawValue,
+                        startedAt: record.startedAt,
+                        lastUpdatedAt: record.lastUpdatedAt,
+                        lastQueuePosition: record.lastQueuePosition,
+                        metadata: record.metadata
+                    )
+                }
+            let queue = RefreshCodeIssues.QueueSnapshot(
+                defaultRequestTimeoutSeconds: defaultRequestTimeoutSeconds,
+                activeByQueueKey: activeByQueueKey,
+                waitingByQueueKey: waitingByQueueKey,
+                activeRequestCount: activeRequests.filter {
+                    $0.state == RefreshCodeIssues.RequestState.running.rawValue
+                }.count,
+                waitingRequestCount: activeRequests.filter {
+                    $0.state != RefreshCodeIssues.RequestState.running.rawValue
+                }.count
+            )
+            return RefreshCodeIssues.DebugSnapshot(
+                queue: queue,
+                activeRequests: activeRequests,
+                recentCompletedRequests: recentCompleted
+            )
+        }
+
+        package func reset() {
+            lock.lock()
+            state = State()
+            lock.unlock()
+        }
+
+        private func updateRequest(
+            requestID: String,
+            mutate: (inout RequestRecord, Date) -> Void
+        ) {
+            let now = clock.now()
+            lock.lock()
+            guard var record = state.activeRequests[requestID] else {
+                lock.unlock()
+                return
+            }
+            mutate(&record, now)
+            state.activeRequests[requestID] = record
+            lock.unlock()
+        }
     }
 }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesWorkflow.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesWorkflow.swift
@@ -9,53 +9,53 @@ package enum RefreshCodeIssues {}
 
 extension RefreshCodeIssues {
     package struct Request: Sendable {
-    package static let toolName = "XcodeRefreshCodeIssuesInFile"
-    package static let globalQueueKey = "__global__"
+        package static let toolName = "XcodeRefreshCodeIssuesInFile"
+        package static let globalQueueKey = "__global__"
 
-    package let tabIdentifier: String?
-    package let filePath: String?
+        package let tabIdentifier: String?
+        package let filePath: String?
 
-    package init(tabIdentifier: String?, filePath: String?) {
-        self.tabIdentifier = tabIdentifier
-        self.filePath = filePath
-    }
-
-    /// The one place that recognizes this feature's tools/call shape.
-    package init?(requestObject object: [String: Any]) {
-        guard
-            object["method"] as? String == "tools/call",
-            let params = object["params"] as? [String: Any],
-            params["name"] as? String == Self.toolName
-        else {
-            return nil
+        package init(tabIdentifier: String?, filePath: String?) {
+            self.tabIdentifier = tabIdentifier
+            self.filePath = filePath
         }
-        let arguments = params["arguments"] as? [String: Any]
-        self.init(
-            tabIdentifier: arguments?["tabIdentifier"] as? String,
-            filePath: arguments?["filePath"] as? String
-        )
-    }
 
-    /// Unwraps a single request object, accepting a batch of exactly one.
-    package static func singleRequestObject(from requestJSON: Any) -> [String: Any]? {
-        if let object = requestJSON as? [String: Any] {
+        /// The one place that recognizes this feature's tools/call shape.
+        package init?(requestObject object: [String: Any]) {
+            guard
+                object["method"] as? String == "tools/call",
+                let params = object["params"] as? [String: Any],
+                params["name"] as? String == Self.toolName
+            else {
+                return nil
+            }
+            let arguments = params["arguments"] as? [String: Any]
+            self.init(
+                tabIdentifier: arguments?["tabIdentifier"] as? String,
+                filePath: arguments?["filePath"] as? String
+            )
+        }
+
+        /// Unwraps a single request object, accepting a batch of exactly one.
+        package static func singleRequestObject(from requestJSON: Any) -> [String: Any]? {
+            if let object = requestJSON as? [String: Any] {
+                return object
+            }
+            guard let requests = requestJSON as? [Any],
+                requests.count == 1,
+                let object = requests.first as? [String: Any]
+            else {
+                return nil
+            }
             return object
         }
-        guard let requests = requestJSON as? [Any],
-            requests.count == 1,
-            let object = requests.first as? [String: Any]
-        else {
-            return nil
-        }
-        return object
-    }
 
-    package var queueKey: String {
-        guard let tabIdentifier, tabIdentifier.isEmpty == false else {
-            return Self.globalQueueKey
+        package var queueKey: String {
+            guard let tabIdentifier, tabIdentifier.isEmpty == false else {
+                return Self.globalQueueKey
+            }
+            return tabIdentifier
         }
-        return tabIdentifier
-    }
     }
 }
 
@@ -77,371 +77,371 @@ extension RefreshCodeIssues {
             case unavailable
         }
 
-    package typealias WindowsProvider =
-        @Sendable (
-            _ sessionID: String,
-            _ eventLoop: EventLoop,
-            _ upstreamIndexOverride: Int?,
-            _ requestTimeoutOverride: TimeAmount?
-        ) async throws -> [XcodeWindowInfo]?
-    package typealias InternalUpstreamChooser = @Sendable (_ sessionID: String) async -> Int?
-    package typealias InternalToolCaller =
-        @Sendable (
-            _ name: String,
-            _ arguments: [String: Any],
-            _ sessionID: String,
-            _ eventLoop: EventLoop,
-            _ upstreamIndexOverride: Int?,
-            _ requestTimeoutOverride: TimeAmount?
-        ) async -> RefreshCodeIssues.Workflow.InternalToolResult
-    package typealias Forwarder =
-        @Sendable (
-            _ bodyData: Data,
-            _ sessionID: String,
-            _ requestIDs: [JSONRPC.ID],
-            _ requestIsBatch: Bool,
-            _ shouldRequeueLeaseOnRetryableFailure: @Sendable () -> Bool,
-            _ eventLoop: EventLoop,
-            _ requestTimeoutOverride: TimeAmount?
-        ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult
+        package typealias WindowsProvider =
+            @Sendable (
+                _ sessionID: String,
+                _ eventLoop: EventLoop,
+                _ upstreamIndexOverride: Int?,
+                _ requestTimeoutOverride: TimeAmount?
+            ) async throws -> [XcodeWindowInfo]?
+        package typealias InternalUpstreamChooser = @Sendable (_ sessionID: String) async -> Int?
+        package typealias InternalToolCaller =
+            @Sendable (
+                _ name: String,
+                _ arguments: [String: Any],
+                _ sessionID: String,
+                _ eventLoop: EventLoop,
+                _ upstreamIndexOverride: Int?,
+                _ requestTimeoutOverride: TimeAmount?
+            ) async -> RefreshCodeIssues.Workflow.InternalToolResult
+        package typealias Forwarder =
+            @Sendable (
+                _ bodyData: Data,
+                _ sessionID: String,
+                _ requestIDs: [JSONRPC.ID],
+                _ requestIsBatch: Bool,
+                _ shouldRequeueLeaseOnRetryableFailure: @Sendable () -> Bool,
+                _ eventLoop: EventLoop,
+                _ requestTimeoutOverride: TimeAmount?
+            ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult
 
-    package static let retryDelaysNanos: [UInt64] = [
-        200_000_000,
-        500_000_000,
-    ]
-    package static let minimumUpstreamFallbackBudgetSeconds: TimeInterval = 0.05
-
-    package struct ExecutionBudget: Sendable {
-        let deadlineUptimeNs: UInt64?
-        let nowUptimeNanoseconds: @Sendable () -> UInt64
-
-        init(
-            requestTimeout: TimeInterval,
-            requestTimeoutOverride: TimeAmount?,
-            clock: ClockClient
-        ) {
-            self.nowUptimeNanoseconds = clock.uptimeNanoseconds
-            if let requestTimeoutOverride, requestTimeoutOverride.nanoseconds > 0 {
-                let timeoutNs = UInt64(requestTimeoutOverride.nanoseconds)
-                self.deadlineUptimeNs = clock.uptimeNanoseconds() &+ timeoutNs
-            } else if requestTimeout > 0 {
-                let timeoutNs = Self.nanoseconds(from: requestTimeout)
-                self.deadlineUptimeNs = clock.uptimeNanoseconds() &+ timeoutNs
-            } else {
-                self.deadlineUptimeNs = nil
-            }
-        }
-
-        func remainingNanoseconds() -> UInt64? {
-            guard let deadlineUptimeNs else {
-                return nil
-            }
-            let now = nowUptimeNanoseconds()
-            if now >= deadlineUptimeNs {
-                return 0
-            }
-            return deadlineUptimeNs - now
-        }
-
-        func remainingTimeout(
-            cappedAt capSeconds: TimeInterval? = nil,
-            reserving reserveSeconds: TimeInterval = 0
-        ) -> TimeAmount? {
-            guard let remainingNs = remainingNanoseconds() else {
-                return nil
-            }
-            let reservedNs = Self.nanoseconds(from: reserveSeconds)
-            guard remainingNs > reservedNs else { return nil }
-
-            var cappedNs = remainingNs - reservedNs
-            if let capSeconds {
-                cappedNs = min(cappedNs, Self.nanoseconds(from: capSeconds))
-            }
-            guard cappedNs > 0 else { return nil }
-
-            let maxTimeAmountNs = UInt64(Int64.max)
-            return .nanoseconds(Int64(min(cappedNs, maxTimeAmountNs)))
-        }
-
-        func stepTimeout(
-            cappedAt capSeconds: TimeInterval,
-            reserving reserveSeconds: TimeInterval = 0
-        ) -> TimeAmount? {
-            remainingTimeout(cappedAt: capSeconds, reserving: reserveSeconds)
-        }
-
-        func waitTimeout() -> TimeAmount? {
-            guard let remainingNs = remainingNanoseconds() else {
-                return nil
-            }
-            let maxTimeAmountNs = UInt64(Int64.max)
-            return .nanoseconds(Int64(min(remainingNs, maxTimeAmountNs)))
-        }
-
-        func canDelay(_ delayNanoseconds: UInt64) -> Bool {
-            guard let remainingNanoseconds = remainingNanoseconds() else {
-                return true
-            }
-            return remainingNanoseconds > delayNanoseconds
-        }
-
-        var isExhausted: Bool {
-            guard let remainingNanoseconds = remainingNanoseconds() else {
-                return false
-            }
-            return remainingNanoseconds == 0
-        }
-
-        var hasDeadline: Bool {
-            deadlineUptimeNs != nil
-        }
-
-        private static func nanoseconds(from interval: TimeInterval) -> UInt64 {
-            let clamped = max(0, interval)
-            let nanoseconds = clamped * 1_000_000_000
-            if nanoseconds >= Double(UInt64.max) {
-                return UInt64.max
-            }
-            return UInt64(nanoseconds.rounded(.up))
-        }
-    }
-
-    package let mode: ProxyConfig.RefreshCodeIssuesMode
-    package let requestTimeout: TimeInterval
-    package let coordinator: RefreshCodeIssues.Coordinator
-    package let targetResolver: RefreshCodeIssues.TargetResolver
-    package let debugState: RefreshCodeIssues.DebugState
-    package let windowLookupTimeoutSeconds: TimeInterval
-    package let navigatorIssuesTimeoutSeconds: TimeInterval
-    package let clock: ClockClient
-    package let logger: Logger
-
-    package init(
-        mode: ProxyConfig.RefreshCodeIssuesMode,
-        requestTimeout: TimeInterval,
-        coordinator: RefreshCodeIssues.Coordinator,
-        targetResolver: RefreshCodeIssues.TargetResolver,
-        debugState: RefreshCodeIssues.DebugState,
-        windowLookupTimeout: TimeInterval = 5,
-        navigatorIssuesTimeout: TimeInterval = 15,
-        clock: ClockClient = .liveValue,
-        logger: Logger
-    ) {
-        self.mode = mode
-        self.requestTimeout = requestTimeout
-        self.coordinator = coordinator
-        self.targetResolver = targetResolver
-        self.debugState = debugState
-        self.windowLookupTimeoutSeconds = windowLookupTimeout
-        self.navigatorIssuesTimeoutSeconds = navigatorIssuesTimeout
-        self.clock = clock
-        self.logger = logger
-    }
-
-    package func run(
-        refreshRequest: RefreshCodeIssues.Request,
-        bodyData: Data,
-        sessionID: String,
-        requestIDs: [JSONRPC.ID],
-        requestIsBatch: Bool,
-        requestTimeoutOverride: TimeAmount? = nil,
-        eventLoop: EventLoop,
-        windowsProvider: @escaping WindowsProvider,
-        internalUpstreamChooser: @escaping InternalUpstreamChooser,
-        internalToolCaller: @escaping InternalToolCaller,
-        forwarder: @escaping Forwarder
-    ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult {
-        let executionBudget = ExecutionBudget(
-            requestTimeout: requestTimeout,
-            requestTimeoutOverride: requestTimeoutOverride,
-            clock: clock
-        )
-        let debugRequestID = debugState.beginRequest(
-            sessionID: sessionID,
-            queueKey: refreshRequest.queueKey,
-            tabIdentifier: refreshRequest.tabIdentifier,
-            filePath: refreshRequest.filePath,
-            mode: mode.rawValue
-        )
-        let baseMetadata: Logger.Metadata = [
-            "session": .string(sessionID),
-            "mode": .string(mode.rawValue),
-            "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
-            "queue_key": .string(refreshRequest.queueKey),
+        package static let retryDelaysNanos: [UInt64] = [
+            200_000_000,
+            500_000_000,
         ]
+        package static let minimumUpstreamFallbackBudgetSeconds: TimeInterval = 0.05
 
-        if executionBudget.isExhausted {
-            debugState.updateStep(
-                requestID: debugRequestID,
-                step: .requestTimeoutExhausted,
-                state: .timedOut
-            )
-            debugState.finishRequest(
-                requestID: debugRequestID,
-                outcome: .timeout
-            )
-            return .timeout(responseIDs: requestIDs, isBatch: requestIsBatch)
+        package struct ExecutionBudget: Sendable {
+            let deadlineUptimeNs: UInt64?
+            let nowUptimeNanoseconds: @Sendable () -> UInt64
+
+            init(
+                requestTimeout: TimeInterval,
+                requestTimeoutOverride: TimeAmount?,
+                clock: ClockClient
+            ) {
+                self.nowUptimeNanoseconds = clock.uptimeNanoseconds
+                if let requestTimeoutOverride, requestTimeoutOverride.nanoseconds > 0 {
+                    let timeoutNs = UInt64(requestTimeoutOverride.nanoseconds)
+                    self.deadlineUptimeNs = clock.uptimeNanoseconds() &+ timeoutNs
+                } else if requestTimeout > 0 {
+                    let timeoutNs = Self.nanoseconds(from: requestTimeout)
+                    self.deadlineUptimeNs = clock.uptimeNanoseconds() &+ timeoutNs
+                } else {
+                    self.deadlineUptimeNs = nil
+                }
+            }
+
+            func remainingNanoseconds() -> UInt64? {
+                guard let deadlineUptimeNs else {
+                    return nil
+                }
+                let now = nowUptimeNanoseconds()
+                if now >= deadlineUptimeNs {
+                    return 0
+                }
+                return deadlineUptimeNs - now
+            }
+
+            func remainingTimeout(
+                cappedAt capSeconds: TimeInterval? = nil,
+                reserving reserveSeconds: TimeInterval = 0
+            ) -> TimeAmount? {
+                guard let remainingNs = remainingNanoseconds() else {
+                    return nil
+                }
+                let reservedNs = Self.nanoseconds(from: reserveSeconds)
+                guard remainingNs > reservedNs else { return nil }
+
+                var cappedNs = remainingNs - reservedNs
+                if let capSeconds {
+                    cappedNs = min(cappedNs, Self.nanoseconds(from: capSeconds))
+                }
+                guard cappedNs > 0 else { return nil }
+
+                let maxTimeAmountNs = UInt64(Int64.max)
+                return .nanoseconds(Int64(min(cappedNs, maxTimeAmountNs)))
+            }
+
+            func stepTimeout(
+                cappedAt capSeconds: TimeInterval,
+                reserving reserveSeconds: TimeInterval = 0
+            ) -> TimeAmount? {
+                remainingTimeout(cappedAt: capSeconds, reserving: reserveSeconds)
+            }
+
+            func waitTimeout() -> TimeAmount? {
+                guard let remainingNs = remainingNanoseconds() else {
+                    return nil
+                }
+                let maxTimeAmountNs = UInt64(Int64.max)
+                return .nanoseconds(Int64(min(remainingNs, maxTimeAmountNs)))
+            }
+
+            func canDelay(_ delayNanoseconds: UInt64) -> Bool {
+                guard let remainingNanoseconds = remainingNanoseconds() else {
+                    return true
+                }
+                return remainingNanoseconds > delayNanoseconds
+            }
+
+            var isExhausted: Bool {
+                guard let remainingNanoseconds = remainingNanoseconds() else {
+                    return false
+                }
+                return remainingNanoseconds == 0
+            }
+
+            var hasDeadline: Bool {
+                deadlineUptimeNs != nil
+            }
+
+            private static func nanoseconds(from interval: TimeInterval) -> UInt64 {
+                let clamped = max(0, interval)
+                let nanoseconds = clamped * 1_000_000_000
+                if nanoseconds >= Double(UInt64.max) {
+                    return UInt64.max
+                }
+                return UInt64(nanoseconds.rounded(.up))
+            }
         }
 
-        do {
-            return try await coordinator.withPermit(
-                key: refreshRequest.queueKey,
-                requestTimeout: executionBudget.waitTimeout()
-            ) { permit in
-                let queueMetadata: Logger.Metadata = [
-                    "pending_for_key": .string("\(permit.pendingForKey)"),
-                    "pending_total": .string("\(permit.pendingTotal)"),
-                ]
-                if permit.queuePosition > 0 {
-                    logger.debug(
-                        "Queued refresh code issues request",
-                        metadata: baseMetadata.merging(
-                            queueMetadata.merging(
-                                ["queued_ahead": .string("\(permit.queuePosition)")],
+        package let mode: ProxyConfig.RefreshCodeIssuesMode
+        package let requestTimeout: TimeInterval
+        package let coordinator: RefreshCodeIssues.Coordinator
+        package let targetResolver: RefreshCodeIssues.TargetResolver
+        package let debugState: RefreshCodeIssues.DebugState
+        package let windowLookupTimeoutSeconds: TimeInterval
+        package let navigatorIssuesTimeoutSeconds: TimeInterval
+        package let clock: ClockClient
+        package let logger: Logger
+
+        package init(
+            mode: ProxyConfig.RefreshCodeIssuesMode,
+            requestTimeout: TimeInterval,
+            coordinator: RefreshCodeIssues.Coordinator,
+            targetResolver: RefreshCodeIssues.TargetResolver,
+            debugState: RefreshCodeIssues.DebugState,
+            windowLookupTimeout: TimeInterval = 5,
+            navigatorIssuesTimeout: TimeInterval = 15,
+            clock: ClockClient = .liveValue,
+            logger: Logger
+        ) {
+            self.mode = mode
+            self.requestTimeout = requestTimeout
+            self.coordinator = coordinator
+            self.targetResolver = targetResolver
+            self.debugState = debugState
+            self.windowLookupTimeoutSeconds = windowLookupTimeout
+            self.navigatorIssuesTimeoutSeconds = navigatorIssuesTimeout
+            self.clock = clock
+            self.logger = logger
+        }
+
+        package func run(
+            refreshRequest: RefreshCodeIssues.Request,
+            bodyData: Data,
+            sessionID: String,
+            requestIDs: [JSONRPC.ID],
+            requestIsBatch: Bool,
+            requestTimeoutOverride: TimeAmount? = nil,
+            eventLoop: EventLoop,
+            windowsProvider: @escaping WindowsProvider,
+            internalUpstreamChooser: @escaping InternalUpstreamChooser,
+            internalToolCaller: @escaping InternalToolCaller,
+            forwarder: @escaping Forwarder
+        ) async -> RefreshCodeIssues.Workflow.ForwardAttemptResult {
+            let executionBudget = ExecutionBudget(
+                requestTimeout: requestTimeout,
+                requestTimeoutOverride: requestTimeoutOverride,
+                clock: clock
+            )
+            let debugRequestID = debugState.beginRequest(
+                sessionID: sessionID,
+                queueKey: refreshRequest.queueKey,
+                tabIdentifier: refreshRequest.tabIdentifier,
+                filePath: refreshRequest.filePath,
+                mode: mode.rawValue
+            )
+            let baseMetadata: Logger.Metadata = [
+                "session": .string(sessionID),
+                "mode": .string(mode.rawValue),
+                "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
+                "queue_key": .string(refreshRequest.queueKey),
+            ]
+
+            if executionBudget.isExhausted {
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: .requestTimeoutExhausted,
+                    state: .timedOut
+                )
+                debugState.finishRequest(
+                    requestID: debugRequestID,
+                    outcome: .timeout
+                )
+                return .timeout(responseIDs: requestIDs, isBatch: requestIsBatch)
+            }
+
+            do {
+                return try await coordinator.withPermit(
+                    key: refreshRequest.queueKey,
+                    requestTimeout: executionBudget.waitTimeout()
+                ) { permit in
+                    let queueMetadata: Logger.Metadata = [
+                        "pending_for_key": .string("\(permit.pendingForKey)"),
+                        "pending_total": .string("\(permit.pendingTotal)"),
+                    ]
+                    if permit.queuePosition > 0 {
+                        logger.debug(
+                            "Queued refresh code issues request",
+                            metadata: baseMetadata.merging(
+                                queueMetadata.merging(
+                                    ["queued_ahead": .string("\(permit.queuePosition)")],
+                                    uniquingKeysWith: { _, new in new }
+                                ),
                                 uniquingKeysWith: { _, new in new }
-                            ),
+                            )
+                        )
+                    }
+                    logger.debug(
+                        "Dequeued refresh code issues request",
+                        metadata: baseMetadata.merging(
+                            queueMetadata,
                             uniquingKeysWith: { _, new in new }
                         )
                     )
-                }
-                logger.debug(
-                    "Dequeued refresh code issues request",
-                    metadata: baseMetadata.merging(
-                        queueMetadata,
-                        uniquingKeysWith: { _, new in new }
-                    )
-                )
 
-                debugState.markPermitAcquired(
-                    requestID: debugRequestID,
-                    queuePosition: permit.queuePosition,
-                    pendingForKey: permit.pendingForKey,
-                    pendingTotal: permit.pendingTotal
-                )
-                try Self.throwIfCancelled(
-                    debugState: debugState,
-                    requestID: debugRequestID
-                )
-
-                if executionBudget.isExhausted {
-                    debugState.updateStep(
+                    debugState.markPermitAcquired(
                         requestID: debugRequestID,
-                        step: .queueWaitTimedOut,
-                        state: .timedOut
+                        queuePosition: permit.queuePosition,
+                        pendingForKey: permit.pendingForKey,
+                        pendingTotal: permit.pendingTotal
                     )
-                    debugState.finishRequest(
-                        requestID: debugRequestID,
-                        outcome: .timeout
-                    )
-                    return .timeout(responseIDs: requestIDs, isBatch: requestIsBatch)
-                }
-                debugState.updateStep(
-                    requestID: debugRequestID,
-                    step: .executionBudgetStarted,
-                    metadata: [
-                        "execution_timeout_ms": Self.timeoutDescription(
-                            executionBudget.remainingTimeout()
-                        )
-                    ]
-                )
-
-                let result: RefreshCodeIssues.Workflow.ForwardAttemptResult
-                if mode == .proxy,
-                    let proxyResponseData = try await runProxyRefresh(
-                        refreshRequest: refreshRequest,
-                        sessionID: sessionID,
-                        requestIDs: requestIDs,
-                        requestIsBatch: requestIsBatch,
-                        eventLoop: eventLoop,
-                        baseMetadata: baseMetadata,
-                        executionBudget: executionBudget,
-                        debugRequestID: debugRequestID,
-                        windowsProvider: windowsProvider,
-                        internalUpstreamChooser: internalUpstreamChooser,
-                        internalToolCaller: internalToolCaller
-                    )
-                {
-                    debugState.updateStep(
-                        requestID: debugRequestID,
-                        step: .proxyCompleted
-                    )
-                    result = .success(proxyResponseData)
-                } else {
                     try Self.throwIfCancelled(
                         debugState: debugState,
                         requestID: debugRequestID
                     )
-                    result = await runForwardAttempts(
-                        bodyData: bodyData,
-                        sessionID: sessionID,
-                        requestIDs: requestIDs,
-                        requestIsBatch: requestIsBatch,
-                        eventLoop: eventLoop,
-                        baseMetadata: baseMetadata,
-                        executionBudget: executionBudget,
-                        debugRequestID: debugRequestID,
-                        forwarder: forwarder
-                    )
-                }
 
+                    if executionBudget.isExhausted {
+                        debugState.updateStep(
+                            requestID: debugRequestID,
+                            step: .queueWaitTimedOut,
+                            state: .timedOut
+                        )
+                        debugState.finishRequest(
+                            requestID: debugRequestID,
+                            outcome: .timeout
+                        )
+                        return .timeout(responseIDs: requestIDs, isBatch: requestIsBatch)
+                    }
+                    debugState.updateStep(
+                        requestID: debugRequestID,
+                        step: .executionBudgetStarted,
+                        metadata: [
+                            "execution_timeout_ms": Self.timeoutDescription(
+                                executionBudget.remainingTimeout()
+                            )
+                        ]
+                    )
+
+                    let result: RefreshCodeIssues.Workflow.ForwardAttemptResult
+                    if mode == .proxy,
+                        let proxyResponseData = try await runProxyRefresh(
+                            refreshRequest: refreshRequest,
+                            sessionID: sessionID,
+                            requestIDs: requestIDs,
+                            requestIsBatch: requestIsBatch,
+                            eventLoop: eventLoop,
+                            baseMetadata: baseMetadata,
+                            executionBudget: executionBudget,
+                            debugRequestID: debugRequestID,
+                            windowsProvider: windowsProvider,
+                            internalUpstreamChooser: internalUpstreamChooser,
+                            internalToolCaller: internalToolCaller
+                        )
+                    {
+                        debugState.updateStep(
+                            requestID: debugRequestID,
+                            step: .proxyCompleted
+                        )
+                        result = .success(proxyResponseData)
+                    } else {
+                        try Self.throwIfCancelled(
+                            debugState: debugState,
+                            requestID: debugRequestID
+                        )
+                        result = await runForwardAttempts(
+                            bodyData: bodyData,
+                            sessionID: sessionID,
+                            requestIDs: requestIDs,
+                            requestIsBatch: requestIsBatch,
+                            eventLoop: eventLoop,
+                            baseMetadata: baseMetadata,
+                            executionBudget: executionBudget,
+                            debugRequestID: debugRequestID,
+                            forwarder: forwarder
+                        )
+                    }
+
+                    debugState.finishRequest(
+                        requestID: debugRequestID,
+                        outcome: Self.debugOutcome(for: result)
+                    )
+                    return result
+                }
+            } catch RefreshCodeIssues.Coordinator.AcquireError.queueWaitTimedOut {
+                logger.warning(
+                    "Refresh code issues request timed out while waiting for permit",
+                    metadata: [
+                        "session": .string(sessionID),
+                        "mode": .string(mode.rawValue),
+                        "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
+                        "queue_key": .string(refreshRequest.queueKey),
+                    ]
+                )
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: .queueWaitTimedOut
+                )
                 debugState.finishRequest(
                     requestID: debugRequestID,
-                    outcome: Self.debugOutcome(for: result)
+                    outcome: .timeout
                 )
-                return result
+                return .timeout(responseIDs: requestIDs, isBatch: requestIsBatch)
+            } catch is CancellationError {
+                logger.debug(
+                    "Cancelled queued refresh code issues request",
+                    metadata: [
+                        "session": .string(sessionID),
+                        "mode": .string(mode.rawValue),
+                        "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
+                        "queue_key": .string(refreshRequest.queueKey),
+                    ]
+                )
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: .cancelled,
+                    state: .cancelled
+                )
+                debugState.finishRequest(
+                    requestID: debugRequestID,
+                    outcome: .cancelled
+                )
+                return .cancelled(responseIDs: requestIDs, isBatch: requestIsBatch)
+            } catch {
+                debugState.updateStep(
+                    requestID: debugRequestID,
+                    step: .invalidRequest,
+                    state: .failed
+                )
+                debugState.finishRequest(
+                    requestID: debugRequestID,
+                    outcome: .invalidRequest
+                )
+                return .invalidRequest
             }
-        } catch RefreshCodeIssues.Coordinator.AcquireError.queueWaitTimedOut {
-            logger.warning(
-                "Refresh code issues request timed out while waiting for permit",
-                metadata: [
-                    "session": .string(sessionID),
-                    "mode": .string(mode.rawValue),
-                    "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
-                    "queue_key": .string(refreshRequest.queueKey),
-                ]
-            )
-            debugState.updateStep(
-                requestID: debugRequestID,
-                step: .queueWaitTimedOut
-            )
-            debugState.finishRequest(
-                requestID: debugRequestID,
-                outcome: .timeout
-            )
-            return .timeout(responseIDs: requestIDs, isBatch: requestIsBatch)
-        } catch is CancellationError {
-            logger.debug(
-                "Cancelled queued refresh code issues request",
-                metadata: [
-                    "session": .string(sessionID),
-                    "mode": .string(mode.rawValue),
-                    "tab_identifier": .string(refreshRequest.tabIdentifier ?? "none"),
-                    "queue_key": .string(refreshRequest.queueKey),
-                ]
-            )
-            debugState.updateStep(
-                requestID: debugRequestID,
-                step: .cancelled,
-                state: .cancelled
-            )
-            debugState.finishRequest(
-                requestID: debugRequestID,
-                outcome: .cancelled
-            )
-            return .cancelled(responseIDs: requestIDs, isBatch: requestIsBatch)
-        } catch {
-            debugState.updateStep(
-                requestID: debugRequestID,
-                step: .invalidRequest,
-                state: .failed
-            )
-            debugState.finishRequest(
-                requestID: debugRequestID,
-                outcome: .invalidRequest
-            )
-            return .invalidRequest
         }
-    }
 
     }
 }

--- a/Sources/ProxyXcodeSupport/PermissionDialogSnapshot.swift
+++ b/Sources/ProxyXcodeSupport/PermissionDialogSnapshot.swift
@@ -13,80 +13,80 @@ extension XcodePermissionDialog {
     }
 
     package struct ButtonSnapshot: Equatable, Sendable {
-    package let title: String?
-    package let role: String?
-    package let subrole: String?
-    package let identifier: String?
+        package let title: String?
+        package let role: String?
+        package let subrole: String?
+        package let identifier: String?
 
-    package init(
-        title: String? = nil,
-        role: String? = nil,
-        subrole: String? = nil,
-        identifier: String? = nil
-    ) {
-        self.title = title
-        self.role = role
-        self.subrole = subrole
-        self.identifier = identifier
-    }
+        package init(
+            title: String? = nil,
+            role: String? = nil,
+            subrole: String? = nil,
+            identifier: String? = nil
+        ) {
+            self.title = title
+            self.role = role
+            self.subrole = subrole
+            self.identifier = identifier
+        }
     }
 
     package struct WindowSnapshot: Equatable, Sendable {
-    package let processBundleIdentifier: String?
-    package let title: String
-    package let textValues: [String]
-    package let role: String?
-    package let subrole: String?
-    package let windowIdentifier: String?
-    package let isModal: Bool
-    package let isMain: Bool?
-    package let isMinimized: Bool?
-    package let document: String?
-    package let childCount: Int
-    package let hasProxy: Bool
-    package let defaultButton: XcodePermissionDialog.ButtonSnapshot?
-    package let cancelButton: XcodePermissionDialog.ButtonSnapshot?
+        package let processBundleIdentifier: String?
+        package let title: String
+        package let textValues: [String]
+        package let role: String?
+        package let subrole: String?
+        package let windowIdentifier: String?
+        package let isModal: Bool
+        package let isMain: Bool?
+        package let isMinimized: Bool?
+        package let document: String?
+        package let childCount: Int
+        package let hasProxy: Bool
+        package let defaultButton: XcodePermissionDialog.ButtonSnapshot?
+        package let cancelButton: XcodePermissionDialog.ButtonSnapshot?
 
-    package init(
-        processBundleIdentifier: String? = nil,
-        title: String,
-        textValues: [String],
-        role: String? = nil,
-        subrole: String? = nil,
-        windowIdentifier: String? = nil,
-        isModal: Bool,
-        isMain: Bool? = nil,
-        isMinimized: Bool? = nil,
-        document: String? = nil,
-        childCount: Int = 0,
-        hasProxy: Bool = false,
-        defaultButton: XcodePermissionDialog.ButtonSnapshot? = nil,
-        cancelButton: XcodePermissionDialog.ButtonSnapshot? = nil
-    ) {
-        self.processBundleIdentifier = processBundleIdentifier
-        self.title = title
-        self.textValues = textValues
-        self.role = role
-        self.subrole = subrole
-        self.windowIdentifier = windowIdentifier
-        self.isModal = isModal
-        self.isMain = isMain
-        self.isMinimized = isMinimized
-        self.document = document
-        self.childCount = childCount
-        self.hasProxy = hasProxy
-        self.defaultButton = defaultButton
-        self.cancelButton = cancelButton
-    }
+        package init(
+            processBundleIdentifier: String? = nil,
+            title: String,
+            textValues: [String],
+            role: String? = nil,
+            subrole: String? = nil,
+            windowIdentifier: String? = nil,
+            isModal: Bool,
+            isMain: Bool? = nil,
+            isMinimized: Bool? = nil,
+            document: String? = nil,
+            childCount: Int = 0,
+            hasProxy: Bool = false,
+            defaultButton: XcodePermissionDialog.ButtonSnapshot? = nil,
+            cancelButton: XcodePermissionDialog.ButtonSnapshot? = nil
+        ) {
+            self.processBundleIdentifier = processBundleIdentifier
+            self.title = title
+            self.textValues = textValues
+            self.role = role
+            self.subrole = subrole
+            self.windowIdentifier = windowIdentifier
+            self.isModal = isModal
+            self.isMain = isMain
+            self.isMinimized = isMinimized
+            self.document = document
+            self.childCount = childCount
+            self.hasProxy = hasProxy
+            self.defaultButton = defaultButton
+            self.cancelButton = cancelButton
+        }
     }
 
     package struct MatchDecision: Equatable, Sendable {
-    package let fingerprint: String
-    package let defaultButtonTitle: String
+        package let fingerprint: String
+        package let defaultButtonTitle: String
 
-    package init(fingerprint: String, defaultButtonTitle: String) {
-        self.fingerprint = fingerprint
-        self.defaultButtonTitle = defaultButtonTitle
-    }
+        package init(fingerprint: String, defaultButtonTitle: String) {
+            self.fingerprint = fingerprint
+            self.defaultButtonTitle = defaultButtonTitle
+        }
     }
 }

--- a/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
@@ -6,251 +6,263 @@ import ProxyCore
 
 extension XcodePermissionDialog {
     package final class AutoApprover: @unchecked Sendable {
-    package struct Dependencies: DependencyClient {
-        package var axClient: any XcodePermissionDialog.AXAccessing
-        package var agentPathCandidates: @Sendable () -> Set<String>
-        package var assistantNameCandidates: @Sendable () -> Set<String>
-        package var serverProcessIDCandidates: @Sendable () -> Set<pid_t>
-        package var sleep: @Sendable (Duration) async -> Void
-        package var pollInterval: Duration
-        package var logger: Logger
+        package struct Dependencies: DependencyClient {
+            package var axClient: any XcodePermissionDialog.AXAccessing
+            package var agentPathCandidates: @Sendable () -> Set<String>
+            package var assistantNameCandidates: @Sendable () -> Set<String>
+            package var serverProcessIDCandidates: @Sendable () -> Set<pid_t>
+            package var sleep: @Sendable (Duration) async -> Void
+            package var pollInterval: Duration
+            package var logger: Logger
 
-        package init(
-            axClient: any XcodePermissionDialog.AXAccessing,
-            agentPathCandidates: @escaping @Sendable () -> Set<String>,
-            assistantNameCandidates: @escaping @Sendable () -> Set<String>,
-            serverProcessIDCandidates: @escaping @Sendable () -> Set<pid_t>,
-            sleep: @escaping @Sendable (Duration) async -> Void,
-            pollInterval: Duration,
-            logger: Logger
-        ) {
-            self.axClient = axClient
-            self.agentPathCandidates = agentPathCandidates
-            self.assistantNameCandidates = assistantNameCandidates
-            self.serverProcessIDCandidates = serverProcessIDCandidates
-            self.sleep = sleep
-            self.pollInterval = pollInterval
-            self.logger = logger
-        }
-
-        package static func live(
-            agentPathCandidates: @escaping @Sendable () -> Set<String> = {
-                XcodePermissionDialog.AutoApprover.defaultAgentPathCandidates()
-            },
-            assistantNameCandidates: @escaping @Sendable () -> Set<String> = {
-                ["XcodeMCPKit"]
-            },
-            serverProcessIDCandidates: @escaping @Sendable () -> Set<pid_t> = {
-                XcodePermissionDialog.AutoApprover.defaultServerProcessIDCandidates()
+            package init(
+                axClient: any XcodePermissionDialog.AXAccessing,
+                agentPathCandidates: @escaping @Sendable () -> Set<String>,
+                assistantNameCandidates: @escaping @Sendable () -> Set<String>,
+                serverProcessIDCandidates: @escaping @Sendable () -> Set<pid_t>,
+                sleep: @escaping @Sendable (Duration) async -> Void,
+                pollInterval: Duration,
+                logger: Logger
+            ) {
+                self.axClient = axClient
+                self.agentPathCandidates = agentPathCandidates
+                self.assistantNameCandidates = assistantNameCandidates
+                self.serverProcessIDCandidates = serverProcessIDCandidates
+                self.sleep = sleep
+                self.pollInterval = pollInterval
+                self.logger = logger
             }
-        ) -> Self {
-            Self(
-                axClient: XcodePermissionDialog.AXClient(),
-                agentPathCandidates: agentPathCandidates,
-                assistantNameCandidates: assistantNameCandidates,
-                serverProcessIDCandidates: serverProcessIDCandidates,
-                sleep: { duration in
-                    try? await Task.sleep(for: duration)
+
+            package static func live(
+                agentPathCandidates: @escaping @Sendable () -> Set<String> = {
+                    XcodePermissionDialog.AutoApprover.defaultAgentPathCandidates()
                 },
-                pollInterval: .milliseconds(250),
-                logger: ProxyLogging.make("xcode.permission")
-            )
-        }
-
-        package static var liveValue: Self {
-            live()
-        }
-
-        package static let testValue = Self(
-            axClient: NoopXcodePermissionDialogAXClient(),
-            agentPathCandidates: { [] },
-            assistantNameCandidates: { [] },
-            serverProcessIDCandidates: { [] },
-            sleep: { _ in
-                try? await Task.sleep(for: .milliseconds(1))
-            },
-            pollInterval: .milliseconds(1),
-            logger: ProxyLogging.make("xcode.permission.test")
-        )
-    }
-
-    private struct State {
-        var started = false
-        var task: Task<Void, Never>?
-        var lastAttemptUptimeByFingerprint: [String: UInt64] = [:]
-        var loggedInspectionFingerprints: Set<String> = []
-        var didLogNoMatch = false
-    }
-
-    private struct MatchedWindow {
-        let processID: pid_t
-        let window: XcodePermissionDialog.AXWindow
-        let decision: XcodePermissionDialog.MatchDecision
-    }
-
-    private let dependencies: Dependencies
-    private let stateLock = NSLock()
-    private var state = State()
-    private let retryIntervalNanoseconds: UInt64 = 500_000_000
-
-    package init(dependencies: Dependencies = .live()) {
-        self.dependencies = dependencies
-    }
-
-    package func start() {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-
-        guard state.started == false else {
-            return
-        }
-        state.started = true
-
-        switch dependencies.axClient.authorizationStatus(promptIfNeeded: false) {
-        case .trusted:
-            let task = Task { [dependencies, weak self] in
-                guard let self else {
-                    return
+                assistantNameCandidates: @escaping @Sendable () -> Set<String> = {
+                    ["XcodeMCPKit"]
+                },
+                serverProcessIDCandidates: @escaping @Sendable () -> Set<pid_t> = {
+                    XcodePermissionDialog.AutoApprover.defaultServerProcessIDCandidates()
                 }
-                await self.runMonitorLoop(dependencies: dependencies)
-            }
-            state.task = task
-        case .untrusted:
-            _ = dependencies.axClient.authorizationStatus(promptIfNeeded: true)
-            dependencies.logger.warning(
-                "Accessibility permission is required to auto-approve the Xcode permission dialog; requested the system prompt and will keep waiting for permission."
-            )
-            let task = Task { [dependencies, weak self] in
-                guard let self else {
-                    return
-                }
-                await self.runMonitorLoop(dependencies: dependencies)
-            }
-            state.task = task
-        }
-    }
-
-    package func stop() {
-        let task: Task<Void, Never>? = stateLock.withLock {
-            state.started = false
-            state.lastAttemptUptimeByFingerprint.removeAll()
-            state.loggedInspectionFingerprints.removeAll()
-            let task = state.task
-            state.task = nil
-            return task
-        }
-
-        task?.cancel()
-    }
-
-    package static func defaultAgentPathCandidates(
-        arguments: [String] = CommandLine.arguments,
-        executableURL: URL? = Bundle.main.executableURL,
-        additionalExecutableCandidates: [String] = []
-    ) -> Set<String> {
-        var candidates: Set<String> = []
-
-        if let raw = arguments.first, raw.isEmpty == false {
-            candidates.insert(raw)
-            let rawURL = URL(fileURLWithPath: raw)
-            candidates.insert(rawURL.standardizedFileURL.path)
-            candidates.insert(rawURL.resolvingSymlinksInPath().path)
-        }
-
-        if let executablePath = executableURL?.path, executablePath.isEmpty == false {
-            let executableURL = URL(fileURLWithPath: executablePath)
-            candidates.insert(executablePath)
-            candidates.insert(executableURL.standardizedFileURL.path)
-            candidates.insert(executableURL.resolvingSymlinksInPath().path)
-        }
-
-        for candidate in additionalExecutableCandidates where candidate.isEmpty == false {
-            let candidateURL = URL(fileURLWithPath: candidate)
-            candidates.insert(candidate)
-            candidates.insert(candidateURL.standardizedFileURL.path)
-            candidates.insert(candidateURL.resolvingSymlinksInPath().path)
-        }
-
-        return Set(candidates.filter { $0.isEmpty == false })
-    }
-
-    package static func defaultServerProcessIDCandidates(
-        parentProcessID: pid_t = ProcessInfo.processInfo.processIdentifier
-    ) -> Set<pid_t> {
-        var candidates: Set<pid_t> = [parentProcessID]
-        var pending = [parentProcessID]
-
-        while let currentProcessID = pending.popLast() {
-            for childProcessID in childProcessIDs(of: currentProcessID)
-            where candidates.insert(childProcessID).inserted {
-                pending.append(childProcessID)
-            }
-        }
-
-        return candidates
-    }
-
-    private func runMonitorLoop(dependencies: Dependencies) async {
-        let agentPathCandidates = dependencies.agentPathCandidates()
-        let assistantNameCandidates = dependencies.assistantNameCandidates()
-        let pathCandidateText = agentPathCandidates.sorted().joined(separator: " | ")
-        var hasLoggedTrustedMonitoring = false
-
-        while Task.isCancelled == false {
-            if dependencies.axClient.authorizationStatus(promptIfNeeded: false) != .trusted {
-                await dependencies.sleep(dependencies.pollInterval)
-                continue
-            }
-
-            if hasLoggedTrustedMonitoring == false {
-                dependencies.logger.info(
-                    "Xcode permission dialog auto-approver is monitoring Xcode.",
-                    metadata: [
-                        "agent_paths": .string(pathCandidateText)
-                    ]
+            ) -> Self {
+                Self(
+                    axClient: XcodePermissionDialog.AXClient(),
+                    agentPathCandidates: agentPathCandidates,
+                    assistantNameCandidates: assistantNameCandidates,
+                    serverProcessIDCandidates: serverProcessIDCandidates,
+                    sleep: { duration in
+                        try? await Task.sleep(for: duration)
+                    },
+                    pollInterval: .milliseconds(250),
+                    logger: ProxyLogging.make("xcode.permission")
                 )
-                hasLoggedTrustedMonitoring = true
             }
 
-            let visibleFingerprints = scanAndApprove(
-                agentPathCandidates: agentPathCandidates,
-                assistantNameCandidates: assistantNameCandidates,
-                dependencies: dependencies
+            package static var liveValue: Self {
+                live()
+            }
+
+            package static let testValue = Self(
+                axClient: NoopXcodePermissionDialogAXClient(),
+                agentPathCandidates: { [] },
+                assistantNameCandidates: { [] },
+                serverProcessIDCandidates: { [] },
+                sleep: { _ in
+                    try? await Task.sleep(for: .milliseconds(1))
+                },
+                pollInterval: .milliseconds(1),
+                logger: ProxyLogging.make("xcode.permission.test")
             )
-            stateLock.withLock {
-                state.lastAttemptUptimeByFingerprint =
-                    state.lastAttemptUptimeByFingerprint.filter { visibleFingerprints.contains($0.key) }
+        }
+
+        private struct State {
+            var started = false
+            var task: Task<Void, Never>?
+            var lastAttemptUptimeByFingerprint: [String: UInt64] = [:]
+            var loggedInspectionFingerprints: Set<String> = []
+            var didLogNoMatch = false
+        }
+
+        private struct MatchedWindow {
+            let processID: pid_t
+            let window: XcodePermissionDialog.AXWindow
+            let decision: XcodePermissionDialog.MatchDecision
+        }
+
+        private let dependencies: Dependencies
+        private let stateLock = NSLock()
+        private var state = State()
+        private let retryIntervalNanoseconds: UInt64 = 500_000_000
+
+        package init(dependencies: Dependencies = .live()) {
+            self.dependencies = dependencies
+        }
+
+        package func start() {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+
+            guard state.started == false else {
+                return
+            }
+            state.started = true
+
+            switch dependencies.axClient.authorizationStatus(promptIfNeeded: false) {
+            case .trusted:
+                let task = Task { [dependencies, weak self] in
+                    guard let self else {
+                        return
+                    }
+                    await self.runMonitorLoop(dependencies: dependencies)
+                }
+                state.task = task
+            case .untrusted:
+                _ = dependencies.axClient.authorizationStatus(promptIfNeeded: true)
+                dependencies.logger.warning(
+                    "Accessibility permission is required to auto-approve the Xcode permission dialog; requested the system prompt and will keep waiting for permission."
+                )
+                let task = Task { [dependencies, weak self] in
+                    guard let self else {
+                        return
+                    }
+                    await self.runMonitorLoop(dependencies: dependencies)
+                }
+                state.task = task
+            }
+        }
+
+        package func stop() {
+            let task: Task<Void, Never>? = stateLock.withLock {
+                state.started = false
+                state.lastAttemptUptimeByFingerprint.removeAll()
+                state.loggedInspectionFingerprints.removeAll()
+                let task = state.task
+                state.task = nil
+                return task
             }
 
-            await dependencies.sleep(dependencies.pollInterval)
+            task?.cancel()
         }
-    }
 
-    private func scanAndApprove(
-        agentPathCandidates: Set<String>,
-        assistantNameCandidates: Set<String>,
-        dependencies: Dependencies
-    ) -> Set<String> {
-        var visibleFingerprints: Set<String> = []
-        var visibleInspectionFingerprints: Set<String> = []
-        var inspectedWindowTitles: [String] = []
-        var matchedWindows: [MatchedWindow] = []
-        let processIDs = dependencies.axClient.runningXcodeProcessIDs()
-        let serverProcessIDCandidates = dependencies.serverProcessIDCandidates()
-        let nowUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
+        package static func defaultAgentPathCandidates(
+            arguments: [String] = CommandLine.arguments,
+            executableURL: URL? = Bundle.main.executableURL,
+            additionalExecutableCandidates: [String] = []
+        ) -> Set<String> {
+            var candidates: Set<String> = []
 
-        for processID in processIDs {
-            let processBundleIdentifier = NSRunningApplication(processIdentifier: processID)?.bundleIdentifier
-            let windows: [XcodePermissionDialog.AXWindow]
-            do {
-                windows = try dependencies.axClient.openWindows(for: processID)
-            } catch {
-                if XcodePermissionDialog.AXFailureClassifier.isBenignOpenWindowsFailure(
-                    error,
-                    processBundleIdentifier: processBundleIdentifier
-                ) {
-                    dependencies.logger.debug(
-                        "Ignoring benign AX window inspection failure for ExternalViewService.",
+            if let raw = arguments.first, raw.isEmpty == false {
+                candidates.insert(raw)
+                let rawURL = URL(fileURLWithPath: raw)
+                candidates.insert(rawURL.standardizedFileURL.path)
+                candidates.insert(rawURL.resolvingSymlinksInPath().path)
+            }
+
+            if let executablePath = executableURL?.path, executablePath.isEmpty == false {
+                let executableURL = URL(fileURLWithPath: executablePath)
+                candidates.insert(executablePath)
+                candidates.insert(executableURL.standardizedFileURL.path)
+                candidates.insert(executableURL.resolvingSymlinksInPath().path)
+            }
+
+            for candidate in additionalExecutableCandidates where candidate.isEmpty == false {
+                let candidateURL = URL(fileURLWithPath: candidate)
+                candidates.insert(candidate)
+                candidates.insert(candidateURL.standardizedFileURL.path)
+                candidates.insert(candidateURL.resolvingSymlinksInPath().path)
+            }
+
+            return Set(candidates.filter { $0.isEmpty == false })
+        }
+
+        package static func defaultServerProcessIDCandidates(
+            parentProcessID: pid_t = ProcessInfo.processInfo.processIdentifier
+        ) -> Set<pid_t> {
+            var candidates: Set<pid_t> = [parentProcessID]
+            var pending = [parentProcessID]
+
+            while let currentProcessID = pending.popLast() {
+                for childProcessID in childProcessIDs(of: currentProcessID)
+                where candidates.insert(childProcessID).inserted {
+                    pending.append(childProcessID)
+                }
+            }
+
+            return candidates
+        }
+
+        private func runMonitorLoop(dependencies: Dependencies) async {
+            let agentPathCandidates = dependencies.agentPathCandidates()
+            let assistantNameCandidates = dependencies.assistantNameCandidates()
+            let pathCandidateText = agentPathCandidates.sorted().joined(separator: " | ")
+            var hasLoggedTrustedMonitoring = false
+
+            while Task.isCancelled == false {
+                if dependencies.axClient.authorizationStatus(promptIfNeeded: false) != .trusted {
+                    await dependencies.sleep(dependencies.pollInterval)
+                    continue
+                }
+
+                if hasLoggedTrustedMonitoring == false {
+                    dependencies.logger.info(
+                        "Xcode permission dialog auto-approver is monitoring Xcode.",
+                        metadata: [
+                            "agent_paths": .string(pathCandidateText)
+                        ]
+                    )
+                    hasLoggedTrustedMonitoring = true
+                }
+
+                let visibleFingerprints = scanAndApprove(
+                    agentPathCandidates: agentPathCandidates,
+                    assistantNameCandidates: assistantNameCandidates,
+                    dependencies: dependencies
+                )
+                stateLock.withLock {
+                    state.lastAttemptUptimeByFingerprint =
+                        state.lastAttemptUptimeByFingerprint.filter {
+                            visibleFingerprints.contains($0.key)
+                        }
+                }
+
+                await dependencies.sleep(dependencies.pollInterval)
+            }
+        }
+
+        private func scanAndApprove(
+            agentPathCandidates: Set<String>,
+            assistantNameCandidates: Set<String>,
+            dependencies: Dependencies
+        ) -> Set<String> {
+            var visibleFingerprints: Set<String> = []
+            var visibleInspectionFingerprints: Set<String> = []
+            var inspectedWindowTitles: [String] = []
+            var matchedWindows: [MatchedWindow] = []
+            let processIDs = dependencies.axClient.runningXcodeProcessIDs()
+            let serverProcessIDCandidates = dependencies.serverProcessIDCandidates()
+            let nowUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
+
+            for processID in processIDs {
+                let processBundleIdentifier = NSRunningApplication(processIdentifier: processID)?
+                    .bundleIdentifier
+                let windows: [XcodePermissionDialog.AXWindow]
+                do {
+                    windows = try dependencies.axClient.openWindows(for: processID)
+                } catch {
+                    if XcodePermissionDialog.AXFailureClassifier.isBenignOpenWindowsFailure(
+                        error,
+                        processBundleIdentifier: processBundleIdentifier
+                    ) {
+                        dependencies.logger.debug(
+                            "Ignoring benign AX window inspection failure for ExternalViewService.",
+                            metadata: [
+                                "pid": "\(processID)",
+                                "error": "\(error)",
+                            ]
+                        )
+                        continue
+                    }
+                    dependencies.logger.warning(
+                        "Failed to inspect AX windows for a running Xcode-related process.",
                         metadata: [
                             "pid": "\(processID)",
                             "error": "\(error)",
@@ -258,233 +270,234 @@ extension XcodePermissionDialog {
                     )
                     continue
                 }
-                dependencies.logger.warning(
-                    "Failed to inspect AX windows for a running Xcode-related process.",
-                    metadata: [
-                        "pid": "\(processID)",
-                        "error": "\(error)",
-                    ]
-                )
-                continue
-            }
-            for window in windows {
-                let trimmedTitle = window.snapshot.title.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmedTitle.isEmpty == false, inspectedWindowTitles.count < 8 {
-                    inspectedWindowTitles.append(trimmedTitle)
-                }
-                let isStructurallyEligible =
-                    XcodePermissionDialog.Matcher.passesStructuralChecks(window.snapshot)
-                guard let decision = XcodePermissionDialog.Matcher.decision(
-                    for: window.snapshot,
-                    processID: processID,
-                    agentPathCandidates: agentPathCandidates,
-                    assistantNameCandidates: assistantNameCandidates,
-                    serverProcessIDCandidates: serverProcessIDCandidates
-                ) else {
-                    if isStructurallyEligible {
-                        visibleInspectionFingerprints.insert(
-                            inspectionFingerprint(processID: processID, snapshot: window.snapshot)
-                        )
-                        logStructurallyEligibleWindowIfNeeded(
+                for window in windows {
+                    let trimmedTitle = window.snapshot.title.trimmingCharacters(
+                        in: .whitespacesAndNewlines)
+                    if trimmedTitle.isEmpty == false, inspectedWindowTitles.count < 8 {
+                        inspectedWindowTitles.append(trimmedTitle)
+                    }
+                    let isStructurallyEligible =
+                        XcodePermissionDialog.Matcher.passesStructuralChecks(window.snapshot)
+                    guard
+                        let decision = XcodePermissionDialog.Matcher.decision(
+                            for: window.snapshot,
                             processID: processID,
-                            snapshot: window.snapshot,
                             agentPathCandidates: agentPathCandidates,
                             assistantNameCandidates: assistantNameCandidates,
-                            dependencies: dependencies
+                            serverProcessIDCandidates: serverProcessIDCandidates
                         )
+                    else {
+                        if isStructurallyEligible {
+                            visibleInspectionFingerprints.insert(
+                                inspectionFingerprint(
+                                    processID: processID, snapshot: window.snapshot)
+                            )
+                            logStructurallyEligibleWindowIfNeeded(
+                                processID: processID,
+                                snapshot: window.snapshot,
+                                agentPathCandidates: agentPathCandidates,
+                                assistantNameCandidates: assistantNameCandidates,
+                                dependencies: dependencies
+                            )
+                        }
+                        continue
                     }
+
+                    visibleFingerprints.insert(decision.fingerprint)
+                    visibleInspectionFingerprints.insert(decision.fingerprint)
+                    matchedWindows.append(
+                        MatchedWindow(
+                            processID: processID,
+                            window: window,
+                            decision: decision
+                        )
+                    )
+                }
+            }
+
+            stateLock.withLock {
+                state.loggedInspectionFingerprints =
+                    state.loggedInspectionFingerprints.filter {
+                        visibleInspectionFingerprints.contains($0)
+                    }
+            }
+
+            for matchedWindow in matchedWindows {
+                logMatchedWindowIfNeeded(matchedWindow, dependencies: dependencies)
+
+                let shouldPress = stateLock.withLock { () -> Bool in
+                    if let lastAttempt = state.lastAttemptUptimeByFingerprint[
+                        matchedWindow.decision.fingerprint],
+                        nowUptimeNanoseconds &- lastAttempt < retryIntervalNanoseconds
+                    {
+                        return false
+                    }
+                    state.lastAttemptUptimeByFingerprint[matchedWindow.decision.fingerprint] =
+                        nowUptimeNanoseconds
+                    return true
+                }
+                guard shouldPress else {
                     continue
                 }
 
-                visibleFingerprints.insert(decision.fingerprint)
-                visibleInspectionFingerprints.insert(decision.fingerprint)
-                matchedWindows.append(
-                    MatchedWindow(
-                        processID: processID,
-                        window: window,
-                        decision: decision
+                do {
+                    try dependencies.axClient.pressDefaultButton(in: matchedWindow.window)
+                    dependencies.logger.info(
+                        "Auto-approved the Xcode permission dialog.",
+                        metadata: [
+                            "pid": "\(matchedWindow.processID)",
+                            "button": .string(matchedWindow.decision.defaultButtonTitle),
+                            "server_pid_candidates": .string(
+                                serverProcessIDCandidates.map(String.init).sorted().joined(
+                                    separator: ",")
+                            ),
+                        ]
                     )
-                )
+                } catch {
+                    dependencies.logger.warning(
+                        "Matched the Xcode permission dialog but could not press its default button.",
+                        metadata: [
+                            "pid": "\(matchedWindow.processID)",
+                            "error": "\(error)",
+                        ]
+                    )
+                }
             }
-        }
 
-        stateLock.withLock {
-            state.loggedInspectionFingerprints =
-                state.loggedInspectionFingerprints.filter { visibleInspectionFingerprints.contains($0) }
-        }
-
-        for matchedWindow in matchedWindows {
-            logMatchedWindowIfNeeded(matchedWindow, dependencies: dependencies)
-
-            let shouldPress = stateLock.withLock { () -> Bool in
-                if let lastAttempt = state.lastAttemptUptimeByFingerprint[matchedWindow.decision.fingerprint],
-                   nowUptimeNanoseconds &- lastAttempt < retryIntervalNanoseconds
-                {
+            let shouldLogNoMatch = stateLock.withLock { () -> Bool in
+                if visibleFingerprints.isEmpty == false {
+                    state.didLogNoMatch = false
                     return false
                 }
-                state.lastAttemptUptimeByFingerprint[matchedWindow.decision.fingerprint] =
-                    nowUptimeNanoseconds
+                guard processIDs.isEmpty == false, state.didLogNoMatch == false else {
+                    return false
+                }
+                state.didLogNoMatch = true
                 return true
             }
-            guard shouldPress else {
-                continue
-            }
-
-            do {
-                try dependencies.axClient.pressDefaultButton(in: matchedWindow.window)
-                dependencies.logger.info(
-                    "Auto-approved the Xcode permission dialog.",
+            if shouldLogNoMatch {
+                dependencies.logger.debug(
+                    "Xcode permission dialog auto-approver found running Xcode windows but no matching permission dialog yet.",
                     metadata: [
-                        "pid": "\(matchedWindow.processID)",
-                        "button": .string(matchedWindow.decision.defaultButtonTitle),
-                        "server_pid_candidates": .string(
-                            serverProcessIDCandidates.map(String.init).sorted().joined(separator: ",")
-                        ),
-                    ]
-                )
-            } catch {
-                dependencies.logger.warning(
-                    "Matched the Xcode permission dialog but could not press its default button.",
-                    metadata: [
-                        "pid": "\(matchedWindow.processID)",
-                        "error": "\(error)",
+                        "xcode_pids": .string(processIDs.map(String.init).joined(separator: ",")),
+                        "window_titles": .string(inspectedWindowTitles.joined(separator: " | ")),
                     ]
                 )
             }
+
+            return visibleFingerprints
         }
 
-        let shouldLogNoMatch = stateLock.withLock { () -> Bool in
-            if visibleFingerprints.isEmpty == false {
-                state.didLogNoMatch = false
-                return false
+        private func logStructurallyEligibleWindowIfNeeded(
+            processID: pid_t,
+            snapshot: XcodePermissionDialog.WindowSnapshot,
+            agentPathCandidates: Set<String>,
+            assistantNameCandidates: Set<String>,
+            dependencies: Dependencies
+        ) {
+            let fingerprint = inspectionFingerprint(processID: processID, snapshot: snapshot)
+            let shouldLog = stateLock.withLock {
+                state.loggedInspectionFingerprints.insert(fingerprint).inserted
             }
-            guard processIDs.isEmpty == false, state.didLogNoMatch == false else {
-                return false
+            guard shouldLog else {
+                return
             }
-            state.didLogNoMatch = true
-            return true
-        }
-        if shouldLogNoMatch {
+
             dependencies.logger.debug(
-                "Xcode permission dialog auto-approver found running Xcode windows but no matching permission dialog yet.",
-                metadata: [
-                    "xcode_pids": .string(processIDs.map(String.init).joined(separator: ",")),
-                    "window_titles": .string(inspectedWindowTitles.joined(separator: " | ")),
-                ]
+                "Observed a structurally eligible Xcode modal window that did not match the assistant-name plus PID/path guard; auto-approve skipped.",
+                metadata: inspectionMetadata(
+                    processID: processID,
+                    snapshot: snapshot,
+                    agentPathCandidates: agentPathCandidates,
+                    assistantNameCandidates: assistantNameCandidates,
+                    serverProcessIDCandidates: dependencies.serverProcessIDCandidates()
+                )
             )
         }
 
-        return visibleFingerprints
-    }
+        private func logMatchedWindowIfNeeded(
+            _ matchedWindow: MatchedWindow,
+            dependencies: Dependencies
+        ) {
+            let shouldLog = stateLock.withLock {
+                state.loggedInspectionFingerprints.insert(matchedWindow.decision.fingerprint)
+                    .inserted
+            }
+            guard shouldLog else {
+                return
+            }
 
-    private func logStructurallyEligibleWindowIfNeeded(
-        processID: pid_t,
-        snapshot: XcodePermissionDialog.WindowSnapshot,
-        agentPathCandidates: Set<String>,
-        assistantNameCandidates: Set<String>,
-        dependencies: Dependencies
-    ) {
-        let fingerprint = inspectionFingerprint(processID: processID, snapshot: snapshot)
-        let shouldLog = stateLock.withLock {
-            state.loggedInspectionFingerprints.insert(fingerprint).inserted
-        }
-        guard shouldLog else {
-            return
-        }
-
-        dependencies.logger.debug(
-            "Observed a structurally eligible Xcode modal window that did not match the assistant-name plus PID/path guard; auto-approve skipped.",
-            metadata: inspectionMetadata(
-                processID: processID,
-                snapshot: snapshot,
-                agentPathCandidates: agentPathCandidates,
-                assistantNameCandidates: assistantNameCandidates,
-                serverProcessIDCandidates: dependencies.serverProcessIDCandidates()
-            )
-        )
-    }
-
-    private func logMatchedWindowIfNeeded(
-        _ matchedWindow: MatchedWindow,
-        dependencies: Dependencies
-    ) {
-        let shouldLog = stateLock.withLock {
-            state.loggedInspectionFingerprints.insert(matchedWindow.decision.fingerprint).inserted
-        }
-        guard shouldLog else {
-            return
-        }
-
-        let snapshot = matchedWindow.window.snapshot
-        dependencies.logger.debug(
-            "Observed AX metadata for a matched Xcode permission dialog candidate.",
-            metadata: inspectionMetadata(
-                processID: matchedWindow.processID,
-                snapshot: snapshot,
-                agentPathCandidates: dependencies.agentPathCandidates(),
-                assistantNameCandidates: dependencies.assistantNameCandidates(),
-                serverProcessIDCandidates: dependencies.serverProcessIDCandidates()
-            )
-        )
-    }
-
-    private func inspectionMetadata(
-        processID: pid_t,
-        snapshot: XcodePermissionDialog.WindowSnapshot,
-        agentPathCandidates: Set<String>,
-        assistantNameCandidates: Set<String>,
-        serverProcessIDCandidates: Set<pid_t>
-    ) -> Logger.Metadata {
-        [
-            "pid": "\(processID)",
-            "bundle_id": .string(snapshot.processBundleIdentifier ?? ""),
-            "window_identifier": .string(snapshot.windowIdentifier ?? ""),
-            "window_role": .string(snapshot.role ?? ""),
-            "window_subrole": .string(snapshot.subrole ?? ""),
-            "window_main": .string("\(snapshot.isMain ?? false)"),
-            "window_minimized": .string("\(snapshot.isMinimized ?? false)"),
-            "window_document": .string(snapshot.document ?? ""),
-            "window_children": .string("\(snapshot.childCount)"),
-            "window_has_proxy": .string("\(snapshot.hasProxy)"),
-            "default_button_identifier": .string(snapshot.defaultButton?.identifier ?? ""),
-            "default_button_role": .string(snapshot.defaultButton?.role ?? ""),
-            "cancel_button_identifier": .string(snapshot.cancelButton?.identifier ?? ""),
-            "cancel_button_role": .string(snapshot.cancelButton?.role ?? ""),
-            "agent_paths": .string(agentPathCandidates.sorted().joined(separator: " | ")),
-            "assistant_names": .string(assistantNameCandidates.sorted().joined(separator: " | ")),
-            "server_pid_candidates": .string(
-                serverProcessIDCandidates.map(String.init).sorted().joined(separator: ",")
-            ),
-        ]
-    }
-
-    private func inspectionFingerprint(
-        processID: pid_t,
-        snapshot: XcodePermissionDialog.WindowSnapshot
-    ) -> String {
-        "candidate|\(XcodePermissionDialog.Matcher.fingerprint(for: snapshot, processID: processID))"
-    }
-
-    private static func childProcessIDs(of parentProcessID: pid_t) -> [pid_t] {
-        let childCount = max(0, proc_listchildpids(parentProcessID, nil, 0))
-        guard childCount > 0 else {
-            return []
-        }
-
-        var childProcessIDs = Array<pid_t>(repeating: 0, count: Int(childCount))
-        let copiedCount = unsafe childProcessIDs.withUnsafeMutableBufferPointer { buffer in
-            unsafe proc_listchildpids(
-                parentProcessID,
-                buffer.baseAddress,
-                Int32(buffer.count * MemoryLayout<pid_t>.stride)
+            let snapshot = matchedWindow.window.snapshot
+            dependencies.logger.debug(
+                "Observed AX metadata for a matched Xcode permission dialog candidate.",
+                metadata: inspectionMetadata(
+                    processID: matchedWindow.processID,
+                    snapshot: snapshot,
+                    agentPathCandidates: dependencies.agentPathCandidates(),
+                    assistantNameCandidates: dependencies.assistantNameCandidates(),
+                    serverProcessIDCandidates: dependencies.serverProcessIDCandidates()
+                )
             )
         }
-        guard copiedCount > 0 else {
-            return []
+
+        private func inspectionMetadata(
+            processID: pid_t,
+            snapshot: XcodePermissionDialog.WindowSnapshot,
+            agentPathCandidates: Set<String>,
+            assistantNameCandidates: Set<String>,
+            serverProcessIDCandidates: Set<pid_t>
+        ) -> Logger.Metadata {
+            [
+                "pid": "\(processID)",
+                "bundle_id": .string(snapshot.processBundleIdentifier ?? ""),
+                "window_identifier": .string(snapshot.windowIdentifier ?? ""),
+                "window_role": .string(snapshot.role ?? ""),
+                "window_subrole": .string(snapshot.subrole ?? ""),
+                "window_main": .string("\(snapshot.isMain ?? false)"),
+                "window_minimized": .string("\(snapshot.isMinimized ?? false)"),
+                "window_document": .string(snapshot.document ?? ""),
+                "window_children": .string("\(snapshot.childCount)"),
+                "window_has_proxy": .string("\(snapshot.hasProxy)"),
+                "default_button_identifier": .string(snapshot.defaultButton?.identifier ?? ""),
+                "default_button_role": .string(snapshot.defaultButton?.role ?? ""),
+                "cancel_button_identifier": .string(snapshot.cancelButton?.identifier ?? ""),
+                "cancel_button_role": .string(snapshot.cancelButton?.role ?? ""),
+                "agent_paths": .string(agentPathCandidates.sorted().joined(separator: " | ")),
+                "assistant_names": .string(
+                    assistantNameCandidates.sorted().joined(separator: " | ")),
+                "server_pid_candidates": .string(
+                    serverProcessIDCandidates.map(String.init).sorted().joined(separator: ",")
+                ),
+            ]
         }
 
-        return childProcessIDs.prefix(Int(copiedCount)).filter { $0 > 0 }
-    }
+        private func inspectionFingerprint(
+            processID: pid_t,
+            snapshot: XcodePermissionDialog.WindowSnapshot
+        ) -> String {
+            "candidate|\(XcodePermissionDialog.Matcher.fingerprint(for: snapshot, processID: processID))"
+        }
+
+        private static func childProcessIDs(of parentProcessID: pid_t) -> [pid_t] {
+            let childCount = max(0, proc_listchildpids(parentProcessID, nil, 0))
+            guard childCount > 0 else {
+                return []
+            }
+
+            var childProcessIDs = [pid_t](repeating: 0, count: Int(childCount))
+            let copiedCount = unsafe childProcessIDs.withUnsafeMutableBufferPointer { buffer in
+                unsafe proc_listchildpids(
+                    parentProcessID,
+                    buffer.baseAddress,
+                    Int32(buffer.count * MemoryLayout<pid_t>.stride)
+                )
+            }
+            guard copiedCount > 0 else {
+                return []
+            }
+
+            return childProcessIDs.prefix(Int(copiedCount)).filter { $0 > 0 }
+        }
     }
 }
 
@@ -504,8 +517,8 @@ private struct NoopXcodePermissionDialogAXClient: XcodePermissionDialog.AXAccess
     func pressDefaultButton(in _: XcodePermissionDialog.AXWindow) throws {}
 }
 
-private extension NSLock {
-    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+extension NSLock {
+    fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
         lock()
         defer { unlock() }
         return try body()

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -204,7 +204,7 @@ struct CLIParserTests {
         do {
             try config.validateModernProtocolConfiguration()
             Issue.record("expected legacy protocolVersion to be rejected")
-        } catch let error as CLIError {
+        } catch let error as ProxyConfig.ValidationError {
             #expect(error.description.contains("2025-06-18"))
             #expect(error.description.contains("2025-03-26"))
         }

--- a/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
@@ -140,7 +140,7 @@ extension HTTPHandlerTests {
             documentationSearchResponder: { requestData in
                 _ = requestData
                 localDocumentationRequests.withLockedValue { $0 += 1 }
-                throw UpstreamSlotAcquisitionError.unavailable
+                throw UpstreamSlotScheduler.AcquisitionError.unavailable
             }
         )
         sessionManager.setInitialized(true)
@@ -165,7 +165,7 @@ extension HTTPHandlerTests {
             #expect(response.statusCode == 200)
             let error = try #require(body["error"] as? [String: Any])
             #expect((error["code"] as? NSNumber)?.intValue == -32001)
-            #expect(error["message"] as? String == DocumentationProviderUnavailableReason.userFacingMessage)
+            #expect(error["message"] as? String == DocumentationProvider.UnavailableReason.userFacingMessage)
             #expect(sessionManager.sentToolNames() == [])
             #expect(localDocumentationRequests.withLockedValue { $0 } == 1)
         } catch {
@@ -596,7 +596,7 @@ extension HTTPHandlerTests {
             documentationSearchResponder: { requestData in
                 _ = requestData
                 localDocumentationRequests.withLockedValue { $0 += 1 }
-                throw UpstreamSlotAcquisitionError.unavailable
+                throw UpstreamSlotScheduler.AcquisitionError.unavailable
             }
         )
         sessionManager.setInitialized(true)
@@ -674,7 +674,7 @@ extension HTTPHandlerTests {
             documentationSearchResponder: { requestData in
                 _ = requestData
                 localDocumentationRequests.withLockedValue { $0 += 1 }
-                throw UpstreamSlotAcquisitionError.unavailable
+                throw UpstreamSlotScheduler.AcquisitionError.unavailable
             }
         )
         sessionManager.setAvailableUpstreamIndices([0, 1])

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -303,7 +303,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
 
     func liveXcodeListWindowsResult(
-        route _: ControlPlaneRoute,
+        route _: ControlPlane.Route,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> JSONValue {
         _ = requestTimeoutOverride
@@ -334,7 +334,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         }
         do {
             return .handled(try await documentationSearchResponder(requestData))
-        } catch is UpstreamSlotAcquisitionError {
+        } catch is UpstreamSlotScheduler.AcquisitionError {
             return .unavailable(.noAvailableProvider)
         }
     }
@@ -621,7 +621,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
     ) async throws -> Data {
         _ = session(id: sessionID)
         guard let upstreamIndex = chooseUpstreamIndex() else {
-            throw UpstreamSlotAcquisitionError.unavailable
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
         state.withLockedValue { state in
             state.upstreamSendCount += 1
@@ -644,16 +644,16 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             try await Task.sleep(nanoseconds: delayNanos)
         }
         guard plan.deliverManually == false else {
-            throw ControlPlaneError.invalidResponse("timeout")
+            throw ControlPlane.Error.invalidResponse("timeout")
         }
         guard let object = try? JSONSerialization.jsonObject(
             with: plan.data,
             options: []
         ) as? [String: Any] else {
-            throw ControlPlaneError.invalidResponse("invalid response")
+            throw ControlPlane.Error.invalidResponse("invalid response")
         }
         if let errorObject = object["error"] as? [String: Any] {
-            throw ControlPlaneError.upstreamRPC(
+            throw ControlPlane.Error.upstreamRPC(
                 code: (errorObject["code"] as? NSNumber)?.intValue ?? -32000,
                 message: errorObject["message"] as? String ?? "upstream error"
             )
@@ -664,7 +664,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         return plan.data
     }
 
-    func debugSnapshot() -> ProxyDebugSnapshot {
+    func debugSnapshot() -> ProxyDebug.Snapshot {
         debugSnapshot(includeSensitiveDebugPayloads: false)
     }
 
@@ -757,15 +757,15 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         )
     }
 
-    func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebugSnapshot {
-        ProxyDebugSnapshot(
+    func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebug.Snapshot {
+        ProxyDebug.Snapshot(
             generatedAt: Date(timeIntervalSince1970: 0),
             proxyInitialized: isInitialized(),
             cachedToolsListAvailable: cachedToolsListResult() != nil,
             warmupInFlight: false,
             controlPlane: nil,
             upstreams: [
-                ProxyUpstreamDebugSnapshot(
+                ProxyDebug.UpstreamSnapshot(
                     upstreamIndex: 0,
                     isInitialized: isInitialized(),
                     initInFlight: false,

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -48,7 +48,7 @@ struct HTTPHandlerTests {
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let snapshot = try decoder.decode(ProxyDebugSnapshot.self, from: Data(response.body.utf8))
+        let snapshot = try decoder.decode(ProxyDebug.Snapshot.self, from: Data(response.body.utf8))
         #expect(snapshot.proxyInitialized == false)
         #expect(snapshot.upstreams.count == 1)
         #expect(snapshot.upstreams[0].upstreamIndex == 0)
@@ -77,7 +77,7 @@ struct HTTPHandlerTests {
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let snapshot = try decoder.decode(ProxyDebugSnapshot.self, from: Data(response.body.utf8))
+        let snapshot = try decoder.decode(ProxyDebug.Snapshot.self, from: Data(response.body.utf8))
         #expect(snapshot.upstreams[0].lastProtocolViolationPreview == "raw-preview")
         #expect(snapshot.upstreams[0].lastProtocolViolationPreviewHex == "61 62")
         #expect(snapshot.upstreams[0].lastProtocolViolationLeadingByteHex == "61")

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -3,12 +3,12 @@ import NIO
 import NIOConcurrencyHelpers
 import NIOEmbedded
 import NIOHTTP1
-import Testing
 import ProxyCore
 import ProxyMCP
 import ProxySession
 import ProxyXcodeFeatures
- import ProxyXcodeSupport
+import ProxyXcodeSupport
+import Testing
 import XcodeMCPTestSupport
 
 @testable import ProxyHTTPGateway
@@ -56,7 +56,8 @@ extension HTTPHandlerTests {
                                 "content": [
                                     [
                                         "type": "text",
-                                        "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"},{\"path\":\"\(temporaryRoot)/Other.swift\",\"message\":\"other warning\",\"line\":99,\"severity\":\"warning\"}],\"totalFound\":2,\"truncated\":false}"
+                                        "text":
+                                            "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"},{\"path\":\"\(temporaryRoot)/Other.swift\",\"message\":\"other warning\",\"line\":99,\"severity\":\"warning\"}],\"totalFound\":2,\"truncated\":false}",
                                     ]
                                 ],
                                 "structuredContent": [
@@ -119,10 +120,11 @@ extension HTTPHandlerTests {
             #expect(issues?.count == 1)
             #expect(issues?.first?["path"] as? String == target.path)
             #expect(issues?.first?["message"] as? String == "target warning")
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeListNavigatorIssues",
-            ])
+            #expect(
+                sessionManager.sentToolNames() == [
+                    "XcodeListWindows",
+                    "XcodeListNavigatorIssues",
+                ])
             #expect(sessionManager.chooseUpstreamShouldPinValues().isEmpty)
             let sentToolRequests = sessionManager.sentToolRequests()
             #expect(sentToolRequests.count == 2)
@@ -135,7 +137,9 @@ extension HTTPHandlerTests {
         try await server.shutdown()
     }
 
-    @Test func httpSingleElementBatchRefreshCodeIssuesUsesNavigatorIssuesProxyByDefault() async throws {
+    @Test func httpSingleElementBatchRefreshCodeIssuesUsesNavigatorIssuesProxyByDefault()
+        async throws
+    {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .proxy
         let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
@@ -177,7 +181,8 @@ extension HTTPHandlerTests {
                                 "content": [
                                     [
                                         "type": "text",
-                                        "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
+                                        "text":
+                                            "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}",
                                     ]
                                 ],
                                 "structuredContent": [
@@ -278,7 +283,8 @@ extension HTTPHandlerTests {
                                     "content": [
                                         [
                                             "type": "text",
-                                            "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
+                                            "text":
+                                                "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}",
                                         ]
                                     ],
                                     "structuredContent": [
@@ -350,7 +356,8 @@ extension HTTPHandlerTests {
         try await server.shutdown()
     }
 
-    @Test func httpMixedBatchReturnsInvalidRequestForScalarLeftoverAfterRefreshSplit() async throws {
+    @Test func httpMixedBatchReturnsInvalidRequestForScalarLeftoverAfterRefreshSplit() async throws
+    {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .proxy
         let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
@@ -392,7 +399,8 @@ extension HTTPHandlerTests {
                                     "content": [
                                         [
                                             "type": "text",
-                                            "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
+                                            "text":
+                                                "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}",
                                         ]
                                     ],
                                     "structuredContent": [
@@ -496,7 +504,8 @@ extension HTTPHandlerTests {
                                     "content": [
                                         [
                                             "type": "text",
-                                            "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
+                                            "text":
+                                                "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}",
                                         ]
                                     ],
                                     "structuredContent": [
@@ -720,7 +729,9 @@ extension HTTPHandlerTests {
         try await server.shutdown()
     }
 
-    @Test func httpRefreshCodeIssuesFallsBackToUpstreamWhenWindowLookupFailsAfterPreviousSuccess() async throws {
+    @Test func httpRefreshCodeIssuesFallsBackToUpstreamWhenWindowLookupFailsAfterPreviousSuccess()
+        async throws
+    {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .proxy
         let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
@@ -775,7 +786,8 @@ extension HTTPHandlerTests {
                                 "content": [
                                     [
                                         "type": "text",
-                                        "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
+                                        "text":
+                                            "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}",
                                     ]
                                 ],
                                 "structuredContent": [
@@ -851,13 +863,15 @@ extension HTTPHandlerTests {
             #expect(secondResponse.statusCode == 200)
             let secondResult = secondBody["result"] as? [String: Any]
             let secondContent = secondResult?["content"] as? [[String: Any]]
-            #expect(secondContent?.first?["text"] as? String == "upstream-after-window-lookup-failure")
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeListNavigatorIssues",
-                "XcodeListWindows",
-                "XcodeRefreshCodeIssuesInFile",
-            ])
+            #expect(
+                secondContent?.first?["text"] as? String == "upstream-after-window-lookup-failure")
+            #expect(
+                sessionManager.sentToolNames() == [
+                    "XcodeListWindows",
+                    "XcodeListNavigatorIssues",
+                    "XcodeListWindows",
+                    "XcodeRefreshCodeIssuesInFile",
+                ])
         } catch {
             try? await server.shutdown()
             throw error
@@ -865,7 +879,9 @@ extension HTTPHandlerTests {
         try await server.shutdown()
     }
 
-    @Test func httpRefreshCodeIssuesFallsBackToUpstreamWhenNavigatorIssuesAreTruncated() async throws {
+    @Test func httpRefreshCodeIssuesFallsBackToUpstreamWhenNavigatorIssuesAreTruncated()
+        async throws
+    {
         var config = makeConfig(requestTimeout: 2)
         config.refreshCodeIssuesMode = .proxy
         let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
@@ -907,7 +923,8 @@ extension HTTPHandlerTests {
                                 "content": [
                                     [
                                         "type": "text",
-                                        "text": "{\"issues\":[],\"totalFound\":0,\"truncated\":true}"
+                                        "text":
+                                            "{\"issues\":[],\"totalFound\":0,\"truncated\":true}",
                                     ]
                                 ],
                                 "structuredContent": [
@@ -959,11 +976,12 @@ extension HTTPHandlerTests {
             let result = body["result"] as? [String: Any]
             let content = result?["content"] as? [[String: Any]]
             #expect(content?.first?["text"] as? String == "upstream-after-truncated-navigator")
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeListNavigatorIssues",
-                "XcodeRefreshCodeIssuesInFile",
-            ])
+            #expect(
+                sessionManager.sentToolNames() == [
+                    "XcodeListWindows",
+                    "XcodeListNavigatorIssues",
+                    "XcodeRefreshCodeIssuesInFile",
+                ])
         } catch {
             try? await server.shutdown()
             throw error
@@ -1035,10 +1053,11 @@ extension HTTPHandlerTests {
             let result = body["result"] as? [String: Any]
             let content = result?["content"] as? [[String: Any]]
             #expect(content?.first?["text"] as? String == "upstream-result")
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeRefreshCodeIssuesInFile",
-            ])
+            #expect(
+                sessionManager.sentToolNames() == [
+                    "XcodeListWindows",
+                    "XcodeRefreshCodeIssuesInFile",
+                ])
             #expect(sessionManager.chooseUpstreamShouldPinValues().isEmpty)
         } catch {
             try? await server.shutdown()
@@ -1090,7 +1109,8 @@ extension HTTPHandlerTests {
                     )
                 case "XcodeRefreshCodeIssuesInFile":
                     return .immediate(
-                        try makeToolSuccessResponse(id: originalID, text: "upstream-after-navigator-failure")
+                        try makeToolSuccessResponse(
+                            id: originalID, text: "upstream-after-navigator-failure")
                     )
                 default:
                     return .immediate(
@@ -1126,11 +1146,12 @@ extension HTTPHandlerTests {
             let result = body["result"] as? [String: Any]
             let content = result?["content"] as? [[String: Any]]
             #expect(content?.first?["text"] as? String == "upstream-after-navigator-failure")
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeListNavigatorIssues",
-                "XcodeRefreshCodeIssuesInFile",
-            ])
+            #expect(
+                sessionManager.sentToolNames() == [
+                    "XcodeListWindows",
+                    "XcodeListNavigatorIssues",
+                    "XcodeRefreshCodeIssuesInFile",
+                ])
             #expect(sessionManager.chooseUpstreamShouldPinValues().isEmpty)
         } catch {
             try? await server.shutdown()
@@ -1239,7 +1260,9 @@ extension HTTPHandlerTests {
         #expect(observedTimeouts.withLockedValue { $0.first } == 50_000_000)
     }
 
-    @Test func refreshWorkflowDoesNotFabricateNavigatorTimeoutWhenRequestTimeoutIsDisabled() async throws {
+    @Test func refreshWorkflowDoesNotFabricateNavigatorTimeoutWhenRequestTimeoutIsDisabled()
+        async throws
+    {
         let temporaryRoot = makeHTTPTemporaryWorkspaceRoot()
         defer { try? FileManager.default.removeItem(atPath: temporaryRoot) }
 
@@ -1317,7 +1340,8 @@ extension HTTPHandlerTests {
                     "content": [
                         [
                             "type": "text",
-                            "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
+                            "text":
+                                "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"target warning\",\"line\":12,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}",
                         ]
                     ],
                     "structuredContent": [
@@ -1516,7 +1540,7 @@ extension HTTPHandlerTests {
                     "content": [
                         [
                             "type": "text",
-                            "text": "{\"issues\":[],\"totalFound\":0,\"truncated\":false}"
+                            "text": "{\"issues\":[],\"totalFound\":0,\"truncated\":false}",
                         ]
                     ],
                     "structuredContent": [
@@ -1615,12 +1639,14 @@ extension HTTPHandlerTests {
             #expect(response.statusCode == 200)
             let result = body["result"] as? [String: Any]
             let content = result?["content"] as? [[String: Any]]
-            #expect(content?.first?["text"] as? String == "upstream-after-unlimited-timeout-fallback")
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeListNavigatorIssues",
-                "XcodeRefreshCodeIssuesInFile",
-            ])
+            #expect(
+                content?.first?["text"] as? String == "upstream-after-unlimited-timeout-fallback")
+            #expect(
+                sessionManager.sentToolNames() == [
+                    "XcodeListWindows",
+                    "XcodeListNavigatorIssues",
+                    "XcodeRefreshCodeIssuesInFile",
+                ])
         } catch {
             try? await server.shutdown()
             throw error
@@ -1913,7 +1939,9 @@ extension HTTPHandlerTests {
             let result = body["result"] as? [String: Any]
             #expect((result?["isError"] as? Bool) == true)
             let content = result?["content"] as? [[String: Any]]
-            #expect(content?.first?["text"] as? String == "tool 'RunAllTests' is disabled by proxy config")
+            #expect(
+                content?.first?["text"] as? String
+                    == "tool 'RunAllTests' is disabled by proxy config")
             #expect(sessionManager.sentToolNames().isEmpty)
         } catch {
             try? await server.shutdown()
@@ -2028,17 +2056,22 @@ extension HTTPHandlerTests {
                         try makeToolResultResponse(
                             id: originalID,
                             result: [
-                                "content": [[
-                                    "type": "text",
-                                    "text": "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"warn\",\"line\":1,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}"
-                                ]],
+                                "content": [
+                                    [
+                                        "type": "text",
+                                        "text":
+                                            "{\"issues\":[{\"path\":\"\(target.path)\",\"message\":\"warn\",\"line\":1,\"severity\":\"warning\"}],\"totalFound\":1,\"truncated\":false}",
+                                    ]
+                                ],
                                 "structuredContent": [
-                                    "issues": [[
-                                        "path": target.path,
-                                        "message": "warn",
-                                        "line": 1,
-                                        "severity": "warning",
-                                    ]],
+                                    "issues": [
+                                        [
+                                            "path": target.path,
+                                            "message": "warn",
+                                            "line": 1,
+                                            "severity": "warning",
+                                        ]
+                                    ],
                                     "totalFound": 1,
                                     "truncated": false,
                                 ],
@@ -2046,7 +2079,8 @@ extension HTTPHandlerTests {
                         )
                     )
                 default:
-                    return .immediate(try makeToolErrorResponse(id: originalID, text: "unexpected tool"))
+                    return .immediate(
+                        try makeToolErrorResponse(id: originalID, text: "unexpected tool"))
                 }
             }
         )
@@ -2270,11 +2304,12 @@ extension HTTPHandlerTests {
             #expect(response.statusCode == 200)
             let error = body["error"] as? [String: Any]
             #expect(error != nil)
-            #expect(sessionManager.sentToolNames() == [
-                "XcodeListWindows",
-                "XcodeListNavigatorIssues",
-                "XcodeRefreshCodeIssuesInFile",
-            ])
+            #expect(
+                sessionManager.sentToolNames() == [
+                    "XcodeListWindows",
+                    "XcodeListNavigatorIssues",
+                    "XcodeRefreshCodeIssuesInFile",
+                ])
             #expect(sessionManager.requestSuccessNotificationCount() == 2)
             #expect(sessionManager.requestTimeoutNotificationCount() == 1)
             #expect(sessionManager.chooseUpstreamShouldPinValues().isEmpty)

--- a/Tests/ProxyHTTPGatewayTests/ToolSurfaceTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/ToolSurfaceTests.swift
@@ -426,7 +426,7 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
 
 
     func liveXcodeListWindowsResult(
-        route: ControlPlaneRoute,
+        route: ControlPlane.Route,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> JSONValue {
         fatalError("unused in ToolSurfaceTests")
@@ -454,8 +454,8 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
     func onRequestTimeout(sessionID: String, requestIDKey: String, upstreamIndex: Int) {}
     func onRequestSucceeded(sessionID: String, requestIDKey: String, upstreamIndex: Int) {}
     func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool) {}
-    func debugSnapshot() -> ProxyDebugSnapshot { fatalError("unused in ToolSurfaceTests") }
-    func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebugSnapshot {
+    func debugSnapshot() -> ProxyDebug.Snapshot { fatalError("unused in ToolSurfaceTests") }
+    func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebug.Snapshot {
         fatalError("unused in ToolSurfaceTests")
     }
 

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -14,7 +14,7 @@ extension RuntimeCoordinatorTests {
         var config = makeConfig(requestTimeout: 5)
         #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config, discovery: StubXcodeTargetDiscovery(targets: [])) != nil)
 
-        config.disabledToolNames = [DocumentationToolCatalog.toolName]
+        config.disabledToolNames = [DocumentationProvider.ToolCatalog.toolName]
         #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config, discovery: StubXcodeTargetDiscovery(targets: [])) == nil)
 
         config.disabledToolNames = []
@@ -98,7 +98,7 @@ extension RuntimeCoordinatorTests {
         )
 
         #expect(toolNames(in: result) == ["XcodeRead"])
-        #expect(DocumentationToolCatalog.descriptor(in: result) == nil)
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: result) == nil)
         #expect(manager.cachedToolsListResult() != nil)
     }
 
@@ -244,10 +244,10 @@ extension RuntimeCoordinatorTests {
             Issue.record("expected handled outcome, got \(outcome)")
             return
         }
-        #expect(DocumentationToolCatalog.responseIsDocumentationNotEnabled(responseData) == false)
+        #expect(DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(responseData) == false)
         #expect(responseData == providerResponse)
         let cachedResult = try #require(manager.cachedToolsListResult())
-        #expect(DocumentationToolCatalog.descriptor(in: cachedResult) != nil)
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: cachedResult) != nil)
         #expect(await documentationProvider.callCount() == 1)
     }
 
@@ -293,7 +293,7 @@ extension RuntimeCoordinatorTests {
             Issue.record("expected unavailable outcome, got \(outcome)")
             return
         }
-        #expect(reason.message == DocumentationProviderUnavailableReason.userFacingMessage)
+        #expect(reason.message == DocumentationProvider.UnavailableReason.userFacingMessage)
         #expect(manager.cachedToolsListResult() != nil)
         #expect(await documentationProvider.callCount() == 1)
     }
@@ -371,7 +371,7 @@ extension RuntimeCoordinatorTests {
         )
 
         let update = await manager.toolListUpdate(requestTimeout: nil)
-        let result = DocumentationToolCatalog.applying(
+        let result = DocumentationProvider.ToolCatalog.applying(
             update,
             to: try jsonValue([
                 "tools": [
@@ -380,7 +380,7 @@ extension RuntimeCoordinatorTests {
             ])
         )
 
-        #expect(DocumentationToolCatalog.descriptor(in: result) == nil)
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: result) == nil)
         #expect(await factory.startedPIDs() == [target.processID])
     }
 
@@ -405,7 +405,7 @@ extension RuntimeCoordinatorTests {
         )
 
         let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [target.processID])
@@ -448,7 +448,7 @@ extension RuntimeCoordinatorTests {
         )
 
         let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         let observedParams = try #require(await factory.initializeParams(for: target.processID).first)
@@ -499,7 +499,7 @@ extension RuntimeCoordinatorTests {
         let results = await [firstUpdate, secondUpdate]
 
         for update in results {
-            let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+            let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
             #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         }
         #expect(await factory.startAttempts() == [target.processID])
@@ -540,7 +540,7 @@ extension RuntimeCoordinatorTests {
         }
 
         let finalUpdate = await longUpdate
-        let result = DocumentationToolCatalog.applying(finalUpdate, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(finalUpdate, to: try jsonValue(["tools": []]))
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [target.processID])
     }
@@ -576,7 +576,7 @@ extension RuntimeCoordinatorTests {
             Issue.record("short tools/list should time out without cancelling provider selection")
         }
 
-        let result = DocumentationToolCatalog.applying(longUpdate, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(longUpdate, to: try jsonValue(["tools": []]))
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [target.processID])
     }
@@ -619,7 +619,7 @@ extension RuntimeCoordinatorTests {
         #expect(Date().timeIntervalSince(cancelStart) < 0.25)
 
         let longUpdate = await manager.toolListUpdate(requestTimeout: .seconds(2))
-        let result = DocumentationToolCatalog.applying(longUpdate, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(longUpdate, to: try jsonValue(["tools": []]))
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [target.processID])
     }
@@ -653,7 +653,7 @@ extension RuntimeCoordinatorTests {
         )
 
         let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
@@ -719,7 +719,7 @@ extension RuntimeCoordinatorTests {
         let update = try await waitWithTimeout("waiting for documentation provider selection") {
             await updateTask.value
         }
-        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [hung.processID, working.processID])
@@ -755,7 +755,7 @@ extension RuntimeCoordinatorTests {
         )
 
         let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-26.6")
         #expect(await factory.startedPIDs() == [pinned.processID])
@@ -790,7 +790,7 @@ extension RuntimeCoordinatorTests {
         )
 
         let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
@@ -838,7 +838,7 @@ extension RuntimeCoordinatorTests {
             sessionFactory: factory
         )
 
-        let initialTools = DocumentationToolCatalog.applying(
+        let initialTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: nil),
             to: try jsonValue(["tools": []])
         )
@@ -853,7 +853,7 @@ extension RuntimeCoordinatorTests {
             Issue.record("expected handled outcome, got \(outcome)")
             return
         }
-        #expect(DocumentationToolCatalog.responseIsDocumentationNotEnabled(responseData) == false)
+        #expect(DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(responseData) == false)
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"retry\"}")
         #expect(await factory.startedPIDs() == [
             xcode26.processID,
@@ -904,7 +904,7 @@ extension RuntimeCoordinatorTests {
             sessionFactory: factory
         )
 
-        let initialTools = DocumentationToolCatalog.applying(
+        let initialTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: nil),
             to: try jsonValue(["tools": []])
         )
@@ -919,11 +919,11 @@ extension RuntimeCoordinatorTests {
             Issue.record("expected unavailable outcome, got \(outcome)")
             return
         }
-        let followUpTools = DocumentationToolCatalog.applying(
+        let followUpTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: .seconds(1)),
             to: try jsonValue(["tools": []])
         )
-        #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
         #expect(await factory.startedPIDs() == [
             xcode26.processID,
             xcode27.processID,
@@ -968,7 +968,7 @@ extension RuntimeCoordinatorTests {
             sessionFactory: factory
         )
 
-        let initialTools = DocumentationToolCatalog.applying(
+        let initialTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: nil),
             to: try jsonValue(["tools": []])
         )
@@ -983,11 +983,11 @@ extension RuntimeCoordinatorTests {
             return
         }
 
-        let followUpTools = DocumentationToolCatalog.applying(
+        let followUpTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: .seconds(1)),
             to: try jsonValue(["tools": []])
         )
-        #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
         #expect(await factory.startedPIDs() == [
             xcode26.processID,
             xcode27.processID,
@@ -1039,7 +1039,7 @@ extension RuntimeCoordinatorTests {
             sessionFactory: factory
         )
 
-        let initialTools = DocumentationToolCatalog.applying(
+        let initialTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: nil),
             to: try jsonValue(["tools": []])
         )
@@ -1054,11 +1054,11 @@ extension RuntimeCoordinatorTests {
             return
         }
 
-        let followUpTools = DocumentationToolCatalog.applying(
+        let followUpTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: .seconds(1)),
             to: try jsonValue(["tools": []])
         )
-        #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
         #expect(await factory.startedPIDs() == [
             xcode26.processID,
             xcode27.processID,
@@ -1094,7 +1094,7 @@ extension RuntimeCoordinatorTests {
             sessionFactory: factory
         )
 
-        let initialTools = DocumentationToolCatalog.applying(
+        let initialTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: nil),
             to: try jsonValue(["tools": []])
         )
@@ -1109,11 +1109,11 @@ extension RuntimeCoordinatorTests {
             return
         }
 
-        let followUpTools = DocumentationToolCatalog.applying(
+        let followUpTools = DocumentationProvider.ToolCatalog.applying(
             await manager.toolListUpdate(requestTimeout: .seconds(1)),
             to: try jsonValue(["tools": []])
         )
-        #expect(DocumentationToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
     }
 
     @Test func documentationProviderManagerDoesNotRetryAfterRequestTimeoutExpires() async throws {
@@ -1192,7 +1192,7 @@ extension RuntimeCoordinatorTests {
         }
 
         let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [xcode.processID])
     }

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -40,7 +40,7 @@ func jsonValue(_ object: [String: Any]) throws -> JSONValue {
 
 func documentationDescriptor(version: String) -> JSONValue {
     JSONValue(any: [
-        "name": DocumentationToolCatalog.toolName,
+        "name": DocumentationProvider.ToolCatalog.toolName,
         "description": "docs-\(version)",
         "inputSchema": [
             "type": "object",
@@ -69,7 +69,7 @@ func toolNames(in result: JSONValue) -> [String] {
 }
 
 func documentationDescriptorDescription(in result: JSONValue) -> String? {
-    guard let descriptor = DocumentationToolCatalog.descriptor(in: result),
+    guard let descriptor = DocumentationProvider.ToolCatalog.descriptor(in: result),
           case .object(let object) = descriptor,
           case .string(let description)? = object["description"] else {
         return nil
@@ -84,7 +84,7 @@ func makeDocumentationSearchRequest(id: Int64, query: String) throws -> Data {
             "id": id,
             "method": "tools/call",
             "params": [
-                "name": DocumentationToolCatalog.toolName,
+                "name": DocumentationProvider.ToolCatalog.toolName,
                 "arguments": [
                     "query": query,
                 ],
@@ -196,7 +196,7 @@ actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
         }
         guard var plans = plansByPID[target.processID],
               plans.isEmpty == false else {
-            throw UpstreamSlotAcquisitionError.unavailable
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
         let plan = plans.removeFirst()
         plansByPID[target.processID] = plans
@@ -430,8 +430,8 @@ actor ScriptedDocumentationSession: UpstreamSession {
 }
 
 actor StubDocumentationProviderManager: DocumentationProviderManaging {
-    private var update: DocumentationToolListUpdate
-    private var callOutcomes: [DocumentationProviderCallOutcome]
+    private var update: DocumentationProvider.ToolListUpdate
+    private var callOutcomes: [DocumentationProvider.CallOutcome]
     private var callCountValue = 0
     private var invalidateReasons: [String] = []
     private var prewarmTimeouts: [TimeAmount?] = []
@@ -443,8 +443,8 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
     private let prewarmBlocker: AsyncGate?
 
     init(
-        toolListUpdate: DocumentationToolListUpdate,
-        callOutcomes: [DocumentationProviderCallOutcome] = [],
+        toolListUpdate: DocumentationProvider.ToolListUpdate,
+        callOutcomes: [DocumentationProvider.CallOutcome] = [],
         prewarmDelayNanoseconds: UInt64? = nil,
         toolListDelayNanoseconds: UInt64? = nil,
         prewarmStarted: TestSignal? = nil,
@@ -458,7 +458,7 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
         self.prewarmBlocker = prewarmBlocker
     }
 
-    func prewarm(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
+    func prewarm(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate {
         prewarmStarted?.signal()
         if let prewarmDelayNanoseconds {
             try? await Task.sleep(nanoseconds: prewarmDelayNanoseconds)
@@ -476,7 +476,7 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
         return await toolListUpdate(requestTimeout: requestTimeout)
     }
 
-    func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationToolListUpdate {
+    func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate {
         toolListTimeouts.append(requestTimeout)
         if let toolListDelayNanoseconds {
             try? await Task.sleep(nanoseconds: toolListDelayNanoseconds)
@@ -488,7 +488,7 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
     func callDocumentationSearch(
         requestData _: Data,
         requestTimeoutOverride: TimeAmount?
-    ) async throws -> DocumentationProviderCallOutcome {
+    ) async throws -> DocumentationProvider.CallOutcome {
         callCountValue += 1
         callTimeouts.append(requestTimeoutOverride)
         guard callOutcomes.isEmpty == false else {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -1951,8 +1951,8 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func controlPlaneRPCHandleCancelBeforeQueueStartCapturesQueuedState() {
-        let handle = ControlPlaneRPCHandle()
-        let cancellation = NIOLockedValueBox<ControlPlaneRPCCancelSnapshot?>(nil)
+        let handle = ControlPlane.RPCHandle()
+        let cancellation = NIOLockedValueBox<ControlPlane.RPCCancelSnapshot?>(nil)
 
         handle.installCancel { snapshot in
             cancellation.withLockedValue { $0 = snapshot }
@@ -1967,8 +1967,8 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func controlPlaneRPCHandleCancelAfterRegisterCapturesRegistrationState() {
-        let handle = ControlPlaneRPCHandle()
-        let cancellation = NIOLockedValueBox<ControlPlaneRPCCancelSnapshot?>(nil)
+        let handle = ControlPlane.RPCHandle()
+        let cancellation = NIOLockedValueBox<ControlPlane.RPCCancelSnapshot?>(nil)
         let token = UUID()
 
         handle.installCancel { snapshot in
@@ -1986,8 +1986,8 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func controlPlaneRPCHandleCancelAfterAssignCapturesRequestMappingState() {
-        let handle = ControlPlaneRPCHandle()
-        let cancellation = NIOLockedValueBox<ControlPlaneRPCCancelSnapshot?>(nil)
+        let handle = ControlPlane.RPCHandle()
+        let cancellation = NIOLockedValueBox<ControlPlane.RPCCancelSnapshot?>(nil)
         let token = UUID()
 
         handle.installCancel { snapshot in
@@ -2005,8 +2005,8 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func controlPlaneRPCHandleCancelAfterSendUsesAssignedSnapshotUntilFinished() {
-        let handle = ControlPlaneRPCHandle()
-        let cancellation = NIOLockedValueBox<ControlPlaneRPCCancelSnapshot?>(nil)
+        let handle = ControlPlane.RPCHandle()
+        let cancellation = NIOLockedValueBox<ControlPlane.RPCCancelSnapshot?>(nil)
         let token = UUID()
 
         handle.installCancel { snapshot in
@@ -2064,7 +2064,7 @@ struct RuntimeCoordinatorTests {
 
     @Test func controlPlaneDoesNotReturnStaleToolsCatalogAfterGenerationClear() async throws {
         let brokerState = CanonicalBrokerState()
-        let debugMirror = ControlPlaneDebugMirror()
+        let debugMirror = ControlPlane.DebugMirror()
         let loadStarted = TestSignal()
         let releaseLoad = AsyncGate()
         let coordinator = ControlPlaneCoordinator(
@@ -2103,7 +2103,7 @@ struct RuntimeCoordinatorTests {
 
     @Test func controlPlaneDoesNotReturnStaleWindowsAfterGenerationClear() async throws {
         let brokerState = CanonicalBrokerState()
-        let debugMirror = ControlPlaneDebugMirror()
+        let debugMirror = ControlPlane.DebugMirror()
         let loadStarted = TestSignal()
         let releaseLoad = AsyncGate()
         let coordinator = ControlPlaneCoordinator(
@@ -2146,7 +2146,7 @@ struct RuntimeCoordinatorTests {
         async throws
     {
         let brokerState = CanonicalBrokerState()
-        let debugMirror = ControlPlaneDebugMirror()
+        let debugMirror = ControlPlane.DebugMirror()
         let loadIndexBox = NIOLockedValueBox(0)
         let firstLoadStarted = TestSignal()
         let secondLoadStarted = TestSignal()
@@ -3348,7 +3348,7 @@ struct RuntimeCoordinatorTests {
             eventLoop.makeSucceededFuture(())
         }
 
-        await #expect(throws: UpstreamSlotAcquisitionError.self) {
+        await #expect(throws: UpstreamSlotScheduler.AcquisitionError.self) {
             try await future.get()
         }
 
@@ -4757,7 +4757,7 @@ struct RuntimeCoordinatorTests {
             upstreamIndex: 0
         )
 
-        await #expect(throws: UpstreamSlotAcquisitionError.self) {
+        await #expect(throws: UpstreamSlotScheduler.AcquisitionError.self) {
             try await queuedFuture.get()
         }
         activePromise.fail(CancellationError())
@@ -4818,7 +4818,7 @@ struct RuntimeCoordinatorTests {
             .message(try JSONSerialization.data(withJSONObject: errorResponse, options: []))
         )
 
-        await #expect(throws: UpstreamSlotAcquisitionError.self) {
+        await #expect(throws: UpstreamSlotScheduler.AcquisitionError.self) {
             try await queuedFuture.get()
         }
     }
@@ -4911,7 +4911,7 @@ struct RuntimeCoordinatorTests {
                 manager.debugSnapshot().queuedRequestCount == 0
             }
         )
-        await #expect(throws: UpstreamSlotAcquisitionError.self) {
+        await #expect(throws: UpstreamSlotScheduler.AcquisitionError.self) {
             try await queuedFuture.get()
         }
 


### PR DESCRIPTION
## Purpose

Continue the domain API surface cleanup by moving support models under the domain owner that defines their contract, while preserving wire shapes, CLI flags, TOML keys, product names, and debug JSON field names.

## Changes

- Move proxy config protocol validation to `ProxyConfig.ValidationError` and keep CLI presentation behavior unchanged.
- Scope documentation provider, control plane, canonical broker, upstream, and proxy debug support types under their owner namespaces.
- Clean up indentation in nested Swift types touched by the domain-owner refactor.
- Update maintainer architecture docs to reflect that `ProxyMCP` depends on `ProxyCore` and extends the `MCP` namespace.

## Testing

- `git diff --check`
- `swift test -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `codex-review --base main` clean, findings 0
