### PR TITLE
Refactor DocumentationSearch provider selection

### DIFF
--- a/Sources/ProxyCore/XcodeTargetDiscovery.swift
+++ b/Sources/ProxyCore/XcodeTargetDiscovery.swift
@@ -5,17 +5,20 @@ package struct DocumentationProviderTarget: Sendable, Equatable {
     package let appPath: String
     package let developerDir: String
     package let mcpbridgePath: String
+    package let xcodeVersion: String
 
     package init(
         processID: pid_t,
         appPath: String,
         developerDir: String,
-        mcpbridgePath: String
+        mcpbridgePath: String,
+        xcodeVersion: String
     ) {
         self.processID = processID
         self.appPath = appPath
         self.developerDir = developerDir
         self.mcpbridgePath = mcpbridgePath
+        self.xcodeVersion = xcodeVersion
     }
 }
 

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -508,7 +508,7 @@ extension HTTPPostService {
     }
 
     private func isDocumentationSearchRequest(_ object: [String: Any]) -> Bool {
-        guard sessionManager.hasDocumentationProvider() else {
+        guard sessionManager.hasDocumentationSearchService() else {
             return false
         }
         guard case .request("tools/call", _) = JSONRPC.Message.Inspector.kind(of: object),

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -67,6 +67,49 @@ package protocol DocumentationProviderManaging: Sendable {
     func shutdown() async
 }
 
+package struct DocumentationProviderRoute: Sendable, Equatable {
+    package let id: String
+    package let target: DocumentationProviderTarget
+    package let upstreamIndex: Int?
+    package let serverVersion: String
+
+    package init(
+        id: String,
+        target: DocumentationProviderTarget,
+        upstreamIndex: Int?,
+        serverVersion: String = ""
+    ) {
+        self.id = id
+        self.target = target
+        self.upstreamIndex = upstreamIndex
+        self.serverVersion = serverVersion
+    }
+}
+
+package protocol DocumentationProviderRouting: Sendable {
+    func openRoute(
+        for target: DocumentationProviderTarget,
+        requestTimeout: TimeAmount?,
+        initializeParams: [String: JSONValue]
+    ) async throws -> DocumentationProviderRoute
+    func toolsList(
+        route: DocumentationProviderRoute,
+        timeout: TimeAmount?
+    ) async throws -> JSONValue
+    func callDocumentationSearch(
+        route: DocumentationProviderRoute,
+        requestData: Data,
+        timeout: TimeAmount?
+    ) async throws -> Data
+    func close(route: DocumentationProviderRoute) async
+    func shutdown() async
+}
+
+extension DocumentationProviderRouting {
+    package func close(route _: DocumentationProviderRoute) async {}
+    package func shutdown() async {}
+}
+
 extension DocumentationProvider {
     package enum ToolCatalog {
         package static let toolName = "DocumentationSearch"
@@ -406,11 +449,124 @@ package actor DocumentationProviderConnection {
     }
 }
 
+package actor SessionBackedDocumentationProviderTransport: DocumentationProviderRouting {
+    private let sessionFactory: any DocumentationProviderSessionMaking
+    private let clock: ClockClient
+    private var connections: [String: DocumentationProviderConnection] = [:]
+
+    package init(
+        sessionFactory: any DocumentationProviderSessionMaking,
+        clock: ClockClient = .liveValue
+    ) {
+        self.sessionFactory = sessionFactory
+        self.clock = clock
+    }
+
+    package func openRoute(
+        for target: DocumentationProviderTarget,
+        requestTimeout: TimeAmount?,
+        initializeParams: [String: JSONValue]
+    ) async throws -> DocumentationProviderRoute {
+        let session = try await sessionFactory.startSession(for: target)
+        let connection = DocumentationProviderConnection(session: session, clock: clock)
+        let routeID = UUID().uuidString
+        do {
+            await connection.start()
+            let initialize = try await connection.call(
+                try Self.makeInitializeRequestData(initializeParams: initializeParams),
+                timeout: requestTimeout
+            )
+            let serverVersion = DocumentationProviderManager.serverVersion(
+                fromInitializeResponse: initialize
+            ) ?? ""
+            try await connection.sendNotification([
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+            ])
+            connections[routeID] = connection
+            return DocumentationProviderRoute(
+                id: routeID,
+                target: target,
+                upstreamIndex: nil,
+                serverVersion: serverVersion
+            )
+        } catch {
+            await connection.stop()
+            throw error
+        }
+    }
+
+    package func toolsList(
+        route: DocumentationProviderRoute,
+        timeout: TimeAmount?
+    ) async throws -> JSONValue {
+        guard let connection = connections[route.id] else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        let toolsList = try await connection.call(
+            try Self.makeToolsListRequestData(),
+            timeout: timeout
+        )
+        return try DocumentationProviderManager.resultValue(from: toolsList)
+    }
+
+    package func callDocumentationSearch(
+        route: DocumentationProviderRoute,
+        requestData: Data,
+        timeout: TimeAmount?
+    ) async throws -> Data {
+        guard let connection = connections[route.id] else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        return try await connection.call(requestData, timeout: timeout)
+    }
+
+    package func close(route: DocumentationProviderRoute) async {
+        guard let connection = connections.removeValue(forKey: route.id) else {
+            return
+        }
+        await connection.stop()
+    }
+
+    package func shutdown() async {
+        let connections = self.connections
+        self.connections.removeAll()
+        for connection in connections.values {
+            await connection.stop()
+        }
+    }
+
+    private static func makeInitializeRequestData(
+        initializeParams: [String: JSONValue]
+    ) throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": "initialize",
+                "method": "initialize",
+                "params": initializeParams.mapValues(\.foundationObject),
+            ],
+            options: []
+        )
+    }
+
+    private static func makeToolsListRequestData() throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": "tools-list",
+                "method": "tools/list",
+            ],
+            options: []
+        )
+    }
+}
+
 package actor DocumentationProviderManager: DocumentationProviderManaging {
     private struct CandidateProfile: Sendable {
         let id: UUID
         let target: DocumentationProviderTarget
-        let connection: DocumentationProviderConnection
+        let route: DocumentationProviderRoute
         var descriptor: JSONValue?
         let serverVersion: String
     }
@@ -479,7 +635,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     }
 
     private let discovery: any XcodeTargetDiscovering
-    private let sessionFactory: any DocumentationProviderSessionMaking
+    private let transport: any DocumentationProviderRouting
     private let providerSelectionTimeout: TimeAmount?
     private let pinnedProcessID: pid_t?
     private let initializeParams: [String: JSONValue]
@@ -493,8 +649,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
 
     package init(
         discovery: any XcodeTargetDiscovering,
-        sessionFactory: any DocumentationProviderSessionMaking =
-            LiveDocumentationProviderSessionFactory(),
+        transport: any DocumentationProviderRouting,
         providerSelectionTimeout: TimeAmount? = .seconds(30),
         pinnedProcessID: pid_t? = nil,
         initializeParams: [String: JSONValue] = InitializeHandshakeJSON.defaultParams(),
@@ -502,12 +657,35 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         logger: Logger = ProxyLogging.make("documentation.provider")
     ) {
         self.discovery = discovery
-        self.sessionFactory = sessionFactory
+        self.transport = transport
         self.providerSelectionTimeout = providerSelectionTimeout
         self.pinnedProcessID = pinnedProcessID
         self.initializeParams = initializeParams
         self.clock = clock
         self.logger = logger
+    }
+
+    package init(
+        discovery: any XcodeTargetDiscovering,
+        sessionFactory: any DocumentationProviderSessionMaking,
+        providerSelectionTimeout: TimeAmount? = .seconds(30),
+        pinnedProcessID: pid_t? = nil,
+        initializeParams: [String: JSONValue] = InitializeHandshakeJSON.defaultParams(),
+        clock: ClockClient = .liveValue,
+        logger: Logger = ProxyLogging.make("documentation.provider")
+    ) {
+        self.init(
+            discovery: discovery,
+            transport: SessionBackedDocumentationProviderTransport(
+                sessionFactory: sessionFactory,
+                clock: clock
+            ),
+            providerSelectionTimeout: providerSelectionTimeout,
+            pinnedProcessID: pinnedProcessID,
+            initializeParams: initializeParams,
+            clock: clock,
+            logger: logger
+        )
     }
 
     package func startBackgroundDiscovery(requestTimeout: TimeAmount?) async
@@ -772,7 +950,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         guard previous.profile.id != profile.id else {
             return false
         }
-        await previous.profile.connection.stop()
+        await transport.close(route: previous.profile.route)
         return true
     }
 
