### PR TITLE
Add verified release installer and simplify setup docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           )
 
           sh -n "${tmp_dir}/install.sh"
-          if ! grep -Fq "VERSION=\"\${VERSION:-${RELEASE_VERSION}}\"" "${tmp_dir}/install.sh"; then
+          if ! grep -Fq "VERSION=\"\${XCODE_MCPKIT_VERSION:-${RELEASE_VERSION}}\"" "${tmp_dir}/install.sh"; then
             echo "install.sh does not default to ${RELEASE_VERSION}." >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Verify release ref
         env:
           RELEASE_VERSION: ${{ inputs.version }}
@@ -146,15 +149,23 @@ jobs:
             --pattern "install.sh" \
             --dir "${tmp_dir}"
 
+          expected_checksum_files=(
+            "xcode-mcp-proxy-darwin-arm64.tar.gz"
+            "install.sh"
+          )
+
           mapfile -t checksum_lines < <(grep -v '^[[:space:]]*$' "${tmp_dir}/SHA256SUMS.txt")
-          if [[ "${#checksum_lines[@]}" -ne 1 ]]; then
-            echo "SHA256SUMS.txt must contain exactly one checksum entry." >&2
+          if [[ "${#checksum_lines[@]}" -ne "${#expected_checksum_files[@]}" ]]; then
+            echo "SHA256SUMS.txt must contain exactly ${#expected_checksum_files[@]} checksum entries." >&2
             exit 1
           fi
-          if [[ ! "${checksum_lines[0]}" =~ ^[0-9a-f]{64}[[:space:]][[:space:]]xcode-mcp-proxy-darwin-arm64[.]tar[.]gz$ ]]; then
-            echo "SHA256SUMS.txt does not match the expected arm64 archive format." >&2
-            exit 1
-          fi
+
+          for expected in "${expected_checksum_files[@]}"; do
+            if ! awk -v name="${expected}" '$1 ~ /^[0-9a-f]{64}$/ && $2 == name { found = 1 } END { exit found ? 0 : 1 }' "${tmp_dir}/SHA256SUMS.txt"; then
+              echo "SHA256SUMS.txt is missing the expected checksum entry for ${expected}." >&2
+              exit 1
+            fi
+          done
 
           (
             cd "${tmp_dir}"
@@ -162,12 +173,13 @@ jobs:
           )
 
           sh -n "${tmp_dir}/install.sh"
-          if ! grep -Fq "VERSION=\"\${XCODE_MCPKIT_VERSION:-${RELEASE_VERSION}}\"" "${tmp_dir}/install.sh"; then
-            echo "install.sh does not default to ${RELEASE_VERSION}." >&2
-            exit 1
-          fi
-          if ! grep -Fq "REPO=\"\${XCODE_MCPKIT_REPO:-${GITHUB_REPOSITORY}}\"" "${tmp_dir}/install.sh"; then
-            echo "install.sh does not default to ${GITHUB_REPOSITORY}." >&2
+          scripts/render-install-script.sh \
+            --version "${RELEASE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --output "${tmp_dir}/install.expected.sh"
+          if ! cmp -s "${tmp_dir}/install.expected.sh" "${tmp_dir}/install.sh"; then
+            echo "install.sh does not match the generated installer for ${RELEASE_VERSION}." >&2
+            diff -u "${tmp_dir}/install.expected.sh" "${tmp_dir}/install.sh" || true
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           expected_assets=(
             "xcode-mcp-proxy-darwin-arm64.tar.gz"
             "SHA256SUMS.txt"
+            "install.sh"
           )
 
           mapfile -t asset_names < <(
@@ -140,6 +141,10 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --pattern "SHA256SUMS.txt" \
             --dir "${tmp_dir}"
+          gh release download "${RELEASE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "install.sh" \
+            --dir "${tmp_dir}"
 
           mapfile -t checksum_lines < <(grep -v '^[[:space:]]*$' "${tmp_dir}/SHA256SUMS.txt")
           if [[ "${#checksum_lines[@]}" -ne 1 ]]; then
@@ -155,6 +160,16 @@ jobs:
             cd "${tmp_dir}"
             shasum -a 256 -c SHA256SUMS.txt
           )
+
+          sh -n "${tmp_dir}/install.sh"
+          if ! grep -Fq "VERSION=\"\${VERSION:-${RELEASE_VERSION}}\"" "${tmp_dir}/install.sh"; then
+            echo "install.sh does not default to ${RELEASE_VERSION}." >&2
+            exit 1
+          fi
+          if ! grep -Fq "REPO=\"\${XCODE_MCPKIT_REPO:-${GITHUB_REPOSITORY}}\"" "${tmp_dir}/install.sh"; then
+            echo "install.sh does not default to ${GITHUB_REPOSITORY}." >&2
+            exit 1
+          fi
 
           is_draft="$(gh release view "${RELEASE_VERSION}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq '.isDraft')"
           is_prerelease="$(gh release view "${RELEASE_VERSION}" --repo "${GITHUB_REPOSITORY}" --json isPrerelease --jq '.isPrerelease')"

--- a/Docs/maintainer-architecture.md
+++ b/Docs/maintainer-architecture.md
@@ -72,10 +72,11 @@ These are used by the default CI workflow and release verification, and intentio
   - `scripts/publish-local-release.sh v1.2.3`
 - Behavior:
   - Builds the arm64 archive, `SHA256SUMS.txt`, and `install.sh` locally.
+  - `SHA256SUMS.txt` covers both the archive and `install.sh`.
   - Pushes the release tag from `main`.
   - Creates a draft GitHub Release.
   - Dispatches `.github/workflows/release.yml` for the tag ref.
-  - The workflow publishes the draft only after `scripts/check.sh` and release asset verification pass.
+  - The workflow publishes the draft only after `scripts/check.sh`, checksum verification, and regenerated installer comparison pass.
 - Distribution:
   - GitHub Releases publish `install.sh`, `xcode-mcp-proxy-darwin-arm64.tar.gz`, and `SHA256SUMS.txt`.
   - x86_64 and universal archives are not produced.

--- a/Docs/maintainer-architecture.md
+++ b/Docs/maintainer-architecture.md
@@ -71,13 +71,13 @@ These are used by the default CI workflow and release verification, and intentio
 - Entry point:
   - `scripts/publish-local-release.sh v1.2.3`
 - Behavior:
-  - Builds the arm64 archive and `SHA256SUMS.txt` locally.
+  - Builds the arm64 archive, `SHA256SUMS.txt`, and `install.sh` locally.
   - Pushes the release tag from `main`.
   - Creates a draft GitHub Release.
   - Dispatches `.github/workflows/release.yml` for the tag ref.
   - The workflow publishes the draft only after `scripts/check.sh` and release asset verification pass.
 - Distribution:
-  - GitHub Releases publish `xcode-mcp-proxy-darwin-arm64.tar.gz` and `SHA256SUMS.txt`.
+  - GitHub Releases publish `install.sh`, `xcode-mcp-proxy-darwin-arm64.tar.gz`, and `SHA256SUMS.txt`.
   - x86_64 and universal archives are not produced.
 
 ## Stress Suite

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,6 +17,9 @@ XcodeMCPKitは、Xcode MCPのためのローカルプロキシです。MCPクラ
 curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/latest/download/install.sh | sh
 ```
 
+<details>
+<summary>その他のインストール方法</summary>
+
 インストール先を変える場合:
 
 ```bash
@@ -50,6 +53,8 @@ swift run -c release xcode-mcp-proxy-install --bindir "$HOME/bin"
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
+
+</details>
 
 ## MCPクライアント設定
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,13 +14,19 @@ XcodeMCPKitは、Xcode MCPのためのローカルプロキシです。MCPクラ
 ### GitHub Releasesからインストール
 
 ```bash
-curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | sh
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/latest/download/install.sh | sh
 ```
 
 インストール先を変える場合:
 
 ```bash
-curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | BINDIR="$HOME/bin" sh
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/latest/download/install.sh | sh -s -- --bindir "$HOME/bin"
+```
+
+バージョンを指定する場合:
+
+```bash
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | sh
 ```
 
 ### ソースからインストール

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,22 +13,14 @@ XcodeMCPKit は、Xcode MCP のためのローカルプロキシです。MCP ク
 
 ### GitHub Releases からインストール
 
-- `xcode-mcp-proxy-darwin-arm64.tar.gz`
-- `SHA256SUMS.txt`
+```bash
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | sh
+```
+
+インストール先を変える場合:
 
 ```bash
-VERSION=v0.11.0
-BASE_URL="https://github.com/lynnswap/XcodeMCPKit/releases/download/${VERSION}"
-
-ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"
-curl -fL -O "${BASE_URL}/${ARCHIVE}"
-curl -fL -O "${BASE_URL}/SHA256SUMS.txt"
-grep "  ${ARCHIVE}\$" SHA256SUMS.txt | shasum -a 256 -c
-
-tar -xzf "${ARCHIVE}"
-mkdir -p "${HOME}/.local/bin"
-install -m 755 bin/xcode-mcp-proxy "${HOME}/.local/bin/"
-install -m 755 bin/xcode-mcp-proxy-server "${HOME}/.local/bin/"
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | BINDIR="$HOME/bin" sh
 ```
 
 ### ソースからインストール

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@ curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/ins
 
 ### ソースからインストール
 
