### PR TITLE
Guard stale initialize callbacks

### DIFF
--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -63,7 +63,14 @@ extension RuntimeCoordinator {
         }
     }
 
-    func handleInitializeResponse(_ object: [String: Any], upstreamIndex: Int) {
+    func handleInitializeResponse(_ object: [String: Any], upstreamIndex: Int, upstreamID: Int64) {
+        guard upstreamHealthManager.initializeAttemptMatches(
+            upstreamIndex: upstreamIndex,
+            expectedUpstreamID: upstreamID
+        ) else {
+            return
+        }
+
         guard let resultValue = object["result"], let result = JSONValue(any: resultValue) else {
             if upstreamIndex == 0 {
                 if let errorObject = object["error"] as? [String: Any], !errorObject.isEmpty {
@@ -72,7 +79,7 @@ extension RuntimeCoordinator {
                     failInitPending(error: TimeoutError())
                 }
             } else {
-                clearUpstreamState(upstreamIndex: upstreamIndex)
+                clearUpstreamState(upstreamIndex: upstreamIndex, expectedUpstreamID: upstreamID)
                 failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
             }
             return
@@ -97,11 +104,23 @@ extension RuntimeCoordinator {
                 failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
                 return
             }
-            sendInitializedNotificationIfNeeded(upstreamIndex: upstreamIndex) { [weak self] in
-                self?.markUpstreamInitialized(upstreamIndex: upstreamIndex)
-                self?.upstreamSlotScheduler.wake()
+            sendInitializedNotificationIfNeeded(
+                upstreamIndex: upstreamIndex,
+                expectedUpstreamID: upstreamID
+            ) { [weak self] in
+                guard let self else { return }
+                guard self.markUpstreamInitialized(
+                    upstreamIndex: upstreamIndex,
+                    expectedUpstreamID: upstreamID
+                ) else {
+                    return
+                }
+                self.upstreamSlotScheduler.wake()
             } onRejected: { [weak self] in
-                self?.handleInitializedNotificationSendOverload(upstreamIndex: upstreamIndex)
+                self?.handleInitializedNotificationSendOverload(
+                    upstreamIndex: upstreamIndex,
+                    expectedUpstreamID: upstreamID
+                )
             }
             return
         }
@@ -110,14 +129,22 @@ extension RuntimeCoordinator {
         guard let update else { return }
         update.timeout?.cancel()
 
-        sendInitializedNotificationIfNeeded(upstreamIndex: upstreamIndex) { [weak self] in
+        sendInitializedNotificationIfNeeded(
+            upstreamIndex: upstreamIndex,
+            expectedUpstreamID: upstreamID
+        ) { [weak self] in
             guard let self else { return }
+            guard self.markUpstreamInitialized(
+                upstreamIndex: upstreamIndex,
+                expectedUpstreamID: upstreamID
+            ) else {
+                return
+            }
             self.canonicalBrokerState.syncCanonicalInitialize(
                 result,
                 sourceUpstream: upstreamIndex
             )
             guard let pending = self.initializeManager.finishPrimaryInitializeSuccess() else { return }
-            self.markUpstreamInitialized(upstreamIndex: upstreamIndex)
             self.upstreamSlotScheduler.wake()
             if update.shouldWarmSecondary {
                 self.initializeManager.markSecondaryWarmupStarted()
@@ -131,6 +158,12 @@ extension RuntimeCoordinator {
             )
         } onRejected: { [weak self] in
             guard let self else { return }
+            guard self.upstreamHealthManager.initializeAttemptMatches(
+                upstreamIndex: upstreamIndex,
+                expectedUpstreamID: upstreamID
+            ) else {
+                return
+            }
             if upstreamIndex == 0,
                 self.hasUsableInitializedSecondaryUpstreams(),
                 let completion = self.initializeManager.finishPrimaryInitializeUsingCachedResult()
@@ -143,12 +176,18 @@ extension RuntimeCoordinator {
                     )
                 )
                 self.eventLoop.execute { [weak self] in
-                    self?.handleInitializedNotificationSendOverload(upstreamIndex: upstreamIndex)
+                    self?.handleInitializedNotificationSendOverload(
+                        upstreamIndex: upstreamIndex,
+                        expectedUpstreamID: upstreamID
+                    )
                 }
                 return
             }
             self.initializeManager.reopenPrimaryInitializeForRetry()
-            self.handleInitializedNotificationSendOverload(upstreamIndex: upstreamIndex)
+            self.handleInitializedNotificationSendOverload(
+                upstreamIndex: upstreamIndex,
+                expectedUpstreamID: upstreamID
+            )
         }
     }
 
@@ -289,6 +328,7 @@ extension RuntimeCoordinator {
 
     func sendInitializedNotificationIfNeeded(
         upstreamIndex: Int,
+        expectedUpstreamID: Int64,
         onAccepted: @escaping @Sendable () -> Void = {},
         onRejected: @escaping @Sendable () -> Void = {}
     ) {
@@ -296,6 +336,12 @@ extension RuntimeCoordinator {
             upstreamIndex: upstreamIndex
         )
         guard shouldSend else {
+            guard upstreamHealthManager.initializeAttemptMatches(
+                upstreamIndex: upstreamIndex,
+                expectedUpstreamID: expectedUpstreamID
+            ) else {
+                return
+            }
             onAccepted()
             return
         }
@@ -305,6 +351,12 @@ extension RuntimeCoordinator {
             "method": "notifications/initialized",
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: notification, options: []) else {
+            guard upstreamHealthManager.initializeAttemptMatches(
+                upstreamIndex: upstreamIndex,
+                expectedUpstreamID: expectedUpstreamID
+            ) else {
+                return
+            }
             onAccepted()
             return
         }
@@ -313,7 +365,12 @@ extension RuntimeCoordinator {
             guard let self else { return }
             let result = await self.upstreams[upstreamIndex].send(data)
             if result == .accepted {
-                self.upstreamHealthManager.markInitializedNotificationSent(upstreamIndex: upstreamIndex)
+                guard self.upstreamHealthManager.markInitializedNotificationSent(
+                    upstreamIndex: upstreamIndex,
+                    expectedUpstreamID: expectedUpstreamID
+                ) else {
+                    return
+                }
                 self.recordTraffic(
                     upstreamIndex: upstreamIndex,
                     direction: "outbound",
@@ -326,8 +383,13 @@ extension RuntimeCoordinator {
         }
     }
 
-    func handleInitializedNotificationSendOverload(upstreamIndex: Int) {
-        clearUpstreamState(upstreamIndex: upstreamIndex)
+    func handleInitializedNotificationSendOverload(upstreamIndex: Int, expectedUpstreamID: Int64) {
+        guard clearUpstreamState(
+            upstreamIndex: upstreamIndex,
+            expectedUpstreamID: expectedUpstreamID
+        ) else {
+            return
+        }
         let hasHealthySecondary = upstreamIndex == 0 && hasUsableInitializedSecondaryUpstreams()
         if canonicalBrokerState.toolsSourceUpstream() == upstreamIndex && !hasHealthySecondary {
             invalidateControlPlane(
@@ -408,9 +470,13 @@ extension RuntimeCoordinator {
         upstreamHealthManager.clearInitInFlight(upstreamIndex: upstreamIndex)
     }
 
-    func clearUpstreamState(upstreamIndex: Int) {
-        guard let cleared = upstreamHealthManager.clearUpstreamState(upstreamIndex: upstreamIndex) else {
-            return
+    @discardableResult
+    func clearUpstreamState(upstreamIndex: Int, expectedUpstreamID: Int64? = nil) -> Bool {
+        guard let cleared = upstreamHealthManager.clearUpstreamState(
+            upstreamIndex: upstreamIndex,
+            expectedUpstreamID: expectedUpstreamID
+        ) else {
+            return false
         }
         cleared.timeout?.cancel()
         if let initUpstreamID = cleared.initUpstreamID {
@@ -420,11 +486,27 @@ extension RuntimeCoordinator {
             )
         }
         debugRecorder.resetUpstream(upstreamIndex)
+        return true
+    }
+
+    @discardableResult
+    func markUpstreamInitialized(upstreamIndex: Int, expectedUpstreamID: Int64) -> Bool {
+        guard let result = upstreamHealthManager.markInitialized(
+            upstreamIndex: upstreamIndex,
+            expectedUpstreamID: expectedUpstreamID
+        ) else {
+            return false
+        }
+        result.timeout?.cancel()
+        noteUpstreamInitializationSucceeded()
+        return true
     }
 
     func markUpstreamInitialized(upstreamIndex: Int) {
-        let timeout = upstreamHealthManager.markInitialized(upstreamIndex: upstreamIndex)
-        timeout?.cancel()
+        guard let result = upstreamHealthManager.markInitialized(upstreamIndex: upstreamIndex) else {
+            return
+        }
+        result.timeout?.cancel()
         noteUpstreamInitializationSucceeded()
     }
 

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -188,7 +188,7 @@ extension RuntimeCoordinator {
         }
 
         if mapping.isInitialize {
-            handleInitializeResponse(object, upstreamIndex: upstreamIndex)
+            handleInitializeResponse(object, upstreamIndex: upstreamIndex, upstreamID: upstreamID)
             return .handled
         }
 

--- a/Sources/ProxySession/Upstream/UpstreamHealthManager.swift
+++ b/Sources/ProxySession/Upstream/UpstreamHealthManager.swift
@@ -46,6 +46,10 @@ package final class UpstreamHealthManager: Sendable {
         package let initUpstreamID: Int64?
     }
 
+    package struct MarkInitializedTransition: Sendable {
+        package let timeout: RuntimeScheduledTimeout?
+    }
+
     package enum InitPhase: Sendable, Equatable {
         case idle
         case initializing(upstreamID: Int64?)
@@ -383,10 +387,31 @@ package final class UpstreamHealthManager: Sendable {
         }
     }
 
-    package func markInitializedNotificationSent(upstreamIndex: Int) {
+    package func markInitializedNotificationSent(
+        upstreamIndex: Int,
+        expectedUpstreamID: Int64
+    ) -> Bool {
         state.withLockedValue { state in
-            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return }
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else {
+                return false
+            }
+            guard state.upstreamStates[upstreamIndex].initUpstreamID == expectedUpstreamID else {
+                return false
+            }
             state.upstreamStates[upstreamIndex].didSendInitialized = true
+            return true
+        }
+    }
+
+    package func initializeAttemptMatches(
+        upstreamIndex: Int,
+        expectedUpstreamID: Int64
+    ) -> Bool {
+        state.withLockedValue { state in
+            guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else {
+                return false
+            }
+            return state.upstreamStates[upstreamIndex].initUpstreamID == expectedUpstreamID
         }
     }
 
@@ -463,8 +488,23 @@ package final class UpstreamHealthManager: Sendable {
         timeout: RuntimeScheduledTimeout?,
         initUpstreamID: Int64?
     )? {
+        clearUpstreamState(upstreamIndex: upstreamIndex, expectedUpstreamID: nil)
+    }
+
+    package func clearUpstreamState(
+        upstreamIndex: Int,
+        expectedUpstreamID: Int64?
+    ) -> (
+        timeout: RuntimeScheduledTimeout?,
+        initUpstreamID: Int64?
+    )? {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
+            if let expectedUpstreamID,
+               state.upstreamStates[upstreamIndex].initUpstreamID != expectedUpstreamID
+            {
+                return nil
+            }
             let timeout = state.upstreamStates[upstreamIndex].initTimeout
             let initUpstreamID = state.upstreamStates[upstreamIndex].initUpstreamID
             state.upstreamStates[upstreamIndex].initTimeout = nil
@@ -483,9 +523,21 @@ package final class UpstreamHealthManager: Sendable {
         }
     }
 
-    package func markInitialized(upstreamIndex: Int) -> RuntimeScheduledTimeout? {
+    package func markInitialized(upstreamIndex: Int) -> UpstreamHealthManager.MarkInitializedTransition? {
+        markInitialized(upstreamIndex: upstreamIndex, expectedUpstreamID: nil)
+    }
+
+    package func markInitialized(
+        upstreamIndex: Int,
+        expectedUpstreamID: Int64?
+    ) -> UpstreamHealthManager.MarkInitializedTransition? {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreamStates.count else { return nil }
+            if let expectedUpstreamID,
+               state.upstreamStates[upstreamIndex].initUpstreamID != expectedUpstreamID
+            {
+                return nil
+            }
             state.upstreamStates[upstreamIndex].isInitialized = true
             state.upstreamStates[upstreamIndex].initInFlight = false
             state.upstreamStates[upstreamIndex].initUpstreamID = nil
@@ -494,7 +546,7 @@ package final class UpstreamHealthManager: Sendable {
             state.upstreamStates[upstreamIndex].healthProbeInFlight = false
             let timeout = state.upstreamStates[upstreamIndex].initTimeout
             state.upstreamStates[upstreamIndex].initTimeout = nil
-            return timeout
+            return UpstreamHealthManager.MarkInitializedTransition(timeout: timeout)
         }
     }
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -1150,6 +1150,19 @@ func sentValue(
     }
 }
 
+func sentValue(
+    from upstream: BlockingInitializedNotificationUpstreamClient,
+    at index: Int,
+    timeout: Duration = .seconds(5)
+) async throws -> Data {
+    try await nextValue(
+        "waiting for sent message \(index + 1)",
+        timeout: timeout
+    ) {
+        await upstream.sentValue(at: index)
+    }
+}
+
 func sentMessage(
     from upstream: TestUpstreamClient,
     matching predicate: @escaping @Sendable (Data) -> Bool,

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -2781,8 +2781,10 @@ struct RuntimeCoordinatorTests {
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
-        try await waitForSentCount(upstream0, count: 3, timeoutSeconds: 2)
-        let upstreamID2 = try extractUpstreamID(from: (await upstream0.sent())[2])
+        try await waitForSentCount(upstream0, count: 4, timeoutSeconds: 2)
+        let secondInitialize = (await upstream0.sent())[3]
+        #expect(methodName(from: secondInitialize) == "initialize")
+        let upstreamID2 = try extractUpstreamID(from: secondInitialize)
         await upstream0.yield(.message(try makeInitializeResponse(id: upstreamID2)))
         _ = try await init2.get()
     }
@@ -4160,6 +4162,73 @@ struct RuntimeCoordinatorTests {
                 manager.testStateSnapshot().upstreams[1].isInitialized == false
             }
         )
+    }
+
+    @Test func sessionManagerIgnoresStaleSecondaryInitializedNotificationAfterReset()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = BlockingInitializedNotificationUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1]
+        )
+        defer { manager.shutdownAndWait() }
+
+        let init0 = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
+        let init0ID = try extractUpstreamID(from: init0)
+        await upstream1.blockNextInitializedNotification()
+        await upstream0.yield(.message(try makeInitializeResponse(id: init0ID)))
+
+        let init1 = try await sentValue(from: upstream1, at: 0, timeout: .seconds(2))
+        let init1ID = try extractUpstreamID(from: init1)
+        await upstream1.yield(.message(try makeInitializeResponse(id: init1ID)))
+        try await upstream1.waitForBlockedInitializedNotification()
+
+        #expect(manager.testStateSnapshot().upstreams[1].initInFlight)
+        manager.clearUpstreamState(upstreamIndex: 1)
+        _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
+        _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
+        _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
+
+        await upstream1.releaseBlockedInitializedNotification(.accepted)
+
+        #expect(
+            await staysTrue(for: .milliseconds(200)) {
+                let snapshot = manager.testStateSnapshot().upstreams[1]
+                if snapshot.isInitialized {
+                    return false
+                }
+                guard case .quarantined = snapshot.healthState else {
+                    return false
+                }
+                return true
+            }
+        )
+    }
+
+    @Test func upstreamHealthManagerIgnoresStaleInitializeCompletionAfterStateReset() {
+        let manager = UpstreamHealthManager(upstreamCount: 1)
+        manager.markInitInFlight(upstreamIndex: 0, upstreamID: 10)
+        guard let _ = manager.clearUpstreamState(upstreamIndex: 0) else {
+            Issue.record("expected initial reset to clear the active initialize attempt")
+            return
+        }
+
+        if let _ = manager.markInitialized(upstreamIndex: 0, expectedUpstreamID: 10) {
+            Issue.record("expected stale initialize completion to be ignored")
+        }
+        if let _ = manager.clearUpstreamState(upstreamIndex: 0, expectedUpstreamID: 10) {
+            Issue.record("expected stale initialized notification rejection to be ignored")
+        }
+        let snapshot = manager.statesSnapshot()[0]
+        #expect(snapshot.isInitialized == false)
+        #expect(snapshot.initInFlight == false)
     }
 
     @Test func sessionManagerPrimaryWarmReinitOverloadFallsBackToEagerInitAfterWarmRetryFailure()

--- a/Tests/ProxySessionTests/TestUpstreamClient.swift
+++ b/Tests/ProxySessionTests/TestUpstreamClient.swift
@@ -60,3 +60,81 @@ actor TestUpstreamClient: UpstreamSlotControlling {
         stopCountValue
     }
 }
+
+actor BlockingInitializedNotificationUpstreamClient: UpstreamSlotControlling {
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
+    private let sentMessages = RecordedValues<Data>()
+    private let blockedSignal = TestSignal()
+    private var shouldBlockInitializedNotification = false
+    private var blockedInitializedNotification: CheckedContinuation<Upstream.SendResult, Never>?
+
+    init() {
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
+        self.events = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+    }
+
+    func start() async {}
+
+    func stop() async {
+        continuation.finish()
+        releaseBlockedInitializedNotification(.backpressure)
+    }
+
+    func blockNextInitializedNotification() {
+        shouldBlockInitializedNotification = true
+    }
+
+    func send(_ data: Data) async -> Upstream.SendResult {
+        await sentMessages.append(data)
+        guard shouldBlockInitializedNotification,
+              methodName(from: data) == "notifications/initialized"
+        else {
+            return .accepted
+        }
+
+        shouldBlockInitializedNotification = false
+        return await withCheckedContinuation { continuation in
+            blockedInitializedNotification = continuation
+            blockedSignal.signal()
+        }
+    }
+
+    func waitForBlockedInitializedNotification() async throws {
+        if blockedInitializedNotification != nil {
+            return
+        }
+        try await blockedSignal.wait(description: "waiting for blocked initialized notification")
+    }
+
+    func releaseBlockedInitializedNotification(_ result: Upstream.SendResult = .accepted) {
+        guard let continuation = blockedInitializedNotification else {
+            return
+        }
+        blockedInitializedNotification = nil
+        continuation.resume(returning: result)
+    }
+
+    func yield(_ event: Upstream.Event) async {
+        continuation.yield(event)
+    }
+
+    func sent() async -> [Data] {
+        await sentMessages.snapshot()
+    }
+
+    func sentCount() async -> Int {
+        await sentMessages.count()
+    }
+
+    func sentValue(at index: Int) async -> Data? {
+        await sentMessages.value(at: index)
+    }
+
+    func nextSent(at index: Int) async throws -> Data {
+        try await sentMessages.nextValue(at: index)
+    }
+}


### PR DESCRIPTION
Purpose
Fix a nondeterministic runtime race where a delayed notifications/initialized send callback from an old initialize attempt could mark a reset or quarantined upstream initialized again.

Changes
- Thread the consumed upstream initialize ID through initialize response handling and initialized notification callbacks.
- Add expected-upstream-ID guarded state transitions in UpstreamHealthManager for initialized notification send, markInitialized, and clearUpstreamState.
- Ignore stale initialize responses and stale accepted/rejected initialized-notification callbacks without changing public API, CLI/config, or wire shape.
- Add regression coverage for delayed secondary initialized notification callbacks after reset/quarantine, plus direct stale transition coverage.
- Update an existing reinitialize test to respond to the fresh initialize request instead of a stale warm-init response.

Testing
- git diff --check
- swift test --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal
- swift test -Xswiftc -strict-concurrency=minimal
- scripts/check.sh
- codex-review: no findings