@@ -789,8 +967,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     ) async throws -> DocumentationAttemptResult {
         let processID = provider.profile.target.processID
         do {
-            let response = try await provider.profile.connection.call(
-                requestData,
+            let response = try await transport.callDocumentationSearch(
+                route: provider.profile.route,
+                requestData: requestData,
                 timeout: remainingTimeout(until: deadline)
             )
             guard !DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(response)
@@ -818,14 +997,17 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let provider = activeProvider
         activeProvider = nil
         for profile in prepared.values where profile.id != provider?.profile.id {
-            await profile.connection.stop()
+            await transport.close(route: profile.route)
         }
-        await provider?.profile.connection.stop()
+        if let provider {
+            await transport.close(route: provider.profile.route)
+        }
     }
 
     package func shutdown() async {
         isShutdown = true
         await invalidate(reason: "shutdown")
+        await transport.shutdown()
     }
 
     private func preparedProvider(
@@ -889,7 +1071,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             let timeout = providerSelectionTimeout
             preparation = ProviderPreparation(
                 task: Task {
-                    try await self.openProviderConnection(
+                    try await self.openProviderRoute(
                         target: target,
                         requestTimeout: timeout
                     )
@@ -910,7 +1092,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
         providerPreparations.removeValue(forKey: target.processID)
         if isShutdown {
-            await profile.connection.stop()
+            await transport.close(route: profile.route)
             throw CancellationError()
         }
         return try await cachePreparedProvider(
@@ -1042,7 +1224,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         if let activeProvider, activeProvider.profile.id == provider.profile.id {
             self.activeProvider = nil
         }
-        await provider.profile.connection.stop()
+        await transport.close(route: provider.profile.route)
     }
 
     private func orderedTargets(
@@ -1072,7 +1254,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
     }
 
-    private func openProviderConnection(
+    private func openProviderRoute(
         target: DocumentationProviderTarget,
         requestTimeout: TimeAmount?
     ) async throws -> CandidateProfile {
@@ -1089,37 +1271,34 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         )
         let startupDeadline = Deadline.fromNow(requestTimeout ?? .seconds(30), clock: clock)
         try Task.checkCancellation()
-        let session = try await sessionFactory.startSession(for: target)
-        let connection = DocumentationProviderConnection(session: session, clock: clock)
+        let startupTimeout = remainingTimeout(until: startupDeadline)
+        guard startupTimeout?.nanoseconds != 0 else {
+            throw TimeoutError()
+        }
+        let route = try await transport.openRoute(
+            for: target,
+            requestTimeout: startupTimeout,
+            initializeParams: initializeParams
+        )
         do {
             try Task.checkCancellation()
-            await connection.start()
-            let initializeTimeout = remainingTimeout(until: startupDeadline)
-            guard initializeTimeout?.nanoseconds != 0 else {
+            guard !isShutdown else {
+                throw CancellationError()
+            }
+            guard remainingTimeout(until: startupDeadline)?.nanoseconds != 0 else {
                 throw TimeoutError()
             }
-            let initialize = try await connection.call(
-                try makeInitializeRequestData(),
-                timeout: initializeTimeout
-            )
-            let serverVersion = Self.serverVersion(fromInitializeResponse: initialize) ?? ""
-            try Task.checkCancellation()
-            try await connection.sendNotification([
-                "jsonrpc": "2.0",
-                "method": "notifications/initialized",
-            ])
-            let profile = CandidateProfile(
-                id: UUID(),
-                target: target,
-                connection: connection,
-                descriptor: nil,
-                serverVersion: serverVersion
-            )
-            return profile
         } catch {
-            await connection.stop()
+            await transport.close(route: route)
             throw error
         }
+        return CandidateProfile(
+            id: UUID(),
+            target: target,
+            route: route,
+            descriptor: nil,
+            serverVersion: route.serverVersion
+        )
     }
 
     private func profileWithDescriptor(
@@ -1131,11 +1310,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         guard toolsListTimeout?.nanoseconds != 0 else {
             throw TimeoutError()
         }
-        let toolsList = try await profile.connection.call(
-            try Self.makeToolsListRequestData(),
+        let toolsResult = try await transport.toolsList(
+            route: profile.route,
             timeout: toolsListTimeout
         )
-        let toolsResult = try Self.resultValue(from: toolsList)
         updated.descriptor = DocumentationProvider.ToolCatalog.descriptor(in: toolsResult)
         return updated
     }
@@ -1168,30 +1346,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
     }
 
-    private func makeInitializeRequestData() throws -> Data {
-        try JSONSerialization.data(
-            withJSONObject: [
-                "jsonrpc": "2.0",
-                "id": "initialize",
-                "method": "initialize",
-                "params": initializeParams.mapValues(\.foundationObject),
-            ],
-            options: []
-        )
-    }
-
-    private static func makeToolsListRequestData() throws -> Data {
-        try JSONSerialization.data(
-            withJSONObject: [
-                "jsonrpc": "2.0",
-                "id": "tools-list",
-                "method": "tools/list",
-            ],
-            options: []
-        )
-    }
-
-    private static func resultValue(from responseData: Data) throws -> JSONValue {
+    package static func resultValue(from responseData: Data) throws -> JSONValue {
         guard
             let object = try JSONSerialization.jsonObject(with: responseData, options: [])
                 as? [String: Any],
@@ -1203,7 +1358,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         return value
     }
 
-    private static func serverVersion(fromInitializeResponse data: Data) -> String? {
+    package static func serverVersion(fromInitializeResponse data: Data) -> String? {
         guard
             let object = try? JSONSerialization.jsonObject(with: data, options: [])
                 as? [String: Any],

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -423,21 +423,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let task: Task<CandidateProfile, Error>
     }
 
-    private struct DescriptorUnavailable: Error {}
-
     private struct PreparationWaitTimedOut: Error {}
-
-    private struct TargetIdentity: Hashable, Sendable {
-        let processID: pid_t
-        let appPath: String
-        let xcodeVersion: String
-
-        init(_ target: DocumentationProviderTarget) {
-            self.processID = target.processID
-            self.appPath = target.appPath
-            self.xcodeVersion = target.xcodeVersion
-        }
-    }
 
     private final class PreparationWaiter: @unchecked Sendable {
         private let lock = NSLock()
@@ -503,7 +489,6 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     private var preparedProviders: [pid_t: CandidateProfile] = [:]
     private var providerPreparations: [pid_t: ProviderPreparation] = [:]
     private var unusableProcessIDs: Set<pid_t> = []
-    private var descriptorMissingTargets: Set<TargetIdentity> = []
     private var isShutdown = false
 
     package init(
@@ -553,6 +538,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 if let descriptor = profile.descriptor {
                     return .available(descriptor)
                 }
+                return toolListUpdateFromCachedState(requestTimeout: requestTimeout)
             } catch is CancellationError {
                 return .unavailable
             } catch {
@@ -606,10 +592,6 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         if targetIDs.isSubset(of: unusableProcessIDs) {
             return .unavailable
         }
-        let targetIdentities = Set(targets.map(TargetIdentity.init))
-        if targetIdentities.isSubset(of: descriptorMissingTargets) {
-            return .unavailable
-        }
         return .unchanged
     }
 
@@ -634,8 +616,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 let fallbackTargets = orderedTargets(
                     excluding: rejectedProcessIDs
                         .union(unusableProcessIDs)
-                        .union([activeProvider.profile.target.processID]),
-                    includeDescriptorMissing: false
+                        .union([activeProvider.profile.target.processID])
                 )
                 let activeDeadline = makeDeadline(
                     fromTimeout: timeoutForCandidate(
@@ -668,8 +649,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             }
 
             let targets = orderedTargets(
-                excluding: rejectedProcessIDs.union(unusableProcessIDs),
-                includeDescriptorMissing: false
+                excluding: rejectedProcessIDs.union(unusableProcessIDs)
             )
             guard targets.isEmpty == false else {
                 try Task.checkCancellation()
@@ -814,7 +794,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     ) async throws -> CandidateProfile {
         if let activeProvider, activeProvider.profile.target.processID == target.processID {
             if fetchDescriptor, activeProvider.profile.descriptor == nil {
-                let updated = try await profileWithRequiredDescriptor(
+                let updated = await profileByRefreshingDescriptor(
                     activeProvider.profile,
                     requestTimeout: requestTimeout
                 )
@@ -834,7 +814,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
         if var prepared = preparedProviders[target.processID] {
             if fetchDescriptor, prepared.descriptor == nil {
-                let updated = try await profileWithRequiredDescriptor(
+                let updated = await profileByRefreshingDescriptor(
                     prepared,
                     requestTimeout: requestTimeout
                 )
@@ -906,7 +886,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     ) async throws -> CandidateProfile {
         if let activeProvider, activeProvider.profile.id == profile.id {
             if fetchDescriptor, activeProvider.profile.descriptor == nil {
-                let updated = try await profileWithRequiredDescriptor(
+                let updated = await profileByRefreshingDescriptor(
                     activeProvider.profile,
                     requestTimeout: requestTimeout
                 )
@@ -919,7 +899,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             prepared.id == profile.id
         {
             if fetchDescriptor, prepared.descriptor == nil {
-                let updated = try await profileWithRequiredDescriptor(
+                let updated = await profileByRefreshingDescriptor(
                     prepared,
                     requestTimeout: requestTimeout
                 )
@@ -932,7 +912,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         var prepared = profile
         preparedProviders[profile.target.processID] = prepared
         if fetchDescriptor, prepared.descriptor == nil {
-            prepared = try await profileWithRequiredDescriptor(
+            prepared = await profileByRefreshingDescriptor(
                 prepared,
                 requestTimeout: requestTimeout
             )
@@ -1025,8 +1005,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     }
 
     private func orderedTargets(
-        excluding excludedProcessIDs: Set<pid_t>,
-        includeDescriptorMissing: Bool = true
+        excluding excludedProcessIDs: Set<pid_t>
     ) -> [DocumentationProviderTarget] {
         let discoveredTargets = discovery.runningXcodeTargets()
         let filtered: [DocumentationProviderTarget]
@@ -1034,12 +1013,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             filtered = discoveredTargets.filter {
                 $0.processID == pinnedProcessID
                     && excludedProcessIDs.contains($0.processID) == false
-                    && (includeDescriptorMissing || descriptorMissingTargets.contains(TargetIdentity($0)) == false)
             }
         } else {
             filtered = discoveredTargets.filter {
                 excludedProcessIDs.contains($0.processID) == false
-                    && (includeDescriptorMissing || descriptorMissingTargets.contains(TargetIdentity($0)) == false)
             }
         }
         return filtered.sorted { lhs, rhs in
@@ -1122,34 +1099,32 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         return updated
     }
 
-    private func profileWithRequiredDescriptor(
+    private func profileByRefreshingDescriptor(
         _ profile: CandidateProfile,
         requestTimeout: TimeAmount?
-    ) async throws -> CandidateProfile {
-        let updated = try await profileWithDescriptor(profile, requestTimeout: requestTimeout)
-        guard updated.descriptor != nil else {
-            await markDescriptorMissingAndStopIfUnused(updated)
-            throw DescriptorUnavailable()
+    ) async -> CandidateProfile {
+        do {
+            let updated = try await profileWithDescriptor(profile, requestTimeout: requestTimeout)
+            if updated.descriptor == nil {
+                logger.debug(
+                    "Documentation provider descriptor missing from tools/list",
+                    metadata: [
+                        "pid": .string("\(profile.target.processID)"),
+                        "app_path": .string(profile.target.appPath),
+                        "xcode_version": .string(profile.target.xcodeVersion),
+                    ]
+                )
+            }
+            return updated
+        } catch is CancellationError {
+            return profile
+        } catch {
+            logger.debug(
+                "Documentation provider descriptor refresh failed",
+                metadata: candidateLogMetadata(target: profile.target, error: error)
+            )
+            return profile
         }
-        descriptorMissingTargets.remove(TargetIdentity(updated.target))
-        return updated
-    }
-
-    private func markDescriptorMissingAndStopIfUnused(_ profile: CandidateProfile) async {
-        let identity = TargetIdentity(profile.target)
-        descriptorMissingTargets.insert(identity)
-        if activeProvider?.profile.id == profile.id {
-            preparedProviders.removeValue(forKey: profile.target.processID)
-            return
-        }
-        if let prepared = preparedProviders[profile.target.processID],
-            prepared.id == profile.id
-        {
-            preparedProviders.removeValue(forKey: profile.target.processID)
-            await prepared.connection.stop()
-            return
-        }
-        await profile.connection.stop()
     }
 
     private func makeInitializeRequestData() throws -> Data {

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -57,7 +57,7 @@ extension DocumentationProvider {
 }
 
 package protocol DocumentationProviderManaging: Sendable {
-    func prewarm(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate
+    func startBackgroundDiscovery(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate
     func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate
     func callDocumentationSearch(
         requestData: Data,
@@ -107,13 +107,6 @@ extension DocumentationProvider {
                 return normalized.contains("documentationsearch")
                     && normalized.contains("not enabled")
             }
-        }
-
-        package static func responseIsToolError(_ data: Data) -> Bool {
-            responseErrorObjects(in: data).isEmpty == false
-                || responseResultObjects(in: data).contains { object in
-                    object["isError"] as? Bool == true
-                }
         }
 
         private static func replacingDocumentationSearch(
@@ -418,8 +411,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let id: UUID
         let target: DocumentationProviderTarget
         let connection: DocumentationProviderConnection
-        let descriptor: JSONValue
-        let toolCount: Int
+        var descriptor: JSONValue?
         let serverVersion: String
     }
 
@@ -427,45 +419,76 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let profile: CandidateProfile
     }
 
-    private struct ProviderSelection: Sendable {
-        let id: UUID
-        let task: Task<CandidateProfile?, Never>
+    private struct ProviderPreparation: Sendable {
+        let task: Task<CandidateProfile, Error>
     }
 
-    private enum ProviderSelectionWaitResult: Sendable {
-        case completed(CandidateProfile?)
-        case timedOut
+    private struct DescriptorUnavailable: Error {}
+
+    private struct PreparationWaitTimedOut: Error {}
+
+    private struct TargetIdentity: Hashable, Sendable {
+        let processID: pid_t
+        let appPath: String
+        let xcodeVersion: String
+
+        init(_ target: DocumentationProviderTarget) {
+            self.processID = target.processID
+            self.appPath = target.appPath
+            self.xcodeVersion = target.xcodeVersion
+        }
     }
 
-    private final class ProviderSelectionWaitState: @unchecked Sendable {
+    private final class PreparationWaiter: @unchecked Sendable {
         private let lock = NSLock()
-        private var continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>?
-        private var resolvedResult: ProviderSelectionWaitResult?
+        private var continuation: CheckedContinuation<CandidateProfile, Error>?
+        private var tasks: [Task<Void, Never>] = []
+        private var resolved = false
 
-        func setContinuation(
-            _ continuation: CheckedContinuation<ProviderSelectionWaitResult, Never>
-        ) {
+        func setContinuation(_ continuation: CheckedContinuation<CandidateProfile, Error>) {
             lock.lock()
-            if let resolvedResult {
+            if resolved {
                 lock.unlock()
-                continuation.resume(returning: resolvedResult)
+                continuation.resume(throwing: CancellationError())
                 return
             }
             self.continuation = continuation
             lock.unlock()
         }
 
-        func resume(_ result: ProviderSelectionWaitResult) {
+        func addTask(_ task: Task<Void, Never>) {
             lock.lock()
-            guard resolvedResult == nil else {
+            if resolved {
+                lock.unlock()
+                task.cancel()
+                return
+            }
+            tasks.append(task)
+            lock.unlock()
+        }
+
+        func resume(_ result: Result<CandidateProfile, Error>) {
+            lock.lock()
+            guard resolved == false else {
                 lock.unlock()
                 return
             }
-            resolvedResult = result
+            resolved = true
             let continuation = continuation
             self.continuation = nil
+            let tasks = tasks
+            self.tasks.removeAll()
             lock.unlock()
-            continuation?.resume(returning: result)
+
+            for task in tasks {
+                task.cancel()
+            }
+            switch result {
+            case .success(let profile):
+                continuation?.resume(returning: profile)
+            case .failure(let error):
+                continuation?.resume(throwing: error)
+            }
         }
     }
 
@@ -477,7 +500,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     private let clock: ClockClient
     private let logger: Logger
     private var activeProvider: ActiveProvider?
-    private var providerSelection: ProviderSelection?
+    private var preparedProviders: [pid_t: CandidateProfile] = [:]
+    private var providerPreparations: [pid_t: ProviderPreparation] = [:]
+    private var unusableProcessIDs: Set<pid_t> = []
+    private var descriptorMissingTargets: Set<TargetIdentity> = []
     private var isShutdown = false
 
     package init(
@@ -499,10 +525,45 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         self.logger = logger
     }
 
-    package func prewarm(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate
+    package func startBackgroundDiscovery(requestTimeout: TimeAmount?) async
+        -> DocumentationProvider.ToolListUpdate
     {
         guard !isShutdown else { return .unavailable }
-        return await toolListUpdate(requestTimeout: requestTimeout)
+        guard requestTimeout?.nanoseconds != 0 else {
+            return .unavailable
+        }
+        let deadline = Deadline.fromNow(requestTimeout, clock: clock)
+        let targets = orderedTargets(excluding: [])
+        guard targets.isEmpty == false else {
+            return .unavailable
+        }
+        for target in targets {
+            guard !Task.isCancelled, !isShutdown else {
+                return .unavailable
+            }
+            guard unusableProcessIDs.contains(target.processID) == false else {
+                continue
+            }
+            do {
+                let profile = try await preparedProvider(
+                    for: target,
+                    requestTimeout: remainingTimeout(until: deadline),
+                    fetchDescriptor: true
+                )
+                if let descriptor = profile.descriptor {
+                    return .available(descriptor)
+                }
+            } catch is CancellationError {
+                return .unavailable
+            } catch {
+                logger.debug(
+                    "Documentation provider background discovery candidate rejected",
+                    metadata: candidateLogMetadata(target: target, error: error)
+                )
+                continue
+            }
+        }
+        return toolListUpdateFromCachedState(requestTimeout: requestTimeout)
     }
 
     package func toolListUpdate(requestTimeout: TimeAmount?) async
@@ -517,10 +578,39 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         guard !Task.isCancelled else {
             return .unavailable
         }
-        guard let provider = await providerIfAvailable(requestTimeout: requestTimeout) else {
+        return toolListUpdateFromCachedState(requestTimeout: requestTimeout)
+    }
+
+    private func toolListUpdateFromCachedState(requestTimeout: TimeAmount?)
+        -> DocumentationProvider.ToolListUpdate
+    {
+        guard requestTimeout?.nanoseconds != 0 else {
             return .unavailable
         }
-        return .available(provider.profile.descriptor)
+        if let activeProvider {
+            guard let descriptor = activeProvider.profile.descriptor else {
+                return .unchanged
+            }
+            return .available(descriptor)
+        }
+        let targets = orderedTargets(excluding: [])
+        guard targets.isEmpty == false else {
+            return .unavailable
+        }
+        for target in targets {
+            if let descriptor = preparedProviders[target.processID]?.descriptor {
+                return .available(descriptor)
+            }
+        }
+        let targetIDs = Set(targets.map(\.processID))
+        if targetIDs.isSubset(of: unusableProcessIDs) {
+            return .unavailable
+        }
+        let targetIdentities = Set(targets.map(TargetIdentity.init))
+        if targetIdentities.isSubset(of: descriptorMissingTargets) {
+            return .unavailable
+        }
+        return .unchanged
     }
 
     package func callDocumentationSearch(
@@ -538,59 +628,158 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             if let deadline, deadline.hasExpired {
                 return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
             }
-            guard
-                let provider = await providerIfAvailable(
-                    requestTimeout: deadline?.remaining(),
-                    excluding: rejectedProcessIDs
-                )
-            else {
+            if let activeProvider,
+                rejectedProcessIDs.contains(activeProvider.profile.target.processID) == false
+            {
+                switch try await attemptDocumentationSearch(
+                    requestData: requestData,
+                    provider: activeProvider,
+                    deadline: deadline
+                ) {
+                case .success(let data):
+                    return .handled(data, invalidatedProvider: invalidatedProvider)
+                case .rejected(let processID, let permanentlyUnusable):
+                    rejectedProcessIDs.insert(processID)
+                    invalidatedProvider = true
+                    if permanentlyUnusable {
+                        unusableProcessIDs.insert(processID)
+                    }
+                    continue
+                case .failed(let error):
+                    if let deadline, deadline.hasExpired {
+                        return .failed(error, invalidatedProvider: invalidatedProvider)
+                    }
+                    rejectedProcessIDs.insert(activeProvider.profile.target.processID)
+                    invalidatedProvider = true
+                    continue
+                }
+            }
+
+            let targets = orderedTargets(
+                excluding: rejectedProcessIDs.union(unusableProcessIDs),
+                includeDescriptorMissing: false
+            )
+            guard targets.isEmpty == false else {
                 try Task.checkCancellation()
                 if let deadline, deadline.hasExpired {
                     return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
                 }
                 return .unavailable(.noAvailableProvider)
             }
-            if let deadline, deadline.hasExpired {
-                return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
-            }
-            do {
-                let response = try await provider.profile.connection.call(
-                    requestData,
-                    timeout: deadline?.remaining()
-                )
-                guard DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(response)
-                else {
-                    return .handled(response, invalidatedProvider: invalidatedProvider)
-                }
-                await invalidate(provider, reason: "documentation_search_not_enabled")
-                rejectedProcessIDs.insert(provider.profile.target.processID)
-                invalidatedProvider = true
-                try Task.checkCancellation()
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                try Task.checkCancellation()
-                await invalidate(provider, reason: "documentation_provider_call_failed")
-                rejectedProcessIDs.insert(provider.profile.target.processID)
-                invalidatedProvider = true
+
+            var progressed = false
+            for target in targets {
                 if let deadline, deadline.hasExpired {
-                    return .failed(error, invalidatedProvider: invalidatedProvider)
+                    return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
                 }
+                do {
+                    let profile = try await preparedProvider(
+                        for: target,
+                        requestTimeout: remainingTimeout(until: deadline),
+                        fetchDescriptor: false
+                    )
+                    let provider = ActiveProvider(profile: profile)
+                    switch try await attemptDocumentationSearch(
+                        requestData: requestData,
+                        provider: provider,
+                        deadline: deadline
+                    ) {
+                    case .success(let data):
+                        activeProvider = provider
+                        preparedProviders.removeValue(forKey: target.processID)
+                        logger.info(
+                            "Selected documentation provider",
+                            metadata: [
+                                "pid": .string("\(target.processID)"),
+                                "app_path": .string(target.appPath),
+                                "xcode_version": .string(target.xcodeVersion),
+                                "server_version": .string(profile.serverVersion),
+                            ]
+                        )
+                        return .handled(data, invalidatedProvider: invalidatedProvider)
+                    case .rejected(let processID, let permanentlyUnusable):
+                        rejectedProcessIDs.insert(processID)
+                        invalidatedProvider = true
+                        progressed = true
+                        if permanentlyUnusable {
+                            unusableProcessIDs.insert(processID)
+                        }
+                        continue
+                    case .failed(let error):
+                        rejectedProcessIDs.insert(target.processID)
+                        invalidatedProvider = true
+                        progressed = true
+                        if let deadline, deadline.hasExpired {
+                            return .failed(error, invalidatedProvider: invalidatedProvider)
+                        }
+                        continue
+                    }
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    try Task.checkCancellation()
+                    rejectedProcessIDs.insert(target.processID)
+                    invalidatedProvider = true
+                    progressed = true
+                    if let deadline, deadline.hasExpired {
+                        return .failed(error, invalidatedProvider: invalidatedProvider)
+                    }
+                    logger.debug(
+                        "Documentation provider candidate rejected before user request",
+                        metadata: candidateLogMetadata(target: target, error: error)
+                    )
+                }
+            }
+            if !progressed {
+                return .unavailable(.noAvailableProvider)
             }
         }
         throw CancellationError()
     }
 
+    private enum DocumentationAttemptResult: Sendable {
+        case success(Data)
+        case rejected(processID: pid_t, permanentlyUnusable: Bool)
+        case failed(any Error)
+    }
+
+    private func attemptDocumentationSearch(
+        requestData: Data,
+        provider: ActiveProvider,
+        deadline: Deadline?
+    ) async throws -> DocumentationAttemptResult {
+        let processID = provider.profile.target.processID
+        do {
+            let response = try await provider.profile.connection.call(
+                requestData,
+                timeout: remainingTimeout(until: deadline)
+            )
+            guard !DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(response)
+            else {
+                await invalidate(provider, reason: "documentation_search_tool_error")
+                return .rejected(processID: processID, permanentlyUnusable: true)
+            }
+            return .success(response)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            await invalidate(provider, reason: "documentation_provider_call_failed")
+            return .failed(error)
+        }
+    }
+
     package func invalidate(reason _: String) async {
-        let selection = providerSelection
-        providerSelection = nil
-        selection?.task.cancel()
+        let preparations = providerPreparations
+        providerPreparations.removeAll()
+        for preparation in preparations.values {
+            preparation.task.cancel()
+        }
+        let prepared = preparedProviders
+        preparedProviders.removeAll()
         let provider = activeProvider
         activeProvider = nil
-        if let selected = await selection?.task.value,
-            selected.id != provider?.profile.id
-        {
-            await selected.connection.stop()
+        for profile in prepared.values where profile.id != provider?.profile.id {
+            await profile.connection.stop()
         }
         await provider?.profile.connection.stop()
     }
@@ -600,274 +789,276 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         await invalidate(reason: "shutdown")
     }
 
-    private func providerIfAvailable(
+    private func preparedProvider(
+        for target: DocumentationProviderTarget,
         requestTimeout: TimeAmount?,
-        excluding excludedProcessIDs: Set<pid_t> = []
-    ) async -> ActiveProvider? {
-        guard !isShutdown else {
-            return nil
-        }
-        if let activeProvider {
-            if excludedProcessIDs.contains(activeProvider.profile.target.processID) {
-                self.activeProvider = nil
-                await activeProvider.profile.connection.stop()
-            } else {
-                return activeProvider
+        fetchDescriptor: Bool
+    ) async throws -> CandidateProfile {
+        if let activeProvider, activeProvider.profile.target.processID == target.processID {
+            if fetchDescriptor, activeProvider.profile.descriptor == nil {
+                let updated = try await profileWithRequiredDescriptor(
+                    activeProvider.profile,
+                    requestTimeout: requestTimeout
+                )
+                if let current = self.activeProvider,
+                    current.profile.id == updated.id
+                {
+                    let merged = profileByPreferringDescriptor(
+                        primary: current.profile,
+                        fallback: updated
+                    )
+                    self.activeProvider = ActiveProvider(profile: merged)
+                    return merged
+                }
+                return updated
             }
+            return activeProvider.profile
         }
-        let selection: ProviderSelection
-        let selectionIsShared: Bool
-        if let providerSelection, excludedProcessIDs.isEmpty {
-            selection = providerSelection
-            selectionIsShared = true
+        if var prepared = preparedProviders[target.processID] {
+            if fetchDescriptor, prepared.descriptor == nil {
+                let updated = try await profileWithRequiredDescriptor(
+                    prepared,
+                    requestTimeout: requestTimeout
+                )
+                if let activeProvider, activeProvider.profile.id == updated.id {
+                    let merged = profileByPreferringDescriptor(
+                        primary: activeProvider.profile,
+                        fallback: updated
+                    )
+                    self.activeProvider = ActiveProvider(profile: merged)
+                    return merged
+                }
+                if let cached = preparedProviders[target.processID],
+                    cached.id == updated.id
+                {
+                    let merged = profileByPreferringDescriptor(
+                        primary: cached,
+                        fallback: updated
+                    )
+                    preparedProviders[target.processID] = merged
+                    return merged
+                }
+                prepared = updated
+                preparedProviders[target.processID] = prepared
+            }
+            return prepared
+        }
+        let preparation: ProviderPreparation
+        if let existing = providerPreparations[target.processID] {
+            preparation = existing
         } else {
-            let selectionTimeout = providerSelectionTimeout
-            selection = ProviderSelection(
-                id: UUID(),
+            let timeout = providerSelectionTimeout
+            preparation = ProviderPreparation(
                 task: Task {
-                    await self.selectProvider(
-                        requestTimeout: selectionTimeout,
-                        excluding: excludedProcessIDs
+                    try await self.openProviderConnection(
+                        target: target,
+                        requestTimeout: timeout
                     )
                 }
             )
-            selectionIsShared = excludedProcessIDs.isEmpty
-            if selectionIsShared {
-                providerSelection = selection
-            }
+            providerPreparations[target.processID] = preparation
         }
-
-        let waitResult = await waitForSelection(selection, requestTimeout: requestTimeout)
-        let selected: CandidateProfile?
-        switch waitResult {
-        case .completed(let profile):
-            selected = profile
-        case .timedOut:
-            return nil
+        let profile: CandidateProfile
+        do {
+            profile = try await waitForPreparation(preparation, requestTimeout: requestTimeout)
+        } catch is PreparationWaitTimedOut {
+            throw TimeoutError()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            providerPreparations.removeValue(forKey: target.processID)
+            throw error
         }
-        let selectionIsCurrent = selectionIsShared ? providerSelection?.id == selection.id : true
-        if selectionIsShared, selectionIsCurrent {
-            providerSelection = nil
-        }
-
+        providerPreparations.removeValue(forKey: target.processID)
         if isShutdown {
-            if let selected {
-                await selected.connection.stop()
-            }
-            return nil
+            await profile.connection.stop()
+            throw CancellationError()
         }
-
-        if let activeProvider {
-            if let selected, selected.id != activeProvider.profile.id {
-                await selected.connection.stop()
-            }
-            return activeProvider
-        }
-
-        guard selectionIsCurrent else {
-            if let selected {
-                await selected.connection.stop()
-            }
-            return nil
-        }
-        guard let selected else {
-            return nil
-        }
-        let provider = ActiveProvider(profile: selected)
-        activeProvider = provider
-        return provider
+        return try await cachePreparedProvider(
+            profile,
+            requestTimeout: requestTimeout,
+            fetchDescriptor: fetchDescriptor
+        )
     }
 
-    private func waitForSelection(
-        _ selection: ProviderSelection,
-        requestTimeout: TimeAmount?
-    ) async -> ProviderSelectionWaitResult {
-        guard !Task.isCancelled else {
-            return .timedOut
-        }
-
-        let state = ProviderSelectionWaitState()
-        let selectionWaitTask = Task {
-            let profile = await selection.task.value
-            state.resume(.completed(profile))
-        }
-        let clock = clock
-        let timeoutTask: Task<Void, Never>?
-        if let requestTimeout, requestTimeout.nanoseconds > 0 {
-            timeoutTask = Task {
-                await clock.sleep(.nanoseconds(requestTimeout.nanoseconds))
-                guard Task.isCancelled == false else {
-                    return
-                }
-                state.resume(.timedOut)
+    private func cachePreparedProvider(
+        _ profile: CandidateProfile,
+        requestTimeout: TimeAmount?,
+        fetchDescriptor: Bool
+    ) async throws -> CandidateProfile {
+        if let activeProvider, activeProvider.profile.id == profile.id {
+            if fetchDescriptor, activeProvider.profile.descriptor == nil {
+                let updated = try await profileWithRequiredDescriptor(
+                    activeProvider.profile,
+                    requestTimeout: requestTimeout
+                )
+                self.activeProvider = ActiveProvider(profile: updated)
+                return updated
             }
-        } else {
-            timeoutTask = nil
+            return activeProvider.profile
+        }
+        if let prepared = preparedProviders[profile.target.processID],
+            prepared.id == profile.id
+        {
+            if fetchDescriptor, prepared.descriptor == nil {
+                let updated = try await profileWithRequiredDescriptor(
+                    prepared,
+                    requestTimeout: requestTimeout
+                )
+                preparedProviders[profile.target.processID] = updated
+                return updated
+            }
+            return prepared
         }
 
-        let result = await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                state.setContinuation(continuation)
+        var prepared = profile
+        preparedProviders[profile.target.processID] = prepared
+        if fetchDescriptor, prepared.descriptor == nil {
+            prepared = try await profileWithRequiredDescriptor(
+                prepared,
+                requestTimeout: requestTimeout
+            )
+            if let activeProvider, activeProvider.profile.id == profile.id {
+                let merged = profileByPreferringDescriptor(
+                    primary: activeProvider.profile,
+                    fallback: prepared
+                )
+                self.activeProvider = ActiveProvider(profile: merged)
+                return merged
+            }
+            if let cached = preparedProviders[profile.target.processID],
+                cached.id == profile.id
+            {
+                let merged = profileByPreferringDescriptor(primary: cached, fallback: prepared)
+                preparedProviders[profile.target.processID] = merged
+                return merged
+            }
+        }
+
+        if let cached = preparedProviders[profile.target.processID],
+            cached.id == profile.id
+        {
+            let merged = profileByPreferringDescriptor(primary: cached, fallback: prepared)
+            preparedProviders[profile.target.processID] = merged
+            return merged
+        }
+        preparedProviders[profile.target.processID] = prepared
+        return prepared
+    }
+
+    private func profileByPreferringDescriptor(
+        primary: CandidateProfile,
+        fallback: CandidateProfile
+    ) -> CandidateProfile {
+        guard primary.descriptor == nil, fallback.descriptor != nil else {
+            return primary
+        }
+        var merged = primary
+        merged.descriptor = fallback.descriptor
+        return merged
+    }
+
+    private func waitForPreparation(
+        _ preparation: ProviderPreparation,
+        requestTimeout: TimeAmount?
+    ) async throws -> CandidateProfile {
+        guard let requestTimeout else {
+            return try await preparation.task.value
+        }
+        guard requestTimeout.nanoseconds > 0 else {
+            throw PreparationWaitTimedOut()
+        }
+        let waiter = PreparationWaiter()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiter.setContinuation(continuation)
+                waiter.addTask(Task {
+                    do {
+                        let profile = try await preparation.task.value
+                        waiter.resume(.success(profile))
+                    } catch {
+                        waiter.resume(.failure(error))
+                    }
+                })
+                let clock = clock
+                waiter.addTask(Task {
+                    await clock.sleep(.nanoseconds(requestTimeout.nanoseconds))
+                    guard Task.isCancelled == false else {
+                        return
+                    }
+                    waiter.resume(.failure(PreparationWaitTimedOut()))
+                })
             }
         } onCancel: {
-            state.resume(.timedOut)
+            waiter.resume(.failure(CancellationError()))
         }
-        selectionWaitTask.cancel()
-        timeoutTask?.cancel()
-        return result
     }
 
     private func invalidate(_ provider: ActiveProvider, reason _: String) async {
-        guard let activeProvider, activeProvider.profile.id == provider.profile.id else {
-            await provider.profile.connection.stop()
-            return
+        if let prepared = preparedProviders[provider.profile.target.processID],
+            prepared.id == provider.profile.id
+        {
+            preparedProviders.removeValue(forKey: provider.profile.target.processID)
         }
-        self.activeProvider = nil
+        if let activeProvider, activeProvider.profile.id == provider.profile.id {
+            self.activeProvider = nil
+        }
         await provider.profile.connection.stop()
     }
 
-    private func selectProvider(
-        requestTimeout: TimeAmount?,
-        excluding excludedProcessIDs: Set<pid_t> = []
-    ) async -> CandidateProfile? {
-        guard !isShutdown else {
-            return nil
-        }
-        let selectionDeadline = Deadline.fromNow(requestTimeout, clock: clock)
+    private func orderedTargets(
+        excluding excludedProcessIDs: Set<pid_t>,
+        includeDescriptorMissing: Bool = true
+    ) -> [DocumentationProviderTarget] {
         let discoveredTargets = discovery.runningXcodeTargets()
-        let targets: [DocumentationProviderTarget]
+        let filtered: [DocumentationProviderTarget]
         if let pinnedProcessID {
-            targets = discoveredTargets.filter {
+            filtered = discoveredTargets.filter {
                 $0.processID == pinnedProcessID
                     && excludedProcessIDs.contains($0.processID) == false
+                    && (includeDescriptorMissing || descriptorMissingTargets.contains(TargetIdentity($0)) == false)
             }
         } else {
-            targets = discoveredTargets.filter {
+            filtered = discoveredTargets.filter {
                 excludedProcessIDs.contains($0.processID) == false
+                    && (includeDescriptorMissing || descriptorMissingTargets.contains(TargetIdentity($0)) == false)
             }
+        }
+        return filtered.sorted { lhs, rhs in
+            let versionComparison = Self.compareVersion(lhs.xcodeVersion, rhs.xcodeVersion)
+            if versionComparison != .orderedSame {
+                return versionComparison == .orderedDescending
+            }
+            if lhs.appPath != rhs.appPath {
+                return lhs.appPath < rhs.appPath
+            }
+            return lhs.processID < rhs.processID
+        }
+    }
+
+    private func openProviderConnection(
+        target: DocumentationProviderTarget,
+        requestTimeout: TimeAmount?
+    ) async throws -> CandidateProfile {
+        guard !isShutdown else {
+            throw CancellationError()
         }
         logger.debug(
-            "Selecting documentation provider from running Xcode processes",
+            "Preparing documentation provider candidate",
             metadata: [
-                "candidate_count": .string("\(targets.count)"),
-                "discovered_candidate_count": .string("\(discoveredTargets.count)"),
-                "excluded_candidate_count": .string("\(excludedProcessIDs.count)"),
-                "pinned_pid": .string(pinnedProcessID.map(String.init) ?? ""),
-                "candidates": .string(
-                    targets.map { "\($0.processID):\($0.appPath)" }.joined(separator: ",")),
+                "pid": .string("\(target.processID)"),
+                "app_path": .string(target.appPath),
+                "xcode_version": .string(target.xcodeVersion),
             ]
         )
-        var profiles: [CandidateProfile] = []
-        for (index, target) in targets.enumerated() {
-            guard !Task.isCancelled, !isShutdown else {
-                break
-            }
-            let candidateTimeout = candidateProbeTimeout(
-                until: selectionDeadline,
-                remainingCandidateCount: targets.count - index
-            )
-            if candidateTimeout?.nanoseconds == 0 {
-                break
-            }
-            do {
-                let profile = try await boundedProbe(
-                    target: target, requestTimeout: candidateTimeout)
-                guard !Task.isCancelled, !isShutdown else {
-                    await profile.connection.stop()
-                    break
-                }
-                profiles.append(profile)
-            } catch is CancellationError {
-                break
-            } catch {
-                logger.debug(
-                    "Documentation provider candidate rejected",
-                    metadata: [
-                        "pid": .string("\(target.processID)"),
-                        "app_path": .string(target.appPath),
-                        "error": .string(String(describing: error)),
-                    ]
-                )
-                continue
-            }
-        }
-
-        if Task.isCancelled || isShutdown {
-            for profile in profiles {
-                await profile.connection.stop()
-            }
-            return nil
-        }
-
-        guard
-            let selected = profiles.max(by: { lhs, rhs in
-                if lhs.toolCount != rhs.toolCount {
-                    return lhs.toolCount < rhs.toolCount
-                }
-                return Self.compareVersion(lhs.serverVersion, rhs.serverVersion)
-                    == .orderedAscending
-            })
-        else {
-            return nil
-        }
-
-        for profile in profiles where profile.target != selected.target {
-            await profile.connection.stop()
-        }
-        logger.info(
-            "Selected documentation provider",
-            metadata: [
-                "pid": .string("\(selected.target.processID)"),
-                "app_path": .string(selected.target.appPath),
-                "server_version": .string(selected.serverVersion),
-                "tool_count": .string("\(selected.toolCount)"),
-            ]
-        )
-        return selected
-    }
-
-    private func boundedProbe(
-        target: DocumentationProviderTarget,
-        requestTimeout: TimeAmount?
-    ) async throws -> CandidateProfile {
-        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
-            return try await probe(target: target, requestTimeout: requestTimeout)
-        }
-        return try await withThrowingTaskGroup(of: CandidateProfile.self) { group in
-            group.addTask {
-                try await self.probe(target: target, requestTimeout: requestTimeout)
-            }
-            let clock = clock
-            group.addTask {
-                await clock.sleep(.nanoseconds(requestTimeout.nanoseconds))
-                try Task.checkCancellation()
-                throw TimeoutError()
-            }
-            do {
-                guard let result = try await group.next() else {
-                    throw UpstreamSlotScheduler.AcquisitionError.unavailable
-                }
-                group.cancelAll()
-                return result
-            } catch {
-                group.cancelAll()
-                throw error
-            }
-        }
-    }
-
-    private func probe(
-        target: DocumentationProviderTarget,
-        requestTimeout: TimeAmount?
-    ) async throws -> CandidateProfile {
-        let probeDeadline = Deadline.fromNow(requestTimeout ?? .seconds(30), clock: clock)
+        let startupDeadline = Deadline.fromNow(requestTimeout ?? .seconds(30), clock: clock)
         try Task.checkCancellation()
         let session = try await sessionFactory.startSession(for: target)
         let connection = DocumentationProviderConnection(session: session, clock: clock)
         do {
             try Task.checkCancellation()
             await connection.start()
-            let initializeTimeout = remainingTimeout(until: probeDeadline)
+            let initializeTimeout = remainingTimeout(until: startupDeadline)
             guard initializeTimeout?.nanoseconds != 0 else {
                 throw TimeoutError()
             }
@@ -881,45 +1072,66 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 "jsonrpc": "2.0",
                 "method": "notifications/initialized",
             ])
-            let toolsListTimeout = remainingTimeout(until: probeDeadline)
-            guard toolsListTimeout?.nanoseconds != 0 else {
-                throw TimeoutError()
-            }
-            let toolsList = try await connection.call(
-                try Self.makeToolsListRequestData(),
-                timeout: toolsListTimeout
-            )
-            let toolsResult = try Self.resultValue(from: toolsList)
-            guard let descriptor = DocumentationProvider.ToolCatalog.descriptor(in: toolsResult)
-            else {
-                throw UpstreamSlotScheduler.AcquisitionError.unavailable
-            }
-            let documentationProbeTimeout = remainingTimeout(until: probeDeadline)
-            guard documentationProbeTimeout?.nanoseconds != 0 else {
-                throw TimeoutError()
-            }
-            let probeResponse = try await connection.call(
-                try Self.makeDocumentationProbeRequestData(),
-                timeout: documentationProbeTimeout
-            )
-            guard
-                !DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(probeResponse),
-                !DocumentationProvider.ToolCatalog.responseIsToolError(probeResponse)
-            else {
-                throw UpstreamSlotScheduler.AcquisitionError.unavailable
-            }
-            return CandidateProfile(
+            let profile = CandidateProfile(
                 id: UUID(),
                 target: target,
                 connection: connection,
-                descriptor: descriptor,
-                toolCount: Self.toolCount(in: toolsResult),
+                descriptor: nil,
                 serverVersion: serverVersion
             )
+            return profile
         } catch {
             await connection.stop()
             throw error
         }
+    }
+
+    private func profileWithDescriptor(
+        _ profile: CandidateProfile,
+        requestTimeout: TimeAmount?
+    ) async throws -> CandidateProfile {
+        var updated = profile
+        let toolsListTimeout = requestTimeout
+        guard toolsListTimeout?.nanoseconds != 0 else {
+            throw TimeoutError()
+        }
+        let toolsList = try await profile.connection.call(
+            try Self.makeToolsListRequestData(),
+            timeout: toolsListTimeout
+        )
+        let toolsResult = try Self.resultValue(from: toolsList)
+        updated.descriptor = DocumentationProvider.ToolCatalog.descriptor(in: toolsResult)
+        return updated
+    }
+
+    private func profileWithRequiredDescriptor(
+        _ profile: CandidateProfile,
+        requestTimeout: TimeAmount?
+    ) async throws -> CandidateProfile {
+        let updated = try await profileWithDescriptor(profile, requestTimeout: requestTimeout)
+        guard updated.descriptor != nil else {
+            await markDescriptorMissingAndStopIfUnused(updated)
+            throw DescriptorUnavailable()
+        }
+        descriptorMissingTargets.remove(TargetIdentity(updated.target))
+        return updated
+    }
+
+    private func markDescriptorMissingAndStopIfUnused(_ profile: CandidateProfile) async {
+        let identity = TargetIdentity(profile.target)
+        descriptorMissingTargets.insert(identity)
+        if activeProvider?.profile.id == profile.id {
+            preparedProviders.removeValue(forKey: profile.target.processID)
+            return
+        }
+        if let prepared = preparedProviders[profile.target.processID],
+            prepared.id == profile.id
+        {
+            preparedProviders.removeValue(forKey: profile.target.processID)
+            await prepared.connection.stop()
+            return
+        }
+        await profile.connection.stop()
     }
 
     private func makeInitializeRequestData() throws -> Data {
@@ -945,23 +1157,6 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         )
     }
 
-    private static func makeDocumentationProbeRequestData() throws -> Data {
-        try JSONSerialization.data(
-            withJSONObject: [
-                "jsonrpc": "2.0",
-                "id": "documentation-probe",
-                "method": "tools/call",
-                "params": [
-                    "name": DocumentationProvider.ToolCatalog.toolName,
-                    "arguments": [
-                        "query": "UIView animate withDuration animations completion"
-                    ],
-                ],
-            ],
-            options: []
-        )
-    }
-
     private static func resultValue(from responseData: Data) throws -> JSONValue {
         guard
             let object = try JSONSerialization.jsonObject(with: responseData, options: [])
@@ -972,15 +1167,6 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             throw ControlPlane.Error.invalidResponse("invalid documentation provider response")
         }
         return value
-    }
-
-    private static func toolCount(in result: JSONValue) -> Int {
-        guard case .object(let object) = result,
-            case .array(let tools)? = object["tools"]
-        else {
-            return 0
-        }
-        return tools.count
     }
 
     private static func serverVersion(fromInitializeResponse data: Data) -> String? {
@@ -1027,17 +1213,15 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         return deadline.remaining()
     }
 
-    private func candidateProbeTimeout(
-        until deadline: Deadline?,
-        remainingCandidateCount: Int
-    ) -> TimeAmount? {
-        guard let remaining = remainingTimeout(until: deadline) else {
-            return nil
-        }
-        guard remaining.nanoseconds > 0 else {
-            return .nanoseconds(0)
-        }
-        let divisor = max(Int64(remainingCandidateCount), 1)
-        return .nanoseconds(max(remaining.nanoseconds / divisor, 1))
+    private func candidateLogMetadata(
+        target: DocumentationProviderTarget,
+        error: any Error
+    ) -> Logger.Metadata {
+        [
+            "pid": .string("\(target.processID)"),
+            "app_path": .string(target.appPath),
+            "xcode_version": .string(target.xcodeVersion),
+            "error": .string(String(describing: error)),
+        ]
     }
 }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -631,10 +631,22 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             if let activeProvider,
                 rejectedProcessIDs.contains(activeProvider.profile.target.processID) == false
             {
+                let fallbackTargets = orderedTargets(
+                    excluding: rejectedProcessIDs
+                        .union(unusableProcessIDs)
+                        .union([activeProvider.profile.target.processID]),
+                    includeDescriptorMissing: false
+                )
+                let activeDeadline = makeDeadline(
+                    fromTimeout: timeoutForCandidate(
+                        until: deadline,
+                        remainingCandidateCount: fallbackTargets.count + 1
+                    )
+                )
                 switch try await attemptDocumentationSearch(
                     requestData: requestData,
                     provider: activeProvider,
-                    deadline: deadline
+                    deadline: activeDeadline
                 ) {
                 case .success(let data):
                     return .handled(data, invalidatedProvider: invalidatedProvider)
@@ -668,21 +680,27 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             }
 
             var progressed = false
-            for target in targets {
+            for (index, target) in targets.enumerated() {
                 if let deadline, deadline.hasExpired {
                     return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
                 }
+                let candidateDeadline = makeDeadline(
+                    fromTimeout: timeoutForCandidate(
+                        until: deadline,
+                        remainingCandidateCount: targets.count - index
+                    )
+                )
                 do {
                     let profile = try await preparedProvider(
                         for: target,
-                        requestTimeout: remainingTimeout(until: deadline),
+                        requestTimeout: remainingTimeout(until: candidateDeadline),
                         fetchDescriptor: false
                     )
                     let provider = ActiveProvider(profile: profile)
                     switch try await attemptDocumentationSearch(
                         requestData: requestData,
                         provider: provider,
-                        deadline: deadline
+                        deadline: candidateDeadline
                     ) {
                     case .success(let data):
                         activeProvider = provider
@@ -1211,6 +1229,32 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             return nil
         }
         return deadline.remaining()
+    }
+
+    private func timeoutForCandidate(
+        until deadline: Deadline?,
+        remainingCandidateCount: Int
+    ) -> TimeAmount? {
+        guard let remaining = remainingTimeout(until: deadline) else {
+            return nil
+        }
+        guard remaining.nanoseconds > 0 else {
+            return .nanoseconds(0)
+        }
+        guard remainingCandidateCount > 1 else {
+            return remaining
+        }
+        return .nanoseconds(max(1, remaining.nanoseconds / Int64(remainingCandidateCount)))
+    }
+
+    private func makeDeadline(fromTimeout timeout: TimeAmount?) -> Deadline? {
+        guard let timeout else {
+            return nil
+        }
+        guard timeout.nanoseconds > 0 else {
+            return Deadline(uptimeNanoseconds: clock.uptimeNanoseconds(), clock: clock)
+        }
+        return Deadline.fromNow(timeout, clock: clock)
     }
 
     private func candidateLogMetadata(

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -536,6 +536,18 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     fetchDescriptor: true
                 )
                 if let descriptor = profile.descriptor {
+                    let didPromote = await promoteToActive(profile)
+                    if didPromote {
+                        logger.info(
+                            "Prewarmed documentation provider",
+                            metadata: [
+                                "pid": .string("\(target.processID)"),
+                                "app_path": .string(target.appPath),
+                                "xcode_version": .string(target.xcodeVersion),
+                                "server_version": .string(profile.serverVersion),
+                            ]
+                        )
+                    }
                     return .available(descriptor)
                 }
                 return toolListUpdateFromCachedState(requestTimeout: requestTimeout)
@@ -611,7 +623,11 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
             }
             if let activeProvider,
-                rejectedProcessIDs.contains(activeProvider.profile.target.processID) == false
+                rejectedProcessIDs.contains(activeProvider.profile.target.processID) == false,
+                activeProviderIsCurrentBest(
+                    activeProvider,
+                    excluding: rejectedProcessIDs.union(unusableProcessIDs)
+                )
             {
                 let fallbackTargets = orderedTargets(
                     excluding: rejectedProcessIDs
@@ -683,17 +699,18 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                         deadline: candidateDeadline
                     ) {
                     case .success(let data):
-                        activeProvider = provider
-                        preparedProviders.removeValue(forKey: target.processID)
-                        logger.info(
-                            "Selected documentation provider",
-                            metadata: [
-                                "pid": .string("\(target.processID)"),
-                                "app_path": .string(target.appPath),
-                                "xcode_version": .string(target.xcodeVersion),
-                                "server_version": .string(profile.serverVersion),
-                            ]
-                        )
+                        let didPromote = await promoteToActive(profile)
+                        if didPromote {
+                            logger.info(
+                                "Selected documentation provider",
+                                metadata: [
+                                    "pid": .string("\(target.processID)"),
+                                    "app_path": .string(target.appPath),
+                                    "xcode_version": .string(target.xcodeVersion),
+                                    "server_version": .string(profile.serverVersion),
+                                ]
+                            )
+                        }
                         return .handled(data, invalidatedProvider: invalidatedProvider)
                     case .rejected(let processID, let permanentlyUnusable):
                         rejectedProcessIDs.insert(processID)
@@ -733,6 +750,30 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             }
         }
         throw CancellationError()
+    }
+
+    private func activeProviderIsCurrentBest(
+        _ activeProvider: ActiveProvider,
+        excluding excludedProcessIDs: Set<pid_t>
+    ) -> Bool {
+        guard let first = orderedTargets(excluding: excludedProcessIDs).first else {
+            return false
+        }
+        return first.processID == activeProvider.profile.target.processID
+    }
+
+    private func promoteToActive(_ profile: CandidateProfile) async -> Bool {
+        let previous = activeProvider
+        activeProvider = ActiveProvider(profile: profile)
+        preparedProviders.removeValue(forKey: profile.target.processID)
+        guard let previous else {
+            return true
+        }
+        guard previous.profile.id != profile.id else {
+            return false
+        }
+        await previous.profile.connection.stop()
+        return true
     }
 
     private enum DocumentationAttemptResult: Sendable {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -150,8 +150,11 @@ extension RuntimeCoordinator {
         label: String,
         requestObject: [String: Any],
         requestTimeout: TimeAmount?,
-        rpcHandle: ControlPlane.RPCHandle? = nil
+        rpcHandle: ControlPlane.RPCHandle? = nil,
+        responseIDOverride: JSONRPC.ID? = nil,
+        throwsOnRPCError: Bool = true
     ) async throws -> ControlPlane.RPCResponse {
+        let requestDeadlineUptimeNs = deadlineUptimeNanoseconds(for: requestTimeout)
         let internalSessionID = controlPlaneSessionID(for: purpose, route: route)
         let session = session(id: internalSessionID)
         let router = session.router
@@ -213,10 +216,19 @@ extension RuntimeCoordinator {
                 if rpcHandle?.isCancelled() == true {
                     return self.eventLoop.makeFailedFuture(CancellationError())
                 }
+                let upstreamRequestTimeout = self.timeAmount(until: requestDeadlineUptimeNs)
+                if upstreamRequestTimeout?.nanoseconds == 0 {
+                    self.failRequestLease(
+                        leaseID,
+                        terminalState: .timedOut,
+                        reason: .timedOut
+                    )
+                    return self.eventLoop.makeFailedFuture(TimeoutError())
+                }
                 let registration = session.router.registerRequestPending(
                     idKey: originalID.key,
                     on: self.eventLoop,
-                    timeout: requestTimeout,
+                    timeout: upstreamRequestTimeout,
                     onTimeout: {
                         self.handleRequestLeaseTimeout(
                             leaseID,
@@ -243,7 +255,7 @@ extension RuntimeCoordinator {
                     leaseID,
                     requestIDKey: originalID.key,
                     upstreamIndex: selectedUpstreamIndex,
-                    timeout: requestTimeout
+                    timeout: upstreamRequestTimeout
                 )
                 let upstreamID = self.assignUpstreamID(
                     sessionID: internalSessionID,
@@ -331,12 +343,19 @@ extension RuntimeCoordinator {
                 }
             }
             let response = try await withTaskCancellationHandler {
-                try await future.get()
+                try await waitForEventLoopFuture(
+                    future,
+                    deadlineUptimeNs: requestDeadlineUptimeNs,
+                    onTimeout: {
+                        rpcHandle?.cancel()
+                    }
+                )
             } onCancel: {
                 rpcHandle?.cancel()
             }
             let responseObject = try extractJSONRPCResponseObject(from: response.responseData)
-            if responseObject["error"] != nil {
+            let isProxyUpstreamFailure = responseIsProxyUpstreamFailure(responseObject)
+            if responseObject["error"] != nil, throwsOnRPCError {
                 failRequestLease(
                     leaseID,
                     terminalState: .failed,
@@ -352,10 +371,24 @@ extension RuntimeCoordinator {
                     )
                 )
             }
+            let responseData: Data
+            if let responseIDOverride {
+                responseData = try responseDataByReplacingJSONRPCID(
+                    in: responseObject,
+                    with: responseIDOverride
+                )
+            } else {
+                responseData = response.responseData
+            }
             rpcHandle?.markFinished()
-            markRequestSucceeded(upstreamIndex: response.upstreamIndex)
+            if !isProxyUpstreamFailure {
+                markRequestSucceeded(upstreamIndex: response.upstreamIndex)
+            }
             completeRequestLease(leaseID)
-            return response
+            return ControlPlane.RPCResponse(
+                responseData: responseData,
+                upstreamIndex: response.upstreamIndex
+            )
         } catch is CancellationError {
             throw CancellationError()
         } catch is TimeoutError {
@@ -419,12 +452,35 @@ extension RuntimeCoordinator {
         return responseObject
     }
 
+    func responseDataByReplacingJSONRPCID(
+        in responseObject: [String: Any],
+        with responseID: JSONRPC.ID
+    ) throws -> Data {
+        var rewritten = responseObject
+        rewritten["id"] = responseID.value.foundationObject
+        guard JSONSerialization.isValidJSONObject(rewritten) else {
+            throw ControlPlane.Error.invalidResponse("invalid rewritten response")
+        }
+        return try JSONSerialization.data(withJSONObject: rewritten, options: [])
+    }
+
     func extractJSONRPCErrorMessage(from responseObject: [String: Any]) -> String? {
         (responseObject["error"] as? [String: Any])?["message"] as? String
     }
 
     func extractJSONRPCErrorCode(from responseObject: [String: Any]) -> Int? {
         ((responseObject["error"] as? [String: Any])?["code"] as? NSNumber)?.intValue
+    }
+
+    func responseIsProxyUpstreamFailure(_ responseObject: [String: Any]) -> Bool {
+        guard
+            let code = extractJSONRPCErrorCode(from: responseObject),
+            let message = extractJSONRPCErrorMessage(from: responseObject)
+        else {
+            return false
+        }
+        return (code == -32001 && message == "upstream unavailable")
+            || (code == -32002 && message == "upstream overloaded")
     }
 
     func controlPlaneFailureReason(for error: any Error) -> String {
@@ -458,9 +514,19 @@ extension RuntimeCoordinator {
         return .nanoseconds(Int64(min(remaining, maxNanos)))
     }
 
+    func deadlineUptimeNanoseconds(for requestTimeout: TimeAmount?) -> UInt64? {
+        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
+            return nil
+        }
+        let now = nowUptimeNanoseconds()
+        let clamped = min(UInt64(requestTimeout.nanoseconds), UInt64.max &- now)
+        return now &+ clamped
+    }
+
     func waitForEventLoopFuture<Output: Sendable>(
         _ future: EventLoopFuture<Output>,
-        deadlineUptimeNs: UInt64?
+        deadlineUptimeNs: UInt64?,
+        onTimeout: @escaping @Sendable () -> Void = {}
     ) async throws -> Output {
         if let deadlineUptimeNs, let timeout = timeAmount(until: deadlineUptimeNs) {
             return try await withThrowingTaskGroup(of: Output.self) { group in
@@ -471,6 +537,7 @@ extension RuntimeCoordinator {
                     try await Task.sleep(
                         nanoseconds: UInt64(max(0, timeout.nanoseconds))
                     )
+                    onTimeout()
                     throw TimeoutError()
                 }
                 let result = try await group.next()!

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -218,6 +218,12 @@ extension RuntimeCoordinator {
                 }
                 let upstreamRequestTimeout = self.timeAmount(until: requestDeadlineUptimeNs)
                 if upstreamRequestTimeout?.nanoseconds == 0 {
+                    self.activateRequestLease(
+                        leaseID,
+                        requestIDKey: nil,
+                        upstreamIndex: selectedUpstreamIndex,
+                        timeout: .nanoseconds(0)
+                    )
                     self.failRequestLease(
                         leaseID,
                         terminalState: .timedOut,

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -81,7 +81,7 @@ package protocol RuntimeCoordinating: Sendable {
         requestData: Data,
         requestTimeoutOverride: TimeAmount?
     ) async throws -> DocumentationSearchOutcome
-    func hasDocumentationProvider() -> Bool
+    func hasDocumentationSearchService() -> Bool
     func chooseUpstreamIndex() -> Int?
     func enqueueOnUpstreamSlot<Output: Sendable>(
         leaseID: LeaseManager.ID,
@@ -140,7 +140,7 @@ extension RuntimeCoordinating {
 
     package func markNotificationClientConnected(sessionID _: String) {}
 
-    package func hasDocumentationProvider() -> Bool {
+    package func hasDocumentationSearchService() -> Bool {
         false
     }
 
@@ -618,7 +618,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                     "timeout_seconds": .string("\(timeoutSeconds)")
                 ]
             )
-            let update = await documentationProviderManager.prewarm(requestTimeout: timeout)
+            let update = await documentationProviderManager.startBackgroundDiscovery(
+                requestTimeout: timeout
+            )
             self?.recordDocumentationToolListUpdate(update)
             guard !Task.isCancelled else { return }
             logger.debug("Documentation provider prewarm completed")
@@ -913,7 +915,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
     }
 
-    package func hasDocumentationProvider() -> Bool {
+    package func hasDocumentationSearchService() -> Bool {
         documentationProviderManager != nil
     }
 

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -234,6 +234,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             RuntimeScheduledTimeout
     package let controlPlaneCoordinator: ControlPlaneCoordinator
     package let documentationProviderManager: (any DocumentationProviderManaging)?
+    package let documentationProviderRoutes: [DocumentationProviderRoute]
     package let prewarmDocumentationProviderOnStartup: Bool
     private let lifecycleStartedBox = NIOLockedValueBox(false)
 
@@ -248,45 +249,80 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         startImmediately: Bool = true
     ) {
         let count = max(1, min(config.upstreamProcessCount, 10))
-        let upstreams = Self.makeDefaultUpstreams(
-            config: config, sharedSessionID: config.upstreamSessionID, count: count)
+        let documentationServiceEnabled = Self.documentationProviderServiceIsConfigured(
+            config: config
+        )
+        let documentationTargets =
+            documentationServiceEnabled
+            ? xcodeTargetDiscovery?.runningXcodeTargets() ?? []
+            : []
+        let upstreamPlan = Self.makeDefaultUpstreamPlan(
+            config: config,
+            sharedSessionID: config.upstreamSessionID,
+            count: count,
+            documentationTargets: documentationTargets
+        )
         let clock = ClockClient.liveValue
-        let documentationProviderManager = xcodeTargetDiscovery.flatMap { discovery in
-            Self.makeDefaultDocumentationProviderManager(config: config, discovery: discovery)
-        }
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let documentationTransport = RuntimeDocumentationProviderTransport(
+            runtimeBox: runtimeBox,
+            fallback: SessionBackedDocumentationProviderTransport(
+                sessionFactory: LiveDocumentationProviderSessionFactory(
+                    baseEnvironment: ProcessInfo.processInfo.environment
+                ),
+                clock: clock
+            ),
+            clock: clock
+        )
+        let documentationProviderManager =
+            documentationServiceEnabled
+            ? xcodeTargetDiscovery.flatMap { discovery in
+                Self.makeDefaultDocumentationProviderManager(
+                    config: config,
+                    discovery: discovery,
+                    transport: documentationTransport
+                )
+            }
+            : nil
         self.init(
             config: config,
             eventLoop: eventLoop,
-            upstreams: upstreams,
+            upstreams: upstreamPlan.upstreams,
             clock: clock,
             upstreamReadinessGate: upstreamReadinessGate,
+            documentationProviderRoutes: upstreamPlan.documentationRoutes,
             documentationProviderManager: documentationProviderManager,
             prewarmDocumentationProviderOnStartup: documentationProviderManager != nil,
-            startImmediately: startImmediately
+            startImmediately: startImmediately,
+            runtimeBox: runtimeBox
         )
     }
 
     package static func makeDefaultDocumentationProviderManager(
         config: ProxyConfig,
-        discovery: any XcodeTargetDiscovering
+        discovery: any XcodeTargetDiscovering,
+        transport: any DocumentationProviderRouting
     ) -> (any DocumentationProviderManaging)? {
-        guard config.disabledToolNames.contains(DocumentationProvider.ToolCatalog.toolName) == false
-        else {
-            return nil
-        }
-        guard XcrunArguments.isDefaultMCPBridgeInvocation(config: config) else {
+        guard documentationProviderServiceIsConfigured(config: config) else {
             return nil
         }
         let environment = ProcessInfo.processInfo.environment
         let pinnedProcessID = environment["MCP_XCODE_PID"].flatMap(pid_t.init)
         return DocumentationProviderManager(
             discovery: discovery,
-            sessionFactory: LiveDocumentationProviderSessionFactory(baseEnvironment: environment),
+            transport: transport,
             pinnedProcessID: pinnedProcessID,
             initializeParams: InitializeHandshakeJSON.resolved(
                 initializeParamsOverride: config.initializeParamsOverride
             )
         )
+    }
+
+    package static func documentationProviderServiceIsConfigured(
+        config: ProxyConfig
+    ) -> Bool {
+        config.disabledToolNames.contains(DocumentationProvider.ToolCatalog.toolName) == false
+            && XcrunArguments.isDefaultMCPBridgeInvocation(config: config)
     }
 
     package init(
@@ -300,12 +336,14 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             @Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
                 RuntimeScheduledTimeout
         )? = nil,
+        documentationProviderRoutes: [DocumentationProviderRoute] = [],
         documentationProviderManager: (any DocumentationProviderManaging)? = nil,
         prewarmDocumentationProviderOnStartup: Bool = false,
-        startImmediately: Bool = true
+        startImmediately: Bool = true,
+        runtimeBox providedRuntimeBox: WeakRuntimeCoordinatorBox? = nil
     ) {
         precondition(!upstreams.isEmpty, "upstreams must not be empty")
-        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let runtimeBox = providedRuntimeBox ?? WeakRuntimeCoordinatorBox()
         let uptimeProvider = nowUptimeNanoseconds ?? clock.uptimeNanoseconds
         let runtimeClock = ClockClient(
             now: clock.now,
@@ -337,6 +375,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.nowUptimeNanoseconds = uptimeProvider
         self.scheduleRuntimeTimeout = timeoutScheduler
         self.documentationProviderManager = documentationProviderManager
+        self.documentationProviderRoutes = documentationProviderRoutes
         self.prewarmDocumentationProviderOnStartup = prewarmDocumentationProviderOnStartup
         let resolvedReadinessGate =
             upstreamReadinessGate

--- a/Sources/ProxySession/Runtime/RuntimeDocumentationProviderTransport.swift
+++ b/Sources/ProxySession/Runtime/RuntimeDocumentationProviderTransport.swift
@@ -1,0 +1,337 @@
+import Foundation
+import NIO
+import NIOConcurrencyHelpers
+import ProxyCore
+import ProxyMCP
+
+package final class RuntimeDocumentationProviderTransport: DocumentationProviderRouting {
+    private struct State: Sendable {
+        var initializeParamsByRouteID: [String: [String: JSONValue]] = [:]
+        var fallbackRoutesByRouteID: [String: DocumentationProviderRoute] = [:]
+    }
+
+    private let runtimeBox: WeakRuntimeCoordinatorBox
+    private let fallback: any DocumentationProviderRouting
+    private let clock: ClockClient
+    private let state = NIOLockedValueBox(State())
+
+    package init(
+        runtimeBox: WeakRuntimeCoordinatorBox,
+        fallback: any DocumentationProviderRouting = UnavailableRuntimeDocumentationProviderTransport(),
+        clock: ClockClient = .liveValue
+    ) {
+        self.runtimeBox = runtimeBox
+        self.fallback = fallback
+        self.clock = clock
+    }
+
+    package func openRoute(
+        for target: DocumentationProviderTarget,
+        requestTimeout: TimeAmount?,
+        initializeParams: [String: JSONValue]
+    ) async throws -> DocumentationProviderRoute {
+        if let runtime = runtimeBox.value,
+            let route = runtime.documentationProviderRoute(for: target)
+        {
+            state.withLockedValue { state in
+                state.initializeParamsByRouteID[route.id] = initializeParams
+            }
+            return route
+        }
+        return try await fallback.openRoute(
+            for: target,
+            requestTimeout: requestTimeout,
+            initializeParams: initializeParams
+        )
+    }
+
+    package func toolsList(
+        route: DocumentationProviderRoute,
+        timeout: TimeAmount?
+    ) async throws -> JSONValue {
+        if let fallbackRoute = fallbackRouteIfActive(for: route) {
+            return try await fallback.toolsList(route: fallbackRoute, timeout: timeout)
+        }
+        guard route.upstreamIndex != nil else {
+            return try await fallback.toolsList(route: route, timeout: timeout)
+        }
+        let deadline = Deadline.fromNow(timeout, clock: clock)
+        do {
+            guard let runtime = runtimeBox.value else { throw CancellationError() }
+            return try await runtime.documentationProviderToolsList(
+                route: route,
+                requestTimeout: try remainingTimeoutOrThrow(until: deadline)
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            let fallbackRoute = try await openFallbackRoute(
+                for: route,
+                timeout: try remainingTimeoutOrThrow(until: deadline)
+            )
+            return try await fallback.toolsList(
+                route: fallbackRoute,
+                timeout: try remainingTimeoutOrThrow(until: deadline)
+            )
+        }
+    }
+
+    package func callDocumentationSearch(
+        route: DocumentationProviderRoute,
+        requestData: Data,
+        timeout: TimeAmount?
+    ) async throws -> Data {
+        if let fallbackRoute = fallbackRouteIfActive(for: route) {
+            return try await fallback.callDocumentationSearch(
+                route: fallbackRoute,
+                requestData: requestData,
+                timeout: timeout
+            )
+        }
+        guard route.upstreamIndex != nil else {
+            return try await fallback.callDocumentationSearch(
+                route: route,
+                requestData: requestData,
+                timeout: timeout
+            )
+        }
+        let deadline = Deadline.fromNow(timeout, clock: clock)
+        let response: Data
+        do {
+            guard let runtime = runtimeBox.value else { throw CancellationError() }
+            response = try await runtime.documentationProviderCall(
+                route: route,
+                requestData: requestData,
+                requestTimeout: try remainingTimeoutOrThrow(until: deadline)
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            let fallbackRoute = try await openFallbackRoute(
+                for: route,
+                timeout: try remainingTimeoutOrThrow(until: deadline)
+            )
+            return try await fallback.callDocumentationSearch(
+                route: fallbackRoute,
+                requestData: requestData,
+                timeout: try remainingTimeoutOrThrow(until: deadline)
+            )
+        }
+        guard Self.responseIsProxyUpstreamFailure(response) else {
+            return response
+        }
+        let fallbackRoute = try await openFallbackRoute(
+            for: route,
+            timeout: try remainingTimeoutOrThrow(until: deadline)
+        )
+        return try await fallback.callDocumentationSearch(
+            route: fallbackRoute,
+            requestData: requestData,
+            timeout: try remainingTimeoutOrThrow(until: deadline)
+        )
+    }
+
+    package func close(route: DocumentationProviderRoute) async {
+        if route.upstreamIndex == nil {
+            await fallback.close(route: route)
+            return
+        }
+        let fallbackRoute = state.withLockedValue { state -> DocumentationProviderRoute? in
+            state.initializeParamsByRouteID.removeValue(forKey: route.id)
+            return state.fallbackRoutesByRouteID.removeValue(forKey: route.id)
+        }
+        if let fallbackRoute {
+            await fallback.close(route: fallbackRoute)
+        }
+    }
+
+    package func shutdown() async {
+        let fallbackRoutes = state.withLockedValue { state -> [DocumentationProviderRoute] in
+            let routes = Array(state.fallbackRoutesByRouteID.values)
+            state.initializeParamsByRouteID.removeAll()
+            state.fallbackRoutesByRouteID.removeAll()
+            return routes
+        }
+        for route in fallbackRoutes {
+            await fallback.close(route: route)
+        }
+        await fallback.shutdown()
+    }
+
+    private func fallbackRouteIfActive(
+        for route: DocumentationProviderRoute
+    ) -> DocumentationProviderRoute? {
+        guard route.upstreamIndex != nil else {
+            return nil
+        }
+        return state.withLockedValue { state in
+            state.fallbackRoutesByRouteID[route.id]
+        }
+    }
+
+    private func openFallbackRoute(
+        for route: DocumentationProviderRoute,
+        timeout: TimeAmount?
+    ) async throws -> DocumentationProviderRoute {
+        if let fallbackRoute = fallbackRouteIfActive(for: route) {
+            return fallbackRoute
+        }
+        guard route.upstreamIndex != nil else {
+            return route
+        }
+        let initializeParams = state.withLockedValue { state in
+            state.initializeParamsByRouteID[route.id]
+        }
+        guard let initializeParams else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        let opened = try await fallback.openRoute(
+            for: route.target,
+            requestTimeout: timeout,
+            initializeParams: initializeParams
+        )
+        var routeToClose: DocumentationProviderRoute?
+        let selected = state.withLockedValue { state -> DocumentationProviderRoute? in
+            guard state.initializeParamsByRouteID[route.id] != nil else {
+                routeToClose = opened
+                return nil
+            }
+            if let existing = state.fallbackRoutesByRouteID[route.id] {
+                routeToClose = opened
+                return existing
+            }
+            state.fallbackRoutesByRouteID[route.id] = opened
+            routeToClose = nil
+            return opened
+        }
+        if let routeToClose {
+            await fallback.close(route: routeToClose)
+        }
+        guard let selected else {
+            throw CancellationError()
+        }
+        return selected
+    }
+
+    private func remainingTimeoutOrThrow(until deadline: Deadline?) throws -> TimeAmount? {
+        guard let deadline else {
+            return nil
+        }
+        let remaining = deadline.remaining()
+        guard remaining.nanoseconds > 0 else {
+            throw TimeoutError()
+        }
+        return remaining
+    }
+
+    private static func responseIsProxyUpstreamFailure(_ data: Data) -> Bool {
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [])
+            as? [String: Any],
+            let error = object["error"] as? [String: Any],
+            let code = (error["code"] as? NSNumber)?.intValue,
+            let message = error["message"] as? String
+        else {
+            return false
+        }
+        return (code == -32001 && message == "upstream unavailable")
+            || (code == -32002 && message == "upstream overloaded")
+    }
+}
+
+package struct UnavailableRuntimeDocumentationProviderTransport: DocumentationProviderRouting {
+    package init() {}
+
+    package func openRoute(
+        for _: DocumentationProviderTarget,
+        requestTimeout _: TimeAmount?,
+        initializeParams _: [String: JSONValue]
+    ) async throws -> DocumentationProviderRoute {
+        throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+
+    package func toolsList(
+        route _: DocumentationProviderRoute,
+        timeout _: TimeAmount?
+    ) async throws -> JSONValue {
+        throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+
+    package func callDocumentationSearch(
+        route _: DocumentationProviderRoute,
+        requestData _: Data,
+        timeout _: TimeAmount?
+    ) async throws -> Data {
+        throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+}
+
+extension RuntimeCoordinator {
+    package func documentationProviderRoute(
+        for target: DocumentationProviderTarget
+    ) -> DocumentationProviderRoute? {
+        documentationProviderRoutes.first { route in
+            route.target.processID == target.processID
+        }
+    }
+
+    package func documentationProviderToolsList(
+        route: DocumentationProviderRoute,
+        requestTimeout: TimeAmount?
+    ) async throws -> JSONValue {
+        guard let upstreamIndex = route.upstreamIndex else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        let rpcHandle = ControlPlane.RPCHandle()
+        do {
+            let response = try await performControlPlaneRPC(
+                route: .pinnedUpstream(upstreamIndex),
+                purpose: "documentation-tools",
+                label: "tools/list:DocumentationProvider",
+                requestObject: [
+                    "jsonrpc": "2.0",
+                    "id": "__documentation-tools-\(UUID().uuidString)",
+                    "method": "tools/list",
+                ],
+                requestTimeout: requestTimeout,
+                rpcHandle: rpcHandle
+            )
+            return try extractJSONRPCResult(from: response.responseData)
+        } catch let error as ControlPlane.RequestError {
+            throw error.underlying
+        }
+    }
+
+    package func documentationProviderCall(
+        route: DocumentationProviderRoute,
+        requestData: Data,
+        requestTimeout: TimeAmount?
+    ) async throws -> Data {
+        guard let upstreamIndex = route.upstreamIndex else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        guard
+            var requestObject = try JSONSerialization.jsonObject(with: requestData, options: [])
+                as? [String: Any],
+            let originalID = JSONRPC.Message.Inspector.requestID(from: requestObject)
+        else {
+            throw ControlPlane.Error.invalidResponse("missing DocumentationSearch request id")
+        }
+        requestObject["id"] = "__documentation-search-\(UUID().uuidString)"
+        let rpcHandle = ControlPlane.RPCHandle()
+        do {
+            let response = try await performControlPlaneRPC(
+                route: .pinnedUpstream(upstreamIndex),
+                purpose: "documentation-search",
+                label: "tools/call:DocumentationSearch",
+                requestObject: requestObject,
+                requestTimeout: requestTimeout,
+                rpcHandle: rpcHandle,
+                responseIDOverride: originalID,
+                throwsOnRPCError: false
+            )
+            return response.responseData
+        } catch let error as ControlPlane.RequestError {
+            throw error.underlying
+        }
+    }
+}

--- a/Sources/ProxySession/Session/UpstreamRouter.swift
+++ b/Sources/ProxySession/Session/UpstreamRouter.swift
@@ -4,11 +4,91 @@ import ProxyCore
 import ProxyMCP
 
 extension RuntimeCoordinator {
+    package struct DefaultUpstreamPlan: Sendable {
+        package let upstreams: [ManagedUpstreamSlot]
+        package let documentationRoutes: [DocumentationProviderRoute]
+
+        package init(
+            upstreams: [ManagedUpstreamSlot],
+            documentationRoutes: [DocumentationProviderRoute]
+        ) {
+            self.upstreams = upstreams
+            self.documentationRoutes = documentationRoutes
+        }
+    }
+
     static func makeDefaultUpstreams(
         config: ProxyConfig,
         sharedSessionID: String?,
         count: Int
     ) -> [ManagedUpstreamSlot] {
+        makeDefaultUpstreamPlan(
+            config: config,
+            sharedSessionID: sharedSessionID,
+            count: count,
+            documentationTargets: []
+        ).upstreams
+    }
+
+    package static func makeDefaultUpstreamPlan(
+        config: ProxyConfig,
+        sharedSessionID: String?,
+        count: Int,
+        documentationTargets: [DocumentationProviderTarget]
+    ) -> DefaultUpstreamPlan {
+        let orderedDocumentationTargets = orderedDocumentationTargets(
+            documentationTargets,
+            pinnedProcessID: ProcessInfo.processInfo.environment["MCP_XCODE_PID"]
+                .flatMap(pid_t.init)
+        )
+        let canReuseDefaultUpstreamForDocumentation =
+            orderedDocumentationTargets.isEmpty == false
+            && config.disabledToolNames.contains(DocumentationProvider.ToolCatalog.toolName) == false
+            && XcrunArguments.isDefaultMCPBridgeInvocation(config: config)
+        let reusableDocumentationTarget: DocumentationProviderTarget?
+        if canReuseDefaultUpstreamForDocumentation,
+            ProcessInfo.processInfo.environment["MCP_XCODE_PID"].flatMap(pid_t.init) != nil
+                || orderedDocumentationTargets.count == 1
+        {
+            reusableDocumentationTarget = orderedDocumentationTargets.first
+        } else {
+            reusableDocumentationTarget = nil
+        }
+        var upstreams: [ManagedUpstreamSlot] = []
+        var documentationRoutes: [DocumentationProviderRoute] = []
+        let upstreamCount = max(1, count)
+        upstreams.reserveCapacity(upstreamCount)
+        documentationRoutes.reserveCapacity(reusableDocumentationTarget == nil ? 0 : 1)
+        for _ in 0..<upstreamCount {
+            let upstreamConfig = makeDefaultUpstreamConfig(
+                config: config,
+                sharedSessionID: sharedSessionID,
+                documentationTarget: nil
+            )
+            upstreams.append(
+                ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig))
+            )
+        }
+        if let reusableDocumentationTarget {
+            documentationRoutes.append(
+                DocumentationProviderRoute(
+                    id: "upstream-0-pid-\(reusableDocumentationTarget.processID)",
+                    target: reusableDocumentationTarget,
+                    upstreamIndex: 0
+                )
+            )
+        }
+        return DefaultUpstreamPlan(
+            upstreams: upstreams,
+            documentationRoutes: documentationRoutes
+        )
+    }
+
+    private static func makeDefaultUpstreamConfig(
+        config: ProxyConfig,
+        sharedSessionID: String?,
+        documentationTarget: DocumentationProviderTarget?
+    ) -> UpstreamProcess.Config {
         var environment = ProcessInfo.processInfo.environment
         environment.removeValue(forKey: "XCODE_PID")
         if let sharedSessionID, !sharedSessionID.isEmpty {
@@ -16,31 +96,86 @@ extension RuntimeCoordinator {
         } else {
             environment.removeValue(forKey: "MCP_XCODE_SESSION_ID")
         }
-        let upstreamConfig = UpstreamProcess.Config(
-            command: config.upstreamCommand,
-            args: config.upstreamArgs,
+        let command: String
+        let args: [String]
+        if let documentationTarget {
+            environment["MCP_XCODE_PID"] = String(documentationTarget.processID)
+            environment["DEVELOPER_DIR"] = documentationTarget.developerDir
+            command = documentationTarget.mcpbridgePath
+            args = []
+        } else {
+            command = config.upstreamCommand
+            args = config.upstreamArgs
+        }
+        return UpstreamProcess.Config(
+            command: command,
+            args: args,
             environment: environment,
-            maxQueuedWriteBytes: {
-                let minimum = 1_048_576
-                guard config.maxBodyBytes > 0 else { return minimum }
-                let multiplied = config.maxBodyBytes.multipliedReportingOverflow(by: 4)
-                if multiplied.overflow {
-                    return Int.max
-                }
-                return max(minimum, multiplied.partialValue)
-            }()
+            maxQueuedWriteBytes: maxQueuedWriteBytes(for: config)
         )
-        if count <= 1 {
-            return [ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig))]
+    }
+
+    private static func maxQueuedWriteBytes(for config: ProxyConfig) -> Int {
+        let minimum = 1_048_576
+        guard config.maxBodyBytes > 0 else { return minimum }
+        let multiplied = config.maxBodyBytes.multipliedReportingOverflow(by: 4)
+        if multiplied.overflow {
+            return Int.max
         }
-        var upstreams: [ManagedUpstreamSlot] = []
-        upstreams.reserveCapacity(count)
-        for _ in 0..<count {
-            upstreams.append(
-                ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig))
+        return max(minimum, multiplied.partialValue)
+    }
+
+    private static func orderedDocumentationTargets(
+        _ targets: [DocumentationProviderTarget],
+        pinnedProcessID: pid_t?
+    ) -> [DocumentationProviderTarget] {
+        let filtered: [DocumentationProviderTarget]
+        if let pinnedProcessID {
+            filtered = targets.filter { $0.processID == pinnedProcessID }
+        } else {
+            filtered = targets
+        }
+        return filtered.sorted { lhs, rhs in
+            let versionComparison = compareDocumentationVersion(
+                lhs.xcodeVersion,
+                rhs.xcodeVersion
             )
+            if versionComparison != .orderedSame {
+                return versionComparison == .orderedDescending
+            }
+            if lhs.appPath != rhs.appPath {
+                return lhs.appPath < rhs.appPath
+            }
+            return lhs.processID < rhs.processID
         }
-        return upstreams
+    }
+
+    private static func compareDocumentationVersion(
+        _ lhs: String,
+        _ rhs: String
+    ) -> ComparisonResult {
+        let lhsParts = numericDocumentationVersionParts(lhs)
+        let rhsParts = numericDocumentationVersionParts(rhs)
+        let count = max(lhsParts.count, rhsParts.count)
+        for index in 0..<count {
+            let lhsValue = index < lhsParts.count ? lhsParts[index] : 0
+            let rhsValue = index < rhsParts.count ? rhsParts[index] : 0
+            if lhsValue < rhsValue {
+                return .orderedAscending
+            }
+            if lhsValue > rhsValue {
+                return .orderedDescending
+            }
+        }
+        return lhs.localizedStandardCompare(rhs)
+    }
+
+    private static func numericDocumentationVersionParts(_ version: String) -> [Int] {
+        version
+            .split { character in
+                !character.isNumber
+            }
+            .compactMap { Int($0) }
     }
 }
 

--- a/Sources/ProxyXcodeSupport/LiveXcodeTargetDiscovery.swift
+++ b/Sources/ProxyXcodeSupport/LiveXcodeTargetDiscovery.swift
@@ -49,12 +49,23 @@ package struct LiveXcodeTargetDiscovery: XcodeTargetDiscovering {
         guard FileManager.default.isExecutableFile(atPath: mcpbridgePath) else {
             return nil
         }
+        let xcodeVersion = Self.xcodeVersion(appPath: appPath)
         return DocumentationProviderTarget(
             processID: processID,
             appPath: appPath,
             developerDir: developerDir,
-            mcpbridgePath: mcpbridgePath
+            mcpbridgePath: mcpbridgePath,
+            xcodeVersion: xcodeVersion
         )
+    }
+
+    private static func xcodeVersion(appPath: String) -> String {
+        guard let bundle = Bundle(url: URL(fileURLWithPath: appPath)) else {
+            return ""
+        }
+        return bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+            ?? ""
     }
 
     private static func appPath(fromExecutablePath path: String) -> String? {

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -339,7 +339,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         }
     }
 
-    func hasDocumentationProvider() -> Bool {
+    func hasDocumentationSearchService() -> Bool {
         documentationSearchResponder != nil
     }
 

--- a/Tests/ProxyHTTPGatewayTests/ToolSurfaceTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/ToolSurfaceTests.swift
@@ -432,7 +432,7 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
         fatalError("unused in ToolSurfaceTests")
     }
 
-    func hasDocumentationProvider() -> Bool { false }
+    func hasDocumentationSearchService() -> Bool { false }
 
     func chooseUpstreamIndex() -> Int? { nil }
 

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -415,7 +415,7 @@ extension RuntimeCoordinatorTests {
         #expect(documentationDescriptorDescription(in: cachedResult) == "docs-27.0")
     }
 
-    @Test func documentationProviderBackgroundDiscoveryRemovesStaleToolWhenDescriptorsAreAbsent()
+    @Test func documentationProviderBackgroundDiscoveryKeepsBaseCatalogWhenDescriptorIsAbsent()
         async throws
     {
         let target = documentationProviderTarget(processID: 115, xcodeVersion: "27.0")
@@ -446,7 +446,7 @@ extension RuntimeCoordinatorTests {
             ])
         )
 
-        #expect(DocumentationProvider.ToolCatalog.descriptor(in: result) == nil)
+        #expect(documentationDescriptorDescription(in: result) == "docs-stale")
         #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 1)
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
     }
@@ -814,7 +814,7 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
     }
 
-    @Test func documentationProviderManagerSkipsDescriptorMissingTargetsForSearch() async throws {
+    @Test func documentationProviderManagerSearchesDescriptorMissingPreparedTarget() async throws {
         let xcode26 = documentationProviderTarget(processID: 610, xcodeVersion: "26.6")
         let xcode27 = documentationProviderTarget(processID: 611, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
@@ -832,7 +832,7 @@ extension RuntimeCoordinatorTests {
                         serverVersion: "27.0",
                         toolCount: 46,
                         includesDocumentationSearch: false,
-                        firstDocumentationResponse: .toolErrorText("missing descriptor target")
+                        firstDocumentationResponse: .successText("{\"answer\":\"actual\"}")
                     ),
                 ],
             ]
@@ -844,7 +844,7 @@ extension RuntimeCoordinatorTests {
 
         let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
         let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
-        #expect(documentationDescriptorDescription(in: result) == "docs-26.6")
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: result) == nil)
 
         let outcome = try await manager.callDocumentationSearch(
             requestData: makeDocumentationSearchRequest(id: 84, query: "SwiftUI"),
@@ -855,10 +855,11 @@ extension RuntimeCoordinatorTests {
             Issue.record("expected handled outcome, got \(outcome)")
             return
         }
-        #expect(try toolContentText(in: responseData) == "{\"answer\":\"advertised\"}")
-        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
-        #expect(await factory.documentationQueries(for: xcode27.processID).isEmpty)
-        #expect(await factory.documentationQueries(for: xcode26.processID) == ["SwiftUI"])
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"actual\"}")
+        #expect(await factory.startedPIDs() == [xcode27.processID])
+        #expect(await factory.requestCount(processID: xcode27.processID, method: "tools/list") == 1)
+        #expect(await factory.documentationQueries(for: xcode27.processID) == ["SwiftUI"])
+        #expect(await factory.documentationQueries(for: xcode26.processID).isEmpty)
     }
 
     @Test func documentationProviderManagerRetriesActualRequestWhenNewestIsNotEnabled() async throws {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -905,6 +905,50 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.documentationQueries(for: xcode26.processID) == ["UIView"])
     }
 
+    @Test func documentationProviderManagerPreservesTimeForFallbackWhenNewestHangs() async throws {
+        let xcode26 = documentationProviderTarget(processID: 425, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 426, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"fallback\"}")
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .hang
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 88, query: "UIView"),
+            requestTimeoutOverride: .milliseconds(200)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"fallback\"}")
+        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
+        #expect(await factory.documentationQueries(for: xcode27.processID) == ["UIView"])
+        #expect(await factory.documentationQueries(for: xcode26.processID) == ["UIView"])
+    }
+
     @Test func documentationProviderManagerRetriesActiveNotEnabledOnNextCandidate() async throws {
         let xcode26 = documentationProviderTarget(processID: 430, xcodeVersion: "26.6")
         let xcode27 = documentationProviderTarget(processID: 431, xcodeVersion: "27.0")

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -351,8 +351,8 @@ extension RuntimeCoordinatorTests {
         #expect(await documentationProvider.shutdownCount() == 1)
     }
 
-    @Test func documentationProviderManagerRejectsDescriptorWhenProbeCallIsNotEnabled() async throws {
-        let target = documentationProviderTarget(processID: 101)
+    @Test func documentationProviderToolListUpdateDoesNotStartDiscoveryOrSearch() async throws {
+        let target = documentationProviderTarget(processID: 101, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 target.processID: [
@@ -360,7 +360,7 @@ extension RuntimeCoordinatorTests {
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .notEnabled
+                        firstDocumentationResponse: .success
                     ),
                 ],
             ]
@@ -371,6 +371,72 @@ extension RuntimeCoordinatorTests {
         )
 
         let update = await manager.toolListUpdate(requestTimeout: nil)
+
+        guard case .unchanged = update else {
+            Issue.record("expected unchanged update, got \(update)")
+            return
+        }
+        #expect(await factory.startedPIDs().isEmpty)
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
+    }
+
+    @Test func documentationProviderBackgroundDiscoveryFetchesDescriptorWithoutSearch() async throws {
+        let target = documentationProviderTarget(processID: 111, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 1)
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
+
+        let cachedUpdate = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let cachedResult = DocumentationProvider.ToolCatalog.applying(
+            cachedUpdate,
+            to: try jsonValue(["tools": []])
+        )
+        #expect(documentationDescriptorDescription(in: cachedResult) == "docs-27.0")
+    }
+
+    @Test func documentationProviderBackgroundDiscoveryRemovesStaleToolWhenDescriptorsAreAbsent()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 115, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 46,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
         let result = DocumentationProvider.ToolCatalog.applying(
             update,
             to: try jsonValue([
@@ -381,11 +447,12 @@ extension RuntimeCoordinatorTests {
         )
 
         #expect(DocumentationProvider.ToolCatalog.descriptor(in: result) == nil)
-        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 1)
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
     }
 
-    @Test func documentationProviderManagerUsesNumericIDsForMCPBridgeProbe() async throws {
-        let target = documentationProviderTarget(processID: 111)
+    @Test func documentationSearchDoesNotWaitForBackgroundDescriptorFetch() async throws {
+        let target = documentationProviderTarget(processID: 114, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 target.processID: [
@@ -393,7 +460,53 @@ extension RuntimeCoordinatorTests {
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success,
+                        hangsToolsList: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"direct\"}")
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let discoveryTask = Task {
+            await manager.startBackgroundDiscovery(requestTimeout: .seconds(2))
+        }
+        defer { discoveryTask.cancel() }
+        try await waitWithTimeout("waiting for background descriptor fetch") {
+            try await factory.waitForRequestCount(
+                1,
+                processID: target.processID,
+                method: "tools/list"
+            )
+        }
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 70, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"direct\"}")
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.documentationQueries(for: target.processID) == ["UIView"])
+    }
+
+    @Test func documentationProviderManagerUsesNumericIDsForMCPBridgeStartup() async throws {
+        let target = documentationProviderTarget(processID: 112, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .success,
                         requiresNumericRequestIDs: true
                     ),
                 ],
@@ -404,15 +517,15 @@ extension RuntimeCoordinatorTests {
             sessionFactory: factory
         )
 
-        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
         let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await factory.startedPIDs() == [target.processID])
     }
 
-    @Test func documentationProviderManagerUsesConfiguredInitializeParamsForProbe() async throws {
-        let target = documentationProviderTarget(processID: 112)
+    @Test func documentationProviderManagerUsesConfiguredInitializeParamsForStartup() async throws {
+        let target = documentationProviderTarget(processID: 113, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 target.processID: [
@@ -420,7 +533,7 @@ extension RuntimeCoordinatorTests {
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success
+                        firstDocumentationResponse: .success
                     ),
                 ],
             ]
@@ -447,10 +560,8 @@ extension RuntimeCoordinatorTests {
             initializeParams: initializeObject
         )
 
-        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        _ = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
 
-        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         let observedParams = try #require(await factory.initializeParams(for: target.processID).first)
         guard case .object(let observedObject) = observedParams else {
             Issue.record("expected initialize params object")
@@ -474,175 +585,25 @@ extension RuntimeCoordinatorTests {
         }
     }
 
-    @Test func documentationProviderManagerCoalescesConcurrentProviderSelection() async throws {
-        let target = documentationProviderTarget(processID: 121)
-        let factory = ScriptedDocumentationSessionFactory(
-            plansByPID: [
-                target.processID: [
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                ],
-            ],
-            startDelayNanoseconds: 100_000_000
-        )
-        let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [target]),
-            sessionFactory: factory
-        )
-
-        async let firstUpdate = manager.toolListUpdate(requestTimeout: .seconds(2))
-        async let secondUpdate = manager.toolListUpdate(requestTimeout: .seconds(2))
-        let results = await [firstUpdate, secondUpdate]
-
-        for update in results {
-            let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
-            #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
-        }
-        #expect(await factory.startAttempts() == [target.processID])
-        #expect(await factory.startedPIDs() == [target.processID])
-    }
-
-    @Test func documentationProviderManagerBoundsReusedProviderSelectionByCallerTimeout() async throws {
-        let target = documentationProviderTarget(processID: 122)
-        let factory = ScriptedDocumentationSessionFactory(
-            plansByPID: [
-                target.processID: [
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                ],
-            ],
-            startDelayNanoseconds: 500_000_000
-        )
-        let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [target]),
-            sessionFactory: factory
-        )
-
-        async let longUpdate = manager.toolListUpdate(requestTimeout: .seconds(2))
-        try await spinUntil("waiting for provider selection to start") {
-            await factory.startAttempts() == [target.processID]
-        }
-
-        let shortStart = Date()
-        let shortUpdate = await manager.toolListUpdate(requestTimeout: .milliseconds(1))
-        #expect(Date().timeIntervalSince(shortStart) < 0.1)
-        if case .unavailable = shortUpdate {
-        } else {
-            Issue.record("short tools/list should time out while reusing provider selection")
-        }
-
-        let finalUpdate = await longUpdate
-        let result = DocumentationProvider.ToolCatalog.applying(finalUpdate, to: try jsonValue(["tools": []]))
-        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
-        #expect(await factory.startedPIDs() == [target.processID])
-    }
-
-    @Test func documentationProviderManagerKeepsSelectionAfterStartingCallerTimesOut() async throws {
-        let target = documentationProviderTarget(processID: 123)
-        let factory = ScriptedDocumentationSessionFactory(
-            plansByPID: [
-                target.processID: [
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                ],
-            ],
-            startDelayNanoseconds: 100_000_000
-        )
-        let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [target]),
-            sessionFactory: factory
-        )
-
-        async let shortUpdate = manager.toolListUpdate(requestTimeout: .milliseconds(1))
-        try await spinUntil("waiting for provider selection to start") {
-            await factory.startAttempts() == [target.processID]
-        }
-
-        let longUpdate = await manager.toolListUpdate(requestTimeout: .seconds(2))
-        if case .unavailable = await shortUpdate {
-        } else {
-            Issue.record("short tools/list should time out without cancelling provider selection")
-        }
-
-        let result = DocumentationProvider.ToolCatalog.applying(longUpdate, to: try jsonValue(["tools": []]))
-        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
-        #expect(await factory.startedPIDs() == [target.processID])
-    }
-
-    @Test func documentationProviderManagerCancelsSelectionWaitForCancelledCaller() async throws {
-        let target = documentationProviderTarget(processID: 124)
-        let factory = ScriptedDocumentationSessionFactory(
-            plansByPID: [
-                target.processID: [
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                ],
-            ],
-            startDelayNanoseconds: 500_000_000
-        )
-        let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [target]),
-            sessionFactory: factory
-        )
-
-        let task = Task {
-            try await manager.callDocumentationSearch(
-                requestData: makeDocumentationSearchRequest(id: 74, query: "UIView"),
-                requestTimeoutOverride: .seconds(2)
-            )
-        }
-        try await spinUntil("waiting for provider selection to start") {
-            await factory.startAttempts() == [target.processID]
-        }
-
-        let cancelStart = Date()
-        task.cancel()
-        await #expect(throws: CancellationError.self) {
-            try await task.value
-        }
-        #expect(Date().timeIntervalSince(cancelStart) < 0.25)
-
-        let longUpdate = await manager.toolListUpdate(requestTimeout: .seconds(2))
-        let result = DocumentationProvider.ToolCatalog.applying(longUpdate, to: try jsonValue(["tools": []]))
-        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
-        #expect(await factory.startedPIDs() == [target.processID])
-    }
-
-    @Test func documentationProviderManagerChecksAllRunningXcodeTargetsBeforePublishingDescriptor() async throws {
-        let xcode26 = documentationProviderTarget(processID: 201)
-        let xcode27 = documentationProviderTarget(processID: 202)
+    @Test func documentationProviderManagerPrefersNewerXcodeVersionOverToolCount() async throws {
+        let xcode26 = documentationProviderTarget(processID: 399, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 401, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 xcode26.processID: [
                     .init(
                         serverVersion: "26.6",
-                        toolCount: 20,
+                        toolCount: 100,
                         includesDocumentationSearch: true,
-                        probeResponse: .notEnabled
+                        firstDocumentationResponse: .successText("{\"answer\":\"old\"}")
                     ),
                 ],
                 xcode27.processID: [
                     .init(
                         serverVersion: "27.0",
-                        toolCount: 47,
+                        toolCount: 1,
                         includesDocumentationSearch: true,
-                        probeResponse: .success
+                        firstDocumentationResponse: .successText("{\"answer\":\"new\"}")
                     ),
                 ],
             ]
@@ -652,82 +613,448 @@ extension RuntimeCoordinatorTests {
             sessionFactory: factory
         )
 
-        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 71, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
 
-        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
-        #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"new\"}")
+        #expect(await factory.startedPIDs() == [xcode27.processID])
+        #expect(await factory.documentationQueries(for: xcode27.processID) == ["SwiftUI"])
+        #expect(await factory.documentationQueries(for: xcode26.processID).isEmpty)
     }
 
-    @Test func documentationProviderManagerContinuesAfterCandidateProbeTimesOut() async throws {
-        let hung = documentationProviderTarget(processID: 205)
-        let working = documentationProviderTarget(processID: 206)
-        let timeoutClock = TestClock()
-        let uptimeClock = TestUptimeClock()
+    @Test func documentationProviderManagerUsesDeterministicOrderWithinSameXcodeVersion() async throws {
+        let first = documentationProviderTarget(processID: 501, xcodeVersion: "27.0")
+        let second = documentationProviderTarget(processID: 502, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
-                hung.processID: [
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 50,
-                        includesDocumentationSearch: true,
-                        probeResponse: .hang
-                    ),
-                ],
-                working.processID: [
+                first.processID: [
                     .init(
                         serverVersion: "27.0",
-                        toolCount: 47,
+                        toolCount: 1,
                         includesDocumentationSearch: true,
-                        probeResponse: .success
+                        firstDocumentationResponse: .successText("{\"answer\":\"first\"}")
+                    ),
+                ],
+                second.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 1,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"second\"}")
                     ),
                 ],
             ]
         )
         let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [hung, working]),
-            sessionFactory: factory,
-            providerSelectionTimeout: .seconds(1),
-            clock: makeDeterministicClockClient(
-                timeoutClock: timeoutClock,
-                uptimeClock: uptimeClock
-            )
+            discovery: StubXcodeTargetDiscovery(targets: [second, first]),
+            sessionFactory: factory
         )
 
-        let updateTask = Task {
-            await manager.toolListUpdate(requestTimeout: .seconds(2))
-        }
-        defer { updateTask.cancel() }
-        try await waitWithTimeout("waiting for hung documentation probe") {
-            try await factory.waitForRequestCount(
-                1,
-                processID: hung.processID,
-                method: "tools/call"
-            )
-        }
-        await timeoutClock.sleep(untilSuspendedBy: 2)
-        uptimeClock.advance(by: .milliseconds(500))
-        timeoutClock.advance(by: .milliseconds(500))
-        try await waitWithTimeout("waiting for replacement documentation probe") {
-            try await factory.waitForRequestCount(
-                1,
-                processID: working.processID,
-                method: "tools/call"
-            )
-        }
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 72, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
 
-        let update = try await waitWithTimeout("waiting for documentation provider selection") {
-            await updateTask.value
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
         }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"first\"}")
+        #expect(await factory.startedPIDs() == [first.processID])
+    }
+
+    @Test func documentationProviderManagerSendsActualRequestsAndReusesSuccessfulSession() async throws {
+        let target = documentationProviderTarget(processID: 601, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"first\"}"),
+                        userCallResponses: [.successText("{\"answer\":\"second\"}")]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let firstOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 73, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        let secondOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 74, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let firstData, _) = firstOutcome,
+              case .handled(let secondData, _) = secondOutcome else {
+            Issue.record("expected handled outcomes, got \(firstOutcome) and \(secondOutcome)")
+            return
+        }
+        #expect(try toolContentText(in: firstData) == "{\"answer\":\"first\"}")
+        #expect(try toolContentText(in: secondData) == "{\"answer\":\"second\"}")
+        #expect(try responseID(in: firstData) == 73)
+        #expect(try responseID(in: secondData) == 74)
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.documentationQueries(for: target.processID) == ["UIView", "SwiftUI"])
+    }
+
+    @Test func documentationProviderManagerPreservesOrdinaryToolErrors() async throws {
+        let target = documentationProviderTarget(processID: 602, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .toolErrorText("query-specific failure"),
+                        userCallResponses: [.successText("{\"answer\":\"after-error\"}")]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let errorOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 82, query: "bad query"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        let followUpOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 83, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let errorData, let invalidatedProvider) = errorOutcome,
+              case .handled(let followUpData, _) = followUpOutcome else {
+            Issue.record("expected handled outcomes, got \(errorOutcome) and \(followUpOutcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try toolResultIsError(in: errorData))
+        #expect(try toolContentText(in: errorData) == "query-specific failure")
+        #expect(try toolContentText(in: followUpData) == "{\"answer\":\"after-error\"}")
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.documentationQueries(for: target.processID) == ["bad query", "SwiftUI"])
+    }
+
+    @Test func documentationProviderManagerDoesNotOverlayPreparedDescriptorForDifferentActiveProvider()
+        async throws
+    {
+        let xcode26 = documentationProviderTarget(processID: 605, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 606, xcodeVersion: "27.0")
+        let discovery = SequencedXcodeTargetDiscovery([
+            [xcode26],
+            [xcode27, xcode26],
+            [xcode27, xcode26],
+        ])
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .success
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"new\"}")
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: discovery,
+            sessionFactory: factory
+        )
+
+        let prewarmUpdate = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let prewarmResult = DocumentationProvider.ToolCatalog.applying(
+            prewarmUpdate,
+            to: try jsonValue(["tools": []])
+        )
+        #expect(documentationDescriptorDescription(in: prewarmResult) == "docs-26.6")
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 87, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"new\"}")
+
+        let activeUpdate = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let activeResult = DocumentationProvider.ToolCatalog.applying(
+            activeUpdate,
+            to: try jsonValue(["tools": []])
+        )
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: activeResult) == nil)
+        #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
+    }
+
+    @Test func documentationProviderManagerSkipsDescriptorMissingTargetsForSearch() async throws {
+        let xcode26 = documentationProviderTarget(processID: 610, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 611, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"advertised\"}")
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 46,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .toolErrorText("missing descriptor target")
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
         let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-26.6")
 
-        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
-        #expect(await factory.startedPIDs() == [hung.processID, working.processID])
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 84, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"advertised\"}")
+        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
+        #expect(await factory.documentationQueries(for: xcode27.processID).isEmpty)
+        #expect(await factory.documentationQueries(for: xcode26.processID) == ["SwiftUI"])
+    }
+
+    @Test func documentationProviderManagerRetriesActualRequestWhenNewestIsNotEnabled() async throws {
+        let xcode26 = documentationProviderTarget(processID: 420, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 421, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"fallback\"}")
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 75, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"fallback\"}")
+        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
+        #expect(await factory.documentationQueries(for: xcode27.processID) == ["UIView"])
+        #expect(await factory.documentationQueries(for: xcode26.processID) == ["UIView"])
+    }
+
+    @Test func documentationProviderManagerRetriesActiveNotEnabledOnNextCandidate() async throws {
+        let xcode26 = documentationProviderTarget(processID: 430, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 431, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"fallback\"}")
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"first\"}"),
+                        userCallResponses: [.notEnabled]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        _ = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 76, query: "First"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        let retryOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 77, query: "Retry"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = retryOutcome else {
+            Issue.record("expected handled outcome, got \(retryOutcome)")
+            return
+        }
+        #expect(invalidatedProvider)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"fallback\"}")
+        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
+        #expect(await factory.documentationQueries(for: xcode27.processID) == ["First", "Retry"])
+        #expect(await factory.documentationQueries(for: xcode26.processID) == ["Retry"])
+    }
+
+    @Test func documentationProviderManagerRetriesActiveTransportFailureOnNextCandidate() async throws {
+        let xcode26 = documentationProviderTarget(processID: 440, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 441, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"fallback\"}")
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"first\"}"),
+                        userCallResponses: [.exit]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        _ = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 78, query: "First"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        let retryOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 79, query: "Retry"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = retryOutcome else {
+            Issue.record("expected handled outcome, got \(retryOutcome)")
+            return
+        }
+        #expect(invalidatedProvider)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"fallback\"}")
+        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
+        #expect(await factory.documentationQueries(for: xcode27.processID) == ["First", "Retry"])
+        #expect(await factory.documentationQueries(for: xcode26.processID) == ["Retry"])
+    }
+
+    @Test func documentationProviderManagerRemovesToolOnlyWhenAllCandidatesAreUnusable() async throws {
+        let xcode26 = documentationProviderTarget(processID: 450, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 451, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 80, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .unavailable(let reason) = outcome else {
+            Issue.record("expected unavailable outcome, got \(outcome)")
+            return
+        }
+        #expect(reason.message == DocumentationProvider.UnavailableReason.userFacingMessage)
+
+        let followUpTools = DocumentationProvider.ToolCatalog.applying(
+            await manager.toolListUpdate(requestTimeout: .seconds(1)),
+            to: try jsonValue([
+                "tools": [
+                    documentationDescriptor(version: "stale").foundationObject,
+                ],
+            ])
+        )
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
     }
 
     @Test func documentationProviderManagerHonorsPinnedProcessID() async throws {
-        let pinned = documentationProviderTarget(processID: 203)
-        let other = documentationProviderTarget(processID: 204)
+        let pinned = documentationProviderTarget(processID: 460, xcodeVersion: "26.6")
+        let other = documentationProviderTarget(processID: 461, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 pinned.processID: [
@@ -735,7 +1062,7 @@ extension RuntimeCoordinatorTests {
                         serverVersion: "26.6",
                         toolCount: 20,
                         includesDocumentationSearch: true,
-                        probeResponse: .success
+                        firstDocumentationResponse: .successText("{\"answer\":\"pinned\"}")
                     ),
                 ],
                 other.processID: [
@@ -743,7 +1070,7 @@ extension RuntimeCoordinatorTests {
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success
+                        firstDocumentationResponse: .successText("{\"answer\":\"other\"}")
                     ),
                 ],
             ]
@@ -754,370 +1081,149 @@ extension RuntimeCoordinatorTests {
             pinnedProcessID: pinned.processID
         )
 
-        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
-
-        #expect(documentationDescriptorDescription(in: result) == "docs-26.6")
-        #expect(await factory.startedPIDs() == [pinned.processID])
-    }
-
-    @Test func documentationProviderManagerPrefersNewerServerVersionWhenToolCountsTie() async throws {
-        let xcode26 = documentationProviderTarget(processID: 211)
-        let xcode27 = documentationProviderTarget(processID: 212)
-        let factory = ScriptedDocumentationSessionFactory(
-            plansByPID: [
-                xcode26.processID: [
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                ],
-                xcode27.processID: [
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                ],
-            ]
-        )
-        let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
-            sessionFactory: factory
-        )
-
-        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
-
-        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
-        #expect(await factory.startedPIDs() == [xcode26.processID, xcode27.processID])
-    }
-
-    @Test func documentationProviderManagerRetriesDocumentationSearchOnAlternateCandidate() async throws {
-        let xcode26 = documentationProviderTarget(processID: 201)
-        let xcode27 = documentationProviderTarget(processID: 202)
-        let factory = ScriptedDocumentationSessionFactory(
-            plansByPID: [
-                xcode26.processID: [
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 50,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.notEnabled]
-                    ),
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 50,
-                        includesDocumentationSearch: true,
-                        probeResponse: .notEnabled
-                    ),
-                ],
-                xcode27.processID: [
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.successText("{\"answer\":\"retry\"}")]
-                    ),
-                ],
-            ]
-        )
-        let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
-            sessionFactory: factory
-        )
-
-        let initialTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: nil),
-            to: try jsonValue(["tools": []])
-        )
-        #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
-
         let outcome = try await manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 73, query: "UIView"),
-            requestTimeoutOverride: nil
+            requestData: makeDocumentationSearchRequest(id: 81, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
         )
 
         guard case .handled(let responseData, _) = outcome else {
             Issue.record("expected handled outcome, got \(outcome)")
             return
         }
-        #expect(DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(responseData) == false)
-        #expect(try toolContentText(in: responseData) == "{\"answer\":\"retry\"}")
-        #expect(await factory.startedPIDs() == [
-            xcode26.processID,
-            xcode27.processID,
-            xcode27.processID,
-        ])
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"pinned\"}")
+        #expect(await factory.startedPIDs() == [pinned.processID])
+        #expect(await factory.documentationQueries(for: pinned.processID) == ["UIView"])
+        #expect(await factory.documentationQueries(for: other.processID).isEmpty)
     }
 
-    @Test func documentationProviderManagerInvalidatesReplacementWhenRetryReturnsNotEnabled() async throws {
-        let xcode26 = documentationProviderTarget(processID: 221)
-        let xcode27 = documentationProviderTarget(processID: 222)
+    @Test func documentationProviderManagerCoalescesConcurrentBackgroundDiscovery() async throws {
+        let target = documentationProviderTarget(processID: 470, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
-                xcode26.processID: [
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 50,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.exit]
-                    ),
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 50,
-                        includesDocumentationSearch: true,
-                        probeResponse: .notEnabled
-                    ),
-                ],
-                xcode27.processID: [
+                target.processID: [
                     .init(
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.notEnabled]
+                        firstDocumentationResponse: .success
                     ),
                 ],
-            ]
+            ],
+            startDelayNanoseconds: 100_000_000
         )
         let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
             sessionFactory: factory
         )
 
-        let initialTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: nil),
-            to: try jsonValue(["tools": []])
-        )
-        #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
+        async let firstUpdate = manager.startBackgroundDiscovery(requestTimeout: .seconds(2))
+        async let secondUpdate = manager.startBackgroundDiscovery(requestTimeout: .seconds(2))
+        let results = await [firstUpdate, secondUpdate]
 
-        let outcome = try await manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 75, query: "UIView"),
-            requestTimeoutOverride: .seconds(1)
-        )
-
-        guard case .unavailable = outcome else {
-            Issue.record("expected unavailable outcome, got \(outcome)")
-            return
+        for update in results {
+            let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+            #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         }
-        let followUpTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: .seconds(1)),
-            to: try jsonValue(["tools": []])
-        )
-        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
-        #expect(await factory.startedPIDs() == [
-            xcode26.processID,
-            xcode27.processID,
-            xcode27.processID,
-            xcode26.processID,
-        ])
+        #expect(await factory.startAttempts() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
     }
 
-    @Test func documentationProviderManagerInvalidatesReplacementWhenRetryTransportFails() async throws {
-        let xcode26 = documentationProviderTarget(processID: 225)
-        let xcode27 = documentationProviderTarget(processID: 226)
+    @Test func documentationProviderManagerCoalescesConcurrentInitialDocumentationSearch() async throws {
+        let target = documentationProviderTarget(processID: 480, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
-                xcode26.processID: [
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 50,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.exit]
-                    ),
-                ],
-                xcode27.processID: [
+                target.processID: [
                     .init(
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.exit]
+                        firstDocumentationResponse: .successText("{\"answer\":\"first\"}"),
+                        userCallResponses: [.successText("{\"answer\":\"second\"}")]
                     ),
                 ],
-            ]
+            ],
+            startDelayNanoseconds: 100_000_000
         )
         let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
             sessionFactory: factory
         )
 
-        let initialTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: nil),
-            to: try jsonValue(["tools": []])
+        async let firstOutcome = manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 101, query: "UIView"),
+            requestTimeoutOverride: .seconds(2)
         )
-        #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
+        async let secondOutcome = manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 102, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(2)
+        )
+        let outcomes = try await [firstOutcome, secondOutcome]
 
-        let outcome = try await manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 77, query: "UIView"),
-            requestTimeoutOverride: .seconds(1)
-        )
-        guard case .unavailable = outcome else {
-            Issue.record("expected unavailable outcome, got \(outcome)")
-            return
+        var ids: [Int64] = []
+        for outcome in outcomes {
+            guard case .handled(let responseData, _) = outcome else {
+                Issue.record("expected handled outcome, got \(outcome)")
+                continue
+            }
+            ids.append(try responseID(in: responseData))
         }
-
-        let followUpTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: .seconds(1)),
-            to: try jsonValue(["tools": []])
-        )
-        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
-        #expect(await factory.startedPIDs() == [
-            xcode26.processID,
-            xcode27.processID,
-            xcode27.processID,
-        ])
+        #expect(Set(ids) == Set([101, 102]))
+        #expect(await factory.startAttempts() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(Set(await factory.documentationQueries(for: target.processID)) == Set(["UIView", "SwiftUI"]))
     }
 
-    @Test func documentationProviderManagerInvalidatesReplacementWhenNotEnabledRetryTransportFails()
+    @Test func documentationProviderManagerBoundsSharedPreparationWaitByCallerTimeout()
         async throws
     {
-        let xcode26 = documentationProviderTarget(processID: 227)
-        let xcode27 = documentationProviderTarget(processID: 228)
+        let target = documentationProviderTarget(processID: 485, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
-                xcode26.processID: [
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 50,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.notEnabled]
-                    ),
-                    .init(
-                        serverVersion: "26.6",
-                        toolCount: 50,
-                        includesDocumentationSearch: true,
-                        probeResponse: .notEnabled
-                    ),
-                ],
-                xcode27.processID: [
+                target.processID: [
                     .init(
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success
-                    ),
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.exit]
+                        firstDocumentationResponse: .successText("{\"answer\":\"after-timeout\"}")
                     ),
                 ],