-proxy server と STDIO adapter の両方をインストールします:
+proxy server と STDIO adapter をまとめてインストールします:
 
 ```bash
 swift run -c release xcode-mcp-proxy-install
@@ -89,34 +89,34 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 
 ## 設定
 
-CLI 全体:
+CLI help:
 
 ```bash
 xcode-mcp-proxy-server --help
 xcode-mcp-proxy --help
 ```
 
-### よく使う server option
+### Server options
 
 | Option | 説明 |
 |--------|------|
 | `--listen host:port` | listen address。既定値は `localhost:8765`。 |
 | `--host host` / `--port port` | `--listen` を使わない場合の listen host / port。 |
 | `--upstream-processes n` | upstream `mcpbridge` process 数。既定値は `1`、最大 `10`。 |
-| `--request-timeout seconds` | request timeout。`0` で initialize 以外の timeout を無効化します。initialize には固定の handshake timeout があります。 |
+| `--request-timeout seconds` | request timeout。`0` で `initialize` 以外の timeout を無効化します。`initialize` には固定の handshake timeout があります。 |
 | `--config path` | TOML config path。 |
 | `--auto-approve` | Xcode の許可ダイアログを自動承認します。Accessibility 権限が必要です。 |
 | `--refresh-code-issues-mode proxy|upstream` | `XcodeRefreshCodeIssuesInFile` を proxy diagnostics で提供するか（`proxy`、既定値）、Xcode live diagnostics に pass-through するか（`upstream`）。 |
 | `--force-restart` | listen port 上の既存 `xcode-mcp-proxy-server` を終了して新しく起動します。 |
 
-### 環境変数
+### Environment Variables
 
-| 変数 | 説明 |
+| Variable | 説明 |
 |------|------|
 | `LISTEN` | listen address。例: `127.0.0.1:8765`。 |
 | `HOST` / `PORT` | `LISTEN` 未指定時の listen host / port。 |
 | `MCP_XCODE_PID` | upstream `mcpbridge` へそのまま渡します。proxy 自身は解釈しません。 |
-| `MCP_XCODE_SESSION_ID` | 任意の明示的な upstream Xcode MCP session ID。 |
+| `MCP_XCODE_SESSION_ID` | 明示的に指定する upstream Xcode MCP session ID。 |
 | `MCP_XCODE_CONFIG` | TOML config path。`--config` が優先されます。 |
 | `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` または `upstream`。 |
 | `MCP_LOG_LEVEL` | `trace`, `debug`, `info`, `notice`, `warning`, `error`, `critical`。 |
@@ -134,7 +134,7 @@ clientName = "XcodeMCPKit"
 disabled = ["RunAllTests", "RunSomeTests"]
 ```
 
-| Key | 型 | 既定値 |
+| Key | Type | Default |
 |-----|----|--------|
 | `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
 | `upstream_handshake.clientVersion` | string | `"dev"` |
@@ -142,7 +142,7 @@ disabled = ["RunAllTests", "RunSomeTests"]
 | `tools.disabled` | array of strings | `[]` |
 
 - `clientVersion` 省略時: Xcode の `IDEChat*Version` defaults entry から解決します。
-- disabled tool: `tools/list` から削除し、直接の `tools/call` は拒否します。
+- disabled tool は `tools/list` から削除し、直接の `tools/call` は拒否します。
 - config 変更後は `xcode-mcp-proxy-server` を再起動してください。
 
 ## 移行
@@ -160,7 +160,7 @@ Codex / Claude Code から利用している場合は、移行作業はありま
 - SwiftPM library product に依存している場合:
   `v0.10.2` に固定するか、executable product に移行してください。
 
-## トラブルシューティング
+## Troubleshooting
 
 - [Troubleshooting](Docs/troubleshooting.md)
 
@@ -183,13 +183,13 @@ scripts/publish-local-release.sh v0.11.0
 - module boundary、release flow、live test、benchmark:
   [Maintainer Architecture](Docs/maintainer-architecture.md)
 
-## 関連ドキュメント
+## Documentation
 
 - [Architecture](Docs/architecture.md)
 - [Troubleshooting](Docs/troubleshooting.md)
 - [MCP / Xcode MCP Benchmark Notes](Docs/mcp-benchmark.md)
 - [MCP Connection Permission Dialog Investigation](Docs/mcp-permission-dialog-investigation.md)
 
-## ライセンス
+## License
 
 [LICENSE](LICENSE)

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,47 +2,22 @@
 
 [English](README.md)
 
-Xcode MCP (mcpbridge) の MCPプロキシ。  
-Xcode のダイアログが、プロキシ起動時に一度だけ表示されるよう設計しています。
+XcodeMCPKit は、Xcode MCP のためのローカルプロキシです。MCP クライアントに安定した endpoint を提供し、`mcpbridge` の承認フローを自動化します。
 
-## クイックスタート
+## 要件
 
-1. プロキシサーバーを起動
-   ```bash
-   xcode-mcp-proxy-server --auto-approve
-   ```
-2. 自動承認に必要な macOS の「アクセシビリティ」権限を許可
-
-`--auto-approve` オプションを使用すると、Xcode の承認ダイアログを監視し、自動で「許可（Allow）」をクリックします。
-
-この機能を利用するには、macOS の「アクセシビリティ」権限が必要なため、デフォルトでは無効（オプトイン方式）になっています。もし権限を与えたくない場合は、`--auto-approve` を付けずにサーバーを起動し、Xcode 上で手動で「許可」をクリックしてください。
-
-## アーキテクチャ
-
-プロセス構成は [アーキテクチャ](Docs/architecture.md) を参照してください。
-モジュール境界とローカル検証コマンドは [Maintainer Architecture](Docs/maintainer-architecture.md) を参照してください。
+- macOS 15.0+
+- Swift 6.2+
 
 ## インストール
 
-### 1. バイナリをインストール
+### GitHub Releases からインストール
 
-#### ソースからビルドしてインストール
-
-```bash
-swift run -c release xcode-mcp-proxy-install
-```
-
-#### GitHub Releases からインストール
-
-各リリースタグ（`v*`）では、次のファイルを公開します:
-
-- `xcode-mcp-proxy-darwin-arm64.tar.gz`（Apple Silicon）
+- `xcode-mcp-proxy-darwin-arm64.tar.gz`
 - `SHA256SUMS.txt`
 
-例:
-
 ```bash
-VERSION=v0.1.0
+VERSION=v0.11.0
 BASE_URL="https://github.com/lynnswap/XcodeMCPKit/releases/download/${VERSION}"
 
 ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"
@@ -52,41 +27,59 @@ grep "  ${ARCHIVE}\$" SHA256SUMS.txt | shasum -a 256 -c
 
 tar -xzf "${ARCHIVE}"
 mkdir -p "${HOME}/.local/bin"