-            ]
+            ],
+            startDelayNanoseconds: 500_000_000
         )
         let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
             sessionFactory: factory
         )
 
-        let initialTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: nil),
-            to: try jsonValue(["tools": []])
+        let shortStart = Date()
+        let shortOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 85, query: "too soon"),
+            requestTimeoutOverride: .milliseconds(1)
         )
-        #expect(documentationDescriptorDescription(in: initialTools) == "docs-26.6")
-
-        let outcome = try await manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 78, query: "UIView"),
-            requestTimeoutOverride: .seconds(1)
-        )
-        guard case .unavailable = outcome else {
-            Issue.record("expected unavailable outcome, got \(outcome)")
+        #expect(Date().timeIntervalSince(shortStart) < 0.1)
+        guard case .failed(let error, _) = shortOutcome else {
+            Issue.record("expected timeout outcome, got \(shortOutcome)")
             return
         }
+        #expect(error is TimeoutError)
 
-        let followUpTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: .seconds(1)),
-            to: try jsonValue(["tools": []])
+        let followUpOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 86, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(2)
         )
-        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
-        #expect(await factory.startedPIDs() == [
-            xcode26.processID,
-            xcode27.processID,
-            xcode27.processID,
-            xcode26.processID,
-        ])
-        #expect(await factory.startAttempts() == [
-            xcode26.processID,
-            xcode27.processID,
-            xcode27.processID,
-            xcode26.processID,
-            xcode27.processID,
-        ])
-    }
-
-    @Test func documentationProviderManagerReportsInactiveProviderWhenRecoveryFindsNoReplacement() async throws {
-        let xcode = documentationProviderTarget(processID: 231)
-        let factory = ScriptedDocumentationSessionFactory(
-            plansByPID: [
-                xcode.processID: [
-                    .init(
-                        serverVersion: "27.0",
-                        toolCount: 47,
-                        includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.exit]
-                    ),
-                ],
-            ]
-        )
-        let manager = DocumentationProviderManager(
-            discovery: StubXcodeTargetDiscovery(targets: [xcode]),
-            sessionFactory: factory
-        )
-
-        let initialTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: nil),
-            to: try jsonValue(["tools": []])
-        )
-        #expect(documentationDescriptorDescription(in: initialTools) == "docs-27.0")
-
-        let outcome = try await manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 76, query: "UIView"),
-            requestTimeoutOverride: .seconds(1)
-        )
-        guard case .unavailable = outcome else {
-            Issue.record("expected unavailable outcome, got \(outcome)")
+        guard case .handled(let responseData, _) = followUpOutcome else {
+            Issue.record("expected handled outcome, got \(followUpOutcome)")
             return
         }
-
-        let followUpTools = DocumentationProvider.ToolCatalog.applying(
-            await manager.toolListUpdate(requestTimeout: .seconds(1)),
-            to: try jsonValue(["tools": []])
-        )
-        #expect(DocumentationProvider.ToolCatalog.descriptor(in: followUpTools) == nil)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"after-timeout\"}")
+        #expect(await factory.startAttempts() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
     }
 
     @Test func documentationProviderManagerDoesNotRetryAfterRequestTimeoutExpires() async throws {
-        let xcode = documentationProviderTarget(processID: 301)
+        let xcode = documentationProviderTarget(processID: 490, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 xcode.processID: [
@@ -1125,15 +1231,13 @@ extension RuntimeCoordinatorTests {
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.hang]
+                        firstDocumentationResponse: .hang
                     ),
                     .init(
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.successText("{\"answer\":\"late\"}")]
+                        firstDocumentationResponse: .successText("{\"answer\":\"late\"}")
                     ),
                 ],
             ]
@@ -1152,12 +1256,14 @@ extension RuntimeCoordinatorTests {
             return
         }
         #expect(error is TimeoutError)
-
         #expect(await factory.startedPIDs() == [xcode.processID])
+        #expect(await factory.documentationQueries(for: xcode.processID) == ["UIView"])
     }
 
-    @Test func documentationProviderManagerKeepsProviderWhenDocumentationCallIsCancelled() async throws {
-        let xcode = documentationProviderTarget(processID: 302)
+    @Test func documentationProviderManagerKeepsPreparedConnectionWhenDocumentationCallIsCancelled()
+        async throws
+    {
+        let xcode = documentationProviderTarget(processID: 491, xcodeVersion: "27.0")
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 xcode.processID: [
@@ -1165,8 +1271,8 @@ extension RuntimeCoordinatorTests {
                         serverVersion: "27.0",
                         toolCount: 47,
                         includesDocumentationSearch: true,
-                        probeResponse: .success,
-                        userCallResponses: [.hang]
+                        firstDocumentationResponse: .hang,
+                        userCallResponses: [.successText("{\"answer\":\"after-cancel\"}")]
                     ),
                 ],
             ]
@@ -1181,19 +1287,29 @@ extension RuntimeCoordinatorTests {
                 requestTimeoutOverride: .seconds(2)
             )
         }