-cp bin/* "${HOME}/.local/bin/"
-chmod +x "${HOME}/.local/bin/xcode-mcp-proxy" \
-         "${HOME}/.local/bin/xcode-mcp-proxy-server" \
-         "${HOME}/.local/bin/xcode-mcp-proxy-install"
+install -m 755 bin/xcode-mcp-proxy "${HOME}/.local/bin/"
+install -m 755 bin/xcode-mcp-proxy-server "${HOME}/.local/bin/"
 ```
 
-#### 任意: インストール先を変更
+### ソースからインストール
+
+proxy server と STDIO adapter の両方をインストールします:
 
 ```bash
-./.build/release/xcode-mcp-proxy-install --prefix "$HOME/.local"
-# または
-./.build/release/xcode-mcp-proxy-install --bindir "$HOME/bin"
+swift run -c release xcode-mcp-proxy-install
 ```
 
-### 2. インストール先を `PATH` に追加
+インストール先を変える場合:
 
-既定では `~/.local/bin` に `xcode-mcp-proxy` と `xcode-mcp-proxy-server` がインストールされます。
+```bash
+swift run -c release xcode-mcp-proxy-install --prefix "$HOME/.local"
+swift run -c release xcode-mcp-proxy-install --bindir "$HOME/bin"
+```
+
+`PATH` に追加:
 
 ```bash
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
-### 3. MCP クライアントに登録
+## MCP クライアント設定
 
-`xcrun mcpbridge` を削除して、用途に応じて以下のいずれかを登録します:
+### 1. プロキシサーバーを起動
+
+```bash
+xcode-mcp-proxy-server --auto-approve
+```
+
+Accessibility 権限を付けられない場合:
+
+```bash
+xcode-mcp-proxy-server
+```
+
+### 2. クライアントに登録
+
+`xcrun mcpbridge` を proxy endpoint に置き換えます。
 
 #### Codex
 
 ```bash
 codex mcp remove xcode
+
 # 推奨: Streamable HTTP
 codex mcp add xcode --url http://localhost:8765/mcp
 
-# 代替: STDIO
+# 互換モード: STDIO
 codex mcp add xcode -- xcode-mcp-proxy
 ```
 
@@ -94,6 +87,7 @@ codex mcp add xcode -- xcode-mcp-proxy
 
 ```bash
 claude mcp remove xcode
+
 # 推奨: Streamable HTTP
 claude mcp add --transport http xcode http://localhost:8765/mcp
 
@@ -101,109 +95,105 @@ claude mcp add --transport http xcode http://localhost:8765/mcp
 claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 ```
 
-## 使い方
+## 設定
 
-### プロキシサーバー: `xcode-mcp-proxy-server`
+CLI 全体:
 
-起動方法は「クイックスタート」を参照してください。
+```bash
+xcode-mcp-proxy-server --help
+xcode-mcp-proxy --help
+```
 
-#### デフォルト値
+### よく使う server option
 
-- command: `xcrun`
-- args: `mcpbridge`
-- upstream processes: `1`（増やすと `mcpbridge` を複数プロセス起動）
-- listen: `localhost:8765`
-- request timeout: `300` seconds（`0` で無制限）
-- max body size: `1048576` bytes
-- initialization: Xcode 未起動なら起動し、利用可能になったら eager initialize / attach
-- discovery: `~/Library/Caches/XcodeMCPProxy/endpoint.json`
+| Option | 説明 |
+|--------|------|
+| `--listen host:port` | listen address。既定値は `localhost:8765`。 |
+| `--host host` / `--port port` | `--listen` を使わない場合の listen host / port。 |
+| `--upstream-processes n` | upstream `mcpbridge` process 数。既定値は `1`、最大 `10`。 |
+| `--request-timeout seconds` | request timeout。`0` で initialize 以外の timeout を無効化します。initialize には固定の handshake timeout があります。 |
+| `--config path` | TOML config path。 |
+| `--auto-approve` | Xcode の許可ダイアログを自動承認します。Accessibility 権限が必要です。 |
+| `--refresh-code-issues-mode proxy|upstream` | `XcodeRefreshCodeIssuesInFile` を proxy diagnostics で提供するか（`proxy`、既定値）、Xcode live diagnostics に pass-through するか（`upstream`）。 |
+| `--force-restart` | listen port 上の既存 `xcode-mcp-proxy-server` を終了して新しく起動します。 |
 
-#### オプション
-
-| オプション | 説明 |
-|--------|-------------|
-| `--upstream-command cmd` | `mcpbridge` 実行コマンド |
-| `--upstream-args a,b,c` | `mcpbridge` 引数（カンマ区切り） |
-| `--upstream-arg value` | `mcpbridge` 引数の追加（単一項目） |
-| `--upstream-processes n` | アップストリーム `mcpbridge` プロセスの起動数（デフォルト: 1、最大: 10） |
-| `--session-id id` | 明示的な Xcode MCP セッション ID |
-| `--max-body-bytes n` | リクエストボディの最大サイズ |
-| `--request-timeout seconds` | リクエストタイムアウト設定（`0` で初期化以外のタイムアウトを無効化。`initialize` 時のハンドシェイクには固定のタイムアウトが適用されます） |
-| `--config path` | アップストリームのハンドシェイクを上書きするためのプロキシ設定（TOML）のパス |
-| `--auto-approve` | Xcode の許可ダイアログ自動承認を有効化する opt-in フラグ |
-| `--refresh-code-issues-mode mode` | `XcodeRefreshCodeIssuesInFile` の提供モード。プロキシ側のナビゲーター問題として処理（`proxy`、デフォルト）、または Xcode のライブ診断へパススルー（`upstream`） |
-| `--force-restart` | ポートが使用中の場合、既存の `xcode-mcp-proxy-server` を終了して再起動 |
-
-#### 環境変数
+### 環境変数
 
 | 変数 | 説明 |
 |------|------|
-| `LISTEN` | listen アドレス。例: `127.0.0.1:8765` |
-| `HOST` | listen ホスト。`LISTEN` 未指定時に `PORT` と組み合わせて使用 |
-| `PORT` | listen ポート。`LISTEN` 未指定時に `HOST` と組み合わせて使用 |
-| `MCP_XCODE_PID` | upstream `mcpbridge` へそのまま渡す互換 env。proxy 自身は解釈しない |
-| `MCP_XCODE_SESSION_ID` | 任意の明示的 upstream session ID |
-| `MCP_XCODE_CONFIG` | proxy config TOML のパス。`--config` が優先 |
-| `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` または `upstream` |
-| `MCP_LOG_LEVEL` | ログレベル: `trace`, `debug`, `info`, `notice`, `warning`, `error`, `critical` |
-| `XCODE_MCP_PROXY_DISCOVERY_FILE` | discovery file の出力先を上書きします。隔離されたローカル/live テスト向けです |
-| `XCODE_MCP_PROXY_CACHE_ROOT` | `XCODE_MCP_PROXY_DISCOVERY_FILE` 未指定時の discovery 用 cache root を上書きします |
+| `LISTEN` | listen address。例: `127.0.0.1:8765`。 |
+| `HOST` / `PORT` | `LISTEN` 未指定時の listen host / port。 |
+| `MCP_XCODE_PID` | upstream `mcpbridge` へそのまま渡します。proxy 自身は解釈しません。 |
+| `MCP_XCODE_SESSION_ID` | 任意の明示的な upstream Xcode MCP session ID。 |
+| `MCP_XCODE_CONFIG` | TOML config path。`--config` が優先されます。 |
+| `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` または `upstream`。 |
+| `MCP_LOG_LEVEL` | `trace`, `debug`, `info`, `notice`, `warning`, `error`, `critical`。 |
+| `XCODE_MCP_PROXY_ENDPOINT` | STDIO adapter の upstream URL。`--url` が優先されます。 |
+| `XCODE_MCP_PROXY_DISCOVERY_FILE` | 隔離された local/live test run 向けの discovery file override。 |
+| `XCODE_MCP_PROXY_CACHE_ROOT` | `XCODE_MCP_PROXY_DISCOVERY_FILE` 未指定時に discovery path を導出する cache root。 |
 
-ログは stderr に出力されます。
+### TOML Config
 
-## Maintainer Commands
+```toml
+[upstream_handshake]
+clientName = "XcodeMCPKit"
+
+[tools]
+disabled = ["RunAllTests", "RunSomeTests"]
+```
+
+| Key | 型 | 既定値 |
+|-----|----|--------|
+| `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
+| `upstream_handshake.clientVersion` | string | `"dev"` |
+| `upstream_handshake.capabilities` | table | `{}` |
+| `tools.disabled` | array of strings | `[]` |
+
+- `clientVersion` 省略時: Xcode の `IDEChat*Version` defaults entry から解決します。
+- disabled tool: `tools/list` から削除し、直接の `tools/call` は拒否します。
+- config 変更後は `xcode-mcp-proxy-server` を再起動してください。
+
+## 移行
+
+### v0.11.0
+
+通常の Codex / Claude Code 設定では、手動の移行作業は不要です。該当する場合だけ
+確認してください:
+
+- Streamable HTTP endpoint を直接呼んでいる場合は、`initialize` 後に server-issued
+  `MCP-Session-Id` と `MCP-Protocol-Version: 2025-06-18` を送り、`POST /mcp` には
+  `Accept: application/json, text/event-stream` を付け、JSON-RPC batch request を
+  送らないようにしてください。
+- SwiftPM library product に依存していた場合は、`v0.10.2` に pin するか、
+  executable product に移行してください。
+
+## トラブルシューティング
+
+- [Troubleshooting](Docs/troubleshooting.md)
+
+## Maintainers
+
+Local checks:
 
 ```bash
 swift test -Xswiftc -strict-concurrency=minimal
 XCODE_MCP_RUN_PROCESS_TESTS=1 swift test --no-parallel --filter ProxyProcessTests -Xswiftc -strict-concurrency=minimal
 scripts/check.sh
-scripts/publish-local-release.sh v0.1.0
-XCODE_MCP_RUN_LIVE_MCPBRIDGE_TESTS=1 swift test --no-parallel --filter ProxyLiveMCPBridgeTests -Xswiftc -strict-concurrency=minimal
-XCODE_MCP_RUN_STRESS_TESTS=1 swift test --no-parallel --filter ProxyStressTests -Xswiftc -strict-concurrency=minimal
-python3 scripts/benchmark-live-server.py --agents 4 --requests-per-agent 100
 ```
 
-- `scripts/check.sh` は default suite と opt-in の process / pipe suite を実行します。
-- `scripts/publish-local-release.sh` は arm64 archive をビルドし、draft GitHub Release を作成して release verification workflow を dispatch します。workflow が通った後に release が公開されます。
-- live `mcpbridge` suite はローカル専用で、CI には含めません。
-- live suite は現在起動中の Xcode を使い、Xcode process が 1 つだけある前提で、`127.0.0.1:0` と temp discovery path を使います。
-- stress suite は明示 opt-in 専用で、`scripts/check.sh` には含めません。大量 HTTP / session multiplexing を検証します。
-- `scripts/benchmark-live-server.py` は起動済み proxy server に直接投げる手動用ベンチマーク資材です。通常テスト、`scripts/check.sh`、CI では実行しません。endpoint は `--endpoint`、`XCODE_MCP_PROXY_ENDPOINT`、discovery file、`http://localhost:8765/mcp` の順で解決し、非 loopback endpoint は `--allow-non-loopback` が必要です。4つの agent を4本の persistent HTTP connection / MCP session として扱い、各 agent が 100 個の `DocumentationSearch` request を closed-loop で送り、throughput と request latency percentile を出します。終了前に benchmark 用 session は削除します。
+Release:
 
-#### Proxy Config
+```bash
+scripts/publish-local-release.sh v0.11.0
+```
 
-| キー | 型 | 既定値 |
-|------|----|--------|
-| `upstream_handshake.protocolVersion` | string | `"2025-06-18"` |
-| `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
-| `upstream_handshake.clientVersion` | string | `"dev"` |
-| `upstream_handshake.capabilities` | table | `{}` |
+- module boundary、release flow、live test、benchmark:
+  [Maintainer Architecture](Docs/maintainer-architecture.md)
 
-`clientVersion` を省略した場合、`clientName` に対応する Xcode の `IDEChat*Version` があれば、その version を自動で使います。
+## 関連ドキュメント
 
-### アダプタ: `xcode-mcp-proxy`
-
-STDIO が必要な MCP クライアント向けの互換アダプタです。HTTP に対応しているクライアントは `xcode-mcp-proxy-server` に Streamable HTTP で直接接続してください。
-
-#### オプション
-
-| オプション | 説明 |
-|-----------|------|
-| `--request-timeout seconds` | HTTP リクエストタイムアウト（`0` で無制限） |
-| `--url url` | 上流 URL を明示（例: `http://localhost:9000/mcp`） |
-
-#### 環境変数
-
-| 変数 | 説明 |
-|------|------|
-| `XCODE_MCP_PROXY_ENDPOINT` | 上流 URL を上書き。`--url` が優先 |
-
-## トラブルシューティング
-
-[Troubleshooting](Docs/troubleshooting.md)
-
-## 参考資料
-
+- [Architecture](Docs/architecture.md)
+- [Troubleshooting](Docs/troubleshooting.md)
 - [MCP / Xcode MCP Benchmark Notes](Docs/mcp-benchmark.md)
 - [MCP Connection Permission Dialog Investigation](Docs/mcp-permission-dialog-investigation.md)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [English](README.md)
 
-XcodeMCPKit は、Xcode MCP のためのローカルプロキシです。MCP クライアントに安定した endpoint を提供し、`mcpbridge` の承認フローを自動化します。
+XcodeMCPKitは、Xcode MCPのためのローカルプロキシです。MCPクライアントに安定したendpointを提供し、`mcpbridge`の承認フローを自動化します。
 
 ## 要件
 
@@ -11,7 +11,7 @@ XcodeMCPKit は、Xcode MCP のためのローカルプロキシです。MCP ク
 
 ## インストール
 
-### GitHub Releases からインストール
+### GitHub Releasesからインストール
 
 ```bash
 curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | sh
@@ -25,7 +25,7 @@ curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/ins
 
 ### ソースからインストール
 
-proxy server と STDIO adapter をまとめてインストールします:
+proxy serverとSTDIO adapterをまとめてインストールします:
 
 ```bash
 swift run -c release xcode-mcp-proxy-install
@@ -38,14 +38,14 @@ swift run -c release xcode-mcp-proxy-install --prefix "$HOME/.local"
 swift run -c release xcode-mcp-proxy-install --bindir "$HOME/bin"
 ```
 
-`PATH` に追加:
+`PATH`に追加:
 
 ```bash
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
-## MCP クライアント設定
+## MCPクライアント設定
 
 ### 1. プロキシサーバーを起動
 
@@ -53,7 +53,9 @@ source ~/.zshrc
 xcode-mcp-proxy-server --auto-approve
 ```
 
-Accessibility 権限を付けられない場合:
+`--auto-approve`はXcodeの**Allow**ボタンを自動でクリックします。macOSのAccessibility権限が必要です。
+
+Accessibility権限を付けられない場合は、`--auto-approve`を外して、手動で**Allow**ボタンを押してください:
 
 ```bash
 xcode-mcp-proxy-server
@@ -61,7 +63,7 @@ xcode-mcp-proxy-server
 
 ### 2. クライアントに登録
 
-`xcrun mcpbridge` を proxy endpoint に置き換えます。
+`xcrun mcpbridge`をproxy endpointに置き換えます。
 
 #### Codex
 
@@ -100,29 +102,29 @@ xcode-mcp-proxy --help
 
 | Option | 説明 |
 |--------|------|
-| `--listen host:port` | listen address。既定値は `localhost:8765`。 |
-| `--host host` / `--port port` | `--listen` を使わない場合の listen host / port。 |
-| `--upstream-processes n` | upstream `mcpbridge` process 数。既定値は `1`、最大 `10`。 |
-| `--request-timeout seconds` | request timeout。`0` で `initialize` 以外の timeout を無効化します。`initialize` には固定の handshake timeout があります。 |
+| `--listen host:port` | listen address。既定値は`localhost:8765`。 |
+| `--host host` / `--port port` | `--listen`を使わない場合のlisten host / port。 |
+| `--upstream-processes n` | upstream `mcpbridge` process数。既定値は`1`、最大`10`。 |
+| `--request-timeout seconds` | request timeout。`0`で`initialize`以外のtimeoutを無効化します。`initialize`には固定のhandshake timeoutがあります。 |
 | `--config path` | TOML config path。 |
-| `--auto-approve` | Xcode の許可ダイアログを自動承認します。Accessibility 権限が必要です。 |
-| `--refresh-code-issues-mode proxy|upstream` | `XcodeRefreshCodeIssuesInFile` を proxy diagnostics で提供するか（`proxy`、既定値）、Xcode live diagnostics に pass-through するか（`upstream`）。 |
-| `--force-restart` | listen port 上の既存 `xcode-mcp-proxy-server` を終了して新しく起動します。 |
+| `--auto-approve` | Xcodeの**Allow**ボタンを自動でクリックします。Accessibility権限が必要です。 |
+| `--refresh-code-issues-mode proxy|upstream` | `XcodeRefreshCodeIssuesInFile`をproxy diagnosticsで提供するか（`proxy`、既定値）、Xcode live diagnosticsにpass-throughするか（`upstream`）。 |
+| `--force-restart` | listen port上の既存`xcode-mcp-proxy-server`を終了して新しく起動します。 |
 
 ### Environment Variables
 
 | Variable | 説明 |
 |------|------|
-| `LISTEN` | listen address。例: `127.0.0.1:8765`。 |
-| `HOST` / `PORT` | `LISTEN` 未指定時の listen host / port。 |
-| `MCP_XCODE_PID` | upstream `mcpbridge` へそのまま渡します。proxy 自身は解釈しません。 |
-| `MCP_XCODE_SESSION_ID` | 明示的に指定する upstream Xcode MCP session ID。 |
-| `MCP_XCODE_CONFIG` | TOML config path。`--config` が優先されます。 |
-| `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` または `upstream`。 |
+| `LISTEN` | listen address。例:`127.0.0.1:8765`。 |
+| `HOST` / `PORT` | `LISTEN`未指定時のlisten host / port。 |
+| `MCP_XCODE_PID` | upstream `mcpbridge`へそのまま渡します。proxy自身は解釈しません。 |
+| `MCP_XCODE_SESSION_ID` | 明示的に指定するupstream Xcode MCP session ID。 |
+| `MCP_XCODE_CONFIG` | TOML config path。`--config`が優先されます。 |
+| `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy`または`upstream`。 |
 | `MCP_LOG_LEVEL` | `trace`, `debug`, `info`, `notice`, `warning`, `error`, `critical`。 |
-| `XCODE_MCP_PROXY_ENDPOINT` | STDIO adapter の upstream URL。`--url` が優先されます。 |
-| `XCODE_MCP_PROXY_DISCOVERY_FILE` | 隔離された local/live test run 向けの discovery file override。 |
-| `XCODE_MCP_PROXY_CACHE_ROOT` | `XCODE_MCP_PROXY_DISCOVERY_FILE` 未指定時に discovery path を導出する cache root。 |
+| `XCODE_MCP_PROXY_ENDPOINT` | STDIO adapterのupstream URL。`--url`が優先されます。 |
+| `XCODE_MCP_PROXY_DISCOVERY_FILE` | 隔離されたlocal/live test run向けのdiscovery file override。 |
+| `XCODE_MCP_PROXY_CACHE_ROOT` | `XCODE_MCP_PROXY_DISCOVERY_FILE`未指定時にdiscovery pathを導出するcache root。 |
 
 ### TOML Config
 
@@ -141,24 +143,24 @@ disabled = ["RunAllTests", "RunSomeTests"]
 | `upstream_handshake.capabilities` | table | `{}` |
 | `tools.disabled` | array of strings | `[]` |
 
-- `clientVersion` 省略時: Xcode の `IDEChat*Version` defaults entry から解決します。
-- disabled tool は `tools/list` から削除し、直接の `tools/call` は拒否します。
-- config 変更後は `xcode-mcp-proxy-server` を再起動してください。
+- `clientVersion`省略時: Xcodeの`IDEChat*Version` defaults entryから解決します。
+- disabled toolは`tools/list`から削除し、直接の`tools/call`は拒否します。
+- config変更後は`xcode-mcp-proxy-server`を再起動してください。
 
 ## 移行
 
 ### v0.11.0
 
-Codex / Claude Code から利用している場合は、移行作業はありません。
+Codex/Claude Codeから利用している場合は、移行作業はありません。
 以下のどちらかに当てはまる場合だけ対応してください。
 
-- Streamable HTTP endpoint を直接呼んでいる場合:
-  `initialize` 後は server が発行した `MCP-Session-Id` と
-  `MCP-Protocol-Version: 2025-06-18` を送り、`POST /mcp` には
-  `Accept: application/json, text/event-stream` を付けてください。
-  JSON-RPC batch request は送らないでください。
-- SwiftPM library product に依存している場合:
-  `v0.10.2` に固定するか、executable product に移行してください。
+- Streamable HTTP endpointを直接呼んでいる場合:
+  `initialize`後はserverが発行した`MCP-Session-Id`と
+  `MCP-Protocol-Version: 2025-06-18`を送り、`POST /mcp`には
+  `Accept: application/json, text/event-stream`を付けてください。
+  JSON-RPC batch requestは送らないでください。
+- SwiftPM library productに依存している場合:
+  `v0.10.2`に固定するか、executable productに移行してください。
 
 ## Troubleshooting
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -149,15 +149,16 @@ disabled = ["RunAllTests", "RunSomeTests"]
 
 ### v0.11.0
 
-通常の Codex / Claude Code 設定では、手動の移行作業は不要です。該当する場合だけ
-確認してください:
+Codex / Claude Code から利用している場合は、移行作業はありません。
+以下のどちらかに当てはまる場合だけ対応してください。
 
-- Streamable HTTP endpoint を直接呼んでいる場合は、`initialize` 後に server-issued
-  `MCP-Session-Id` と `MCP-Protocol-Version: 2025-06-18` を送り、`POST /mcp` には
-  `Accept: application/json, text/event-stream` を付け、JSON-RPC batch request を
-  送らないようにしてください。
-- SwiftPM library product に依存していた場合は、`v0.10.2` に pin するか、
-  executable product に移行してください。
+- Streamable HTTP endpoint を直接呼んでいる場合:
+  `initialize` 後は server が発行した `MCP-Session-Id` と
+  `MCP-Protocol-Version: 2025-06-18` を送り、`POST /mcp` には
+  `Accept: application/json, text/event-stream` を付けてください。
+  JSON-RPC batch request は送らないでください。
+- SwiftPM library product に依存している場合:
+  `v0.10.2` に固定するか、executable product に移行してください。
 
 ## トラブルシューティング
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,14 @@ endpoint and automates the `mcpbridge` approval flow.
 
 ### From GitHub Releases
 
-- `xcode-mcp-proxy-darwin-arm64.tar.gz`
-- `SHA256SUMS.txt`
+```bash
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | sh
+```
+
+Custom destination:
 
 ```bash
-VERSION=v0.11.0
-BASE_URL="https://github.com/lynnswap/XcodeMCPKit/releases/download/${VERSION}"
-
-ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"
-curl -fL -O "${BASE_URL}/${ARCHIVE}"
-curl -fL -O "${BASE_URL}/SHA256SUMS.txt"
-grep "  ${ARCHIVE}\$" SHA256SUMS.txt | shasum -a 256 -c
-
-tar -xzf "${ARCHIVE}"
-mkdir -p "${HOME}/.local/bin"
-install -m 755 bin/xcode-mcp-proxy "${HOME}/.local/bin/"
-install -m 755 bin/xcode-mcp-proxy-server "${HOME}/.local/bin/"
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | BINDIR="$HOME/bin" sh
 ```
 
 ### From Source

--- a/README.md
+++ b/README.md
@@ -155,15 +155,16 @@ disabled = ["RunAllTests", "RunSomeTests"]
 
 ### v0.11.0
 
-Most Codex and Claude Code setups do not need a manual migration. Check these
-only if they apply:
+If you use XcodeMCPKit through Codex or Claude Code, no migration is required.
+Only the following cases need changes:
 
-- If you call the Streamable HTTP endpoint directly, use the server-issued
-  `MCP-Session-Id`, send `MCP-Protocol-Version: 2025-06-18` after `initialize`,
-  include `Accept: application/json, text/event-stream` on `POST /mcp`, and stop
-  sending JSON-RPC batch requests.
-- If you depended on the old SwiftPM library product, pin to `v0.10.2` or
-  migrate to the executable products.
+- Direct Streamable HTTP clients:
+  after `initialize`, send the server-issued `MCP-Session-Id` and
+  `MCP-Protocol-Version: 2025-06-18`. Include
+  `Accept: application/json, text/event-stream` on `POST /mcp`, and do not send
+  JSON-RPC batch requests.
+- SwiftPM library users:
+  pin to `v0.10.2` or migrate to the executable products.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ endpoint and automates the `mcpbridge` approval flow.
 curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | sh
 ```
 
-Custom destination:
+Custom install directory:
 
 ```bash
 curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | BINDIR="$HOME/bin" sh
@@ -32,7 +32,7 @@ Installs both the proxy server and the STDIO adapter:
 swift run -c release xcode-mcp-proxy-install
 ```
 
-Custom destination:
+Custom install directory:
 
 ```bash
 swift run -c release xcode-mcp-proxy-install --prefix "$HOME/.local"
@@ -53,10 +53,6 @@ source ~/.zshrc
 ```bash
 xcode-mcp-proxy-server --auto-approve
 ```
-
-- Recommended default.
-- Keep it running while MCP clients use Xcode.
-- Requires macOS Accessibility permission.
 
 Without Accessibility permission:
 
@@ -94,14 +90,14 @@ claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 
 ## Configuration
 
-Full CLI surface:
+CLI help:
 
 ```bash
 xcode-mcp-proxy-server --help
 xcode-mcp-proxy --help
 ```
 
-### Common Server Options
+### Server Options
 
 | Option | Description |
 |--------|-------------|
@@ -129,7 +125,7 @@ xcode-mcp-proxy --help
 | `XCODE_MCP_PROXY_DISCOVERY_FILE` | Discovery file override for isolated local/live test runs. |
 | `XCODE_MCP_PROXY_CACHE_ROOT` | Cache root used to derive the discovery path when `XCODE_MCP_PROXY_DISCOVERY_FILE` is unset. |
 
-### TOML Config
+### TOML Configuration
 
 ```toml
 [upstream_handshake]
@@ -189,7 +185,7 @@ scripts/publish-local-release.sh v0.11.0
 - Module boundaries, release flow, live tests, benchmarks:
   [Maintainer Architecture](Docs/maintainer-architecture.md)
 
-## More Documentation
+## Documentation
 
 - [Architecture](Docs/architecture.md)
 - [Troubleshooting](Docs/troubleshooting.md)

--- a/README.md
+++ b/README.md
@@ -2,47 +2,23 @@
 
 [日本語](README.ja.md)
 
-An MCP proxy for Xcode MCP (mcpbridge).  
-Designed so the Xcode permission dialog appears once when the proxy starts.
+XcodeMCPKit is a local proxy for Xcode MCP. It gives your MCP clients one stable
+endpoint and automates the `mcpbridge` approval flow.
 
-## Quick Start
+## Requirements
 
-1. Start the proxy server
-   ```bash
-   xcode-mcp-proxy-server --auto-approve
-   ```
-2. Grant the macOS Accessibility permission required for automatic approval.
+- macOS 15.0+
+- Swift 6.2+
 
-When you use the `--auto-approve` option, the server watches for Xcode’s permission dialog and automatically clicks **Allow**.
+## Install
 
-This feature requires macOS Accessibility permission, so it is disabled by default and opt-in. If you do not want to grant that permission, start the server without `--auto-approve` and click **Allow** manually in Xcode.
+### From GitHub Releases
 
-## Architecture
-
-See [Architecture](Docs/architecture.md) for the process overview.
-See [Maintainer Architecture](Docs/maintainer-architecture.md) for module boundaries and local verification commands.
-
-## Installation
-
-### 1. Install the binaries
-
-#### Build from source
-
-```bash
-swift run -c release xcode-mcp-proxy-install
-```
-
-#### Install from GitHub Releases
-
-Each release tag (`v*`) publishes:
-
-- `xcode-mcp-proxy-darwin-arm64.tar.gz` (Apple Silicon)
+- `xcode-mcp-proxy-darwin-arm64.tar.gz`
 - `SHA256SUMS.txt`
 
-Example:
-
 ```bash
-VERSION=v0.1.0
+VERSION=v0.11.0
 BASE_URL="https://github.com/lynnswap/XcodeMCPKit/releases/download/${VERSION}"
 
 ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"
@@ -52,41 +28,63 @@ grep "  ${ARCHIVE}\$" SHA256SUMS.txt | shasum -a 256 -c
 
 tar -xzf "${ARCHIVE}"
 mkdir -p "${HOME}/.local/bin"
-cp bin/* "${HOME}/.local/bin/"
-chmod +x "${HOME}/.local/bin/xcode-mcp-proxy" \
-         "${HOME}/.local/bin/xcode-mcp-proxy-server" \
-         "${HOME}/.local/bin/xcode-mcp-proxy-install"
+install -m 755 bin/xcode-mcp-proxy "${HOME}/.local/bin/"
+install -m 755 bin/xcode-mcp-proxy-server "${HOME}/.local/bin/"
 ```
 
-#### Optional: change the installation destination
+### From Source
+
+Installs both the proxy server and the STDIO adapter:
 
 ```bash
-./.build/release/xcode-mcp-proxy-install --prefix "$HOME/.local"
-# or
-./.build/release/xcode-mcp-proxy-install --bindir "$HOME/bin"
+swift run -c release xcode-mcp-proxy-install
 ```
 
-### 2. Add the install directory to your `PATH`
+Custom destination:
 
-By default, `xcode-mcp-proxy` and `xcode-mcp-proxy-server` are installed to `~/.local/bin`.
+```bash
+swift run -c release xcode-mcp-proxy-install --prefix "$HOME/.local"
+swift run -c release xcode-mcp-proxy-install --bindir "$HOME/bin"
+```
+
+Add to `PATH`:
 
 ```bash
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
-### 3. Register the proxy in your MCP client
+## Set Up Your MCP Client
 
-Replace `xcrun mcpbridge` with one of the following:
+### 1. Start the Proxy Server
+
+```bash
+xcode-mcp-proxy-server --auto-approve
+```
+
+- Recommended default.
+- Keep it running while MCP clients use Xcode.
+- Requires macOS Accessibility permission.
+
+Without Accessibility permission:
+
+```bash
+xcode-mcp-proxy-server
+```
+
+### 2. Register the Client
+
+Replace `xcrun mcpbridge` with the proxy endpoint.
 
 #### Codex
 
 ```bash
 codex mcp remove xcode
+
 # Recommended: Streamable HTTP
 codex mcp add xcode --url http://localhost:8765/mcp
 
-# Alternative: STDIO
+# Compatibility mode: STDIO
 codex mcp add xcode -- xcode-mcp-proxy
 ```
 
@@ -94,6 +92,7 @@ codex mcp add xcode -- xcode-mcp-proxy
 
 ```bash
 claude mcp remove xcode
+
 # Recommended: Streamable HTTP
 claude mcp add --transport http xcode http://localhost:8765/mcp
 
@@ -101,89 +100,44 @@ claude mcp add --transport http xcode http://localhost:8765/mcp
 claude mcp add --transport stdio xcode -- xcode-mcp-proxy
 ```
 
-## Usage
+## Configuration
 
-### Proxy Server: `xcode-mcp-proxy-server`
+Full CLI surface:
 
-See Quick Start for how to launch.
+```bash
+xcode-mcp-proxy-server --help
+xcode-mcp-proxy --help
+```
 
-#### Defaults
-
-- command: `xcrun`
-- args: `mcpbridge`
-- upstream processes: `1` (spawns multiple `mcpbridge` processes when increased)
-- listen: `localhost:8765`
-- request timeout: `300` seconds (`0` disables)
-- requests sharing the same MCP session are forwarded FIFO, one at a time
-- max body size: `1048576` bytes
-- initialization: launches Xcode if needed, eager when Xcode is available, and attaches after Xcode becomes ready
-- discovery: `~/Library/Caches/XcodeMCPProxy/endpoint.json`
-
-#### Options
+### Common Server Options
 
 | Option | Description |
 |--------|-------------|
-| `--upstream-command cmd` | `mcpbridge` command |
-| `--upstream-args a,b,c` | `mcpbridge` args (comma-separated) |
-| `--upstream-arg value` | Append a single `mcpbridge` arg |
-| `--upstream-processes n` | Spawn `n` upstream `mcpbridge` processes (default: 1, max: 10) |
-| `--session-id id` | Explicit Xcode MCP session ID |
-| `--max-body-bytes n` | Max request body size |
-| `--request-timeout seconds` | Request timeout (`0` disables non-initialize timeouts; `initialize` still uses a bounded handshake timeout) |
-| `--config path` | Path to proxy config TOML for overriding the upstream handshake |
-| `--auto-approve` | Opt in to auto-approve the Xcode permission dialog |
-| `--refresh-code-issues-mode mode` | Serve `XcodeRefreshCodeIssuesInFile` via proxy navigator issues (`proxy`, default) or pass through to Xcode live diagnostics (`upstream`) |
-| `--force-restart` | If the listen port is in use, terminate an existing `xcode-mcp-proxy-server` and restart |
+| `--listen host:port` | Listen address. Defaults to `localhost:8765`. |
+| `--host host` / `--port port` | Listen host and port when `--listen` is not used. |
+| `--upstream-processes n` | Number of upstream `mcpbridge` processes. Default: `1`, max: `10`. |
+| `--request-timeout seconds` | Request timeout. `0` disables non-initialize timeouts; initialize still has a bounded handshake timeout. |
+| `--config path` | TOML config path. |
+| `--auto-approve` | Automatically approve the Xcode permission dialog. Requires Accessibility permission. |
+| `--refresh-code-issues-mode proxy|upstream` | Serve `XcodeRefreshCodeIssuesInFile` through proxy diagnostics (`proxy`, default) or pass through to Xcode live diagnostics (`upstream`). |
+| `--force-restart` | Terminate an existing `xcode-mcp-proxy-server` on the listen port and start a new one. |
 
-#### Environment Variables
+### Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `LISTEN` | Listen address; example: `127.0.0.1:8765` |
-| `HOST` | Listen host; used with `PORT` when `LISTEN` is unset |
-| `PORT` | Listen port; used with `HOST` when `LISTEN` is unset |
-| `MCP_XCODE_PID` | Passed through to upstream `mcpbridge`; the proxy itself does not parse it |
-| `MCP_XCODE_SESSION_ID` | Optional explicit upstream session ID |
-| `MCP_XCODE_CONFIG` | Proxy config TOML path; `--config` takes precedence |
-| `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` or `upstream` |
-| `MCP_LOG_LEVEL` | Log level: `trace`, `debug`, `info`, `notice`, `warning`, `error`, `critical` |
-| `XCODE_MCP_PROXY_DISCOVERY_FILE` | Override the discovery file path for isolated local/live test runs |
-| `XCODE_MCP_PROXY_CACHE_ROOT` | Override the cache root used to derive the discovery path when `XCODE_MCP_PROXY_DISCOVERY_FILE` is unset |
+| `LISTEN` | Listen address, for example `127.0.0.1:8765`. |
+| `HOST` / `PORT` | Listen host and port when `LISTEN` is unset. |
+| `MCP_XCODE_PID` | Passed through to upstream `mcpbridge`; the proxy does not interpret it. |
+| `MCP_XCODE_SESSION_ID` | Optional explicit upstream Xcode MCP session ID. |
+| `MCP_XCODE_CONFIG` | TOML config path. `--config` takes precedence. |
+| `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` or `upstream`. |
+| `MCP_LOG_LEVEL` | `trace`, `debug`, `info`, `notice`, `warning`, `error`, or `critical`. |
+| `XCODE_MCP_PROXY_ENDPOINT` | STDIO adapter upstream URL. `--url` takes precedence. |
+| `XCODE_MCP_PROXY_DISCOVERY_FILE` | Discovery file override for isolated local/live test runs. |
+| `XCODE_MCP_PROXY_CACHE_ROOT` | Cache root used to derive the discovery path when `XCODE_MCP_PROXY_DISCOVERY_FILE` is unset. |
 
-Logs are written to stderr.
-
-## Maintainer Commands
-
-```bash
-swift test -Xswiftc -strict-concurrency=minimal
-XCODE_MCP_RUN_PROCESS_TESTS=1 swift test --no-parallel --filter ProxyProcessTests -Xswiftc -strict-concurrency=minimal
-scripts/check.sh
-scripts/publish-local-release.sh v0.1.0
-XCODE_MCP_RUN_LIVE_MCPBRIDGE_TESTS=1 swift test --no-parallel --filter ProxyLiveMCPBridgeTests -Xswiftc -strict-concurrency=minimal
-XCODE_MCP_RUN_STRESS_TESTS=1 swift test --no-parallel --filter ProxyStressTests -Xswiftc -strict-concurrency=minimal
-python3 scripts/benchmark-live-server.py --agents 4 --requests-per-agent 100
-```
-
-- `scripts/check.sh` runs the default suite and the opt-in process / pipe suite.
-- `scripts/publish-local-release.sh` builds the arm64 archive, creates a draft GitHub Release, and dispatches release verification. The release is published only after the workflow passes.
-- The live `mcpbridge` suite is local-only and intentionally excluded from CI.
-- The live suite uses the currently running Xcode session, requires exactly one Xcode process, uses `127.0.0.1:0`, and writes discovery output under a temp path.
-- The stress suite is opt-in only and intentionally excluded from `scripts/check.sh`; it runs high-volume HTTP/session multiplexing checks.
-- `scripts/benchmark-live-server.py` targets an already-running proxy server and is never run by default, `scripts/check.sh`, or CI. It resolves the endpoint from `--endpoint`, `XCODE_MCP_PROXY_ENDPOINT`, the discovery file, then `http://localhost:8765/mcp`; non-loopback endpoints require `--allow-non-loopback`. It models four agents as four persistent HTTP connections / MCP sessions, sends 100 `DocumentationSearch` requests per agent in a closed loop, reports throughput plus per-request latency percentiles, and deletes benchmark sessions before exit.
-
-#### Proxy Config
-
-| Key | Type | Default |
-|-----|------|---------|
-| `upstream_handshake.protocolVersion` | string | `"2025-06-18"` |
-| `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
-| `upstream_handshake.clientVersion` | string | `"dev"` |
-| `upstream_handshake.capabilities` | table | `{}` |
-| `tools.disabled` | array of strings | `[]` |
-
-If `clientVersion` is omitted, the proxy auto-resolves it from the Xcode `IDEChat*Version` entry matching `clientName` when available.
-
-Example:
+### TOML Config
 
 ```toml
 [upstream_handshake]
@@ -193,31 +147,59 @@ clientName = "XcodeMCPKit"
 disabled = ["RunAllTests", "RunSomeTests"]
 ```
 
-Disabled tools are removed from `tools/list` and rejected on direct `tools/call` requests with a tool error. The config is loaded when the proxy starts; restart `xcode-mcp-proxy-server` after editing the file.
+| Key | Type | Default |
+|-----|------|---------|
+| `upstream_handshake.clientName` | string | `"XcodeMCPKit"` |
+| `upstream_handshake.clientVersion` | string | `"dev"` |
+| `upstream_handshake.capabilities` | table | `{}` |
+| `tools.disabled` | array of strings | `[]` |
 
-### Adapter: `xcode-mcp-proxy`
+- Omitted `clientVersion`: resolved from Xcode's matching `IDEChat*Version`
+  defaults entry when available.
+- Disabled tools: removed from `tools/list` and rejected on direct `tools/call`.
+- Config changes require restarting `xcode-mcp-proxy-server`.
 
-Compatibility adapter for MCP clients that still require STDIO. HTTP-capable clients should connect directly to `xcode-mcp-proxy-server` with Streamable HTTP.
+## Migration
 
-#### Options
+### v0.11.0
 
-| Option | Description |
-|--------|-------------|
-| `--request-timeout seconds` | HTTP request timeout (`0` disables) |
-| `--url url` | Explicit upstream URL (example: `http://localhost:9000/mcp`) |
+Most Codex and Claude Code setups do not need a manual migration. Check these
+only if they apply:
 
-#### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `XCODE_MCP_PROXY_ENDPOINT` | Override upstream URL; `--url` takes precedence |
+- If you call the Streamable HTTP endpoint directly, use the server-issued
+  `MCP-Session-Id`, send `MCP-Protocol-Version: 2025-06-18` after `initialize`,
+  include `Accept: application/json, text/event-stream` on `POST /mcp`, and stop
+  sending JSON-RPC batch requests.
+- If you depended on the old SwiftPM library product, pin to `v0.10.2` or
+  migrate to the executable products.
 
 ## Troubleshooting
 
-[Troubleshooting](Docs/troubleshooting.md)
+- [Troubleshooting](Docs/troubleshooting.md)
 
-## References
+## Maintainers
 
+Local checks:
+
+```bash
+swift test -Xswiftc -strict-concurrency=minimal
+XCODE_MCP_RUN_PROCESS_TESTS=1 swift test --no-parallel --filter ProxyProcessTests -Xswiftc -strict-concurrency=minimal
+scripts/check.sh
+```
+
+Release:
+
+```bash
+scripts/publish-local-release.sh v0.11.0
+```
+
+- Module boundaries, release flow, live tests, benchmarks:
+  [Maintainer Architecture](Docs/maintainer-architecture.md)
+
+## More Documentation
+
+- [Architecture](Docs/architecture.md)
+- [Troubleshooting](Docs/troubleshooting.md)
 - [MCP / Xcode MCP Benchmark Notes](Docs/mcp-benchmark.md)
 - [MCP Connection Permission Dialog Investigation](Docs/mcp-permission-dialog-investigation.md)
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ endpoint and automates the `mcpbridge` approval flow.
 ### From GitHub Releases
 
 ```bash
-curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | sh
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/latest/download/install.sh | sh
 ```
 
 Custom install directory:
 
 ```bash
-curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | BINDIR="$HOME/bin" sh
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/latest/download/install.sh | sh -s -- --bindir "$HOME/bin"
+```
+
+Install a specific version:
+
+```bash
+curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/download/v0.11.0/install.sh | sh
 ```
 
 ### From Source

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ source ~/.zshrc
 xcode-mcp-proxy-server --auto-approve
 ```
 
-Without Accessibility permission:
+`--auto-approve` clicks the Xcode **Allow** button automatically. It requires macOS Accessibility permission.
+
+Without Accessibility permission, omit `--auto-approve` and click **Allow** yourself:
 
 ```bash
 xcode-mcp-proxy-server

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ endpoint and automates the `mcpbridge` approval flow.
 curl -fsSL https://github.com/lynnswap/XcodeMCPKit/releases/latest/download/install.sh | sh
 ```
 
+<details>
+<summary>Other install options</summary>
+
 Custom install directory:
 
 ```bash
@@ -51,6 +54,8 @@ Add to `PATH`:
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 ```
+
+</details>
 
 ## Set Up Your MCP Client
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -54,7 +54,6 @@ bin_out="$out_dir/bin"
 products=(
   "xcode-mcp-proxy"
   "xcode-mcp-proxy-server"
-  "xcode-mcp-proxy-install"
 )
 
 pushd "$repo_root" >/dev/null

--- a/scripts/install-release.sh.in
+++ b/scripts/install-release.sh.in
@@ -1,0 +1,116 @@
+#!/usr/bin/env sh
+set -eu
+
+VERSION="__VERSION__"
+REPO="__REPO__"
+DEFAULT_BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+BASE_URL="${XCODE_MCPKIT_BASE_URL:-$DEFAULT_BASE_URL}"
+PREFIX="${PREFIX:-${HOME}/.local}"
+BINDIR="${BINDIR:-}"
+ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [--prefix <dir>] [--bindir <dir>]
+EOF
+}
+
+need_value() {
+  if [ -z "${2:-}" ]; then
+    echo "$1 requires a value." >&2
+    usage >&2
+    exit 1
+  fi
+}
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prefix)
+      need_value "$1" "${2:-}"
+      PREFIX="$2"
+      shift 2
+      ;;
+    --bindir)
+      need_value "$1" "${2:-}"
+      BINDIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+need curl
+need grep
+need install
+need mktemp
+need shasum
+need tar
+need uname
+
+if [ -z "$BINDIR" ]; then
+  BINDIR="${PREFIX}/bin"
+fi
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+if [ "$OS" != "Darwin" ]; then
+  echo "GitHub release archives are macOS arm64 only. Build from source on ${OS}/${ARCH}." >&2
+  exit 1
+fi
+
+ARM64_CAPABLE=0
+if [ "$ARCH" = "arm64" ]; then
+  ARM64_CAPABLE=1
+elif [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]; then
+  ARM64_CAPABLE=1
+fi
+
+if [ "$ARM64_CAPABLE" != "1" ]; then
+  echo "GitHub release archives are macOS arm64 only. Build from source on ${OS}/${ARCH}." >&2
+  exit 1
+fi
+
+tmp_root="${TMPDIR:-/tmp}"
+tmp_dir="$(mktemp -d "${tmp_root%/}/xcode-mcpkit.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+curl -fsSL -o "$tmp_dir/$ARCHIVE" "$BASE_URL/$ARCHIVE"
+curl -fsSL -o "$tmp_dir/SHA256SUMS.txt" "$BASE_URL/SHA256SUMS.txt"
+
+(
+  cd "$tmp_dir"
+  grep "  ${ARCHIVE}\$" SHA256SUMS.txt > SHA256SUMS.selected
+  shasum -a 256 -c SHA256SUMS.selected
+  tar -xzf "$ARCHIVE"
+)
+
+mkdir -p "$BINDIR"
+install -m 755 "$tmp_dir/bin/xcode-mcp-proxy" "$BINDIR/xcode-mcp-proxy"
+install -m 755 "$tmp_dir/bin/xcode-mcp-proxy-server" "$BINDIR/xcode-mcp-proxy-server"
+
+echo "Installed XcodeMCPKit ${VERSION} to ${BINDIR}"
+case ":${PATH}:" in
+  *":${BINDIR}:"*) ;;
+  *)
+    echo "Add this directory to PATH:"
+    echo "  export PATH=\"${BINDIR}:\$PATH\""
+    ;;
+esac

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/package-release.sh [--dist-root <dir>] [--output-dir <dir>]
+Usage: scripts/package-release.sh --version <tag> [--repo <owner/repo>] [--dist-root <dir>] [--output-dir <dir>]
 
 Requires staged arm64 binaries from:
   <dist-root>/arm64/bin/
@@ -11,14 +11,25 @@ Requires staged arm64 binaries from:
 Outputs:
   <output-dir>/xcode-mcp-proxy-darwin-arm64.tar.gz
   <output-dir>/SHA256SUMS.txt
+  <output-dir>/install.sh
 EOF
 }
 
+version=""
+release_repo="lynnswap/XcodeMCPKit"
 dist_root="dist"
 output_dir="release"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      release_repo="${2:-}"
+      shift 2
+      ;;
     --dist-root)
       dist_root="${2:-}"
       shift 2
@@ -38,6 +49,22 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -z "$version" ]]; then
+  echo "--version is required." >&2
+  usage
+  exit 1
+fi
+
+if [[ ! "$version" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must look like v1.2.3." >&2
+  exit 1
+fi
+
+if [[ ! "$release_repo" =~ ^[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+$ ]]; then
+  echo "Release repo must look like owner/repo." >&2
+  exit 1
+fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if [[ "$dist_root" = /* ]]; then
@@ -63,8 +90,9 @@ trap 'rm -rf "$tmp_dir"' EXIT
 mkdir -p "$output_base"
 
 archive="$output_base/xcode-mcp-proxy-darwin-arm64.tar.gz"
+install_script="$output_base/install.sh"
 find "$output_base" -maxdepth 1 -type f -name 'xcode-mcp-proxy*.tar.gz' -delete
-rm -f "$output_base/SHA256SUMS.txt"
+rm -f "$output_base/SHA256SUMS.txt" "$install_script"
 
 products=(
   "xcode-mcp-proxy"
@@ -99,5 +127,93 @@ tar -C "$tmp_dir" -czf "$archive" bin
   shasum -a 256 xcode-mcp-proxy-darwin-arm64.tar.gz > SHA256SUMS.txt
 )
 
+cat > "$install_script" <<'INSTALL_SH'
+#!/usr/bin/env sh
+set -eu
+
+VERSION="${VERSION:-__VERSION__}"
+REPO="${XCODE_MCPKIT_REPO:-__REPO__}"
+ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"
+DEFAULT_BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+BASE_URL="${XCODE_MCPKIT_BASE_URL:-$DEFAULT_BASE_URL}"
+
+if [ -z "${BINDIR:-}" ]; then
+  PREFIX="${PREFIX:-${HOME}/.local}"
+  BINDIR="${PREFIX}/bin"
+fi
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need curl
+need grep
+need install
+need mktemp
+need shasum
+need tar
+need uname
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+if [ "$OS" != "Darwin" ]; then
+  echo "GitHub release archives are macOS arm64 only. Build from source on ${OS}/${ARCH}." >&2
+  exit 1
+fi
+
+ARM64_CAPABLE=0
+if [ "$ARCH" = "arm64" ]; then
+  ARM64_CAPABLE=1
+elif [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]; then
+  ARM64_CAPABLE=1
+fi
+
+if [ "$ARM64_CAPABLE" != "1" ]; then
+  echo "GitHub release archives are macOS arm64 only. Build from source on ${OS}/${ARCH}." >&2
+  exit 1
+fi
+
+tmp_root="${TMPDIR:-/tmp}"
+tmp_dir="$(mktemp -d "${tmp_root%/}/xcode-mcpkit.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+curl -fsSL -o "$tmp_dir/$ARCHIVE" "$BASE_URL/$ARCHIVE"
+curl -fsSL -o "$tmp_dir/SHA256SUMS.txt" "$BASE_URL/SHA256SUMS.txt"
+
+(
+  cd "$tmp_dir"
+  grep "  ${ARCHIVE}\$" SHA256SUMS.txt > SHA256SUMS.selected
+  shasum -a 256 -c SHA256SUMS.selected
+  tar -xzf "$ARCHIVE"
+)
+
+mkdir -p "$BINDIR"
+install -m 755 "$tmp_dir/bin/xcode-mcp-proxy" "$BINDIR/xcode-mcp-proxy"
+install -m 755 "$tmp_dir/bin/xcode-mcp-proxy-server" "$BINDIR/xcode-mcp-proxy-server"
+
+echo "Installed XcodeMCPKit ${VERSION} to ${BINDIR}"
+case ":${PATH}:" in
+  *":${BINDIR}:"*) ;;
+  *)
+    echo "Add this directory to PATH:"
+    echo "  export PATH=\"${BINDIR}:\$PATH\""
+    ;;
+esac
+INSTALL_SH
+
+sed \
+  -e "s|__VERSION__|$version|g" \
+  -e "s|__REPO__|$release_repo|g" \
+  "$install_script" > "$install_script.tmp"
+mv "$install_script.tmp" "$install_script"
+chmod +x "$install_script"
+
 echo "Created release package: $archive"
 echo "Created checksum file: $output_base/SHA256SUMS.txt"
+echo "Created install script: $install_script"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -131,7 +131,7 @@ cat > "$install_script" <<'INSTALL_SH'
 #!/usr/bin/env sh
 set -eu
 
-VERSION="${VERSION:-__VERSION__}"
+VERSION="${XCODE_MCPKIT_VERSION:-__VERSION__}"
 REPO="${XCODE_MCPKIT_REPO:-__REPO__}"
 ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"
 DEFAULT_BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -69,7 +69,6 @@ rm -f "$output_base/SHA256SUMS.txt"
 products=(
   "xcode-mcp-proxy"
   "xcode-mcp-proxy-server"
-  "xcode-mcp-proxy-install"
 )
 
 for product in "${products[@]}"; do
@@ -80,8 +79,9 @@ for product in "${products[@]}"; do
   fi
 done
 
-cp -R "$arm_bin" "$tmp_dir/bin"
+mkdir -p "$tmp_dir/bin"
 for product in "${products[@]}"; do
+  cp "$arm_bin/$product" "$tmp_dir/bin/$product"
   chmod +x "$tmp_dir/bin/$product"
   if command -v lipo >/dev/null 2>&1; then
     archs="$(lipo -archs "$tmp_dir/bin/$product")"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -122,97 +122,15 @@ done
 
 tar -C "$tmp_dir" -czf "$archive" bin
 
+"$repo_root/scripts/render-install-script.sh" \
+  --version "$version" \
+  --repo "$release_repo" \
+  --output "$install_script"
+
 (
   cd "$output_base"
-  shasum -a 256 xcode-mcp-proxy-darwin-arm64.tar.gz > SHA256SUMS.txt
+  shasum -a 256 xcode-mcp-proxy-darwin-arm64.tar.gz install.sh > SHA256SUMS.txt
 )
-
-cat > "$install_script" <<'INSTALL_SH'
-#!/usr/bin/env sh
-set -eu
-
-VERSION="${XCODE_MCPKIT_VERSION:-__VERSION__}"
-REPO="${XCODE_MCPKIT_REPO:-__REPO__}"
-ARCHIVE="xcode-mcp-proxy-darwin-arm64.tar.gz"
-DEFAULT_BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
-BASE_URL="${XCODE_MCPKIT_BASE_URL:-$DEFAULT_BASE_URL}"
-
-if [ -z "${BINDIR:-}" ]; then
-  PREFIX="${PREFIX:-${HOME}/.local}"
-  BINDIR="${PREFIX}/bin"
-fi
-
-need() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    echo "Missing required command: $1" >&2
-    exit 1
-  fi
-}
-
-need curl
-need grep
-need install
-need mktemp
-need shasum
-need tar
-need uname
-
-OS="$(uname -s)"
-ARCH="$(uname -m)"
-if [ "$OS" != "Darwin" ]; then
-  echo "GitHub release archives are macOS arm64 only. Build from source on ${OS}/${ARCH}." >&2
-  exit 1
-fi
-
-ARM64_CAPABLE=0
-if [ "$ARCH" = "arm64" ]; then
-  ARM64_CAPABLE=1
-elif [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]; then
-  ARM64_CAPABLE=1
-fi
-
-if [ "$ARM64_CAPABLE" != "1" ]; then
-  echo "GitHub release archives are macOS arm64 only. Build from source on ${OS}/${ARCH}." >&2
-  exit 1
-fi
-
-tmp_root="${TMPDIR:-/tmp}"
-tmp_dir="$(mktemp -d "${tmp_root%/}/xcode-mcpkit.XXXXXX")"
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-curl -fsSL -o "$tmp_dir/$ARCHIVE" "$BASE_URL/$ARCHIVE"
-curl -fsSL -o "$tmp_dir/SHA256SUMS.txt" "$BASE_URL/SHA256SUMS.txt"
-
-(
-  cd "$tmp_dir"
-  grep "  ${ARCHIVE}\$" SHA256SUMS.txt > SHA256SUMS.selected
-  shasum -a 256 -c SHA256SUMS.selected
-  tar -xzf "$ARCHIVE"
-)
-
-mkdir -p "$BINDIR"
-install -m 755 "$tmp_dir/bin/xcode-mcp-proxy" "$BINDIR/xcode-mcp-proxy"
-install -m 755 "$tmp_dir/bin/xcode-mcp-proxy-server" "$BINDIR/xcode-mcp-proxy-server"
-
-echo "Installed XcodeMCPKit ${VERSION} to ${BINDIR}"
-case ":${PATH}:" in
-  *":${BINDIR}:"*) ;;
-  *)
-    echo "Add this directory to PATH:"
-    echo "  export PATH=\"${BINDIR}:\$PATH\""
-    ;;
-esac
-INSTALL_SH
-
-sed \
-  -e "s|__VERSION__|$version|g" \
-  -e "s|__REPO__|$release_repo|g" \
-  "$install_script" > "$install_script.tmp"
-mv "$install_script.tmp" "$install_script"
-chmod +x "$install_script"
 
 echo "Created release package: $archive"
 echo "Created checksum file: $output_base/SHA256SUMS.txt"

--- a/scripts/publish-local-release.sh
+++ b/scripts/publish-local-release.sh
@@ -89,7 +89,7 @@ refresh_tag_state() {
 
 is_release_asset() {
   case "$1" in
-    xcode-mcp-proxy-darwin-arm64.tar.gz|SHA256SUMS.txt)
+    xcode-mcp-proxy-darwin-arm64.tar.gz|SHA256SUMS.txt|install.sh)
       return 0
       ;;
     *)
@@ -228,7 +228,11 @@ if [[ "$skip_tests" -eq 0 ]]; then
 fi
 
 scripts/build-release.sh --version "$tag" --dist-root "$dist_root"
-scripts/package-release.sh --dist-root "$dist_root" --output-dir "$output_dir"
+package_args=(--version "$tag" --dist-root "$dist_root" --output-dir "$output_dir")
+if [[ -n "$github_repo" ]]; then
+  package_args+=(--repo "$github_repo")
+fi
+scripts/package-release.sh "${package_args[@]}"
 
 if [[ "$output_dir" = /* ]]; then
   output_base="$output_dir"
@@ -237,6 +241,7 @@ else
 fi
 archive_path="$output_base/xcode-mcp-proxy-darwin-arm64.tar.gz"
 checksum_path="$output_base/SHA256SUMS.txt"
+install_script_path="$output_base/install.sh"
 
 if [[ ! -f "$archive_path" ]]; then
   echo "Expected release archive was not created: $archive_path" >&2
@@ -244,6 +249,10 @@ if [[ ! -f "$archive_path" ]]; then
 fi
 if [[ ! -f "$checksum_path" ]]; then
   echo "Expected checksum file was not created: $checksum_path" >&2
+  exit 1
+fi
+if [[ ! -f "$install_script_path" ]]; then
+  echo "Expected install script was not created: $install_script_path" >&2
   exit 1
 fi
 
@@ -255,6 +264,7 @@ fi
 if [[ "$allow_dirty" -eq 1 ]]; then
   echo "Created local-only release archive: $archive_path"
   echo "Created local-only checksum file: $checksum_path"
+  echo "Created local-only install script: $install_script_path"
   echo "Skipped tag push, GitHub Release upload, and release workflow dispatch because --allow-dirty was supplied."
   exit 0
 fi
@@ -285,9 +295,9 @@ if gh release view "$tag" --repo "$github_repo" >/dev/null 2>&1; then
     fi
   done < <(gh release view "$tag" --repo "$github_repo" --json assets --jq '.assets[].name')
 
-  gh release upload "$tag" "$archive_path" "$checksum_path" --repo "$github_repo" --clobber
+  gh release upload "$tag" "$archive_path" "$checksum_path" "$install_script_path" --repo "$github_repo" --clobber
 else
-  gh release create "$tag" "$archive_path" "$checksum_path" --repo "$github_repo" --draft --generate-notes --title "$tag" --verify-tag
+  gh release create "$tag" "$archive_path" "$checksum_path" "$install_script_path" --repo "$github_repo" --draft --generate-notes --title "$tag" --verify-tag
 fi
 
 gh workflow run release.yml --repo "$github_repo" --ref "$tag" -f version="$tag"
@@ -295,5 +305,6 @@ gh workflow run release.yml --repo "$github_repo" --ref "$tag" -f version="$tag"
 echo "Created local release draft for $tag with assets:"
 echo "  $archive_path"
 echo "  $checksum_path"
+echo "  $install_script_path"
 echo "Dispatched Release Verification workflow for $tag"
 echo "The workflow will publish the draft release after verification succeeds."

--- a/scripts/render-install-script.sh
+++ b/scripts/render-install-script.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/render-install-script.sh --version <tag> --repo <owner/repo> --output <path>
+EOF
+}
+
+version=""
+release_repo=""
+output=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      release_repo="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$version" || -z "$release_repo" || -z "$output" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ ! "$version" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must look like v1.2.3." >&2
+  exit 1
+fi
+
+if [[ ! "$release_repo" =~ ^[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+$ ]]; then
+  echo "Release repo must look like owner/repo." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+template="$repo_root/scripts/install-release.sh.in"
+
+if [[ ! -f "$template" ]]; then
+  echo "Missing installer template: $template" >&2
+  exit 1
+fi
+
+output_dir="$(dirname "$output")"
+mkdir -p "$output_dir"
+tmp_output="${output}.tmp"
+sed \
+  -e "s|__VERSION__|$version|g" \
+  -e "s|__REPO__|$release_repo|g" \
+  "$template" > "$tmp_output"
+mv "$tmp_output" "$output"
+chmod +x "$output"


### PR DESCRIPTION
## Purpose

Prepare the v0.11.0 release docs and installation path so users can install the proxy server and STDIO adapter with a short command.

## Changes

- Add a generated `install.sh` release asset for installing both `xcode-mcp-proxy-server` and `xcode-mcp-proxy`.
- Move installer generation into a checked-in template plus render script so the release workflow can regenerate and compare the uploaded asset.
- Include both the archive and `install.sh` in `SHA256SUMS.txt` and verify both before publishing a draft release.
- Switch README install commands to the `releases/latest/download/install.sh` URL, with version selection done by using a versioned release URL.
- Simplify the English and Japanese README setup flow, migration notes, terminology, and maintainer release instructions.

## Testing

- `scripts/check.sh`
- `git diff --check`
- Installer render smoke test with `sh -n` and `--help`
- Release package smoke test with temporary staged binaries, `shasum -a 256 -c SHA256SUMS.txt`, archive listing, and generated installer comparison
- `codex-review --uncommitted`
- `codex-review --base main`