-        let didStart = await waitUntil(timeout: .seconds(1)) {
-            await factory.startedPIDs() == [xcode.processID]
+        try await waitWithTimeout("waiting for documentation request") {
+            try await factory.waitForRequestCount(
+                1,
+                processID: xcode.processID,
+                method: "tools/call"
+            )
         }
-        #expect(didStart)
 
         task.cancel()
         await #expect(throws: CancellationError.self) {
             try await task.value
         }
 
-        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
-        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
-        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 93, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"after-cancel\"}")
         #expect(await factory.startedPIDs() == [xcode.processID])
+        #expect(await factory.documentationQueries(for: xcode.processID) == ["UIView", "SwiftUI"])
     }
 }

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -12,18 +12,633 @@ import XcodeMCPTestSupport
 extension RuntimeCoordinatorTests {
     @Test func defaultDocumentationProviderIsEnabledOnlyForDefaultMCPBridgeInvocation() {
         var config = makeConfig(requestTimeout: 5)
-        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config, discovery: StubXcodeTargetDiscovery(targets: [])) != nil)
+        let transport = UnavailableDocumentationProviderTransport()
+        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(
+            config: config,
+            discovery: StubXcodeTargetDiscovery(targets: []),
+            transport: transport
+        ) != nil)
 
         config.disabledToolNames = [DocumentationProvider.ToolCatalog.toolName]
-        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config, discovery: StubXcodeTargetDiscovery(targets: [])) == nil)
+        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(
+            config: config,
+            discovery: StubXcodeTargetDiscovery(targets: []),
+            transport: transport
+        ) == nil)
 
         config.disabledToolNames = []
         config.upstreamArgs = ["--sdk", "macosx", "swift"]
-        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config, discovery: StubXcodeTargetDiscovery(targets: [])) == nil)
+        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(
+            config: config,
+            discovery: StubXcodeTargetDiscovery(targets: []),
+            transport: transport
+        ) == nil)
 
         config.upstreamCommand = "/bin/echo"
         config.upstreamArgs = ["xcrun", "mcpbridge"]
-        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(config: config, discovery: StubXcodeTargetDiscovery(targets: [])) == nil)
+        #expect(RuntimeCoordinator.makeDefaultDocumentationProviderManager(
+            config: config,
+            discovery: StubXcodeTargetDiscovery(targets: []),
+            transport: transport
+        ) == nil)
+    }
+
+    @Test func defaultUpstreamPlanReusesSingleXcodeProcessWithoutAddingProviderSlot() throws {
+        let target = documentationProviderTarget(processID: 710, xcodeVersion: "27.0")
+        var config = makeConfig(requestTimeout: 5)
+        config.upstreamSessionID = "shared-docs-session"
+
+        let plan = try withEnvironmentVariables(["MCP_XCODE_PID": ""]) {
+            RuntimeCoordinator.makeDefaultUpstreamPlan(
+                config: config,
+                sharedSessionID: config.upstreamSessionID,
+                count: 2,
+                documentationTargets: [target]
+            )
+        }
+
+        #expect(plan.upstreams.count == 2)
+        #expect(plan.documentationRoutes.map(\.target.processID) == [target.processID])
+        #expect(plan.documentationRoutes.first?.upstreamIndex == 0)
+        for upstream in plan.upstreams {
+            let environment = try upstreamEnvironment(from: upstream)
+            #expect(try upstreamCommand(from: upstream) == config.upstreamCommand)
+            #expect(try upstreamArgs(from: upstream) == config.upstreamArgs)
+            #expect(environment["MCP_XCODE_PID"]?.isEmpty ?? true)
+            #expect(environment["DEVELOPER_DIR"] == nil)
+            #expect(environment["MCP_XCODE_SESSION_ID"] == "shared-docs-session")
+        }
+    }
+
+    @Test func defaultUpstreamPlanDoesNotLimitDocumentationCandidatesToUpstreamCount()
+        throws
+    {
+        let older = documentationProviderTarget(processID: 720, xcodeVersion: "26.6")
+        let newer = documentationProviderTarget(processID: 721, xcodeVersion: "27.0")
+        let config = makeConfig(requestTimeout: 5)
+
+        let plan = try withEnvironmentVariables(["MCP_XCODE_PID": ""]) {
+            RuntimeCoordinator.makeDefaultUpstreamPlan(
+                config: config,
+                sharedSessionID: config.upstreamSessionID,
+                count: 1,
+                documentationTargets: [older, newer]
+            )
+        }
+
+        #expect(plan.upstreams.count == 1)
+        #expect(plan.documentationRoutes.isEmpty)
+        let upstream = try #require(plan.upstreams.first)
+        #expect(try upstreamCommand(from: upstream) == config.upstreamCommand)
+        #expect(try upstreamArgs(from: upstream) == config.upstreamArgs)
+    }
+
+    @Test func defaultUpstreamPlanHonorsPinnedDocumentationProcess() throws {
+        let pinned = documentationProviderTarget(processID: 730, xcodeVersion: "26.6")
+        let newer = documentationProviderTarget(processID: 731, xcodeVersion: "27.0")
+        let config = makeConfig(requestTimeout: 5)
+
+        let plan = try withEnvironmentVariables(["MCP_XCODE_PID": "\(pinned.processID)"]) {
+            RuntimeCoordinator.makeDefaultUpstreamPlan(
+                config: config,
+                sharedSessionID: config.upstreamSessionID,
+                count: 2,
+                documentationTargets: [newer, pinned]
+            )
+        }
+
+        #expect(plan.upstreams.count == 2)
+        #expect(plan.documentationRoutes.map(\.target.processID) == [pinned.processID])
+        #expect(plan.documentationRoutes.first?.upstreamIndex == 0)
+        for upstream in plan.upstreams {
+            let environment = try upstreamEnvironment(from: upstream)
+            #expect(environment["MCP_XCODE_PID"] == "\(pinned.processID)")
+            #expect(try upstreamCommand(from: upstream) == config.upstreamCommand)
+            #expect(try upstreamArgs(from: upstream) == config.upstreamArgs)
+        }
+    }
+
+    @Test func runtimeCoordinatorSkipsXcodeDiscoveryWhenDocumentationServiceIsDisabled()
+        throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let target = documentationProviderTarget(processID: 735, xcodeVersion: "27.0")
+
+        do {
+            var config = makeConfig(requestTimeout: 5)
+            config.disabledToolNames = [DocumentationProvider.ToolCatalog.toolName]
+            let discovery = CountingXcodeTargetDiscovery(targets: [target])
+            let manager = RuntimeCoordinator(
+                config: config,
+                eventLoop: eventLoop,
+                xcodeTargetDiscovery: discovery,
+                startImmediately: false
+            )
+            defer { manager.shutdownAndWait() }
+
+            #expect(discovery.callCount() == 0)
+            #expect(manager.hasDocumentationSearchService() == false)
+        }
+
+        do {
+            var config = makeConfig(requestTimeout: 5)
+            config.upstreamArgs = ["--sdk", "macosx", "swift"]
+            let discovery = CountingXcodeTargetDiscovery(targets: [target])
+            let manager = RuntimeCoordinator(
+                config: config,
+                eventLoop: eventLoop,
+                xcodeTargetDiscovery: discovery,
+                startImmediately: false
+            )
+            defer { manager.shutdownAndWait() }
+
+            #expect(discovery.callCount() == 0)
+            #expect(manager.hasDocumentationSearchService() == false)
+        }
+    }
+
+    @Test func runtimeDocumentationTransportReusesPrewarmedUpstreamRouteForSearch()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = documentationProviderTarget(processID: 740, xcodeVersion: "27.0")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let providerManager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: RuntimeDocumentationProviderTransport(runtimeBox: runtimeBox),
+            providerSelectionTimeout: .seconds(1)
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [
+                DocumentationProviderRoute(
+                    id: "upstream-0-pid-\(target.processID)",
+                    target: target,
+                    upstreamIndex: 0
+                )
+            ],
+            documentationProviderManager: providerManager,
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        async let prewarmUpdate = providerManager.startBackgroundDiscovery(
+            requestTimeout: .seconds(1)
+        )
+        let toolsRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: toolsRequest) == "tools/list")
+        let toolsRequestID = try extractUpstreamID(from: toolsRequest)
+        await yieldMessage(
+            try makeDocumentationToolsListResponse(id: toolsRequestID, version: "27.0"),
+            to: upstream
+        )
+        let update = await prewarmUpdate
+        let result = DocumentationProvider.ToolCatalog.applying(
+            update,
+            to: try jsonValue(["tools": []])
+        )
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+
+        async let searchOutcome = providerManager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 91, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        let searchRequest = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
+        #expect(methodName(from: searchRequest) == "tools/call")
+        #expect(try documentationSearchQuery(in: searchRequest) == "UIView")
+        let searchRequestID = try extractUpstreamID(from: searchRequest)
+        await yieldMessage(
+            try makeDocumentationSearchResponse(
+                id: searchRequestID,
+                text: "{\"answer\":\"route\"}"
+            ),
+            to: upstream
+        )
+
+        let outcome = try await searchOutcome
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try responseID(in: responseData) == 91)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"route\"}")
+        #expect(await upstream.sentCount() == 2)
+    }
+
+    @Test func runtimeDocumentationTransportFallsBackWhenReusedUpstreamRouteFails()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = ToggleableOverloadUpstreamClient()
+        await upstream.overloadNextSend()
+        let target = documentationProviderTarget(processID: 742, xcodeVersion: "27.0")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"fallback\"}"),
+                        userCallResponses: [.successText("{\"answer\":\"reused-fallback\"}")]
+                    ),
+                ],
+            ]
+        )
+        let providerManager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: RuntimeDocumentationProviderTransport(
+                runtimeBox: runtimeBox,
+                fallback: SessionBackedDocumentationProviderTransport(sessionFactory: factory)
+            ),
+            providerSelectionTimeout: .seconds(1)
+        )
+        let route = DocumentationProviderRoute(
+            id: "upstream-0-pid-\(target.processID)",
+            target: target,
+            upstreamIndex: 0
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [route],
+            documentationProviderManager: providerManager,
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let firstOutcome = try await providerManager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 94, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        let firstRuntimeRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: firstRuntimeRequest) == "tools/call")
+        guard case .handled(let firstData, _) = firstOutcome else {
+            Issue.record("expected handled fallback outcome, got \(firstOutcome)")
+            return
+        }
+        #expect(try toolContentText(in: firstData) == "{\"answer\":\"fallback\"}")
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.documentationQueries(for: target.processID) == ["UIView"])
+        guard case .degraded = manager.testStateSnapshot().upstreams[0].healthState else {
+            Issue.record("proxy-generated upstream failure should not be marked successful")
+            return
+        }
+
+        let secondOutcome = try await providerManager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 95, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let secondData, _) = secondOutcome else {
+            Issue.record("expected handled fallback reuse outcome, got \(secondOutcome)")
+            return
+        }
+        #expect(try toolContentText(in: secondData) == "{\"answer\":\"reused-fallback\"}")
+        #expect(await upstream.sentCount() == 1)
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.documentationQueries(for: target.processID) == ["UIView", "SwiftUI"])
+    }
+
+    @Test func runtimeDocumentationTransportTimesOutQueuedPinnedRouteBeforeDispatch()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = documentationProviderTarget(processID: 746, xcodeVersion: "27.0")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let providerManager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: RuntimeDocumentationProviderTransport(runtimeBox: runtimeBox),
+            providerSelectionTimeout: .seconds(1)
+        )
+        let route = DocumentationProviderRoute(
+            id: "upstream-0-pid-\(target.processID)",
+            target: target,
+            upstreamIndex: 0
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [route],
+            documentationProviderManager: providerManager,
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let activeDescriptor = SessionRequestPipeline.Descriptor(
+            sessionID: "session-active",
+            label: "tools/call:LongRunning",
+            isBatch: false,
+            expectsResponse: true,
+            isTopLevelClientRequest: true
+        )
+        let activeLeaseID = manager.createRequestLease(descriptor: activeDescriptor)
+        let activePromise = eventLoop.makePromise(of: Void.self)
+        let activeFuture: EventLoopFuture<Void> = manager.enqueueOnUpstreamSlot(
+            leaseID: activeLeaseID,
+            descriptor: activeDescriptor,
+            on: eventLoop,
+            preferredUpstreamIndex: 0
+        ) { selectedUpstreamIndex in
+            manager.activateRequestLease(
+                activeLeaseID,
+                requestIDKey: nil,
+                upstreamIndex: selectedUpstreamIndex,
+                timeout: nil
+            )
+            return activePromise.futureResult
+        }
+        _ = activeFuture
+        try await waitForCondition(timeoutSeconds: 2) {
+            manager.debugSnapshot().leases.contains { lease in
+                lease.leaseID == activeLeaseID.uuidString && lease.state == .active
+            }
+        }
+
+        let started = Date()
+        let outcome = try await providerManager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 96, query: "UIView"),
+            requestTimeoutOverride: .milliseconds(10)
+        )
+
+        #expect(Date().timeIntervalSince(started) < 0.5)
+        guard case .failed(let error, _) = outcome else {
+            Issue.record("expected timed-out outcome, got \(outcome)")
+            activePromise.fail(CancellationError())
+            return
+        }
+        #expect(error is TimeoutError)
+        #expect(await upstream.sentCount() == 0)
+        try await waitForCondition(timeoutSeconds: 2) {
+            manager.debugSnapshot().queuedRequestCount == 0
+        }
+
+        activePromise.fail(CancellationError())
+    }
+
+    @Test func runtimeDocumentationTransportClosesFallbackOpenedAfterRouteInvalidation()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = ToggleableOverloadUpstreamClient()
+        await upstream.overloadNextSend()
+        let target = documentationProviderTarget(processID: 743, xcodeVersion: "27.0")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let openStarted = TestSignal()
+        let openGate = AsyncGate()
+        let fallback = BlockingFallbackDocumentationProviderTransport(
+            openStarted: openStarted,
+            openGate: openGate
+        )
+        let providerManager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: RuntimeDocumentationProviderTransport(
+                runtimeBox: runtimeBox,
+                fallback: fallback
+            ),
+            providerSelectionTimeout: .seconds(1)
+        )
+        let route = DocumentationProviderRoute(
+            id: "upstream-0-pid-\(target.processID)",
+            target: target,
+            upstreamIndex: 0
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [route],
+            documentationProviderManager: providerManager,
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let searchTask = Task {
+            try await providerManager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 96, query: "UIView"),
+                requestTimeoutOverride: .seconds(1)
+            )
+        }
+        _ = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        try await openStarted.wait(description: "waiting for fallback open")
+
+        await providerManager.invalidate(reason: "test_invalidation")
+        await openGate.signal()
+
+        do {
+            _ = try await waitWithTimeout(
+                "waiting for invalidated documentation search",
+                timeout: .seconds(2)
+            ) {
+                try await searchTask.value
+            }
+            Issue.record("expected invalidated documentation search to be cancelled")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("expected CancellationError for invalidated search, got \(error)")
+        }
+        #expect(await fallback.closeCount() == 1)
+    }
+
+    @Test func documentationProviderManagerClosesRouteOpenedAfterPreparationCancellation()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 744, xcodeVersion: "27.0")
+        let openStarted = TestSignal()
+        let openGate = AsyncGate()
+        let transport = BlockingFallbackDocumentationProviderTransport(
+            openStarted: openStarted,
+            openGate: openGate,
+            ignoresOpenCancellation: true
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: transport,
+            providerSelectionTimeout: .seconds(5)
+        )
+
+        let searchTask = Task {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 97, query: "UIView"),
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+        try await openStarted.wait(description: "waiting for provider open")
+
+        await manager.invalidate(reason: "test_invalidation")
+        await openGate.signal()
+
+        do {
+            _ = try await waitWithTimeout(
+                "waiting for cancelled provider preparation",
+                timeout: .seconds(2)
+            ) {
+                try await searchTask.value
+            }
+            Issue.record("expected provider preparation to be cancelled")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("expected CancellationError for provider preparation, got \(error)")
+        }
+        #expect(await transport.closeCount() == 1)
+    }
+
+    @Test func runtimeDocumentationTransportCancellationReleasesControlPlaneLease()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = documentationProviderTarget(processID: 745, xcodeVersion: "27.0")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let route = DocumentationProviderRoute(
+            id: "upstream-0-pid-\(target.processID)",
+            target: target,
+            upstreamIndex: 0
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 30),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [route],
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let toolsListTask = Task {
+            try await manager.documentationProviderToolsList(
+                route: route,
+                requestTimeout: .seconds(30)
+            )
+        }
+        let toolsRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: toolsRequest) == "tools/list")
+
+        toolsListTask.cancel()
+        do {
+            _ = try await waitWithTimeout(
+                "waiting for cancelled documentation tools/list",
+                timeout: .seconds(2)
+            ) {
+                try await toolsListTask.value
+            }
+            Issue.record("expected documentation tools/list to be cancelled")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("expected CancellationError for documentation tools/list, got \(error)")
+        }
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            let snapshot = manager.debugSnapshot()
+            return snapshot.queuedRequestCount == 0
+                && snapshot.upstreams[0].activeCorrelatedRequestCount == 0
+        })
+
+        let searchTask = Task {
+            try await manager.documentationProviderCall(
+                route: route,
+                requestData: makeDocumentationSearchRequest(id: 93, query: "UIView"),
+                requestTimeout: .seconds(30)
+            )
+        }
+        let searchRequest = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
+        #expect(methodName(from: searchRequest) == "tools/call")
+        #expect(try documentationSearchQuery(in: searchRequest) == "UIView")
+
+        searchTask.cancel()
+        do {
+            _ = try await waitWithTimeout(
+                "waiting for cancelled documentation search",
+                timeout: .seconds(2)
+            ) {
+                try await searchTask.value
+            }
+            Issue.record("expected documentation search to be cancelled")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("expected CancellationError for documentation search, got \(error)")
+        }
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            let snapshot = manager.debugSnapshot()
+            return snapshot.queuedRequestCount == 0
+                && snapshot.upstreams[0].activeCorrelatedRequestCount == 0
+        })
+    }
+
+    @Test func runtimeDocumentationTransportFallsBackToDirectCandidateWhenNoUpstreamRouteExists()
+        async throws
+    {
+        let newer = documentationProviderTarget(processID: 750, xcodeVersion: "27.0")
+        let older = documentationProviderTarget(processID: 751, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                newer.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"newer\"}")
+                    ),
+                ],
+                older.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"older\"}")
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [older, newer]),
+            transport: RuntimeDocumentationProviderTransport(
+                runtimeBox: WeakRuntimeCoordinatorBox(),
+                fallback: SessionBackedDocumentationProviderTransport(sessionFactory: factory)
+            ),
+            providerSelectionTimeout: .seconds(1)
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 92, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"newer\"}")
+        #expect(await factory.startedPIDs() == [newer.processID])
+        #expect(await factory.documentationQueries(for: newer.processID) == ["UIView"])
+        #expect(await factory.documentationQueries(for: older.processID).isEmpty)
     }
 
     @Test func sharedToolsListMergesDocumentationProviderDescriptor() async throws {
@@ -749,6 +1364,53 @@ extension RuntimeCoordinatorTests {
         #expect(try toolResultIsError(in: errorData))
         #expect(try toolContentText(in: errorData) == "query-specific failure")
         #expect(try toolContentText(in: followUpData) == "{\"answer\":\"after-error\"}")
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.documentationQueries(for: target.processID) == ["bad query", "SwiftUI"])
+    }
+
+    @Test func documentationProviderManagerPreservesRequestScopedJSONRPCErrors()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 603, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .jsonRPCError(
+                            code: -32602,
+                            message: "Invalid params"
+                        ),
+                        userCallResponses: [.successText("{\"answer\":\"after-jsonrpc-error\"}")]
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let errorOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 84, query: "bad query"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        let followUpOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 85, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let errorData, let invalidatedProvider) = errorOutcome,
+              case .handled(let followUpData, _) = followUpOutcome else {
+            Issue.record("expected handled outcomes, got \(errorOutcome) and \(followUpOutcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try responseID(in: errorData) == 84)
+        #expect(try jsonRPCErrorMessage(in: errorData) == "Invalid params")
+        #expect(try toolContentText(in: followUpData) == "{\"answer\":\"after-jsonrpc-error\"}")
         #expect(await factory.startedPIDs() == [target.processID])
         #expect(await factory.documentationQueries(for: target.processID) == ["bad query", "SwiftUI"])
     }

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -130,6 +130,14 @@ func responseID(in responseData: Data) throws -> Int64 {
     return id.int64Value
 }
 
+func jsonRPCErrorMessage(in responseData: Data) throws -> String? {
+    let object = try #require(
+        JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any]
+    )
+    let error = try #require(object["error"] as? [String: Any])
+    return error["message"] as? String
+}
+
 func documentationProviderTarget(processID: pid_t) -> DocumentationProviderTarget {
     DocumentationProviderTarget(
         processID: processID,
@@ -161,6 +169,138 @@ struct StubXcodeTargetDiscovery: XcodeTargetDiscovering {
     }
 }
 
+final class CountingXcodeTargetDiscovery: XcodeTargetDiscovering, @unchecked Sendable {
+    private let lock = NSLock()
+    private let targets: [DocumentationProviderTarget]
+    private var callCountValue = 0
+
+    init(targets: [DocumentationProviderTarget]) {
+        self.targets = targets
+    }
+
+    func runningXcodeTargets() -> [DocumentationProviderTarget] {
+        lock.lock()
+        callCountValue += 1
+        lock.unlock()
+        return targets
+    }
+
+    func callCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return callCountValue
+    }
+}
+
+actor BlockingFallbackDocumentationProviderTransport: DocumentationProviderRouting {
+    private let openStarted: TestSignal
+    private let openGate: AsyncGate
+    private let ignoresOpenCancellation: Bool
+    private var openCountValue = 0
+    private var closedRouteIDs: [String] = []
+
+    init(
+        openStarted: TestSignal,
+        openGate: AsyncGate,
+        ignoresOpenCancellation: Bool = false
+    ) {
+        self.openStarted = openStarted
+        self.openGate = openGate
+        self.ignoresOpenCancellation = ignoresOpenCancellation
+    }
+
+    func openRoute(
+        for target: DocumentationProviderTarget,
+        requestTimeout _: TimeAmount?,
+        initializeParams _: [String: JSONValue]
+    ) async throws -> DocumentationProviderRoute {
+        openCountValue += 1
+        let routeID = "blocking-fallback-\(target.processID)-\(openCountValue)"
+        openStarted.signal()
+        if ignoresOpenCancellation {
+            await openGate.waitIgnoringCancellation()
+        } else {
+            try await openGate.wait()
+        }
+        return DocumentationProviderRoute(
+            id: routeID,
+            target: target,
+            upstreamIndex: nil,
+            serverVersion: "fallback"
+        )
+    }
+
+    func toolsList(
+        route _: DocumentationProviderRoute,
+        timeout _: TimeAmount?
+    ) async throws -> JSONValue {
+        try jsonValue([
+            "tools": [
+                documentationDescriptor(version: "fallback").foundationObject,
+            ],
+        ])
+    }
+
+    func callDocumentationSearch(
+        route _: DocumentationProviderRoute,
+        requestData: Data,
+        timeout _: TimeAmount?
+    ) async throws -> Data {
+        let object = try JSONSerialization.jsonObject(with: requestData, options: [])
+            as? [String: Any]
+        let id = object?["id"] ?? 0
+        return try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": [
+                    "content": [
+                        [
+                            "type": "text",
+                            "text": "{\"answer\":\"fallback\"}",
+                        ],
+                    ],
+                    "isError": false,
+                ],
+            ],
+            options: []
+        )
+    }
+
+    func close(route: DocumentationProviderRoute) async {
+        closedRouteIDs.append(route.id)
+    }
+
+    func closeCount() -> Int {
+        closedRouteIDs.count
+    }
+}
+
+struct UnavailableDocumentationProviderTransport: DocumentationProviderRouting {
+    func openRoute(
+        for _: DocumentationProviderTarget,
+        requestTimeout _: TimeAmount?,
+        initializeParams _: [String: JSONValue]
+    ) async throws -> DocumentationProviderRoute {
+        throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+
+    func toolsList(
+        route _: DocumentationProviderRoute,
+        timeout _: TimeAmount?
+    ) async throws -> JSONValue {
+        throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+
+    func callDocumentationSearch(
+        route _: DocumentationProviderRoute,
+        requestData _: Data,
+        timeout _: TimeAmount?
+    ) async throws -> Data {
+        throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+}
+
 final class SequencedXcodeTargetDiscovery: XcodeTargetDiscovering, @unchecked Sendable {
     private let lock = NSLock()
     private var remainingSequences: [[DocumentationProviderTarget]]
@@ -187,6 +327,7 @@ enum ScriptedDocumentationResponse: Sendable {
     case success
     case successText(String)
     case toolErrorText(String)
+    case jsonRPCError(code: Int, message: String)
     case hang
     case notEnabled
     case exit
@@ -462,6 +603,8 @@ actor ScriptedDocumentationSession: UpstreamSession {
             yieldToolResponse(id: id, text: text, isError: false)
         case .toolErrorText(let text):
             yieldToolResponse(id: id, text: text, isError: true)
+        case .jsonRPCError(let code, let message):
+            yieldJSONRPCError(id: id, code: code, message: message)
         case .hang:
             break
         case .notEnabled:
@@ -473,6 +616,22 @@ actor ScriptedDocumentationSession: UpstreamSession {
         case .exit:
             continuation.yield(.exit(1))
         }
+    }
+
+    private func yieldJSONRPCError(id: Any, code: Int, message: String) {
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": [
+                "code": code,
+                "message": message,
+            ],
+        ]
+        guard JSONSerialization.isValidJSONObject(response),
+              let data = try? JSONSerialization.data(withJSONObject: response, options: []) else {
+            return
+        }
+        continuation.yield(.message(data))
     }
 
     private func yieldToolResponse(id: Any, text: String, isError: Bool) {
@@ -629,6 +788,31 @@ func defaultUpstreamEnvironment(sharedSessionID: String?) throws -> [String: Str
 }
 
 func upstreamEnvironment(from upstream: ManagedUpstreamSlot) throws -> [String: String] {
+    let configMirror = try upstreamConfigMirror(from: upstream)
+    return try #require(
+        configMirror.children.first(where: { $0.label == "environment" })?.value
+            as? [String: String],
+        "UpstreamProcess.Config should include environment for tests"
+    )
+}
+
+func upstreamCommand(from upstream: ManagedUpstreamSlot) throws -> String {
+    let configMirror = try upstreamConfigMirror(from: upstream)
+    return try #require(
+        configMirror.children.first(where: { $0.label == "command" })?.value as? String,
+        "UpstreamProcess.Config should include command for tests"
+    )
+}
+
+func upstreamArgs(from upstream: ManagedUpstreamSlot) throws -> [String] {
+    let configMirror = try upstreamConfigMirror(from: upstream)
+    return try #require(
+        configMirror.children.first(where: { $0.label == "args" })?.value as? [String],
+        "UpstreamProcess.Config should include args for tests"
+    )
+}
+
+private func upstreamConfigMirror(from upstream: ManagedUpstreamSlot) throws -> Mirror {
     let upstreamMirror = Mirror(reflecting: upstream)
     let factory = try #require(
         upstreamMirror.children.first(where: { $0.label == "factory" })?.value,
@@ -639,12 +823,7 @@ func upstreamEnvironment(from upstream: ManagedUpstreamSlot) throws -> [String: 
         factoryMirror.children.first(where: { $0.label == "config" })?.value,
         "UpstreamProcess factory should expose a stored config for tests"
     )
-    let configMirror = Mirror(reflecting: config)
-    return try #require(
-        configMirror.children.first(where: { $0.label == "environment" })?.value
-            as? [String: String],
-        "UpstreamProcess.Config should include environment for tests"
-    )
+    return Mirror(reflecting: config)
 }
 
 func withEnvironmentVariables<T>(
@@ -1195,6 +1374,49 @@ func makeToolListResponse(id: Int64) throws -> Data {
         ],
         options: []
     )
+}
+
+func makeDocumentationToolsListResponse(id: Int64, version: String) throws -> Data {
+    try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "tools": [
+                    documentationDescriptor(version: version).foundationObject,
+                ],
+            ],
+        ],
+        options: []
+    )
+}
+
+func makeDocumentationSearchResponse(id: Int64, text: String) throws -> Data {
+    try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": text,
+                    ],
+                ],
+                "isError": false,
+            ],
+        ],
+        options: []
+    )
+}
+
+func documentationSearchQuery(in data: Data) throws -> String? {
+    let object = try #require(
+        JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    )
+    let params = try #require(object["params"] as? [String: Any])
+    let arguments = try #require(params["arguments"] as? [String: Any])
+    return arguments["query"] as? String
 }
 
 func yieldMessage(_ data: Data, to upstream: TestUpstreamClient) async {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -114,12 +114,42 @@ func toolContentText(in responseData: Data) throws -> String? {
     return content.first?["text"] as? String
 }
 
+func toolResultIsError(in responseData: Data) throws -> Bool {
+    let object = try #require(
+        JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any]
+    )
+    let result = try #require(object["result"] as? [String: Any])
+    return result["isError"] as? Bool == true
+}
+
+func responseID(in responseData: Data) throws -> Int64 {
+    let object = try #require(
+        JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any]
+    )
+    let id = try #require(object["id"] as? NSNumber)
+    return id.int64Value
+}
+
 func documentationProviderTarget(processID: pid_t) -> DocumentationProviderTarget {
     DocumentationProviderTarget(
         processID: processID,
         appPath: "/Applications/Xcode-\(processID).app",
         developerDir: "/Applications/Xcode-\(processID).app/Contents/Developer",
-        mcpbridgePath: "/Applications/Xcode-\(processID).app/Contents/Developer/usr/bin/mcpbridge"
+        mcpbridgePath: "/Applications/Xcode-\(processID).app/Contents/Developer/usr/bin/mcpbridge",
+        xcodeVersion: "\(processID).0"
+    )
+}
+
+func documentationProviderTarget(
+    processID: pid_t,
+    xcodeVersion: String
+) -> DocumentationProviderTarget {
+    DocumentationProviderTarget(
+        processID: processID,
+        appPath: "/Applications/Xcode-\(processID).app",
+        developerDir: "/Applications/Xcode-\(processID).app/Contents/Developer",
+        mcpbridgePath: "/Applications/Xcode-\(processID).app/Contents/Developer/usr/bin/mcpbridge",
+        xcodeVersion: xcodeVersion
     )
 }
 
@@ -131,9 +161,32 @@ struct StubXcodeTargetDiscovery: XcodeTargetDiscovering {
     }
 }
 
+final class SequencedXcodeTargetDiscovery: XcodeTargetDiscovering, @unchecked Sendable {
+    private let lock = NSLock()
+    private var remainingSequences: [[DocumentationProviderTarget]]
+    private var lastSequence: [DocumentationProviderTarget]
+
+    init(_ sequences: [[DocumentationProviderTarget]]) {
+        self.remainingSequences = sequences
+        self.lastSequence = sequences.last ?? []
+    }
+
+    func runningXcodeTargets() -> [DocumentationProviderTarget] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard remainingSequences.isEmpty == false else {
+            return lastSequence
+        }
+        let targets = remainingSequences.removeFirst()
+        lastSequence = targets
+        return targets
+    }
+}
+
 enum ScriptedDocumentationResponse: Sendable {
     case success
     case successText(String)
+    case toolErrorText(String)
     case hang
     case notEnabled
     case exit
@@ -143,7 +196,8 @@ struct ScriptedDocumentationSessionPlan: Sendable {
     let serverVersion: String
     let toolCount: Int
     let includesDocumentationSearch: Bool
-    let probeResponse: ScriptedDocumentationResponse
+    let hangsToolsList: Bool
+    let firstDocumentationResponse: ScriptedDocumentationResponse
     let userCallResponses: [ScriptedDocumentationResponse]
     let requiresNumericRequestIDs: Bool
 
@@ -151,14 +205,16 @@ struct ScriptedDocumentationSessionPlan: Sendable {
         serverVersion: String,
         toolCount: Int,
         includesDocumentationSearch: Bool,
-        probeResponse: ScriptedDocumentationResponse,
+        hangsToolsList: Bool = false,
+        firstDocumentationResponse: ScriptedDocumentationResponse,
         userCallResponses: [ScriptedDocumentationResponse] = [],
         requiresNumericRequestIDs: Bool = false
     ) {
         self.serverVersion = serverVersion
         self.toolCount = toolCount
         self.includesDocumentationSearch = includesDocumentationSearch
-        self.probeResponse = probeResponse
+        self.hangsToolsList = hangsToolsList
+        self.firstDocumentationResponse = firstDocumentationResponse
         self.userCallResponses = userCallResponses
         self.requiresNumericRequestIDs = requiresNumericRequestIDs
     }
@@ -178,6 +234,7 @@ actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
     private var startedProcessIDs: [pid_t] = []
     private var initializeParamsByPID: [pid_t: [JSONValue]] = [:]
     private var requestCountsByPID: [pid_t: [String: Int]] = [:]
+    private var documentationQueriesByPID: [pid_t: [String]] = [:]
     private var requestCountWaiters: [RequestCountWaiter] = []
     private let startDelayNanoseconds: UInt64?
 
@@ -231,6 +288,14 @@ actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
 
     func requestCount(processID: pid_t, method: String) -> Int {
         requestCountsByPID[processID]?[method] ?? 0
+    }
+
+    func recordDocumentationQuery(_ query: String, for processID: pid_t) {
+        documentationQueriesByPID[processID, default: []].append(query)
+    }
+
+    func documentationQueries(for processID: pid_t) -> [String] {
+        documentationQueriesByPID[processID] ?? []
     }
 
     func waitForRequestCount(_ count: Int, processID: pid_t, method: String) async throws {
@@ -337,6 +402,9 @@ actor ScriptedDocumentationSession: UpstreamSession {
                 ]
             )
         case "tools/list":
+            guard plan.hangsToolsList == false else {
+                return .accepted
+            }
             yieldResponse(
                 id: requestID,
                 result: [
@@ -344,10 +412,15 @@ actor ScriptedDocumentationSession: UpstreamSession {
                 ]
             )
         case "tools/call":
+            if let params = object["params"] as? [String: Any],
+               let arguments = params["arguments"] as? [String: Any],
+               let query = arguments["query"] as? String {
+                await recorder.recordDocumentationQuery(query, for: processID)
+            }
             documentationCallCount += 1
             let response: ScriptedDocumentationResponse
             if documentationCallCount == 1 {
-                response = plan.probeResponse
+                response = plan.firstDocumentationResponse
             } else if remainingUserCallResponses.isEmpty == false {
                 response = remainingUserCallResponses.removeFirst()
             } else {
@@ -387,6 +460,8 @@ actor ScriptedDocumentationSession: UpstreamSession {
             yieldToolResponse(id: id, text: "{\"ok\":true}", isError: false)
         case .successText(let text):
             yieldToolResponse(id: id, text: text, isError: false)
+        case .toolErrorText(let text):
+            yieldToolResponse(id: id, text: text, isError: true)
         case .hang:
             break
         case .notEnabled:
@@ -458,7 +533,9 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
         self.prewarmBlocker = prewarmBlocker
     }
 
-    func prewarm(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate {
+    func startBackgroundDiscovery(requestTimeout: TimeAmount?) async
+        -> DocumentationProvider.ToolListUpdate
+    {
         prewarmStarted?.signal()
         if let prewarmDelayNanoseconds {
             try? await Task.sleep(nanoseconds: prewarmDelayNanoseconds)


### PR DESCRIPTION
## Purpose

Fix cold `DocumentationSearch` routing so provider selection is driven by the actual user request, not a synthetic search probe, and so the successful route/session is reused instead of re-warmed.

## Changes

- Move DocumentationSearch candidate lifecycle and fallback policy into `DocumentationProviderManager`.
- Discover running Xcode targets by Xcode version, honor `MCP_XCODE_PID` as a hard pin, and keep `--upstream-processes` scoped to regular upstream processes only.
- Separate descriptor discovery from provider activation; `tools/list` no longer triggers a synthetic DocumentationSearch usability probe.
- Add runtime-backed documentation provider routing that can reuse the prewarmed upstream route and fall back to a direct route only when needed.
- Preserve actual request IDs while forwarding DocumentationSearch through provider routes.
- Tighten control-plane timeout/cancellation handling so queued or reserved pinned requests do not leak scheduler slots.
- Expand tests for version ordering, actual-request selection, fallback, route reuse, descriptor overlay, pinned PID behavior, and concurrency/timeout cases.

## Testing

- `swift test --filter DocumentationProviderTests -Xswiftc -strict-concurrency=minimal`
- `swift test -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- Live smoke on `127.0.0.1:8891` with `--auto-approve`: two DocumentationSearch calls succeeded; no extra mcpbridge process or post-search prewarm appeared.
- Codex review against `main`: no findings.