### PR TITLE
Fix DocumentationSearch recovery paths

### DIFF
--- a/Sources/ProxyCore/ProcessRunner.swift
+++ b/Sources/ProxyCore/ProcessRunner.swift
@@ -78,6 +78,67 @@ private final class ProcessTimeoutState: @unchecked Sendable {
     }
 }
 
+private final class ProcessCancellationState: @unchecked Sendable {
+    private struct Registered: Sendable {
+        let cleanup: @Sendable () -> Void
+        let resume: @Sendable (Result<ProcessOutput, Error>) -> Void
+    }
+
+    private struct State: Sendable {
+        var registered: Registered?
+        var cancelled = false
+        var completed = false
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    func install(
+        cleanup: @escaping @Sendable () -> Void,
+        resume: @escaping @Sendable (Result<ProcessOutput, Error>) -> Void
+    ) -> Bool {
+        state.withLockedValue { state in
+            guard state.completed == false, state.cancelled == false else {
+                return false
+            }
+            state.registered = Registered(cleanup: cleanup, resume: resume)
+            return true
+        }
+    }
+
+    func complete() {
+        state.withLockedValue { state in
+            state.completed = true
+            state.registered = nil
+        }
+    }
+
+    func isCancelled() -> Bool {
+        state.withLockedValue { state in
+            state.cancelled
+        }
+    }
+
+    func cancel() {
+        let registered = state.withLockedValue { state -> Registered? in
+            guard state.completed == false else {
+                return nil
+            }
+            state.cancelled = true
+            guard let registered = state.registered else {
+                return nil
+            }
+            state.completed = true
+            state.registered = nil
+            return registered
+        }
+        guard let registered else {
+            return
+        }
+        registered.cleanup()
+        registered.resume(.failure(CancellationError()))
+    }
+}
+
 package struct ProcessRequest: Sendable {
     package let label: String
     package let executablePath: String
@@ -128,93 +189,125 @@ package struct ProcessRunner: ProcessRunning {
     package init() {}
 
     package func run(_ request: ProcessRequest) async throws -> ProcessOutput {
-        try await withCheckedThrowingContinuation { continuation in
-            let process = Process()
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            let stdinPipe = Pipe()
-            let drainGroup = DispatchGroup()
-            let stdoutCollector = PipeCollector(
-                fileHandle: stdoutPipe.fileHandleForReading,
-                drainGroup: drainGroup,
-                label: "XcodeMCPProxy.ProcessRunner.stdout"
-            )
-            let stderrCollector = PipeCollector(
-                fileHandle: stderrPipe.fileHandleForReading,
-                drainGroup: drainGroup,
-                label: "XcodeMCPProxy.ProcessRunner.stderr"
-            )
-            let timeoutState = ProcessTimeoutState()
-            let didResume = NIOLockedValueBox(false)
-            let timeoutWorkItem = Self.makeTimeoutWorkItem(
-                timeoutNanoseconds: request.timeoutNanoseconds,
-                process: process,
-                timeoutState: timeoutState
-            )
-            let resumeOnce: @Sendable (Result<ProcessOutput, Error>) -> Void = { result in
-                let shouldResume = didResume.withLockedValue { didResume in
-                    guard didResume == false else { return false }
-                    didResume = true
-                    return true
+        let cancellationState = ProcessCancellationState()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let process = Process()
+                let stdoutPipe = Pipe()
+                let stderrPipe = Pipe()
+                let stdinPipe = Pipe()
+                let drainGroup = DispatchGroup()
+                let stdoutCollector = PipeCollector(
+                    fileHandle: stdoutPipe.fileHandleForReading,
+                    drainGroup: drainGroup,
+                    label: "XcodeMCPProxy.ProcessRunner.stdout"
+                )
+                let stderrCollector = PipeCollector(
+                    fileHandle: stderrPipe.fileHandleForReading,
+                    drainGroup: drainGroup,
+                    label: "XcodeMCPProxy.ProcessRunner.stderr"
+                )
+                let timeoutState = ProcessTimeoutState()
+                let didResume = NIOLockedValueBox(false)
+                let timeoutWorkItem = Self.makeTimeoutWorkItem(
+                    timeoutNanoseconds: request.timeoutNanoseconds,
+                    process: process,
+                    timeoutState: timeoutState
+                )
+                let resumeOnce: @Sendable (Result<ProcessOutput, Error>) -> Void = { result in
+                    let shouldResume = didResume.withLockedValue { didResume in
+                        guard didResume == false else { return false }
+                        didResume = true
+                        return true
+                    }
+                    guard shouldResume else { return }
+                    cancellationState.complete()
+                    continuation.resume(with: result)
                 }
-                guard shouldResume else { return }
-                continuation.resume(with: result)
-            }
 
-            process.executableURL = URL(fileURLWithPath: request.executablePath)
-            process.arguments = request.arguments
-            process.standardOutput = stdoutPipe
-            process.standardError = stderrPipe
-            if request.input != nil {
-                process.standardInput = stdinPipe
-            }
-            stdoutCollector.start()
-            stderrCollector.start()
+                process.executableURL = URL(fileURLWithPath: request.executablePath)
+                process.arguments = request.arguments
+                process.standardOutput = stdoutPipe
+                process.standardError = stderrPipe
+                if request.input != nil {
+                    process.standardInput = stdinPipe
+                }
+                stdoutCollector.start()
+                stderrCollector.start()
+                let cancelResources: @Sendable () -> Void = {
+                    process.terminationHandler = nil
+                    if process.isRunning {
+                        process.terminate()
+                        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(1)) {
+                            guard process.isRunning else {
+                                return
+                            }
+                            kill(process.processIdentifier, SIGKILL)
+                        }
+                    }
+                    stdoutCollector.cancel()
+                    stderrCollector.cancel()
+                    try? stdoutPipe.fileHandleForWriting.close()
+                    try? stderrPipe.fileHandleForWriting.close()
+                    try? stdinPipe.fileHandleForWriting.close()
+                }
+                guard cancellationState.install(cleanup: cancelResources, resume: resumeOnce) else {
+                    cancelResources()
+                    resumeOnce(.failure(CancellationError()))
+                    return
+                }
 
-            process.terminationHandler = { process in
-                DispatchQueue.global().async {
-                    drainGroup.wait()
-                    if timeoutState.markTerminatedAndCheckTimedOut() {
-                        resumeOnce(.failure(ProcessTimeoutError(label: request.label)))
+                process.terminationHandler = { process in
+                    DispatchQueue.global().async {
+                        drainGroup.wait()
+                        if timeoutState.markTerminatedAndCheckTimedOut() {
+                            resumeOnce(.failure(ProcessTimeoutError(label: request.label)))
+                            return
+                        }
+                        let output = ProcessOutput(
+                            terminationStatus: process.terminationStatus,
+                            stdout: String(decoding: stdoutCollector.collectedData(), as: UTF8.self),
+                            stderr: String(decoding: stderrCollector.collectedData(), as: UTF8.self)
+                        )
+                        resumeOnce(.success(output))
+                    }
+                }
+
+                do {
+                    try process.run()
+                    if cancellationState.isCancelled() {
+                        cancelResources()
                         return
                     }
-                    let output = ProcessOutput(
-                        terminationStatus: process.terminationStatus,
-                        stdout: String(decoding: stdoutCollector.collectedData(), as: UTF8.self),
-                        stderr: String(decoding: stderrCollector.collectedData(), as: UTF8.self)
-                    )
-                    resumeOnce(.success(output))
-                }
-            }
-
-            do {
-                try process.run()
-                if let timeoutWorkItem {
-                    DispatchQueue.global().asyncAfter(
-                        deadline: .now() + .nanoseconds(Int(request.timeoutNanoseconds ?? 0)),
-                        execute: timeoutWorkItem
-                    )
-                }
-                try? stdoutPipe.fileHandleForWriting.close()
-                try? stderrPipe.fileHandleForWriting.close()
-                if let input = request.input {
-                    if let inputData = input.data(using: .utf8) {
-                        try stdinPipe.fileHandleForWriting.write(contentsOf: inputData)
+                    if let timeoutWorkItem {
+                        DispatchQueue.global().asyncAfter(
+                            deadline: .now() + .nanoseconds(Int(request.timeoutNanoseconds ?? 0)),
+                            execute: timeoutWorkItem
+                        )
                     }
-                    try stdinPipe.fileHandleForWriting.close()
+                    try? stdoutPipe.fileHandleForWriting.close()
+                    try? stderrPipe.fileHandleForWriting.close()
+                    if let input = request.input {
+                        if let inputData = input.data(using: .utf8) {
+                            try stdinPipe.fileHandleForWriting.write(contentsOf: inputData)
+                        }
+                        try stdinPipe.fileHandleForWriting.close()
+                    }
+                } catch {
+                    process.terminationHandler = nil
+                    if process.isRunning {
+                        process.terminate()
+                    }
+                    stdoutCollector.cancel()
+                    stderrCollector.cancel()
+                    try? stdoutPipe.fileHandleForWriting.close()
+                    try? stderrPipe.fileHandleForWriting.close()
+                    try? stdinPipe.fileHandleForWriting.close()
+                    resumeOnce(.failure(error))
                 }
-            } catch {
-                process.terminationHandler = nil
-                if process.isRunning {
-                    process.terminate()
-                }
-                stdoutCollector.cancel()
-                stderrCollector.cancel()
-                try? stdoutPipe.fileHandleForWriting.close()
-                try? stderrPipe.fileHandleForWriting.close()
-                try? stdinPipe.fileHandleForWriting.close()
-                resumeOnce(.failure(error))
             }
+        } onCancel: {
+            cancellationState.cancel()
         }
     }
 

--- a/Sources/ProxyCore/ProcessRunner.swift
+++ b/Sources/ProxyCore/ProcessRunner.swift
@@ -259,11 +259,13 @@ package struct ProcessRunner: ProcessRunning {
 
                 process.terminationHandler = { process in
                     DispatchQueue.global().async {
-                        drainGroup.wait()
                         if timeoutState.markTerminatedAndCheckTimedOut() {
+                            stdoutCollector.cancel()
+                            stderrCollector.cancel()
                             resumeOnce(.failure(ProcessTimeoutError(label: request.label)))
                             return
                         }
+                        drainGroup.wait()
                         let output = ProcessOutput(
                             terminationStatus: process.terminationStatus,
                             stdout: String(decoding: stdoutCollector.collectedData(), as: UTF8.self),

--- a/Sources/ProxyCore/ProcessRunner.swift
+++ b/Sources/ProxyCore/ProcessRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 import NIOConcurrencyHelpers
 
 final class DispatchGroupLeaveGuard: @unchecked Sendable {
@@ -56,17 +57,54 @@ private final class PipeCollector: @unchecked Sendable {
     }
 }
 
+private final class ProcessTimeoutState: @unchecked Sendable {
+    private let state = NIOLockedValueBox((terminated: false, timedOut: false))
+
+    func markTimedOutIfRunning() -> Bool {
+        state.withLockedValue { state in
+            guard state.terminated == false, state.timedOut == false else {
+                return false
+            }
+            state.timedOut = true
+            return true
+        }
+    }
+
+    func markTerminatedAndCheckTimedOut() -> Bool {
+        state.withLockedValue { state in
+            state.terminated = true
+            return state.timedOut
+        }
+    }
+}
+
 package struct ProcessRequest: Sendable {
     package let label: String
     package let executablePath: String
     package let arguments: [String]
     package let input: String?
+    package let timeoutNanoseconds: Int64?
 
-    package init(label: String, executablePath: String, arguments: [String], input: String?) {
+    package init(
+        label: String,
+        executablePath: String,
+        arguments: [String],
+        input: String?,
+        timeoutNanoseconds: Int64? = nil
+    ) {
         self.label = label
         self.executablePath = executablePath
         self.arguments = arguments
         self.input = input
+        self.timeoutNanoseconds = timeoutNanoseconds
+    }
+}
+
+package struct ProcessTimeoutError: Error, Sendable {
+    package let label: String
+
+    package init(label: String) {
+        self.label = label
     }
 }
 
@@ -106,7 +144,13 @@ package struct ProcessRunner: ProcessRunning {
                 drainGroup: drainGroup,
                 label: "XcodeMCPProxy.ProcessRunner.stderr"
             )
+            let timeoutState = ProcessTimeoutState()
             let didResume = NIOLockedValueBox(false)
+            let timeoutWorkItem = Self.makeTimeoutWorkItem(
+                timeoutNanoseconds: request.timeoutNanoseconds,
+                process: process,
+                timeoutState: timeoutState
+            )
             let resumeOnce: @Sendable (Result<ProcessOutput, Error>) -> Void = { result in
                 let shouldResume = didResume.withLockedValue { didResume in
                     guard didResume == false else { return false }
@@ -130,6 +174,10 @@ package struct ProcessRunner: ProcessRunning {
             process.terminationHandler = { process in
                 DispatchQueue.global().async {
                     drainGroup.wait()
+                    if timeoutState.markTerminatedAndCheckTimedOut() {
+                        resumeOnce(.failure(ProcessTimeoutError(label: request.label)))
+                        return
+                    }
                     let output = ProcessOutput(
                         terminationStatus: process.terminationStatus,
                         stdout: String(decoding: stdoutCollector.collectedData(), as: UTF8.self),
@@ -141,6 +189,12 @@ package struct ProcessRunner: ProcessRunning {
 
             do {
                 try process.run()
+                if let timeoutWorkItem {
+                    DispatchQueue.global().asyncAfter(
+                        deadline: .now() + .nanoseconds(Int(request.timeoutNanoseconds ?? 0)),
+                        execute: timeoutWorkItem
+                    )
+                }
                 try? stdoutPipe.fileHandleForWriting.close()
                 try? stderrPipe.fileHandleForWriting.close()
                 if let input = request.input {
@@ -160,6 +214,28 @@ package struct ProcessRunner: ProcessRunning {
                 try? stderrPipe.fileHandleForWriting.close()
                 try? stdinPipe.fileHandleForWriting.close()
                 resumeOnce(.failure(error))
+            }
+        }
+    }
+
+    private static func makeTimeoutWorkItem(
+        timeoutNanoseconds: Int64?,
+        process: Process,
+        timeoutState: ProcessTimeoutState
+    ) -> DispatchWorkItem? {
+        guard let timeoutNanoseconds, timeoutNanoseconds > 0 else {
+            return nil
+        }
+        return DispatchWorkItem {
+            guard process.isRunning, timeoutState.markTimedOutIfRunning() else {
+                return
+            }
+            process.terminate()
+            DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(1)) {
+                guard process.isRunning else {
+                    return
+                }
+                kill(process.processIdentifier, SIGKILL)
             }
         }
     }

--- a/Sources/ProxyCore/ProcessRunner.swift
+++ b/Sources/ProxyCore/ProcessRunner.swift
@@ -57,24 +57,74 @@ private final class PipeCollector: @unchecked Sendable {
     }
 }
 
-private final class ProcessTimeoutState: @unchecked Sendable {
-    private let state = NIOLockedValueBox((terminated: false, timedOut: false))
+private final class ProcessTimeoutController: @unchecked Sendable {
+    typealias Action = @Sendable () -> Void
 
-    func markTimedOutIfRunning() -> Bool {
+    private struct State {
+        var timeoutNanoseconds: Int64?
+        var workItem: DispatchWorkItem?
+        var action: Action?
+        var scheduled = false
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    func configure(timeoutNanoseconds: Int64?, action: @escaping Action) {
+        guard let timeoutNanoseconds, timeoutNanoseconds > 0 else {
+            return
+        }
+        let workItem = DispatchWorkItem { [self] in
+            fire()
+        }
         state.withLockedValue { state in
-            guard state.terminated == false, state.timedOut == false else {
-                return false
-            }
-            state.timedOut = true
-            return true
+            state.timeoutNanoseconds = timeoutNanoseconds
+            state.workItem = workItem
+            state.action = action
         }
     }
 
-    func markTerminatedAndCheckTimedOut() -> Bool {
-        state.withLockedValue { state in
-            state.terminated = true
-            return state.timedOut
+    func schedule() {
+        let scheduled = state.withLockedValue { state -> (DispatchWorkItem, Int64)? in
+            guard
+                state.scheduled == false,
+                let workItem = state.workItem,
+                let timeoutNanoseconds = state.timeoutNanoseconds,
+                state.action != nil
+            else {
+                return nil
+            }
+            state.scheduled = true
+            return (workItem, timeoutNanoseconds)
         }
+        guard let scheduled else {
+            return
+        }
+        DispatchQueue.global().asyncAfter(
+            deadline: .now() + .nanoseconds(Int(scheduled.1)),
+            execute: scheduled.0
+        )
+    }
+
+    func cancel() {
+        state.withLockedValue { state in
+            state.workItem?.cancel()
+            state.timeoutNanoseconds = nil
+            state.workItem = nil
+            state.action = nil
+        }
+    }
+
+    private func fire() {
+        let action = state.withLockedValue { state -> Action? in
+            guard let action = state.action else {
+                return nil
+            }
+            state.timeoutNanoseconds = nil
+            state.workItem = nil
+            state.action = nil
+            return action
+        }
+        action?()
     }
 }
 
@@ -197,6 +247,7 @@ package struct ProcessRunner: ProcessRunning {
                 let stderrPipe = Pipe()
                 let stdinPipe = Pipe()
                 let drainGroup = DispatchGroup()
+                let timeoutController = ProcessTimeoutController()
                 let stdoutCollector = PipeCollector(
                     fileHandle: stdoutPipe.fileHandleForReading,
                     drainGroup: drainGroup,
@@ -207,22 +258,23 @@ package struct ProcessRunner: ProcessRunning {
                     drainGroup: drainGroup,
                     label: "XcodeMCPProxy.ProcessRunner.stderr"
                 )
-                let timeoutState = ProcessTimeoutState()
                 let didResume = NIOLockedValueBox(false)
-                let timeoutWorkItem = Self.makeTimeoutWorkItem(
-                    timeoutNanoseconds: request.timeoutNanoseconds,
-                    process: process,
-                    timeoutState: timeoutState
-                )
-                let resumeOnce: @Sendable (Result<ProcessOutput, Error>) -> Void = { result in
+                let reserveResume: @Sendable () -> Bool = {
                     let shouldResume = didResume.withLockedValue { didResume in
                         guard didResume == false else { return false }
                         didResume = true
                         return true
                     }
-                    guard shouldResume else { return }
+                    return shouldResume
+                }
+                let resumeReserved: @Sendable (Result<ProcessOutput, Error>) -> Void = { result in
+                    timeoutController.cancel()
                     cancellationState.complete()
                     continuation.resume(with: result)
+                }
+                let resumeOnce: @Sendable (Result<ProcessOutput, Error>) -> Void = { result in
+                    guard reserveResume() else { return }
+                    resumeReserved(result)
                 }
 
                 process.executableURL = URL(fileURLWithPath: request.executablePath)
@@ -251,6 +303,13 @@ package struct ProcessRunner: ProcessRunning {
                     try? stderrPipe.fileHandleForWriting.close()
                     try? stdinPipe.fileHandleForWriting.close()
                 }
+                timeoutController.configure(timeoutNanoseconds: request.timeoutNanoseconds) {
+                    guard reserveResume() else {
+                        return
+                    }
+                    cancelResources()
+                    resumeReserved(.failure(ProcessTimeoutError(label: request.label)))
+                }
                 guard cancellationState.install(cleanup: cancelResources, resume: resumeOnce) else {
                     cancelResources()
                     resumeOnce(.failure(CancellationError()))
@@ -259,12 +318,6 @@ package struct ProcessRunner: ProcessRunning {
 
                 process.terminationHandler = { process in
                     DispatchQueue.global().async {
-                        if timeoutState.markTerminatedAndCheckTimedOut() {
-                            stdoutCollector.cancel()
-                            stderrCollector.cancel()
-                            resumeOnce(.failure(ProcessTimeoutError(label: request.label)))
-                            return
-                        }
                         drainGroup.wait()
                         let output = ProcessOutput(
                             terminationStatus: process.terminationStatus,
@@ -281,12 +334,7 @@ package struct ProcessRunner: ProcessRunning {
                         cancelResources()
                         return
                     }
-                    if let timeoutWorkItem {
-                        DispatchQueue.global().asyncAfter(
-                            deadline: .now() + .nanoseconds(Int(request.timeoutNanoseconds ?? 0)),
-                            execute: timeoutWorkItem
-                        )
-                    }
+                    timeoutController.schedule()
                     try? stdoutPipe.fileHandleForWriting.close()
                     try? stderrPipe.fileHandleForWriting.close()
                     if let input = request.input {
@@ -310,28 +358,6 @@ package struct ProcessRunner: ProcessRunning {
             }
         } onCancel: {
             cancellationState.cancel()
-        }
-    }
-
-    private static func makeTimeoutWorkItem(
-        timeoutNanoseconds: Int64?,
-        process: Process,
-        timeoutState: ProcessTimeoutState
-    ) -> DispatchWorkItem? {
-        guard let timeoutNanoseconds, timeoutNanoseconds > 0 else {
-            return nil
-        }
-        return DispatchWorkItem {
-            guard process.isRunning, timeoutState.markTimedOutIfRunning() else {
-                return
-            }
-            process.terminate()
-            DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(1)) {
-                guard process.isRunning else {
-                    return
-                }
-                kill(process.processIdentifier, SIGKILL)
-            }
         }
     }
 }

--- a/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator.swift
+++ b/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator.swift
@@ -169,15 +169,18 @@ package actor ControlPlaneCoordinator {
         }
     }
 
-    package func prewarmToolsCatalogIfNeeded(deadlineUptimeNs: UInt64?) async {
+    package func prewarmToolsCatalogIfNeeded(deadlineUptimeNs: UInt64?) async -> JSONValue? {
         cancelInvalidatedLoads()
+        if let rawResult = brokerState.toolsCatalogRaw() {
+            syncDebug()
+            return rawResult
+        }
         guard
-            brokerState.toolsCatalogRaw() == nil,
             toolsCatalogLoad == nil,
             prewarmToolsCatalogLoad == nil
         else {
             syncDebug()
-            return
+            return nil
         }
 
         let loadID = startToolsCatalogLoad(
@@ -187,7 +190,7 @@ package actor ControlPlaneCoordinator {
         let waiterID = WaiterID()
 
         do {
-            _ = try await withCheckedThrowingContinuation {
+            return try await withCheckedThrowingContinuation {
                 (continuation: CheckedContinuation<JSONValue, Error>) in
                 registerToolsCatalogWaiter(
                     loadID: loadID,
@@ -202,6 +205,7 @@ package actor ControlPlaneCoordinator {
                 "tools catalog prewarm failed",
                 metadata: ["error": .string(String(describing: error))]
             )
+            return nil
         }
     }
 

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1051,6 +1051,9 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
         guard let data = output.stdout.data(using: .utf8) else {
             return []
         }
+        guard output.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
+            return []
+        }
         return try JSONDecoder().decode([SearchRow].self, from: data)
     }
 

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -845,6 +845,85 @@ private final class ProcessOutputTimeoutWaiter: @unchecked Sendable {
     }
 }
 
+private final class DocumentationSearchServiceRepairWaiter: @unchecked Sendable {
+    struct Result: Sendable {
+        let repairResult: DocumentationSearchServiceRepairResult?
+        let timedOut: Bool
+    }
+
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Result, Never>?
+    private var tasks: [Task<Void, Never>] = []
+    private var resolved = false
+
+    func wait(
+        for task: Task<DocumentationSearchServiceRepairResult, Never>,
+        timeout: TimeAmount
+    ) async -> Result {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                setContinuation(continuation)
+                addTask(Task {
+                    let result = await task.value
+                    self.resume(Result(repairResult: result, timedOut: false))
+                })
+                addTask(Task {
+                    try? await Task.sleep(nanoseconds: UInt64(timeout.nanoseconds))
+                    guard Task.isCancelled == false else {
+                        return
+                    }
+                    task.cancel()
+                    self.resume(Result(repairResult: nil, timedOut: true))
+                })
+            }
+        } onCancel: {
+            task.cancel()
+            resume(Result(repairResult: nil, timedOut: true))
+        }
+    }
+
+    private func setContinuation(_ continuation: CheckedContinuation<Result, Never>) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            continuation.resume(returning: Result(repairResult: nil, timedOut: true))
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    private func addTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            task.cancel()
+            return
+        }
+        tasks.append(task)
+        lock.unlock()
+    }
+
+    private func resume(_ result: Result) {
+        lock.lock()
+        guard resolved == false else {
+            lock.unlock()
+            return
+        }
+        resolved = true
+        let continuation = continuation
+        self.continuation = nil
+        let tasks = tasks
+        self.tasks.removeAll()
+        lock.unlock()
+
+        for task in tasks {
+            task.cancel()
+        }
+        continuation?.resume(returning: result)
+    }
+}
+
 package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
     private struct SearchArguments {
         let requestID: JSONRPC.ID
@@ -932,6 +1011,9 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
         timeout: TimeAmount?
     ) async throws -> [SearchRow] {
         let sql = Self.searchSQL(arguments: arguments)
+        let timeoutNanoseconds = timeout.flatMap { timeout in
+            timeout.nanoseconds > 0 ? timeout.nanoseconds : nil
+        }
         let request = ProcessRequest(
             label: "documentation-search-local",
             executablePath: "/usr/bin/sqlite3",
@@ -940,18 +1022,23 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
                 asset.indexURL.path,
                 sql,
             ],
-            input: nil
+            input: nil,
+            timeoutNanoseconds: timeoutNanoseconds
         )
         let output: ProcessOutput
-        if let timeout, timeout.nanoseconds > 0 {
-            output = try await ProcessOutputTimeoutWaiter().wait(
-                for: Task {
-                    try await processRunner.run(request)
-                },
-                timeout: timeout
-            )
-        } else {
-            output = try await processRunner.run(request)
+        do {
+            if let timeout, timeout.nanoseconds > 0 {
+                output = try await ProcessOutputTimeoutWaiter().wait(
+                    for: Task {
+                        try await processRunner.run(request)
+                    },
+                    timeout: timeout
+                )
+            } else {
+                output = try await processRunner.run(request)
+            }
+        } catch is ProcessTimeoutError {
+            throw TimeoutError()
         }
         guard output.terminationStatus == 0 else {
             throw ControlPlane.Error.invalidResponse(
@@ -2267,16 +2354,23 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         _ profile: CandidateProfile,
         requestTimeout: TimeAmount?
     ) async -> CandidateProfile {
+        guard requestTimeout?.nanoseconds != 0 else {
+            return profile
+        }
+        let deadline = Deadline.fromNow(requestTimeout, clock: clock)
         let refreshed = await profileByRefreshingDescriptor(
             profile,
-            requestTimeout: requestTimeout
+            requestTimeout: remainingTimeout(until: deadline)
         )
         guard refreshed.descriptor == nil else {
             return refreshed
         }
+        guard remainingTimeout(until: deadline)?.nanoseconds != 0 else {
+            return refreshed
+        }
         let repaired = await profileByRepairingDocumentationSearchService(
             refreshed,
-            requestTimeout: requestTimeout
+            requestTimeout: remainingTimeout(until: deadline)
         )
         guard repaired.descriptor == nil else {
             return repaired
@@ -2288,10 +2382,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         _ profile: CandidateProfile,
         requestTimeout: TimeAmount?
     ) async -> CandidateProfile {
-        guard reserveServiceRepairAttempt(for: profile.target.processID) else {
+        guard requestTimeout?.nanoseconds != 0, !Task.isCancelled, !isShutdown else {
             return profile
         }
-        guard requestTimeout?.nanoseconds != 0, !Task.isCancelled, !isShutdown else {
+        guard reserveServiceRepairAttempt(for: profile.target.processID) else {
             return profile
         }
 
@@ -2305,7 +2399,21 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         )
 
         let deadline = Deadline.fromNow(requestTimeout, clock: clock)
-        let repairResult = await serviceRepairer.repairDocumentationSearch(for: profile.target)
+        guard let repairResult = await repairDocumentationSearch(
+            for: profile.target,
+            timeout: remainingTimeout(until: deadline)
+        ) else {
+            serviceRepairAttemptedProcessIDs.remove(profile.target.processID)
+            logger.debug(
+                "Xcode documentation service repair did not finish before timeout",
+                metadata: [
+                    "pid": .string("\(profile.target.processID)"),
+                    "app_path": .string(profile.target.appPath),
+                    "xcode_version": .string(profile.target.xcodeVersion),
+                ]
+            )
+            return profile
+        }
         switch repairResult {
         case .repaired(let report):
             logger.info(
@@ -2338,6 +2446,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     "reason": .string(reason),
                 ]
             )
+            return profile
+        }
+        guard remainingTimeout(until: deadline)?.nanoseconds != 0 else {
             return profile
         }
 
@@ -2380,6 +2491,25 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             )
             return profile
         }
+    }
+
+    private func repairDocumentationSearch(
+        for target: DocumentationProviderTarget,
+        timeout: TimeAmount?
+    ) async -> DocumentationSearchServiceRepairResult? {
+        guard timeout?.nanoseconds != 0 else {
+            return nil
+        }
+        guard let timeout, timeout.nanoseconds > 0 else {
+            return await serviceRepairer.repairDocumentationSearch(for: target)
+        }
+        let result = await DocumentationSearchServiceRepairWaiter().wait(
+            for: Task {
+                await serviceRepairer.repairDocumentationSearch(for: target)
+            },
+            timeout: timeout
+        )
+        return result.repairResult
     }
 
     private func profileByAddingInstalledDocumentationAssetFallback(

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -762,6 +762,88 @@ package struct LiveDocumentationSearchServiceRepairer: DocumentationSearchServic
     }
 }
 
+private final class ProcessOutputTimeoutWaiter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<ProcessOutput, Error>?
+    private var tasks: [Task<Void, Never>] = []
+    private var resolved = false
+
+    func wait(
+        for task: Task<ProcessOutput, Error>,
+        timeout: TimeAmount
+    ) async throws -> ProcessOutput {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                setContinuation(continuation)
+                addTask(Task {
+                    do {
+                        let output = try await task.value
+                        self.resume(.success(output))
+                    } catch {
+                        self.resume(.failure(error))
+                    }
+                })
+                addTask(Task {
+                    try? await Task.sleep(nanoseconds: UInt64(timeout.nanoseconds))
+                    guard Task.isCancelled == false else {
+                        return
+                    }
+                    self.resume(.failure(TimeoutError()))
+                })
+            }
+        } onCancel: {
+            task.cancel()
+            resume(.failure(CancellationError()))
+        }
+    }
+
+    private func setContinuation(_ continuation: CheckedContinuation<ProcessOutput, Error>) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    private func addTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            task.cancel()
+            return
+        }
+        tasks.append(task)
+        lock.unlock()
+    }
+
+    private func resume(_ result: Result<ProcessOutput, Error>) {
+        lock.lock()
+        guard resolved == false else {
+            lock.unlock()
+            return
+        }
+        resolved = true
+        let continuation = continuation
+        self.continuation = nil
+        let tasks = tasks
+        self.tasks.removeAll()
+        lock.unlock()
+
+        for task in tasks {
+            task.cancel()
+        }
+        switch result {
+        case .success(let output):
+            continuation?.resume(returning: output)
+        case .failure(let error):
+            continuation?.resume(throwing: error)
+        }
+    }
+}
+
 package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
     private struct SearchArguments {
         let requestID: JSONRPC.ID
@@ -811,13 +893,16 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
     package func callDocumentationSearch(
         requestData: Data,
         for target: DocumentationProviderTarget,
-        timeout _: TimeAmount?
+        timeout: TimeAmount?
     ) async throws -> Data {
+        guard timeout?.nanoseconds != 0 else {
+            throw TimeoutError()
+        }
         let arguments = try Self.searchArguments(from: requestData)
         guard let asset = installedAsset(for: target) else {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
-        let rows = try await searchRows(arguments: arguments, asset: asset)
+        let rows = try await searchRows(arguments: arguments, asset: asset, timeout: timeout)
         return try Self.makeResponse(
             requestID: arguments.requestID,
             query: arguments.query,
@@ -842,10 +927,11 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
 
     private func searchRows(
         arguments: SearchArguments,
-        asset: DocumentationSearchInstalledAsset
+        asset: DocumentationSearchInstalledAsset,
+        timeout: TimeAmount?
     ) async throws -> [SearchRow] {
         let sql = Self.searchSQL(arguments: arguments)
-        let output = try await processRunner.run(ProcessRequest(
+        let request = ProcessRequest(
             label: "documentation-search-local",
             executablePath: "/usr/bin/sqlite3",
             arguments: [
@@ -854,7 +940,18 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
                 sql,
             ],
             input: nil
-        ))
+        )
+        let output: ProcessOutput
+        if let timeout, timeout.nanoseconds > 0 {
+            output = try await ProcessOutputTimeoutWaiter().wait(
+                for: Task {
+                    try await processRunner.run(request)
+                },
+                timeout: timeout
+            )
+        } else {
+            output = try await processRunner.run(request)
+        }
         guard output.terminationStatus == 0 else {
             throw ControlPlane.Error.invalidResponse(
                 "local DocumentationSearch sqlite failed: \(output.stderr)"

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -67,6 +67,75 @@ package protocol DocumentationProviderManaging: Sendable {
     func shutdown() async
 }
 
+package struct DocumentationSearchServiceRepairReport: Sendable, Equatable {
+    package let configURL: String
+    package let xcodeVersion: String
+    package let osVersion: String
+    package let documentationRelease: Int?
+    package let changedDefault: Bool
+
+    package init(
+        configURL: String,
+        xcodeVersion: String,
+        osVersion: String,
+        documentationRelease: Int?,
+        changedDefault: Bool
+    ) {
+        self.configURL = configURL
+        self.xcodeVersion = xcodeVersion
+        self.osVersion = osVersion
+        self.documentationRelease = documentationRelease
+        self.changedDefault = changedDefault
+    }
+}
+
+package enum DocumentationSearchServiceRepairResult: Sendable, Equatable {
+    case repaired(DocumentationSearchServiceRepairReport)
+    case skipped(String)
+    case failed(String)
+}
+
+package protocol DocumentationSearchServiceRepairing: Sendable {
+    func repairDocumentationSearch(
+        for target: DocumentationProviderTarget
+    ) async -> DocumentationSearchServiceRepairResult
+}
+
+package protocol DocumentationSearchProviding: Sendable {
+    func descriptor(for target: DocumentationProviderTarget) async -> JSONValue?
+    func callDocumentationSearch(
+        requestData: Data,
+        for target: DocumentationProviderTarget,
+        timeout: TimeAmount?
+    ) async throws -> Data
+}
+
+package struct NoopDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairing {
+    package init() {}
+
+    package func repairDocumentationSearch(
+        for _: DocumentationProviderTarget
+    ) async -> DocumentationSearchServiceRepairResult {
+        .skipped("disabled")
+    }
+}
+
+package struct UnavailableDocumentationSearchProvider: DocumentationSearchProviding {
+    package init() {}
+
+    package func descriptor(for _: DocumentationProviderTarget) async -> JSONValue? {
+        nil
+    }
+
+    package func callDocumentationSearch(
+        requestData _: Data,
+        for _: DocumentationProviderTarget,
+        timeout _: TimeAmount?
+    ) async throws -> Data {
+        throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+}
+
 package struct DocumentationProviderRoute: Sendable, Equatable {
     package let id: String
     package let target: DocumentationProviderTarget
@@ -149,6 +218,19 @@ extension DocumentationProvider {
                 let normalized = text.lowercased()
                 return normalized.contains("documentationsearch")
                     && normalized.contains("not enabled")
+            }
+        }
+
+        package static func responseIsDocumentationProviderFailure(_ data: Data) -> Bool {
+            responseErrorTexts(in: data).contains { text in
+                let normalized = text.lowercased()
+                return normalized.contains("config.json")
+                    || normalized.contains("documentation database")
+                    || normalized.contains("asset is not installed")
+                    || normalized.contains("unable to obtain asset location")
+                    || normalized.contains("no matching asset")
+                    || normalized.contains("cannot complete asset query")
+                    || normalized.contains("cannot resolve asset query")
             }
         }
 
@@ -281,6 +363,678 @@ package struct LiveDocumentationProviderSessionFactory: DocumentationProviderSes
             maxQueuedWriteBytes: 4 * 1_048_576
         )
         return try await UpstreamProcess(config: config).startSession()
+    }
+}
+
+package struct DocumentationSearchInstalledAsset: Sendable, Equatable {
+    package let assetURL: URL
+    package let configURL: URL
+    package let indexURL: URL
+    package let xcodeVersion: String
+    package let osVersion: String
+    package let documentationRelease: Int?
+
+    package init(
+        assetURL: URL,
+        configURL: URL,
+        indexURL: URL,
+        xcodeVersion: String,
+        osVersion: String,
+        documentationRelease: Int?
+    ) {
+        self.assetURL = assetURL
+        self.configURL = configURL
+        self.indexURL = indexURL
+        self.xcodeVersion = xcodeVersion
+        self.osVersion = osVersion
+        self.documentationRelease = documentationRelease
+    }
+}
+
+package struct DocumentationSearchAssetScan: Sendable, Equatable {
+    package let root: String
+    package let candidateCount: Int
+    package let assets: [DocumentationSearchInstalledAsset]
+    package let rejectionCounts: [String: Int]
+
+    package init(
+        root: String,
+        candidateCount: Int,
+        assets: [DocumentationSearchInstalledAsset],
+        rejectionCounts: [String: Int]
+    ) {
+        self.root = root
+        self.candidateCount = candidateCount
+        self.assets = assets
+        self.rejectionCounts = rejectionCounts
+    }
+
+    package var noAssetReason: String {
+        var parts = [
+            "no_installed_documentation_asset",
+            "root=\(root)",
+            "candidates=\(candidateCount)",
+            "accepted=\(assets.count)",
+        ]
+        let rejected = rejectionCounts
+            .sorted { lhs, rhs in
+                if lhs.value != rhs.value {
+                    return lhs.value > rhs.value
+                }
+                return lhs.key < rhs.key
+            }
+            .map { "\($0.key):\($0.value)" }
+            .joined(separator: ",")
+        if rejected.isEmpty == false {
+            parts.append("rejected=\(rejected)")
+        }
+        return parts.joined(separator: " ")
+    }
+}
+
+package enum DocumentationSearchAssetLocator {
+    private enum AssetCandidate {
+        case asset(DocumentationSearchInstalledAsset)
+        case rejected(String)
+    }
+
+    package static let defaultAssetRoot = URL(
+        fileURLWithPath: "/System/Library/AssetsV2/com_apple_MobileAsset_AppleDeveloperDocumentation",
+        isDirectory: true
+    )
+
+    package static func scanInstalledAssets(in root: URL) throws -> DocumentationSearchAssetScan {
+        let assetURLs = try FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        var candidateCount = 0
+        var assets: [DocumentationSearchInstalledAsset] = []
+        var rejectionCounts: [String: Int] = [:]
+        for assetURL in assetURLs where assetURL.pathExtension == "asset" {
+            candidateCount += 1
+            switch installedAsset(at: assetURL) {
+            case .asset(let asset):
+                assets.append(asset)
+            case .rejected(let reason):
+                rejectionCounts[reason, default: 0] += 1
+            }
+        }
+        return DocumentationSearchAssetScan(
+            root: root.path,
+            candidateCount: candidateCount,
+            assets: assets,
+            rejectionCounts: rejectionCounts
+        )
+    }
+
+    private static func installedAsset(at assetURL: URL) -> AssetCandidate {
+        let configURL = assetURL
+            .appendingPathComponent("AssetData", isDirectory: true)
+            .appendingPathComponent("config.json", isDirectory: false)
+        let indexURL = assetURL
+            .appendingPathComponent("AssetData", isDirectory: true)
+            .appendingPathComponent("documentation-db", isDirectory: true)
+            .appendingPathComponent("index.sql", isDirectory: false)
+        guard FileManager.default.isReadableFile(atPath: configURL.path) else {
+            return .rejected("config_not_readable")
+        }
+        guard FileManager.default.isReadableFile(atPath: indexURL.path) else {
+            return .rejected("index_not_readable")
+        }
+
+        let infoURL = assetURL.appendingPathComponent("Info.plist", isDirectory: false)
+        let data: Data
+        do {
+            data = try Data(contentsOf: infoURL)
+        } catch {
+            return .rejected("info_plist_not_readable")
+        }
+        let plist: AssetInfoPlist
+        do {
+            plist = try PropertyListDecoder().decode(AssetInfoPlist.self, from: data)
+        } catch {
+            return .rejected("info_plist_decode_failed")
+        }
+        let properties = plist.mobileAssetProperties
+
+        return .asset(DocumentationSearchInstalledAsset(
+            assetURL: assetURL,
+            configURL: configURL,
+            indexURL: indexURL,
+            xcodeVersion: properties.xcodeVersion,
+            osVersion: properties.osVersion,
+            documentationRelease: properties.documentationRelease
+        ))
+    }
+
+    package static func bestAsset(
+        for targetXcodeVersion: String,
+        currentOSVersion: String,
+        from assets: [DocumentationSearchInstalledAsset]
+    ) -> DocumentationSearchInstalledAsset? {
+        assets.max { lhs, rhs in
+            isBetter(rhs, than: lhs, targetXcodeVersion: targetXcodeVersion, currentOSVersion: currentOSVersion)
+        }
+    }
+
+    private static func isBetter(
+        _ lhs: DocumentationSearchInstalledAsset,
+        than rhs: DocumentationSearchInstalledAsset,
+        targetXcodeVersion: String,
+        currentOSVersion: String
+    ) -> Bool {
+        let lhsRank = rank(lhs, targetXcodeVersion: targetXcodeVersion, currentOSVersion: currentOSVersion)
+        let rhsRank = rank(rhs, targetXcodeVersion: targetXcodeVersion, currentOSVersion: currentOSVersion)
+        if lhsRank.exactXcodeVersion != rhsRank.exactXcodeVersion {
+            return lhsRank.exactXcodeVersion
+        }
+        if lhsRank.sameXcodeMajor != rhsRank.sameXcodeMajor {
+            return lhsRank.sameXcodeMajor
+        }
+        if lhsRank.notNewerThanTargetXcode != rhsRank.notNewerThanTargetXcode {
+            return lhsRank.notNewerThanTargetXcode
+        }
+        if lhsRank.xcodeVersionDistance != rhsRank.xcodeVersionDistance {
+            return lhsRank.xcodeVersionDistance < rhsRank.xcodeVersionDistance
+        }
+        if lhsRank.notNewerThanCurrentOS != rhsRank.notNewerThanCurrentOS {
+            return lhsRank.notNewerThanCurrentOS
+        }
+        if lhsRank.osVersionDistance != rhsRank.osVersionDistance {
+            return lhsRank.osVersionDistance < rhsRank.osVersionDistance
+        }
+        if lhsRank.documentationRelease != rhsRank.documentationRelease {
+            return lhsRank.documentationRelease > rhsRank.documentationRelease
+        }
+        return lhs.assetURL.path < rhs.assetURL.path
+    }
+
+    private struct AssetRank {
+        let exactXcodeVersion: Bool
+        let sameXcodeMajor: Bool
+        let notNewerThanTargetXcode: Bool
+        let xcodeVersionDistance: Int
+        let notNewerThanCurrentOS: Bool
+        let osVersionDistance: Int
+        let documentationRelease: Int
+    }
+
+    private static func rank(
+        _ asset: DocumentationSearchInstalledAsset,
+        targetXcodeVersion: String,
+        currentOSVersion: String
+    ) -> AssetRank {
+        let assetXcodeParts = numericVersionParts(asset.xcodeVersion)
+        let targetXcodeParts = numericVersionParts(targetXcodeVersion)
+        let assetOSParts = numericVersionParts(asset.osVersion)
+        let currentOSParts = numericVersionParts(currentOSVersion)
+        return AssetRank(
+            exactXcodeVersion: compareVersion(asset.xcodeVersion, targetXcodeVersion) == .orderedSame,
+            sameXcodeMajor: assetXcodeParts.first != nil && assetXcodeParts.first == targetXcodeParts.first,
+            notNewerThanTargetXcode: compareVersion(asset.xcodeVersion, targetXcodeVersion) != .orderedDescending,
+            xcodeVersionDistance: versionDistance(assetXcodeParts, targetXcodeParts),
+            notNewerThanCurrentOS: compareVersion(asset.osVersion, currentOSVersion) != .orderedDescending,
+            osVersionDistance: versionDistance(assetOSParts, currentOSParts),
+            documentationRelease: asset.documentationRelease ?? 0
+        )
+    }
+
+    package static func currentOperatingSystemVersionString() -> String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+
+    private static func compareVersion(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let lhsParts = numericVersionParts(lhs)
+        let rhsParts = numericVersionParts(rhs)
+        let count = max(lhsParts.count, rhsParts.count)
+        for index in 0..<count {
+            let lhsValue = index < lhsParts.count ? lhsParts[index] : 0
+            let rhsValue = index < rhsParts.count ? rhsParts[index] : 0
+            if lhsValue < rhsValue {
+                return .orderedAscending
+            }
+            if lhsValue > rhsValue {
+                return .orderedDescending
+            }
+        }
+        return lhs.localizedStandardCompare(rhs)
+    }
+
+    private static func numericVersionParts(_ version: String) -> [Int] {
+        version
+            .split { character in
+                !character.isNumber
+            }
+            .compactMap { Int($0) }
+    }
+
+    private static func versionDistance(_ lhs: [Int], _ rhs: [Int]) -> Int {
+        guard lhs.isEmpty == false, rhs.isEmpty == false else {
+            return Int.max
+        }
+        let count = max(lhs.count, rhs.count)
+        var multiplier = 1
+        var distance = 0
+        for index in stride(from: count - 1, through: 0, by: -1) {
+            let lhsValue = index < lhs.count ? lhs[index] : 0
+            let rhsValue = index < rhs.count ? rhs[index] : 0
+            distance += abs(lhsValue - rhsValue) * multiplier
+            multiplier *= 1_000
+        }
+        return distance
+    }
+
+    private struct AssetInfoPlist: Decodable {
+        let mobileAssetProperties: MobileAssetProperties
+
+        private enum CodingKeys: String, CodingKey {
+            case mobileAssetProperties = "MobileAssetProperties"
+        }
+    }
+
+    private struct MobileAssetProperties: Decodable {
+        let documentationRelease: Int?
+        let xcodeVersion: String
+        let osVersion: String
+
+        private enum CodingKeys: String, CodingKey {
+            case documentationRelease = "DocumentationRelease"
+            case xcodeVersion = "XcodeVersion"
+            case osVersion = "OSVersion"
+        }
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            xcodeVersion = try container.decode(String.self, forKey: .xcodeVersion)
+            osVersion = try container.decode(String.self, forKey: .osVersion)
+            documentationRelease = Self.decodeDocumentationRelease(from: container)
+        }
+
+        private static func decodeDocumentationRelease(
+            from container: KeyedDecodingContainer<CodingKeys>
+        ) -> Int? {
+            if let value = try? container.decode(Int.self, forKey: .documentationRelease) {
+                return value
+            }
+            if let value = try? container.decode(String.self, forKey: .documentationRelease) {
+                return Int(value)
+            }
+            return nil
+        }
+    }
+}
+
+package struct LiveDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairing {
+    private static let xcodeDefaultsDomain = "com.apple.dt.Xcode"
+    private static let configURLDefaultsKey = "IDEChatDocumentationSearchConfigURL"
+
+    private let assetRoot: URL
+    private let currentOSVersion: @Sendable () -> String
+    private let readConfigURLOverride: @Sendable () -> String?
+    private let writeConfigURLOverride: @Sendable (String) -> Bool
+
+    package init(
+        assetRoot: URL = DocumentationSearchAssetLocator.defaultAssetRoot,
+        currentOSVersion: @escaping @Sendable () -> String =
+            DocumentationSearchAssetLocator.currentOperatingSystemVersionString,
+        readConfigURLOverride: @escaping @Sendable () -> String? = Self.currentConfigURLOverride,
+        writeConfigURLOverride: @escaping @Sendable (String) -> Bool = Self.writeConfigURLOverride
+    ) {
+        self.assetRoot = assetRoot
+        self.currentOSVersion = currentOSVersion
+        self.readConfigURLOverride = readConfigURLOverride
+        self.writeConfigURLOverride = writeConfigURLOverride
+    }
+
+    package func repairDocumentationSearch(
+        for target: DocumentationProviderTarget
+    ) async -> DocumentationSearchServiceRepairResult {
+        let scan: DocumentationSearchAssetScan
+        do {
+            scan = try DocumentationSearchAssetLocator.scanInstalledAssets(in: assetRoot)
+        } catch {
+            return .failed("asset_scan_failed: \(error)")
+        }
+        guard let asset = DocumentationSearchAssetLocator.bestAsset(
+            for: target.xcodeVersion,
+            currentOSVersion: currentOSVersion(),
+            from: scan.assets
+        ) else {
+            return .skipped(scan.noAssetReason)
+        }
+
+        let configURLString = asset.configURL.path
+        let currentConfigURLString = readConfigURLOverride()
+        guard currentConfigURLString != configURLString else {
+            return .repaired(
+                Self.report(for: asset, configURLString: configURLString, changedDefault: false)
+            )
+        }
+
+        guard writeConfigURLOverride(configURLString) else {
+            return .failed("defaults_write_failed")
+        }
+        return .repaired(
+            Self.report(for: asset, configURLString: configURLString, changedDefault: true)
+        )
+    }
+
+    private static func report(
+        for asset: DocumentationSearchInstalledAsset,
+        configURLString: String,
+        changedDefault: Bool
+    ) -> DocumentationSearchServiceRepairReport {
+        DocumentationSearchServiceRepairReport(
+            configURL: configURLString,
+            xcodeVersion: asset.xcodeVersion,
+            osVersion: asset.osVersion,
+            documentationRelease: asset.documentationRelease,
+            changedDefault: changedDefault
+        )
+    }
+
+    private static func currentConfigURLOverride() -> String? {
+        guard let value = CFPreferencesCopyAppValue(
+            configURLDefaultsKey as CFString,
+            xcodeDefaultsDomain as CFString
+        ) else {
+            return nil
+        }
+        if let string = value as? String {
+            return string
+        }
+        if let url = value as? URL {
+            return url.absoluteString
+        }
+        return nil
+    }
+
+    private static func writeConfigURLOverride(_ value: String) -> Bool {
+        CFPreferencesSetAppValue(
+            configURLDefaultsKey as CFString,
+            value as CFString,
+            xcodeDefaultsDomain as CFString
+        )
+        return CFPreferencesAppSynchronize(xcodeDefaultsDomain as CFString)
+    }
+}
+
+package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
+    private struct SearchArguments {
+        let requestID: JSONRPC.ID
+        let query: String
+        let frameworks: [String]
+        let limit: Int
+    }
+
+    private struct SearchRow: Decodable {
+        let assetID: String?
+        let type: String?
+        let framework: String?
+        let title: String?
+        let content: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case assetID = "asset_id"
+            case type
+            case framework
+            case title
+            case content
+        }
+    }
+
+    private let assetRoot: URL
+    private let currentOSVersion: @Sendable () -> String
+    private let processRunner: any ProcessRunning
+
+    package init(
+        assetRoot: URL = DocumentationSearchAssetLocator.defaultAssetRoot,
+        currentOSVersion: @escaping @Sendable () -> String =
+            DocumentationSearchAssetLocator.currentOperatingSystemVersionString,
+        processRunner: any ProcessRunning = ProcessRunner()
+    ) {
+        self.assetRoot = assetRoot
+        self.currentOSVersion = currentOSVersion
+        self.processRunner = processRunner
+    }
+
+    package func descriptor(for target: DocumentationProviderTarget) async -> JSONValue? {
+        guard installedAsset(for: target) != nil else {
+            return nil
+        }
+        return Self.descriptor
+    }
+
+    package func callDocumentationSearch(
+        requestData: Data,
+        for target: DocumentationProviderTarget,
+        timeout _: TimeAmount?
+    ) async throws -> Data {
+        let arguments = try Self.searchArguments(from: requestData)
+        guard let asset = installedAsset(for: target) else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        let rows = try await searchRows(arguments: arguments, asset: asset)
+        return try Self.makeResponse(
+            requestID: arguments.requestID,
+            query: arguments.query,
+            asset: asset,
+            rows: rows
+        )
+    }
+
+    private func installedAsset(
+        for target: DocumentationProviderTarget
+    ) -> DocumentationSearchInstalledAsset? {
+        guard let scan = try? DocumentationSearchAssetLocator.scanInstalledAssets(in: assetRoot)
+        else {
+            return nil
+        }
+        return DocumentationSearchAssetLocator.bestAsset(
+            for: target.xcodeVersion,
+            currentOSVersion: currentOSVersion(),
+            from: scan.assets
+        )
+    }
+
+    private func searchRows(
+        arguments: SearchArguments,
+        asset: DocumentationSearchInstalledAsset
+    ) async throws -> [SearchRow] {
+        let sql = Self.searchSQL(arguments: arguments)
+        let output = try await processRunner.run(ProcessRequest(
+            label: "documentation-search-local",
+            executablePath: "/usr/bin/sqlite3",
+            arguments: [
+                "-json",
+                asset.indexURL.path,
+                sql,
+            ],
+            input: nil
+        ))
+        guard output.terminationStatus == 0 else {
+            throw ControlPlane.Error.invalidResponse(
+                "local DocumentationSearch sqlite failed: \(output.stderr)"
+            )
+        }
+        guard let data = output.stdout.data(using: .utf8) else {
+            return []
+        }
+        return try JSONDecoder().decode([SearchRow].self, from: data)
+    }
+
+    private static var descriptor: JSONValue {
+        .object([
+            "name": .string(DocumentationProvider.ToolCatalog.toolName),
+            "description": .string(
+                "Searches installed Apple Developer Documentation."
+            ),
+            "inputSchema": .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("Search query."),
+                    ]),
+                    "frameworks": .object([
+                        "type": .string("array"),
+                        "items": .object([
+                            "type": .string("string"),
+                        ]),
+                        "description": .string("Optional framework filter."),
+                    ]),
+                ]),
+                "required": .array([
+                    .string("query"),
+                ]),
+            ]),
+        ])
+    }
+
+    private static func searchArguments(from data: Data) throws -> SearchArguments {
+        guard
+            let object = try JSONSerialization.jsonObject(with: data, options: [])
+                as? [String: Any],
+            let requestID = JSONRPC.Message.Inspector.requestID(from: object)
+        else {
+            throw ControlPlane.Error.invalidResponse("missing DocumentationSearch request id")
+        }
+        guard
+            let params = object["params"] as? [String: Any],
+            let arguments = params["arguments"] as? [String: Any],
+            let query = arguments["query"] as? String,
+            query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        else {
+            throw ControlPlane.Error.invalidResponse("missing DocumentationSearch query")
+        }
+        let frameworks = Self.frameworks(from: arguments["frameworks"])
+        let limit = min(max((arguments["limit"] as? NSNumber)?.intValue ?? 8, 1), 20)
+        return SearchArguments(
+            requestID: requestID,
+            query: query.trimmingCharacters(in: .whitespacesAndNewlines),
+            frameworks: frameworks,
+            limit: limit
+        )
+    }
+
+    private static func frameworks(from value: Any?) -> [String] {
+        if let string = value as? String {
+            return [string].filter { $0.isEmpty == false }
+        }
+        guard let array = value as? [Any] else {
+            return []
+        }
+        return array.compactMap { $0 as? String }.filter { $0.isEmpty == false }
+    }
+
+    private static func searchSQL(arguments: SearchArguments) -> String {
+        let loweredQuery = arguments.query.lowercased()
+        let terms = loweredQuery
+            .split { character in
+                character.isWhitespace || character.isNewline
+            }
+            .prefix(6)
+            .map(String.init)
+        let termClauses = terms.isEmpty
+            ? [likeClause(for: loweredQuery)]
+            : terms.map(likeClause(for:))
+        var filters = termClauses
+        if arguments.frameworks.isEmpty == false {
+            let frameworks = arguments.frameworks
+                .map { sqliteStringLiteral($0) }
+                .joined(separator: ",")
+            filters.append("framework IN (\(frameworks))")
+        }
+        let whereClause = filters.joined(separator: " AND ")
+        let queryLiteral = sqliteStringLiteral(loweredQuery)
+        let prefixLiteral = sqliteStringLiteral("\(loweredQuery)%")
+        let containsLiteral = sqliteStringLiteral("%\(loweredQuery)%")
+        return """
+            SELECT asset_id,
+                   type,
+                   framework,
+                   title,
+                   substr(content, 1, 4000) AS content
+            FROM attributes
+            WHERE title IS NOT NULL
+              AND content IS NOT NULL
+              AND \(whereClause)
+            ORDER BY CASE
+                WHEN lower(title) = \(queryLiteral) THEN 0
+                WHEN lower(title) LIKE \(prefixLiteral) THEN 1
+                WHEN lower(title) LIKE \(containsLiteral) THEN 2
+                WHEN lower(content) LIKE \(prefixLiteral) THEN 3
+                ELSE 4
+              END,
+              CASE type WHEN 'symbol' THEN 0 WHEN 'article' THEN 1 ELSE 2 END,
+              length(content)
+            LIMIT \(arguments.limit)
+            """
+    }
+
+    private static func likeClause(for term: String) -> String {
+        let pattern = sqliteStringLiteral("%\(term)%")
+        return "(lower(title) LIKE \(pattern) OR lower(content) LIKE \(pattern))"
+    }
+
+    private static func sqliteStringLiteral(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "''"))'"
+    }
+
+    private static func makeResponse(
+        requestID: JSONRPC.ID,
+        query: String,
+        asset: DocumentationSearchInstalledAsset,
+        rows: [SearchRow]
+    ) throws -> Data {
+        let documents = rows.map { row -> [String: Any] in
+            var document: [String: Any] = [
+                "title": row.title ?? "",
+                "type": row.type ?? "",
+                "content": row.content ?? "",
+            ]
+            if let assetID = row.assetID {
+                document["identifier"] = assetID
+                document["url"] = "https://developer.apple.com\(assetID)"
+            }
+            if let framework = row.framework, framework.isEmpty == false {
+                document["framework"] = framework
+            }
+            return document
+        }
+        var assetPayload: [String: Any] = [
+            "path": asset.assetURL.path,
+            "xcodeVersion": asset.xcodeVersion,
+            "osVersion": asset.osVersion,
+        ]
+        if let documentationRelease = asset.documentationRelease {
+            assetPayload["documentationRelease"] = documentationRelease
+        }
+        let payload: [String: Any] = [
+            "query": query,
+            "source": "installed-documentation-asset",
+            "asset": assetPayload,
+            "documents": documents,
+        ]
+        let payloadData = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        let payloadText = String(decoding: payloadData, as: UTF8.self)
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": requestID.value.foundationObject,
+            "result": [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": payloadText,
+                    ],
+                ],
+                "isError": false,
+            ],
+        ]
+        return try JSONSerialization.data(withJSONObject: response, options: [])
     }
 }
 
@@ -563,11 +1317,17 @@ package actor SessionBackedDocumentationProviderTransport: DocumentationProvider
 }
 
 package actor DocumentationProviderManager: DocumentationProviderManaging {
+    private enum DescriptorSource: Sendable, Equatable {
+        case xcode
+        case installedDocumentationAsset
+    }
+
     private struct CandidateProfile: Sendable {
         let id: UUID
         let target: DocumentationProviderTarget
         let route: DocumentationProviderRoute
         var descriptor: JSONValue?
+        var descriptorSource: DescriptorSource?
         let serverVersion: String
     }
 
@@ -639,12 +1399,16 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     private let providerSelectionTimeout: TimeAmount?
     private let pinnedProcessID: pid_t?
     private let initializeParams: [String: JSONValue]
+    private let serviceRepairer: any DocumentationSearchServiceRepairing
+    private let localSearchProvider: any DocumentationSearchProviding
     private let clock: ClockClient
     private let logger: Logger
+    private let descriptorRefreshRetryDelayNanoseconds: Int64 = 250_000_000
     private var activeProvider: ActiveProvider?
     private var preparedProviders: [pid_t: CandidateProfile] = [:]
     private var providerPreparations: [pid_t: ProviderPreparation] = [:]
     private var unusableProcessIDs: Set<pid_t> = []
+    private var serviceRepairAttemptedProcessIDs: Set<pid_t> = []
     private var isShutdown = false
 
     package init(
@@ -653,6 +1417,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         providerSelectionTimeout: TimeAmount? = .seconds(30),
         pinnedProcessID: pid_t? = nil,
         initializeParams: [String: JSONValue] = InitializeHandshakeJSON.defaultParams(),
+        serviceRepairer: any DocumentationSearchServiceRepairing = NoopDocumentationSearchServiceRepairer(),
+        localSearchProvider: any DocumentationSearchProviding = UnavailableDocumentationSearchProvider(),
         clock: ClockClient = .liveValue,
         logger: Logger = ProxyLogging.make("documentation.provider")
     ) {
@@ -661,6 +1427,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         self.providerSelectionTimeout = providerSelectionTimeout
         self.pinnedProcessID = pinnedProcessID
         self.initializeParams = initializeParams
+        self.serviceRepairer = serviceRepairer
+        self.localSearchProvider = localSearchProvider
         self.clock = clock
         self.logger = logger
     }
@@ -671,6 +1439,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         providerSelectionTimeout: TimeAmount? = .seconds(30),
         pinnedProcessID: pid_t? = nil,
         initializeParams: [String: JSONValue] = InitializeHandshakeJSON.defaultParams(),
+        serviceRepairer: any DocumentationSearchServiceRepairing = NoopDocumentationSearchServiceRepairer(),
+        localSearchProvider: any DocumentationSearchProviding = UnavailableDocumentationSearchProvider(),
         clock: ClockClient = .liveValue,
         logger: Logger = ProxyLogging.make("documentation.provider")
     ) {
@@ -683,6 +1453,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             providerSelectionTimeout: providerSelectionTimeout,
             pinnedProcessID: pinnedProcessID,
             initializeParams: initializeParams,
+            serviceRepairer: serviceRepairer,
+            localSearchProvider: localSearchProvider,
             clock: clock,
             logger: logger
         )
@@ -728,7 +1500,15 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     }
                     return .available(descriptor)
                 }
-                return toolListUpdateFromCachedState(requestTimeout: requestTimeout)
+                logger.info(
+                    "Documentation provider candidate did not advertise DocumentationSearch; trying next candidate",
+                    metadata: [
+                        "pid": .string("\(target.processID)"),
+                        "app_path": .string(target.appPath),
+                        "xcode_version": .string(target.xcodeVersion),
+                    ]
+                )
+                continue
             } catch is CancellationError {
                 return .unavailable
             } catch {
@@ -966,6 +1746,20 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         deadline: Deadline?
     ) async throws -> DocumentationAttemptResult {
         let processID = provider.profile.target.processID
+        if provider.profile.descriptorSource == .installedDocumentationAsset {
+            do {
+                let response = try await localSearchProvider.callDocumentationSearch(
+                    requestData: requestData,
+                    for: provider.profile.target,
+                    timeout: remainingTimeout(until: deadline)
+                )
+                return .success(response)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                return .failed(error)
+            }
+        }
         do {
             let response = try await transport.callDocumentationSearch(
                 route: provider.profile.route,
@@ -974,13 +1768,38 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             )
             guard !DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(response)
             else {
+                if let localResponse = try await callInstalledDocumentationAssetFallback(
+                    requestData: requestData,
+                    target: provider.profile.target,
+                    deadline: deadline
+                ) {
+                    await invalidate(provider, reason: "documentation_search_tool_error")
+                    return .success(localResponse)
+                }
                 await invalidate(provider, reason: "documentation_search_tool_error")
                 return .rejected(processID: processID, permanentlyUnusable: true)
+            }
+            if DocumentationProvider.ToolCatalog.responseIsDocumentationProviderFailure(response),
+               let localResponse = try await callInstalledDocumentationAssetFallback(
+                   requestData: requestData,
+                   target: provider.profile.target,
+                   deadline: deadline
+               ) {
+                await invalidate(provider, reason: "documentation_search_provider_failure")
+                return .success(localResponse)
             }
             return .success(response)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
+            if let localResponse = try await callInstalledDocumentationAssetFallback(
+                requestData: requestData,
+                target: provider.profile.target,
+                deadline: deadline
+            ) {
+                await invalidate(provider, reason: "documentation_provider_call_failed")
+                return .success(localResponse)
+            }
             await invalidate(provider, reason: "documentation_provider_call_failed")
             return .failed(error)
         }
@@ -1017,7 +1836,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     ) async throws -> CandidateProfile {
         if let activeProvider, activeProvider.profile.target.processID == target.processID {
             if fetchDescriptor, activeProvider.profile.descriptor == nil {
-                let updated = await profileByRefreshingDescriptor(
+                let updated = await profileByRefreshingDescriptorWithRepair(
                     activeProvider.profile,
                     requestTimeout: requestTimeout
                 )
@@ -1037,7 +1856,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
         if var prepared = preparedProviders[target.processID] {
             if fetchDescriptor, prepared.descriptor == nil {
-                let updated = await profileByRefreshingDescriptor(
+                let updated = await profileByRefreshingDescriptorWithRepair(
                     prepared,
                     requestTimeout: requestTimeout
                 )
@@ -1109,7 +1928,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     ) async throws -> CandidateProfile {
         if let activeProvider, activeProvider.profile.id == profile.id {
             if fetchDescriptor, activeProvider.profile.descriptor == nil {
-                let updated = await profileByRefreshingDescriptor(
+                let updated = await profileByRefreshingDescriptorWithRepair(
                     activeProvider.profile,
                     requestTimeout: requestTimeout
                 )
@@ -1122,7 +1941,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             prepared.id == profile.id
         {
             if fetchDescriptor, prepared.descriptor == nil {
-                let updated = await profileByRefreshingDescriptor(
+                let updated = await profileByRefreshingDescriptorWithRepair(
                     prepared,
                     requestTimeout: requestTimeout
                 )
@@ -1135,7 +1954,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         var prepared = profile
         preparedProviders[profile.target.processID] = prepared
         if fetchDescriptor, prepared.descriptor == nil {
-            prepared = await profileByRefreshingDescriptor(
+            prepared = await profileByRefreshingDescriptorWithRepair(
                 prepared,
                 requestTimeout: requestTimeout
             )
@@ -1176,6 +1995,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
         var merged = primary
         merged.descriptor = fallback.descriptor
+        merged.descriptorSource = fallback.descriptorSource
         return merged
     }
 
@@ -1297,6 +2117,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             target: target,
             route: route,
             descriptor: nil,
+            descriptorSource: nil,
             serverVersion: route.serverVersion
         )
     }
@@ -1315,18 +2136,110 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             timeout: toolsListTimeout
         )
         updated.descriptor = DocumentationProvider.ToolCatalog.descriptor(in: toolsResult)
+        updated.descriptorSource = updated.descriptor == nil ? nil : .xcode
         return updated
     }
 
-    private func profileByRefreshingDescriptor(
+    private func profileByRefreshingDescriptorWithRepair(
         _ profile: CandidateProfile,
         requestTimeout: TimeAmount?
     ) async -> CandidateProfile {
+        let refreshed = await profileByRefreshingDescriptor(
+            profile,
+            requestTimeout: requestTimeout
+        )
+        guard refreshed.descriptor == nil else {
+            return refreshed
+        }
+        let repaired = await profileByRepairingDocumentationSearchService(
+            refreshed,
+            requestTimeout: requestTimeout
+        )
+        guard repaired.descriptor == nil else {
+            return repaired
+        }
+        return await profileByAddingInstalledDocumentationAssetFallback(repaired)
+    }
+
+    private func profileByRepairingDocumentationSearchService(
+        _ profile: CandidateProfile,
+        requestTimeout: TimeAmount?
+    ) async -> CandidateProfile {
+        guard reserveServiceRepairAttempt(for: profile.target.processID) else {
+            return profile
+        }
+        guard requestTimeout?.nanoseconds != 0, !Task.isCancelled, !isShutdown else {
+            return profile
+        }
+
+        logger.warning(
+            "DocumentationSearch descriptor missing; attempting Xcode documentation service repair",
+            metadata: [
+                "pid": .string("\(profile.target.processID)"),
+                "app_path": .string(profile.target.appPath),
+                "xcode_version": .string(profile.target.xcodeVersion),
+            ]
+        )
+
+        let deadline = Deadline.fromNow(requestTimeout, clock: clock)
+        let repairResult = await serviceRepairer.repairDocumentationSearch(for: profile.target)
+        switch repairResult {
+        case .repaired(let report):
+            logger.info(
+                "Repaired Xcode documentation service configuration",
+                metadata: [
+                    "pid": .string("\(profile.target.processID)"),
+                    "config_url": .string(report.configURL),
+                    "asset_xcode_version": .string(report.xcodeVersion),
+                    "asset_os_version": .string(report.osVersion),
+                    "documentation_release": .string(
+                        report.documentationRelease.map(String.init) ?? "unknown"
+                    ),
+                    "changed_default": .string("\(report.changedDefault)"),
+                ]
+            )
+        case .skipped(let reason):
+            logger.info(
+                "Skipped Xcode documentation service repair",
+                metadata: [
+                    "pid": .string("\(profile.target.processID)"),
+                    "reason": .string(reason),
+                ]
+            )
+            return profile
+        case .failed(let reason):
+            logger.warning(
+                "Xcode documentation service repair failed",
+                metadata: [
+                    "pid": .string("\(profile.target.processID)"),
+                    "reason": .string(reason),
+                ]
+            )
+            return profile
+        }
+
         do {
-            let updated = try await profileWithDescriptor(profile, requestTimeout: requestTimeout)
+            let replacement = try await openProviderRoute(
+                target: profile.target,
+                requestTimeout: remainingTimeout(until: deadline)
+            )
+            await transport.close(route: profile.route)
+            let updated = await profileByRefreshingDescriptor(
+                replacement,
+                requestTimeout: remainingTimeout(until: deadline)
+            )
             if updated.descriptor == nil {
-                logger.debug(
-                    "Documentation provider descriptor missing from tools/list",
+                logger.warning(
+                    "Xcode documentation service repair did not restore DocumentationSearch",
+                    metadata: [
+                        "pid": .string("\(profile.target.processID)"),
+                        "app_path": .string(profile.target.appPath),
+                        "xcode_version": .string(profile.target.xcodeVersion),
+                    ]
+                )
+            } else {
+                logger.info(
+                    "Xcode documentation service repair restored DocumentationSearch",
                     metadata: [
                         "pid": .string("\(profile.target.processID)"),
                         "app_path": .string(profile.target.appPath),
@@ -1338,12 +2251,132 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         } catch is CancellationError {
             return profile
         } catch {
-            logger.debug(
-                "Documentation provider descriptor refresh failed",
+            logger.warning(
+                "Xcode documentation service repair could not reopen provider route",
                 metadata: candidateLogMetadata(target: profile.target, error: error)
             )
             return profile
         }
+    }
+
+    private func profileByAddingInstalledDocumentationAssetFallback(
+        _ profile: CandidateProfile
+    ) async -> CandidateProfile {
+        guard let descriptor = await localSearchProvider.descriptor(for: profile.target) else {
+            return profile
+        }
+        logger.warning(
+            "Using installed documentation asset fallback for DocumentationSearch",
+            metadata: [
+                "pid": .string("\(profile.target.processID)"),
+                "app_path": .string(profile.target.appPath),
+                "xcode_version": .string(profile.target.xcodeVersion),
+            ]
+        )
+        var updated = profile
+        updated.descriptor = descriptor
+        updated.descriptorSource = .installedDocumentationAsset
+        return updated
+    }
+
+    private func callInstalledDocumentationAssetFallback(
+        requestData: Data,
+        target: DocumentationProviderTarget,
+        deadline: Deadline?
+    ) async throws -> Data? {
+        guard await localSearchProvider.descriptor(for: target) != nil else {
+            return nil
+        }
+        logger.warning(
+            "Falling back to installed documentation asset for DocumentationSearch",
+            metadata: [
+                "pid": .string("\(target.processID)"),
+                "app_path": .string(target.appPath),
+                "xcode_version": .string(target.xcodeVersion),
+            ]
+        )
+        return try await localSearchProvider.callDocumentationSearch(
+            requestData: requestData,
+            for: target,
+            timeout: remainingTimeout(until: deadline)
+        )
+    }
+
+    private func reserveServiceRepairAttempt(for processID: pid_t) -> Bool {
+        guard serviceRepairAttemptedProcessIDs.contains(processID) == false else {
+            return false
+        }
+        serviceRepairAttemptedProcessIDs.insert(processID)
+        return true
+    }
+
+    private func profileByRefreshingDescriptor(
+        _ profile: CandidateProfile,
+        requestTimeout: TimeAmount?
+    ) async -> CandidateProfile {
+        let deadline = Deadline.fromNow(requestTimeout, clock: clock)
+        let maxAttempts = maxDescriptorRefreshAttempts(for: requestTimeout)
+        var attempt = 0
+        while !Task.isCancelled {
+            do {
+                let updated = try await profileWithDescriptor(
+                    profile,
+                    requestTimeout: remainingTimeout(until: deadline)
+                )
+                if updated.descriptor == nil {
+                    logger.info(
+                        "DocumentationSearch descriptor missing from Xcode tools/list",
+                        metadata: [
+                            "pid": .string("\(profile.target.processID)"),
+                            "app_path": .string(profile.target.appPath),
+                            "xcode_version": .string(profile.target.xcodeVersion),
+                        ]
+                    )
+                }
+                return updated
+            } catch is CancellationError {
+                return profile
+            } catch {
+                logger.debug(
+                    "Documentation provider descriptor refresh failed",
+                    metadata: candidateLogMetadata(target: profile.target, error: error)
+                )
+                guard descriptorRefreshErrorIsRetryable(error),
+                      attempt < maxAttempts,
+                      remainingTimeout(until: deadline)?.nanoseconds != 0 else {
+                    return profile
+                }
+                attempt += 1
+                await sleepBeforeRetryingDescriptorRefresh(until: deadline)
+            }
+        }
+        return profile
+    }
+
+    private func descriptorRefreshErrorIsRetryable(_ error: any Error) -> Bool {
+        if error is UpstreamSlotScheduler.AcquisitionError {
+            return true
+        }
+        return false
+    }
+
+    private func maxDescriptorRefreshAttempts(for requestTimeout: TimeAmount?) -> Int {
+        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
+            return 120
+        }
+        let attempts = (requestTimeout.nanoseconds + descriptorRefreshRetryDelayNanoseconds - 1)
+            / descriptorRefreshRetryDelayNanoseconds
+        return max(1, min(120, Int(attempts)))
+    }
+
+    private func sleepBeforeRetryingDescriptorRefresh(until deadline: Deadline?) async {
+        guard let remaining = remainingTimeout(until: deadline),
+              remaining.nanoseconds > 0 else {
+            return
+        }
+        await clock.sleep(
+            .nanoseconds(min(remaining.nanoseconds, descriptorRefreshRetryDelayNanoseconds))
+        )
     }
 
     package static func resultValue(from responseData: Data) throws -> JSONValue {

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1524,6 +1524,11 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let task: Task<CandidateProfile, Error>
     }
 
+    private struct InstalledDocumentationAssetFallback: Sendable {
+        let responseData: Data
+        let descriptor: JSONValue
+    }
+
     private struct PreparationWaitTimedOut: Error {}
 
     private final class PreparationWaiter: @unchecked Sendable {
@@ -1788,7 +1793,14 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     provider: activeProvider,
                     deadline: activeDeadline
                 ) {
-                case .success(let data):
+                case .success(let data, let replacementProfile):
+                    if let replacementProfile {
+                        await cacheInstalledDocumentationAssetReplacement(
+                            replacementProfile,
+                            replacing: activeProvider.profile
+                        )
+                        invalidatedProvider = true
+                    }
                     return .handled(data, invalidatedProvider: invalidatedProvider)
                 case .rejected(let processID, let permanentlyUnusable):
                     rejectedProcessIDs.insert(processID)
@@ -1841,8 +1853,16 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                         provider: provider,
                         deadline: candidateDeadline
                     ) {
-                    case .success(let data):
-                        let didPromote = await promoteToActive(profile)
+                    case .success(let data, let replacementProfile):
+                        let selectedProfile = replacementProfile ?? profile
+                        if let replacementProfile {
+                            await cacheInstalledDocumentationAssetReplacement(
+                                replacementProfile,
+                                replacing: profile
+                            )
+                            invalidatedProvider = true
+                        }
+                        let didPromote = await promoteToActive(selectedProfile)
                         if didPromote {
                             logger.info(
                                 "Selected documentation provider",
@@ -1920,7 +1940,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     }
 
     private enum DocumentationAttemptResult: Sendable {
-        case success(Data)
+        case success(data: Data, replacementProfile: CandidateProfile?)
         case rejected(processID: pid_t, permanentlyUnusable: Bool)
         case failed(any Error)
     }
@@ -1938,7 +1958,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     for: provider.profile.target,
                     timeout: remainingTimeout(until: deadline)
                 )
-                return .success(response)
+                return .success(data: response, replacementProfile: nil)
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
@@ -1953,37 +1973,52 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             )
             guard !DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(response)
             else {
-                if let localResponse = try await callInstalledDocumentationAssetFallbackIfAvailable(
+                if let fallback = try await callInstalledDocumentationAssetFallbackIfAvailable(
                     requestData: requestData,
                     target: provider.profile.target,
                     deadline: deadline
                 ) {
-                    await invalidate(provider, reason: "documentation_search_tool_error")
-                    return .success(localResponse)
+                    return .success(
+                        data: fallback.responseData,
+                        replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
+                            provider.profile,
+                            fallback: fallback
+                        )
+                    )
                 }
                 await invalidate(provider, reason: "documentation_search_tool_error")
                 return .rejected(processID: processID, permanentlyUnusable: true)
             }
             if DocumentationProvider.ToolCatalog.responseIsDocumentationProviderFailure(response),
-               let localResponse = try await callInstalledDocumentationAssetFallbackIfAvailable(
+               let fallback = try await callInstalledDocumentationAssetFallbackIfAvailable(
                    requestData: requestData,
                    target: provider.profile.target,
                    deadline: deadline
                ) {
-                await invalidate(provider, reason: "documentation_search_provider_failure")
-                return .success(localResponse)
+                return .success(
+                    data: fallback.responseData,
+                    replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
+                        provider.profile,
+                        fallback: fallback
+                    )
+                )
             }
-            return .success(response)
+            return .success(data: response, replacementProfile: nil)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            if let localResponse = try await callInstalledDocumentationAssetFallbackIfAvailable(
+            if let fallback = try await callInstalledDocumentationAssetFallbackIfAvailable(
                 requestData: requestData,
                 target: provider.profile.target,
                 deadline: deadline
             ) {
-                await invalidate(provider, reason: "documentation_provider_call_failed")
-                return .success(localResponse)
+                return .success(
+                    data: fallback.responseData,
+                    replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
+                        provider.profile,
+                        fallback: fallback
+                    )
+                )
             }
             await invalidate(provider, reason: "documentation_provider_call_failed")
             return .failed(error)
@@ -1994,7 +2029,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         requestData: Data,
         target: DocumentationProviderTarget,
         deadline: Deadline?
-    ) async throws -> Data? {
+    ) async throws -> InstalledDocumentationAssetFallback? {
         do {
             return try await callInstalledDocumentationAssetFallback(
                 requestData: requestData,
@@ -2028,6 +2063,22 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         if let provider {
             await transport.close(route: provider.profile.route)
         }
+    }
+
+    private func cacheInstalledDocumentationAssetReplacement(
+        _ replacementProfile: CandidateProfile,
+        replacing replacedProfile: CandidateProfile
+    ) async {
+        providerPreparations.removeValue(forKey: replacedProfile.target.processID)?.task.cancel()
+        if let activeProvider, activeProvider.profile.id == replacedProfile.id {
+            self.activeProvider = ActiveProvider(profile: replacementProfile)
+        }
+        if let prepared = preparedProviders[replacedProfile.target.processID],
+           prepared.id == replacedProfile.id
+        {
+            preparedProviders[replacedProfile.target.processID] = replacementProfile
+        }
+        await transport.close(route: replacedProfile.route)
     }
 
     package func shutdown() async {
@@ -2538,12 +2589,22 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         return updated
     }
 
+    private func profileByUsingInstalledDocumentationAssetFallback(
+        _ profile: CandidateProfile,
+        fallback: InstalledDocumentationAssetFallback
+    ) -> CandidateProfile {
+        var updated = profile
+        updated.descriptor = fallback.descriptor
+        updated.descriptorSource = .installedDocumentationAsset
+        return updated
+    }
+
     private func callInstalledDocumentationAssetFallback(
         requestData: Data,
         target: DocumentationProviderTarget,
         deadline: Deadline?
-    ) async throws -> Data? {
-        guard await localSearchProvider.descriptor(for: target) != nil else {
+    ) async throws -> InstalledDocumentationAssetFallback? {
+        guard let descriptor = await localSearchProvider.descriptor(for: target) else {
             return nil
         }
         logger.warning(
@@ -2554,11 +2615,12 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 "xcode_version": .string(target.xcodeVersion),
             ]
         )
-        return try await localSearchProvider.callDocumentationSearch(
+        let responseData = try await localSearchProvider.callDocumentationSearch(
             requestData: requestData,
             for: target,
             timeout: remainingTimeout(until: deadline)
         )
+        return InstalledDocumentationAssetFallback(responseData: responseData, descriptor: descriptor)
     }
 
     private func reserveServiceRepairAttempt(for processID: pid_t) -> Bool {

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1021,6 +1021,7 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
             label: "documentation-search-local",
             executablePath: "/usr/bin/sqlite3",
             arguments: [
+                "-readonly",
                 "-json",
                 asset.indexURL.path,
                 sql,

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1815,6 +1815,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                         unusableProcessIDs.insert(processID)
                     }
                     continue
+                case .requestFailed(let error):
+                    return .failed(error, invalidatedProvider: invalidatedProvider)
                 case .failed(let error):
                     if let deadline, deadline.hasExpired {
                         return .failed(error, invalidatedProvider: invalidatedProvider)
@@ -1889,6 +1891,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                             unusableProcessIDs.insert(processID)
                         }
                         continue
+                    case .requestFailed(let error):
+                        return .failed(error, invalidatedProvider: invalidatedProvider)
                     case .failed(let error):
                         rejectedProcessIDs.insert(target.processID)
                         invalidatedProvider = true
@@ -1948,6 +1952,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     private enum DocumentationAttemptResult: Sendable {
         case success(data: Data, replacementProfile: CandidateProfile?)
         case rejected(processID: pid_t, permanentlyUnusable: Bool)
+        case requestFailed(any Error)
         case failed(any Error)
     }
 
@@ -1968,6 +1973,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
+                if installedDocumentationAssetFailureIsRequestScoped(error) {
+                    return .requestFailed(error)
+                }
                 await invalidate(provider, reason: "installed_documentation_asset_call_failed")
                 return .rejected(processID: processID, permanentlyUnusable: true)
             }
@@ -2033,6 +2041,23 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             await invalidate(provider, reason: "documentation_provider_call_failed")
             return .failed(error)
         }
+    }
+
+    private func installedDocumentationAssetFailureIsRequestScoped(_ error: any Error) -> Bool {
+        if error is TimeoutError {
+            return true
+        }
+        if let controlPlaneError = error as? ControlPlane.Error {
+            switch controlPlaneError {
+            case .invalidResponse(let message):
+                return message == "missing DocumentationSearch request id"
+                    || message == "missing DocumentationSearch query"
+            case .upstreamRPC:
+                return true
+            }
+        }
+        let nsError = error as NSError
+        return nsError.domain == NSCocoaErrorDomain
     }
 
     private func callInstalledDocumentationAssetFallbackIfAvailable(

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -2090,6 +2090,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         guard primary.descriptor == nil, fallback.descriptor != nil else {
             return primary
         }
+        guard primary.id == fallback.id else {
+            return fallback
+        }
         var merged = primary
         merged.descriptor = fallback.descriptor
         merged.descriptorSource = fallback.descriptorSource

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -2057,6 +2057,12 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     self.activeProvider = ActiveProvider(profile: merged)
                     return merged
                 }
+                if let current = self.activeProvider,
+                   current.profile.id == activeProvider.profile.id
+                {
+                    self.activeProvider = ActiveProvider(profile: updated)
+                    return updated
+                }
                 return updated
             }
             return activeProvider.profile

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1965,7 +1965,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
-                return .failed(error)
+                await invalidate(provider, reason: "installed_documentation_asset_call_failed")
+                return .rejected(processID: processID, permanentlyUnusable: true)
             }
         }
         do {

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -788,6 +788,7 @@ private final class ProcessOutputTimeoutWaiter: @unchecked Sendable {
                     guard Task.isCancelled == false else {
                         return
                     }
+                    task.cancel()
                     self.resume(.failure(TimeoutError()))
                 })
             }
@@ -1865,7 +1866,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             )
             guard !DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(response)
             else {
-                if let localResponse = try await callInstalledDocumentationAssetFallback(
+                if let localResponse = try await callInstalledDocumentationAssetFallbackIfAvailable(
                     requestData: requestData,
                     target: provider.profile.target,
                     deadline: deadline
@@ -1877,7 +1878,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 return .rejected(processID: processID, permanentlyUnusable: true)
             }
             if DocumentationProvider.ToolCatalog.responseIsDocumentationProviderFailure(response),
-               let localResponse = try await callInstalledDocumentationAssetFallback(
+               let localResponse = try await callInstalledDocumentationAssetFallbackIfAvailable(
                    requestData: requestData,
                    target: provider.profile.target,
                    deadline: deadline
@@ -1889,7 +1890,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            if let localResponse = try await callInstalledDocumentationAssetFallback(
+            if let localResponse = try await callInstalledDocumentationAssetFallbackIfAvailable(
                 requestData: requestData,
                 target: provider.profile.target,
                 deadline: deadline
@@ -1899,6 +1900,28 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             }
             await invalidate(provider, reason: "documentation_provider_call_failed")
             return .failed(error)
+        }
+    }
+
+    private func callInstalledDocumentationAssetFallbackIfAvailable(
+        requestData: Data,
+        target: DocumentationProviderTarget,
+        deadline: Deadline?
+    ) async throws -> Data? {
+        do {
+            return try await callInstalledDocumentationAssetFallback(
+                requestData: requestData,
+                target: target,
+                deadline: deadline
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            logger.debug(
+                "Installed documentation asset fallback failed",
+                metadata: candidateLogMetadata(target: target, error: error)
+            )
+            return nil
         }
     }
 

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -2514,7 +2514,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 target: profile.target,
                 requestTimeout: remainingTimeout(until: deadline)
             )
-            await transport.close(route: profile.route)
+            if replacement.route.id != profile.route.id {
+                await transport.close(route: profile.route)
+            }
             let updated = await profileByRefreshingDescriptor(
                 replacement,
                 requestTimeout: remainingTimeout(until: deadline)

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1956,6 +1956,12 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         case failed(any Error)
     }
 
+    private enum InstalledDocumentationAssetFallbackAttempt: Sendable {
+        case success(InstalledDocumentationAssetFallback)
+        case unavailable
+        case requestFailed(any Error)
+    }
+
     private func attemptDocumentationSearch(
         requestData: Data,
         provider: ActiveProvider,
@@ -1988,35 +1994,23 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             )
             guard !DocumentationProvider.ToolCatalog.responseIsDocumentationNotEnabled(response)
             else {
-                if let fallback = try await callInstalledDocumentationAssetFallbackIfAvailable(
+                if let fallbackResult = try await documentationAttemptResultFromInstalledDocumentationAssetFallback(
                     requestData: requestData,
-                    target: provider.profile.target,
+                    provider: provider.profile,
                     deadline: deadline
                 ) {
-                    return .success(
-                        data: fallback.responseData,
-                        replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
-                            provider.profile,
-                            fallback: fallback
-                        )
-                    )
+                    return fallbackResult
                 }
                 await invalidate(provider, reason: "documentation_search_tool_error")
                 return .rejected(processID: processID, permanentlyUnusable: true)
             }
             if DocumentationProvider.ToolCatalog.responseIsDocumentationProviderFailure(response) {
-                if let fallback = try await callInstalledDocumentationAssetFallbackIfAvailable(
+                if let fallbackResult = try await documentationAttemptResultFromInstalledDocumentationAssetFallback(
                     requestData: requestData,
-                    target: provider.profile.target,
+                    provider: provider.profile,
                     deadline: deadline
                 ) {
-                    return .success(
-                        data: fallback.responseData,
-                        replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
-                            provider.profile,
-                            fallback: fallback
-                        )
-                    )
+                    return fallbackResult
                 }
                 await invalidate(provider, reason: "documentation_search_provider_failure")
                 return .rejected(processID: processID, permanentlyUnusable: false)
@@ -2025,18 +2019,12 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            if let fallback = try await callInstalledDocumentationAssetFallbackIfAvailable(
+            if let fallbackResult = try await documentationAttemptResultFromInstalledDocumentationAssetFallback(
                 requestData: requestData,
-                target: provider.profile.target,
+                provider: provider.profile,
                 deadline: deadline
             ) {
-                return .success(
-                    data: fallback.responseData,
-                    replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
-                        provider.profile,
-                        fallback: fallback
-                    )
-                )
+                return fallbackResult
             }
             await invalidate(provider, reason: "documentation_provider_call_failed")
             return .failed(error)
@@ -2060,17 +2048,45 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         return nsError.domain == NSCocoaErrorDomain
     }
 
-    private func callInstalledDocumentationAssetFallbackIfAvailable(
+    private func documentationAttemptResultFromInstalledDocumentationAssetFallback(
+        requestData: Data,
+        provider: CandidateProfile,
+        deadline: Deadline?
+    ) async throws -> DocumentationAttemptResult? {
+        switch try await attemptInstalledDocumentationAssetFallback(
+            requestData: requestData,
+            target: provider.target,
+            deadline: deadline
+        ) {
+        case .success(let fallback):
+            return .success(
+                data: fallback.responseData,
+                replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
+                    provider,
+                    fallback: fallback
+                )
+            )
+        case .unavailable:
+            return nil
+        case .requestFailed(let error):
+            return .requestFailed(error)
+        }
+    }
+
+    private func attemptInstalledDocumentationAssetFallback(
         requestData: Data,
         target: DocumentationProviderTarget,
         deadline: Deadline?
-    ) async throws -> InstalledDocumentationAssetFallback? {
+    ) async throws -> InstalledDocumentationAssetFallbackAttempt {
         do {
-            return try await callInstalledDocumentationAssetFallback(
+            guard let fallback = try await callInstalledDocumentationAssetFallback(
                 requestData: requestData,
                 target: target,
                 deadline: deadline
-            )
+            ) else {
+                return .unavailable
+            }
+            return .success(fallback)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
@@ -2078,7 +2094,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 "Installed documentation asset fallback failed",
                 metadata: candidateLogMetadata(target: target, error: error)
             )
-            return nil
+            if installedDocumentationAssetFailureIsRequestScoped(error) {
+                return .requestFailed(error)
+            }
+            return .unavailable
         }
     }
 

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -600,6 +600,9 @@ package enum DocumentationSearchAssetLocator {
                 return .orderedDescending
             }
         }
+        if lhsParts.isEmpty == false, rhsParts.isEmpty == false {
+            return .orderedSame
+        }
         return lhs.localizedStandardCompare(rhs)
     }
 
@@ -2742,6 +2745,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             if lhsValue > rhsValue {
                 return .orderedDescending
             }
+        }
+        if lhsParts.isEmpty == false, rhsParts.isEmpty == false {
+            return .orderedSame
         }
         return lhs.localizedStandardCompare(rhs)
     }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1771,6 +1771,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let deadline = Deadline.fromNow(requestTimeoutOverride, clock: clock)
         var rejectedProcessIDs: Set<pid_t> = []
         var invalidatedProvider = false
+        var lastCandidateFailure: (any Error)?
 
         while !Task.isCancelled {
             if let deadline, deadline.hasExpired {
@@ -1817,6 +1818,10 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     continue
                 case .requestFailed(let error):
                     return .failed(error, invalidatedProvider: invalidatedProvider)
+                case .candidateFailed(let error):
+                    rejectedProcessIDs.insert(activeProvider.profile.target.processID)
+                    lastCandidateFailure = error
+                    continue
                 case .failed(let error):
                     if let deadline, deadline.hasExpired {
                         return .failed(error, invalidatedProvider: invalidatedProvider)
@@ -1834,6 +1839,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 try Task.checkCancellation()
                 if let deadline, deadline.hasExpired {
                     return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
+                }
+                if let lastCandidateFailure {
+                    return .failed(lastCandidateFailure, invalidatedProvider: invalidatedProvider)
                 }
                 return .unavailable(.noAvailableProvider)
             }
@@ -1893,6 +1901,11 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                         continue
                     case .requestFailed(let error):
                         return .failed(error, invalidatedProvider: invalidatedProvider)
+                    case .candidateFailed(let error):
+                        rejectedProcessIDs.insert(target.processID)
+                        lastCandidateFailure = error
+                        progressed = true
+                        continue
                     case .failed(let error):
                         rejectedProcessIDs.insert(target.processID)
                         invalidatedProvider = true
@@ -1953,6 +1966,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         case success(data: Data, replacementProfile: CandidateProfile?)
         case rejected(processID: pid_t, permanentlyUnusable: Bool)
         case requestFailed(any Error)
+        case candidateFailed(any Error)
         case failed(any Error)
     }
 
@@ -1960,6 +1974,13 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         case success(InstalledDocumentationAssetFallback)
         case unavailable
         case requestFailed(any Error)
+        case candidateFailed(any Error)
+    }
+
+    private enum InstalledDocumentationAssetFailureScope {
+        case request
+        case candidate
+        case provider
     }
 
     private func attemptDocumentationSearch(
@@ -1979,8 +2000,13 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
-                if installedDocumentationAssetFailureIsRequestScoped(error) {
+                switch installedDocumentationAssetFailureScope(error) {
+                case .request:
                     return .requestFailed(error)
+                case .candidate:
+                    return .candidateFailed(error)
+                case .provider:
+                    break
                 }
                 await invalidate(provider, reason: "installed_documentation_asset_call_failed")
                 return .rejected(processID: processID, permanentlyUnusable: true)
@@ -2031,21 +2057,30 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
     }
 
-    private func installedDocumentationAssetFailureIsRequestScoped(_ error: any Error) -> Bool {
+    private func installedDocumentationAssetFailureScope(_ error: any Error)
+        -> InstalledDocumentationAssetFailureScope
+    {
         if error is TimeoutError {
-            return true
+            return .candidate
         }
         if let controlPlaneError = error as? ControlPlane.Error {
             switch controlPlaneError {
             case .invalidResponse(let message):
-                return message == "missing DocumentationSearch request id"
+                if message == "missing DocumentationSearch request id"
                     || message == "missing DocumentationSearch query"
+                {
+                    return .request
+                }
+                return .provider
             case .upstreamRPC:
-                return true
+                return .request
             }
         }
         let nsError = error as NSError
-        return nsError.domain == NSCocoaErrorDomain
+        if nsError.domain == NSCocoaErrorDomain {
+            return .request
+        }
+        return .provider
     }
 
     private func documentationAttemptResultFromInstalledDocumentationAssetFallback(
@@ -2070,6 +2105,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             return nil
         case .requestFailed(let error):
             return .requestFailed(error)
+        case .candidateFailed(let error):
+            return .candidateFailed(error)
         }
     }
 
@@ -2094,10 +2131,14 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 "Installed documentation asset fallback failed",
                 metadata: candidateLogMetadata(target: target, error: error)
             )
-            if installedDocumentationAssetFailureIsRequestScoped(error) {
+            switch installedDocumentationAssetFailureScope(error) {
+            case .request:
                 return .requestFailed(error)
+            case .candidate:
+                return .candidateFailed(error)
+            case .provider:
+                return .unavailable
             }
-            return .unavailable
         }
     }
 

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1989,19 +1989,22 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 await invalidate(provider, reason: "documentation_search_tool_error")
                 return .rejected(processID: processID, permanentlyUnusable: true)
             }
-            if DocumentationProvider.ToolCatalog.responseIsDocumentationProviderFailure(response),
-               let fallback = try await callInstalledDocumentationAssetFallbackIfAvailable(
-                   requestData: requestData,
-                   target: provider.profile.target,
-                   deadline: deadline
-               ) {
-                return .success(
-                    data: fallback.responseData,
-                    replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
-                        provider.profile,
-                        fallback: fallback
+            if DocumentationProvider.ToolCatalog.responseIsDocumentationProviderFailure(response) {
+                if let fallback = try await callInstalledDocumentationAssetFallbackIfAvailable(
+                    requestData: requestData,
+                    target: provider.profile.target,
+                    deadline: deadline
+                ) {
+                    return .success(
+                        data: fallback.responseData,
+                        replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
+                            provider.profile,
+                            fallback: fallback
+                        )
                     )
-                )
+                }
+                await invalidate(provider, reason: "documentation_search_provider_failure")
+                return .rejected(processID: processID, permanentlyUnusable: false)
             }
             return .success(data: response, replacementProfile: nil)
         } catch is CancellationError {
@@ -2254,11 +2257,11 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         primary: CandidateProfile,
         fallback: CandidateProfile
     ) -> CandidateProfile {
-        guard primary.descriptor == nil, fallback.descriptor != nil else {
-            return primary
-        }
         guard primary.id == fallback.id else {
             return fallback
+        }
+        guard primary.descriptor == nil, fallback.descriptor != nil else {
+            return primary
         }
         var merged = primary
         merged.descriptor = fallback.descriptor

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -211,7 +211,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let upstreamStderrLogLimiter = UpstreamStderrLogLimiter()
     package let primaryInitializeReadinessTokenBox =
         NIOLockedValueBox<UpstreamReadinessWaiterToken?>(nil)
-    package let documentationPrewarmTaskBox = NIOLockedValueBox<Task<Void, Never>?>(nil)
+    package let documentationPrewarmTaskBox =
+        NIOLockedValueBox<Task<DocumentationProvider.ToolListUpdate, Never>?>(nil)
+    package let toolCatalogSummaryLoggedBox = NIOLockedValueBox(false)
     package let debugRecorder: ProxyDebugRecorder
     package let leaseManager: LeaseManager
     package let eventLoop: EventLoop
@@ -314,7 +316,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             pinnedProcessID: pinnedProcessID,
             initializeParams: InitializeHandshakeJSON.resolved(
                 initializeParamsOverride: config.initializeParamsOverride
-            )
+            ),
+            serviceRepairer: LiveDocumentationSearchServiceRepairer(),
+            localSearchProvider: LiveDocumentationAssetSearchProvider()
         )
     }
 
@@ -603,7 +607,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             }
             if let documentationPrewarmTask {
                 group.addTask {
-                    await documentationPrewarmTask.value
+                    _ = await documentationPrewarmTask.value
                 }
             }
         }
@@ -636,9 +640,18 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             )
         )
         Task { [weak self] in
-            await self?.controlPlaneCoordinator.prewarmToolsCatalogIfNeeded(
-                deadlineUptimeNs: deadline
+            guard let self,
+                  let baseResult = await self.controlPlaneCoordinator.prewarmToolsCatalogIfNeeded(
+                      deadlineUptimeNs: deadline
+                  ) else {
+                return
+            }
+            let finalResult = await self.startupPrewarmToolsListResultWithDocumentationOverlay(
+                baseResult: baseResult,
+                requestTimeout: self.timeAmount(until: deadline),
+                metadata: ["origin": .string("prewarm")]
             )
+            self.logToolCatalogSummaryIfNeeded(finalResult)
         }
     }
 
@@ -649,8 +662,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             ? min(config.requestTimeout, 30)
             : 30
         let timeout = MCP.MethodDispatcher.timeoutForControlPlane(defaultSeconds: timeoutSeconds)
-        let task = Task { [weak self, documentationProviderManager, logger] in
-            guard !Task.isCancelled else { return }
+        let task = Task<DocumentationProvider.ToolListUpdate, Never> {
+            [weak self, documentationProviderManager, logger] in
+            guard !Task.isCancelled else { return .unavailable }
             logger.debug(
                 "Prewarming documentation provider",
                 metadata: [
@@ -661,8 +675,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 requestTimeout: timeout
             )
             self?.recordDocumentationToolListUpdate(update)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else { return .unavailable }
             logger.debug("Documentation provider prewarm completed")
+            return update
         }
         let previous = documentationPrewarmTaskBox.withLockedValue { taskBox in
             let previous = taskBox
@@ -884,22 +899,13 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 "has_documentation_provider": .string("\(documentationProviderManager != nil)"),
             ]
         )
-        guard let documentationProviderManager else {
-            return baseResult
-        }
-        let update = await documentationToolListUpdate(
-            manager: documentationProviderManager,
-            requestTimeout: timeAmount(until: deadline)
+        let finalResult = await toolsListResultWithDocumentationOverlay(
+            baseResult: baseResult,
+            requestTimeout: timeAmount(until: deadline),
+            metadata: ["session": .string(sessionID)]
         )
-        recordDocumentationToolListUpdate(update)
-        logger.debug(
-            "Applied documentation provider tools/list overlay",
-            metadata: [
-                "session": .string(sessionID),
-                "update": .string(update.debugLabel),
-            ]
-        )
-        return DocumentationProvider.ToolCatalog.applying(update, to: baseResult)
+        logToolCatalogSummaryIfNeeded(finalResult)
+        return finalResult
     }
 
     package func liveXcodeListWindowsResult(
@@ -956,6 +962,139 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     package func hasDocumentationSearchService() -> Bool {
         documentationProviderManager != nil
+    }
+
+    private func logToolCatalogSummaryIfNeeded(_ result: JSONValue) {
+        let shouldLog = toolCatalogSummaryLoggedBox.withLockedValue { logged in
+            if logged {
+                return false
+            }
+            logged = true
+            return true
+        }
+        guard shouldLog else {
+            return
+        }
+
+        logger.info("\(ToolCatalogStartupLogFormatter.summary(from: result))")
+    }
+
+    private func toolsListResultWithDocumentationOverlay(
+        baseResult: JSONValue,
+        requestTimeout: TimeAmount?,
+        metadata: Logger.Metadata
+    ) async -> JSONValue {
+        guard let documentationProviderManager else {
+            return baseResult
+        }
+        let update = await documentationToolListUpdateForPublicToolsList(
+            manager: documentationProviderManager,
+            requestTimeout: requestTimeout
+        )
+        return toolsListResultApplyingDocumentationUpdate(
+            update,
+            to: baseResult,
+            metadata: metadata
+        )
+    }
+
+    private func startupPrewarmToolsListResultWithDocumentationOverlay(
+        baseResult: JSONValue,
+        requestTimeout: TimeAmount?,
+        metadata: Logger.Metadata
+    ) async -> JSONValue {
+        guard let documentationProviderManager else {
+            return baseResult
+        }
+        let update: DocumentationProvider.ToolListUpdate
+        if let documentationPrewarmTask = documentationPrewarmTaskBox.withLockedValue({ $0 }) {
+            update = await documentationToolListUpdate(
+                fromPrewarmTask: documentationPrewarmTask,
+                requestTimeout: requestTimeout
+            )
+        } else {
+            update = await documentationProviderManager.startBackgroundDiscovery(
+                requestTimeout: requestTimeout
+            )
+        }
+        return toolsListResultApplyingDocumentationUpdate(
+            update,
+            to: baseResult,
+            metadata: metadata
+        )
+    }
+
+    private func toolsListResultApplyingDocumentationUpdate(
+        _ update: DocumentationProvider.ToolListUpdate,
+        to baseResult: JSONValue,
+        metadata: Logger.Metadata
+    ) -> JSONValue {
+        recordDocumentationToolListUpdate(update)
+        var logMetadata = metadata
+        logMetadata["update"] = .string(update.debugLabel)
+        logger.debug(
+            "Applied documentation provider tools/list overlay",
+            metadata: logMetadata
+        )
+        return DocumentationProvider.ToolCatalog.applying(update, to: baseResult)
+    }
+
+    private func documentationToolListUpdateForPublicToolsList(
+        manager: any DocumentationProviderManaging,
+        requestTimeout: TimeAmount?
+    ) async -> DocumentationProvider.ToolListUpdate {
+        if let documentationPrewarmTask = documentationPrewarmTaskBox.withLockedValue({ $0 }) {
+            let prewarmUpdate = await documentationToolListUpdate(
+                fromPrewarmTask: documentationPrewarmTask,
+                requestTimeout: requestTimeout
+            )
+            if case .available = prewarmUpdate {
+                return prewarmUpdate
+            }
+            documentationPrewarmTaskBox.withLockedValue { $0 = nil }
+        }
+        return await documentationToolListUpdate(
+            manager: manager,
+            requestTimeout: requestTimeout
+        )
+    }
+
+    private func documentationToolListUpdate(
+        fromPrewarmTask task: Task<DocumentationProvider.ToolListUpdate, Never>,
+        requestTimeout: TimeAmount?
+    ) async -> DocumentationProvider.ToolListUpdate {
+        guard requestTimeout?.nanoseconds != 0 else {
+            return .unavailable
+        }
+        guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
+            return await task.value
+        }
+        do {
+            return try await withThrowingTaskGroup(of: DocumentationProvider.ToolListUpdate.self) {
+                group in
+                group.addTask {
+                    await task.value
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
+                    throw TimeoutError()
+                }
+                guard let update = try await group.next() else {
+                    throw TimeoutError()
+                }
+                group.cancelAll()
+                return update
+            }
+        } catch {
+            logger.debug(
+                "documentation provider prewarm did not finish before tools/list timeout",
+                metadata: [
+                    "error": .string(String(describing: error)),
+                    "timeout_ns": .string("\(requestTimeout.nanoseconds)"),
+                ]
+            )
+            return .unavailable
+        }
     }
 
     private func recordDocumentationToolListUpdate(_ update: DocumentationProvider.ToolListUpdate) {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -1086,11 +1086,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             return baseResult
         }
         let update: DocumentationProvider.ToolListUpdate
-        if let documentationPrewarmTask = documentationPrewarmTaskBox.withLockedValue({ $0 }) {
-            update = await documentationToolListUpdate(
-                fromPrewarmTask: documentationPrewarmTask,
-                requestTimeout: requestTimeout
-            ).update
+        if let prewarmResult = await consumeDocumentationPrewarmTaskUpdate(
+            requestTimeout: requestTimeout
+        ) {
+            update = prewarmResult.update
         } else {
             update = await documentationProviderManager.startBackgroundDiscovery(
                 requestTimeout: requestTimeout
@@ -1122,11 +1121,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         manager: any DocumentationProviderManaging,
         requestTimeout: TimeAmount?
     ) async -> DocumentationProvider.ToolListUpdate {
-        if let documentationPrewarmTask = documentationPrewarmTaskBox.withLockedValue({ $0 }) {
-            let prewarmResult = await documentationToolListUpdate(
-                fromPrewarmTask: documentationPrewarmTask,
-                requestTimeout: requestTimeout
-            )
+        if let prewarmResult = await consumeDocumentationPrewarmTaskUpdate(
+            requestTimeout: requestTimeout
+        ) {
             let prewarmUpdate = prewarmResult.update
             if case .available = prewarmUpdate {
                 return prewarmUpdate
@@ -1134,12 +1131,27 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             if prewarmResult.timedOut {
                 return .unavailable
             }
-            documentationPrewarmTaskBox.withLockedValue { $0 = nil }
         }
         return await documentationToolListUpdate(
             manager: manager,
             requestTimeout: requestTimeout
         )
+    }
+
+    private func consumeDocumentationPrewarmTaskUpdate(
+        requestTimeout: TimeAmount?
+    ) async -> DocumentationToolListUpdateWaiter.Result? {
+        guard let documentationPrewarmTask = documentationPrewarmTaskBox.withLockedValue({ $0 }) else {
+            return nil
+        }
+        let result = await documentationToolListUpdate(
+            fromPrewarmTask: documentationPrewarmTask,
+            requestTimeout: requestTimeout
+        )
+        if result.timedOut == false {
+            documentationPrewarmTaskBox.withLockedValue { $0 = nil }
+        }
+        return result
     }
 
     private func documentationToolListUpdate(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -36,6 +36,85 @@ package final class WeakRuntimeCoordinatorBox: @unchecked Sendable {
     package init() {}
 }
 
+private final class DocumentationToolListUpdateWaiter: @unchecked Sendable {
+    struct Result: Sendable {
+        let update: DocumentationProvider.ToolListUpdate
+        let timedOut: Bool
+    }
+
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Result, Never>?
+    private var tasks: [Task<Void, Never>] = []
+    private var resolved = false
+
+    func wait(
+        for task: Task<DocumentationProvider.ToolListUpdate, Never>,
+        timeout: TimeAmount
+    ) async -> Result {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                setContinuation(continuation)
+                addTask(Task {
+                    let update = await task.value
+                    self.resume(Result(update: update, timedOut: false))
+                })
+                addTask(Task {
+                    try? await Task.sleep(nanoseconds: UInt64(timeout.nanoseconds))
+                    guard Task.isCancelled == false else {
+                        return
+                    }
+                    self.resume(Result(update: .unavailable, timedOut: true))
+                })
+            }
+        } onCancel: {
+            resume(Result(update: .unavailable, timedOut: true))
+        }
+    }
+
+    private func setContinuation(
+        _ continuation: CheckedContinuation<Result, Never>
+    ) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            continuation.resume(returning: Result(update: .unavailable, timedOut: true))
+            return
+        }
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    private func addTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        if resolved {
+            lock.unlock()
+            task.cancel()
+            return
+        }
+        tasks.append(task)
+        lock.unlock()
+    }
+
+    private func resume(_ result: Result) {
+        lock.lock()
+        guard resolved == false else {
+            lock.unlock()
+            return
+        }
+        resolved = true
+        let continuation = continuation
+        self.continuation = nil
+        let tasks = tasks
+        self.tasks.removeAll()
+        lock.unlock()
+
+        for task in tasks {
+            task.cancel()
+        }
+        continuation?.resume(returning: result)
+    }
+}
+
 /// The single routing decision for a DocumentationSearch tools/call:
 /// either the provider produced the response, or proxy-managed
 /// DocumentationSearch is unavailable.
@@ -1011,7 +1090,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             update = await documentationToolListUpdate(
                 fromPrewarmTask: documentationPrewarmTask,
                 requestTimeout: requestTimeout
-            )
+            ).update
         } else {
             update = await documentationProviderManager.startBackgroundDiscovery(
                 requestTimeout: requestTimeout
@@ -1044,12 +1123,16 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         requestTimeout: TimeAmount?
     ) async -> DocumentationProvider.ToolListUpdate {
         if let documentationPrewarmTask = documentationPrewarmTaskBox.withLockedValue({ $0 }) {
-            let prewarmUpdate = await documentationToolListUpdate(
+            let prewarmResult = await documentationToolListUpdate(
                 fromPrewarmTask: documentationPrewarmTask,
                 requestTimeout: requestTimeout
             )
+            let prewarmUpdate = prewarmResult.update
             if case .available = prewarmUpdate {
                 return prewarmUpdate
+            }
+            if prewarmResult.timedOut {
+                return .unavailable
             }
             documentationPrewarmTaskBox.withLockedValue { $0 = nil }
         }
@@ -1062,39 +1145,29 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     private func documentationToolListUpdate(
         fromPrewarmTask task: Task<DocumentationProvider.ToolListUpdate, Never>,
         requestTimeout: TimeAmount?
-    ) async -> DocumentationProvider.ToolListUpdate {
+    ) async -> DocumentationToolListUpdateWaiter.Result {
         guard requestTimeout?.nanoseconds != 0 else {
-            return .unavailable
+            return DocumentationToolListUpdateWaiter.Result(update: .unavailable, timedOut: true)
         }
         guard let requestTimeout, requestTimeout.nanoseconds > 0 else {
-            return await task.value
+            return DocumentationToolListUpdateWaiter.Result(
+                update: await task.value,
+                timedOut: false
+            )
         }
-        do {
-            return try await withThrowingTaskGroup(of: DocumentationProvider.ToolListUpdate.self) {
-                group in
-                group.addTask {
-                    await task.value
-                }
-                group.addTask {
-                    try await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
-                    throw TimeoutError()
-                }
-                guard let update = try await group.next() else {
-                    throw TimeoutError()
-                }
-                group.cancelAll()
-                return update
-            }
-        } catch {
+        let result = await DocumentationToolListUpdateWaiter().wait(
+            for: task,
+            timeout: requestTimeout
+        )
+        if result.timedOut {
             logger.debug(
                 "documentation provider prewarm did not finish before tools/list timeout",
                 metadata: [
-                    "error": .string(String(describing: error)),
                     "timeout_ns": .string("\(requestTimeout.nanoseconds)"),
                 ]
             )
-            return .unavailable
         }
+        return result
     }
 
     private func recordDocumentationToolListUpdate(_ update: DocumentationProvider.ToolListUpdate) {

--- a/Sources/ProxySession/Runtime/RuntimeDocumentationProviderTransport.swift
+++ b/Sources/ProxySession/Runtime/RuntimeDocumentationProviderTransport.swift
@@ -56,24 +56,11 @@ package final class RuntimeDocumentationProviderTransport: DocumentationProvider
             return try await fallback.toolsList(route: route, timeout: timeout)
         }
         let deadline = Deadline.fromNow(timeout, clock: clock)
-        do {
-            guard let runtime = runtimeBox.value else { throw CancellationError() }
-            return try await runtime.documentationProviderToolsList(
-                route: route,
-                requestTimeout: try remainingTimeoutOrThrow(until: deadline)
-            )
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            let fallbackRoute = try await openFallbackRoute(
-                for: route,
-                timeout: try remainingTimeoutOrThrow(until: deadline)
-            )
-            return try await fallback.toolsList(
-                route: fallbackRoute,
-                timeout: try remainingTimeoutOrThrow(until: deadline)
-            )
-        }
+        guard let runtime = runtimeBox.value else { throw CancellationError() }
+        return try await runtime.documentationProviderToolsList(
+            route: route,
+            requestTimeout: try remainingTimeoutOrThrow(until: deadline)
+        )
     }
 
     package func callDocumentationSearch(

--- a/Sources/ProxySession/Runtime/ToolCatalogStartupLogFormatter.swift
+++ b/Sources/ProxySession/Runtime/ToolCatalogStartupLogFormatter.swift
@@ -1,0 +1,48 @@
+import Foundation
+import ProxyMCP
+
+package enum ToolCatalogStartupLogFormatter {
+    package static func summary(from result: JSONValue) -> String {
+        let names = toolNames(in: result)
+        let documentationSearchStatus =
+            names.contains(DocumentationProvider.ToolCatalog.toolName)
+            ? "available"
+            : "unavailable"
+
+        var lines = [
+            "Tools",
+            "  DocumentationSearch: \(documentationSearchStatus)",
+            "  Count: \(names.count)",
+            "  Available:",
+        ]
+
+        if names.isEmpty {
+            lines.append("    - none")
+        } else {
+            for name in names {
+                lines.append("    - \(name)")
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func toolNames(in result: JSONValue) -> [String] {
+        guard case .object(let object) = result,
+              case .array(let tools)? = object["tools"] else {
+            return []
+        }
+
+        let names = tools.compactMap { tool -> String? in
+            guard case .object(let toolObject) = tool,
+                  case .string(let name)? = toolObject["name"] else {
+                return nil
+            }
+            return name
+        }
+
+        return Array(Set(names)).sorted {
+            $0.localizedStandardCompare($1) == .orderedAscending
+        }
+    }
+}

--- a/Sources/ProxyXcodeSupport/LiveXcodeTargetDiscovery.swift
+++ b/Sources/ProxyXcodeSupport/LiveXcodeTargetDiscovery.swift
@@ -2,7 +2,7 @@ import AppKit
 import Foundation
 import ProxyCore
 
-package struct LiveXcodeTargetDiscovery: XcodeTargetDiscovering {
+package struct LiveXcodeTargetDiscovery: XcodeTargetDiscovering, Sendable {
     package init() {}
 
     package func runningXcodeTargets() -> [DocumentationProviderTarget] {

--- a/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/ProxyXcodeSupport/XcodePermissionDialogAutoApprover.swift
@@ -203,8 +203,9 @@ extension XcodePermissionDialog {
                 }
 
                 if hasLoggedTrustedMonitoring == false {
-                    dependencies.logger.info(
-                        "Xcode permission dialog auto-approver is monitoring Xcode.",
+                    dependencies.logger.info("\(Self.monitoringLogSummary())")
+                    dependencies.logger.debug(
+                        "Xcode permission dialog auto-approver monitoring details.",
                         metadata: [
                             "agent_paths": .string(pathCandidateText)
                         ]
@@ -342,8 +343,13 @@ extension XcodePermissionDialog {
 
                 do {
                     try dependencies.axClient.pressDefaultButton(in: matchedWindow.window)
-                    dependencies.logger.info(
-                        "Auto-approved the Xcode permission dialog.",
+                    let summary = Self.approvalLogSummary(
+                        processID: matchedWindow.processID,
+                        buttonTitle: matchedWindow.decision.defaultButtonTitle
+                    )
+                    dependencies.logger.info("\(summary)")
+                    dependencies.logger.debug(
+                        "Auto-approved Xcode permission dialog details.",
                         metadata: [
                             "pid": "\(matchedWindow.processID)",
                             "button": .string(matchedWindow.decision.defaultButtonTitle),
@@ -386,6 +392,22 @@ extension XcodePermissionDialog {
             }
 
             return visibleFingerprints
+        }
+
+        private static func monitoringLogSummary() -> String {
+            """
+            Permission
+              Auto-approver: monitoring
+            """
+        }
+
+        private static func approvalLogSummary(processID: pid_t, buttonTitle: String) -> String {
+            """
+            Permission
+              Auto-approved Xcode permission dialog
+              Xcode PID: \(processID)
+              Button: \(buttonTitle)
+            """
         }
 
         private func logStructurallyEligibleWindowIfNeeded(

--- a/Sources/XcodeMCPProxy/ProxyServer.swift
+++ b/Sources/XcodeMCPProxy/ProxyServer.swift
@@ -13,6 +13,7 @@ public final class ProxyServer {
         package var discoveryClient: DiscoveryClient
         package var executableLookupClient: ExecutableLookupClient
         package var processID: @Sendable () -> Int
+        package var runningXcodeTargets: @Sendable () -> [DocumentationProviderTarget]
         package var makeAutoApprover: @Sendable () -> any ProxyServerPermissionDialogAutoApprover
         package var makeRuntimeCoordinator:
             @Sendable (_ config: ProxyConfig, _ eventLoop: EventLoop) -> any RuntimeCoordinating
@@ -23,12 +24,16 @@ public final class ProxyServer {
             processID: @escaping @Sendable () -> Int = {
                 Int(ProcessInfo.processInfo.processIdentifier)
             },
+            runningXcodeTargets: @escaping @Sendable () -> [DocumentationProviderTarget] = {
+                []
+            },
             makeAutoApprover: @escaping @Sendable () -> any ProxyServerPermissionDialogAutoApprover,
             makeRuntimeCoordinator: @escaping @Sendable (_ config: ProxyConfig, _ eventLoop: EventLoop) -> any RuntimeCoordinating
         ) {
             self.discoveryClient = discoveryClient
             self.executableLookupClient = executableLookupClient
             self.processID = processID
+            self.runningXcodeTargets = runningXcodeTargets
             self.makeAutoApprover = makeAutoApprover
             self.makeRuntimeCoordinator = makeRuntimeCoordinator
         }
@@ -37,6 +42,9 @@ public final class ProxyServer {
             let executableLookupClient = ExecutableLookupClient.liveValue
             return Self(
                 executableLookupClient: executableLookupClient,
+                runningXcodeTargets: {
+                    LiveXcodeTargetDiscovery().runningXcodeTargets()
+                },
                 makeAutoApprover: {
                     let additionalCandidates = ProxyServer.additionalPermissionDialogExecutableCandidates(
                         config: config,
@@ -102,7 +110,13 @@ public final class ProxyServer {
         let (host, port) = resolvedListenAddress(for: channel)
         let displayHost = config.listenHost == "localhost" ? "localhost" : host
         writeDiscovery(resolvedHost: host, port: port)
-        logger.info("\(Self.listeningLogLine(displayHost: displayHost, port: port))")
+        let summary = Self.startupSummary(
+            displayHost: displayHost,
+            port: port,
+            config: config,
+            xcodeTargets: dependencies.runningXcodeTargets()
+        )
+        logger.info("\(summary)")
         return (host, port)
     }
 
@@ -244,6 +258,52 @@ public final class ProxyServer {
 
     package static func listeningLogLine(displayHost: String, port: Int) -> String {
         "Xcode MCP proxy listening on http://\(displayHost):\(port) (version \(ProxyBuildInfo.version))"
+    }
+
+    package static func startupSummary(
+        displayHost: String,
+        port: Int,
+        config: ProxyConfig,
+        xcodeTargets: [DocumentationProviderTarget]
+    ) -> String {
+        var lines = [
+            "XcodeMCPKit \(ProxyBuildInfo.version)",
+            "",
+            "Server",
+            "  URL: http://\(displayHost):\(port)/mcp",
+            "  Upstream processes: \(config.upstreamProcessCount)",
+            "  Auto approve: \(config.autoApproveXcodeDialog ? "enabled" : "disabled")",
+            "",
+            "Xcode",
+        ]
+
+        switch xcodeTargets.count {
+        case 0:
+            lines.append("  Status: not detected")
+        case 1:
+            if let target = xcodeTargets.first {
+                lines.append("  App: \(target.appPath)")
+                lines.append("  PID: \(target.processID)")
+            }
+        default:
+            lines.append("  Detected: \(xcodeTargets.count)")
+            lines.append("  Apps:")
+            for target in xcodeTargets {
+                lines.append("    - \(target.appPath) (PID: \(target.processID))")
+            }
+        }
+
+        lines.append(
+            "  DocumentationSearch: \(documentationSearchStartupStatus(config: config))"
+        )
+        return lines.joined(separator: "\n")
+    }
+
+    private static func documentationSearchStartupStatus(config: ProxyConfig) -> String {
+        if RuntimeCoordinator.documentationProviderServiceIsConfigured(config: config) {
+            return "pending"
+        }
+        return "disabled"
     }
 
     package static func additionalPermissionDialogExecutableCandidates(

--- a/Tests/ProxyIntegrationTests/ProxyServerBuildInfoTests.swift
+++ b/Tests/ProxyIntegrationTests/ProxyServerBuildInfoTests.swift
@@ -1,13 +1,48 @@
+import ProxyCore
 import Testing
 
 @testable import XcodeMCPProxy
 
 @Suite
 struct ProxyServerBuildInfoTests {
-    @Test func proxyServerListeningLogLineIncludesURLAndVersion() throws {
-        let line = ProxyServer.listeningLogLine(displayHost: "localhost", port: 8765)
+    @Test func proxyServerStartupSummaryUsesReadableSections() throws {
+        let config = ProxyConfig(
+            listenHost: "localhost",
+            listenPort: 8765,
+            upstreamCommand: "xcrun",
+            upstreamArgs: ["mcpbridge"],
+            upstreamProcessCount: 2,
+            maxBodyBytes: 1_048_576,
+            requestTimeout: 300,
+            autoApproveXcodeDialog: true
+        )
+        let target = DocumentationProviderTarget(
+            processID: 9004,
+            appPath: "/Applications/Xcode.app",
+            developerDir: "/Applications/Xcode.app/Contents/Developer",
+            mcpbridgePath: "/Applications/Xcode.app/Contents/Developer/usr/bin/mcpbridge",
+            xcodeVersion: "26.0"
+        )
 
-        #expect(line.contains("http://localhost:8765"))
-        #expect(line.contains("version \(ProxyBuildInfo.version)"))
+        let summary = ProxyServer.startupSummary(
+            displayHost: "localhost",
+            port: 8765,
+            config: config,
+            xcodeTargets: [target]
+        )
+
+        #expect(summary == """
+        XcodeMCPKit \(ProxyBuildInfo.version)
+
+        Server
+          URL: http://localhost:8765/mcp
+          Upstream processes: 2
+          Auto approve: enabled
+
+        Xcode
+          App: /Applications/Xcode.app
+          PID: 9004
+          DocumentationSearch: pending
+        """)
     }
 }

--- a/Tests/ProxyProcessTests/ProcessRunnerTests.swift
+++ b/Tests/ProxyProcessTests/ProcessRunnerTests.swift
@@ -62,6 +62,27 @@ struct ProcessRunnerTests {
         #expect(output.terminationStatus == 0)
         #expect(output.stdout == expected)
     }
+
+    @Test func processRunnerTerminatesTimedOutProcess() async throws {
+        let runner = ProcessRunner()
+
+        await #expect(throws: ProcessTimeoutError.self) {
+            _ = try await waitWithTimeout(
+                "ProcessRunner should terminate a timed out process",
+                timeout: .seconds(3)
+            ) {
+                try await runner.run(
+                    ProcessRequest(
+                        label: "timeout",
+                        executablePath: "/bin/sleep",
+                        arguments: ["5"],
+                        input: nil,
+                        timeoutNanoseconds: 100_000_000
+                    )
+                )
+            }
+        }
+    }
 }
 
 private extension String {

--- a/Tests/ProxyProcessTests/ProcessRunnerTests.swift
+++ b/Tests/ProxyProcessTests/ProcessRunnerTests.swift
@@ -84,6 +84,34 @@ struct ProcessRunnerTests {
         }
     }
 
+    @Test func processRunnerTimeoutDoesNotWaitForInheritedPipeEOF() async throws {
+        let runner = ProcessRunner()
+        let script = """
+        import subprocess
+        import time
+
+        subprocess.Popen(["/bin/sleep", "3"])
+        time.sleep(3)
+        """
+
+        await #expect(throws: ProcessTimeoutError.self) {
+            _ = try await waitWithTimeout(
+                "ProcessRunner should time out without waiting for child-held pipes",
+                timeout: .seconds(2)
+            ) {
+                try await runner.run(
+                    ProcessRequest(
+                        label: "timeout-inherited-pipe",
+                        executablePath: "/usr/bin/python3",
+                        arguments: ["-c", script],
+                        input: nil,
+                        timeoutNanoseconds: 100_000_000
+                    )
+                )
+            }
+        }
+    }
+
     @Test func processRunnerCancelsRunningProcessPromptly() async throws {
         let runner = ProcessRunner()
         let task = Task {

--- a/Tests/ProxyProcessTests/ProcessRunnerTests.swift
+++ b/Tests/ProxyProcessTests/ProcessRunnerTests.swift
@@ -83,6 +83,32 @@ struct ProcessRunnerTests {
             }
         }
     }
+
+    @Test func processRunnerCancelsRunningProcessPromptly() async throws {
+        let runner = ProcessRunner()
+        let task = Task {
+            try await runner.run(
+                ProcessRequest(
+                    label: "cancel",
+                    executablePath: "/bin/sleep",
+                    arguments: ["5"],
+                    input: nil
+                )
+            )
+        }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await waitWithTimeout(
+                "ProcessRunner should finish promptly when cancelled",
+                timeout: .seconds(1)
+            ) {
+                try await task.value
+            }
+        }
+    }
 }
 
 private extension String {

--- a/Tests/ProxyProcessTests/ProcessRunnerTests.swift
+++ b/Tests/ProxyProcessTests/ProcessRunnerTests.swift
@@ -84,14 +84,12 @@ struct ProcessRunnerTests {
         }
     }
 
-    @Test func processRunnerTimeoutDoesNotWaitForInheritedPipeEOF() async throws {
+    @Test func processRunnerTimeoutDoesNotWaitForChildHeldPipeAfterParentExit() async throws {
         let runner = ProcessRunner()
         let script = """
         import subprocess
-        import time
 
         subprocess.Popen(["/bin/sleep", "3"])
-        time.sleep(3)
         """
 
         await #expect(throws: ProcessTimeoutError.self) {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1919,6 +1919,62 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 2)
     }
 
+    @Test func documentationProviderTriesNextCandidateAfterInitialAssetFallbackTimeout()
+        async throws
+    {
+        let newer = documentationProviderTarget(processID: 130, xcodeVersion: "26.6")
+        let older = documentationProviderTarget(processID: 131, xcodeVersion: "26.5")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                newer.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+                older.processID: [
+                    .init(
+                        serverVersion: "26.5",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"older\"}")
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 133,
+                text: "{\"answer\":\"asset\"}"
+            ),
+            timeoutOnceAfterSuccessfulCallCount: 0
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [newer, older]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 133, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"older\"}")
+        #expect(await localProvider.requestedCallPIDs() == [newer.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI"])
+        #expect(await factory.documentationQueries(for: newer.processID) == ["SwiftUI"])
+        #expect(await factory.documentationQueries(for: older.processID) == ["SwiftUI"])
+    }
+
     @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeConfigIsBroken()
         async throws
     {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -732,6 +732,62 @@ extension RuntimeCoordinatorTests {
         #expect(observedTimeout.nanoseconds > 0)
     }
 
+    @Test func sharedToolsListWaitsForStartupDocumentationPrewarm() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let prewarmStarted = TestSignal()
+        let prewarmGate = AsyncGate()
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0")),
+            prewarmStarted: prewarmStarted,
+            prewarmBlocker: prewarmGate
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider,
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ]),
+            sourceUpstream: 0
+        )
+
+        manager.prewarmDocumentationProvider()
+        try await prewarmStarted.wait(description: "documentation prewarm started")
+
+        let resultTask = Task {
+            try await manager.sharedToolsList(
+                sessionID: "session-docs-tools-prewarm",
+                requestTimeoutOverride: .seconds(1)
+            )
+        }
+        #expect(
+            await staysTrue(for: .milliseconds(100)) {
+                await documentationProvider.toolListUpdateCount() == 0
+            }
+        )
+
+        await prewarmGate.signal()
+        let result = try await resultTask.value
+
+        #expect(toolNames(in: result) == ["XcodeRead", "DocumentationSearch"])
+        #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
+        #expect(await documentationProvider.prewarmCount() == 1)
+        #expect(await documentationProvider.toolListUpdateCount() == 1)
+    }
+
     @Test func sharedToolsListRemovesStaleDocumentationSearchWhenProviderUnavailable() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -1080,6 +1136,342 @@ extension RuntimeCoordinatorTests {
             to: try jsonValue(["tools": []])
         )
         #expect(documentationDescriptorDescription(in: cachedResult) == "docs-27.0")
+    }
+
+    @Test func documentationProviderBackgroundDiscoveryRetriesTransientDescriptorUnavailable()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 116, xcodeVersion: "27.0")
+        let transport = TransientUnavailableDescriptorTransport()
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: transport
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-transient")
+        #expect(await transport.toolsListCount() == 2)
+    }
+
+    @Test func documentationProviderBackgroundDiscoveryRepairsDescriptorMissingService()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 117, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "26.5",
+                    osVersion: "26.2",
+                    documentationRelease: 900339,
+                    changedDefault: true
+                )
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            serviceRepairer: repairer
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-26.6")
+        #expect(await repairer.repairedPIDs() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
+    }
+
+    @Test func documentationProviderUsesInstalledAssetFallbackWhenRepairDoesNotRestoreDescriptor()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 119, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "26.5",
+                    osVersion: "26.2",
+                    documentationRelease: 900339,
+                    changedDefault: true
+                )
+            )
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 120,
+                text: "{\"answer\":\"asset\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            serviceRepairer: repairer,
+            localSearchProvider: localProvider
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-asset-fallback")
+        #expect(await repairer.repairedPIDs() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 120, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
+        #expect(await localProvider.requestedCallPIDs() == [target.processID])
+        #expect(await localProvider.requestedQueries() == ["UIView"])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
+    }
+
+    @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeReturnsNotEnabled()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 121, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 122,
+                text: "{\"answer\":\"asset\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 122, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
+        #expect(await localProvider.requestedCallPIDs() == [target.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI"])
+        #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
+    }
+
+    @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeConfigIsBroken()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 124, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .toolErrorText(
+                            "The file “config.json” couldn’t be opened because there is no such file."
+                        ),
+                        userCallResponses: [.successText("{\"answer\":\"after-error\"}")]
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 124,
+                text: "{\"answer\":\"asset\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 124, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
+        #expect(await localProvider.requestedCallPIDs() == [target.processID])
+        #expect(await localProvider.requestedQueries() == ["UIView"])
+        #expect(await factory.documentationQueries(for: target.processID) == ["UIView"])
+    }
+
+    @Test func liveDocumentationSearchServiceRepairerSelectsClosestSameMajorAsset()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-27",
+            xcodeVersion: "27.0",
+            osVersion: "26.6",
+            documentationRelease: 950001
+        )
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-3",
+            xcodeVersion: "26.3",
+            osVersion: "26.2",
+            documentationRelease: 900124
+        )
+        let writtenValues = NIOLockedValueBox<[String]>([])
+        let repairer = LiveDocumentationSearchServiceRepairer(
+            assetRoot: root,
+            currentOSVersion: { "26.5.1" },
+            readConfigURLOverride: { nil },
+            writeConfigURLOverride: { value in
+                writtenValues.withLockedValue { $0.append(value) }
+                return true
+            }
+        )
+
+        let result = await repairer.repairDocumentationSearch(
+            for: documentationProviderTarget(processID: 118, xcodeVersion: "26.6")
+        )
+
+        guard case .repaired(let report) = result else {
+            Issue.record("expected repaired result, got \(result)")
+            return
+        }
+        #expect(report.xcodeVersion == "26.5")
+        #expect(report.osVersion == "26.2")
+        #expect(report.documentationRelease == 900339)
+        #expect(report.changedDefault)
+        #expect(report.configURL.hasPrefix("/"))
+        #expect(report.configURL.contains("xcode-26-5.asset/AssetData/config.json"))
+        #expect(writtenValues.withLockedValue { $0 } == [report.configURL])
+    }
+
+    @Test func liveDocumentationAssetSearchProviderReturnsInstalledAssetResults()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        let runner = StubProcessRunner(output: ProcessOutput(
+            terminationStatus: 0,
+            stdout: """
+                [{"asset_id":"/documentation/UIKit/UIView","type":"symbol","framework":"UIKit","title":"UIView","content":"UIView\\nClass of UIKit"}]
+                """,
+            stderr: ""
+        ))
+        let provider = LiveDocumentationAssetSearchProvider(
+            assetRoot: root,
+            currentOSVersion: { "26.5.1" },
+            processRunner: runner
+        )
+        let target = documentationProviderTarget(processID: 123, xcodeVersion: "26.6")
+
+        #expect(await provider.descriptor(for: target) != nil)
+        let response = try await provider.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 123, query: "UIView"),
+            for: target,
+            timeout: .seconds(1)
+        )
+
+        let maybeText = try toolContentText(in: response)
+        let text = try #require(maybeText)
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
+        )
+        #expect(payload["source"] as? String == "installed-documentation-asset")
+        let documents = try #require(payload["documents"] as? [[String: Any]])
+        let firstTitle = documents.first?["title"] as? String
+        #expect(firstTitle == "UIView")
+        let requests = await runner.recordedRequests()
+        #expect(requests.count == 1)
+        #expect(requests.first?.arguments.first == "-json")
+        #expect(requests.first?.arguments.joined(separator: " ").contains(
+            "xcode-26-5.asset/AssetData/documentation-db/index.sql"
+        ) == true)
     }
 
     @Test func documentationProviderBackgroundDiscoveryKeepsBaseCatalogWhenDescriptorIsAbsent()
@@ -1558,7 +1950,7 @@ extension RuntimeCoordinatorTests {
 
         let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
         let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
-        #expect(DocumentationProvider.ToolCatalog.descriptor(in: result) == nil)
+        #expect(documentationDescriptorDescription(in: result) == "docs-26.6")
 
         let outcome = try await manager.callDocumentationSearch(
             requestData: makeDocumentationSearchRequest(id: 84, query: "SwiftUI"),
@@ -1570,8 +1962,9 @@ extension RuntimeCoordinatorTests {
             return
         }
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"actual\"}")
-        #expect(await factory.startedPIDs() == [xcode27.processID])
+        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
         #expect(await factory.requestCount(processID: xcode27.processID, method: "tools/list") == 1)
+        #expect(await factory.requestCount(processID: xcode26.processID, method: "tools/list") == 1)
         #expect(await factory.documentationQueries(for: xcode27.processID) == ["SwiftUI"])
         #expect(await factory.documentationQueries(for: xcode26.processID).isEmpty)
     }

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -2173,7 +2173,7 @@ extension RuntimeCoordinatorTests {
         #expect(firstTitle == "UIView")
         let requests = await runner.recordedRequests()
         #expect(requests.count == 1)
-        #expect(requests.first?.arguments.first == "-json")
+        #expect(requests.first?.arguments.prefix(2) == ["-readonly", "-json"])
         #expect(requests.first?.arguments.joined(separator: " ").contains(
             "xcode-26-5.asset/AssetData/documentation-db/index.sql"
         ) == true)

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -788,6 +788,57 @@ extension RuntimeCoordinatorTests {
         #expect(await documentationProvider.toolListUpdateCount() == 1)
     }
 
+    @Test func sharedToolsListRefreshesAfterConsumingStartupDocumentationPrewarm() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0"))
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider,
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ]),
+            sourceUpstream: 0
+        )
+
+        manager.prewarmDocumentationProvider()
+        try await spinUntil("waiting for documentation prewarm") {
+            await documentationProvider.prewarmCount() == 1
+        }
+
+        let prewarmedResult = try await manager.sharedToolsList(
+            sessionID: "session-docs-tools-prewarm-once",
+            requestTimeoutOverride: .seconds(1)
+        )
+        #expect(toolNames(in: prewarmedResult) == ["XcodeRead", "DocumentationSearch"])
+        #expect(documentationDescriptorDescription(in: prewarmedResult) == "docs-27.0")
+
+        await documentationProvider.invalidate(reason: "test")
+        let refreshedResult = try await manager.sharedToolsList(
+            sessionID: "session-docs-tools-after-prewarm",
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        #expect(toolNames(in: refreshedResult) == ["XcodeRead"])
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: refreshedResult) == nil)
+        #expect(await documentationProvider.toolListUpdateCount() == 2)
+    }
+
     @Test func sharedToolsListDoesNotWaitPastTimeoutForStartupDocumentationPrewarm()
         async throws
     {
@@ -1782,6 +1833,41 @@ extension RuntimeCoordinatorTests {
         #expect(report.configURL.hasPrefix("/"))
         #expect(report.configURL.contains("xcode-26-5.asset/AssetData/config.json"))
         #expect(writtenValues.withLockedValue { $0 } == [report.configURL])
+    }
+
+    @Test func documentationAssetLocatorTreatsTrailingZeroXcodeVersionsAsExactMatch()
+        throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26",
+            xcodeVersion: "26",
+            osVersion: "26.0",
+            documentationRelease: 900100
+        )
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-0-0",
+            xcodeVersion: "26.0.0",
+            osVersion: "26.0",
+            documentationRelease: 900200
+        )
+        let scan = try DocumentationSearchAssetLocator.scanInstalledAssets(in: root)
+
+        let asset = try #require(
+            DocumentationSearchAssetLocator.bestAsset(
+                for: "26.0",
+                currentOSVersion: "26.0",
+                from: scan.assets
+            )
+        )
+
+        #expect(asset.xcodeVersion == "26.0.0")
+        #expect(asset.documentationRelease == 900200)
     }
 
     @Test func liveDocumentationAssetSearchProviderReturnsInstalledAssetResults()

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1540,20 +1540,33 @@ extension RuntimeCoordinatorTests {
             localSearchProvider: localProvider
         )
 
-        let outcome = try await manager.callDocumentationSearch(
+        let firstOutcome = try await manager.callDocumentationSearch(
             requestData: makeDocumentationSearchRequest(id: 122, query: "SwiftUI"),
             requestTimeoutOverride: .seconds(1)
         )
 
-        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
-            Issue.record("expected handled outcome, got \(outcome)")
+        guard case .handled(let firstData, let firstInvalidatedProvider) = firstOutcome else {
+            Issue.record("expected handled outcome, got \(firstOutcome)")
             return
         }
-        #expect(invalidatedProvider == false)
-        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
-        #expect(await localProvider.requestedCallPIDs() == [target.processID])
-        #expect(await localProvider.requestedQueries() == ["SwiftUI"])
+        #expect(firstInvalidatedProvider)
+        #expect(try toolContentText(in: firstData) == "{\"answer\":\"asset\"}")
+
+        let secondOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 123, query: "UIKit"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let secondData, let secondInvalidatedProvider) = secondOutcome else {
+            Issue.record("expected second handled outcome, got \(secondOutcome)")
+            return
+        }
+        #expect(secondInvalidatedProvider == false)
+        #expect(try toolContentText(in: secondData) == "{\"answer\":\"asset\"}")
+        #expect(await localProvider.requestedCallPIDs() == [target.processID, target.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI", "UIKit"])
         #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 1)
     }
 
     @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeConfigIsBroken()
@@ -1588,20 +1601,33 @@ extension RuntimeCoordinatorTests {
             localSearchProvider: localProvider
         )
 
-        let outcome = try await manager.callDocumentationSearch(
+        let firstOutcome = try await manager.callDocumentationSearch(
             requestData: makeDocumentationSearchRequest(id: 124, query: "UIView"),
             requestTimeoutOverride: .seconds(1)
         )
 
-        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
-            Issue.record("expected handled outcome, got \(outcome)")
+        guard case .handled(let firstData, let firstInvalidatedProvider) = firstOutcome else {
+            Issue.record("expected handled outcome, got \(firstOutcome)")
             return
         }
-        #expect(invalidatedProvider == false)
-        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
-        #expect(await localProvider.requestedCallPIDs() == [target.processID])
-        #expect(await localProvider.requestedQueries() == ["UIView"])
+        #expect(firstInvalidatedProvider)
+        #expect(try toolContentText(in: firstData) == "{\"answer\":\"asset\"}")
+
+        let secondOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 125, query: "SwiftData"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let secondData, let secondInvalidatedProvider) = secondOutcome else {
+            Issue.record("expected second handled outcome, got \(secondOutcome)")
+            return
+        }
+        #expect(secondInvalidatedProvider == false)
+        #expect(try toolContentText(in: secondData) == "{\"answer\":\"asset\"}")
+        #expect(await localProvider.requestedCallPIDs() == [target.processID, target.processID])
+        #expect(await localProvider.requestedQueries() == ["UIView", "SwiftData"])
         #expect(await factory.documentationQueries(for: target.processID) == ["UIView"])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 1)
     }
 
     @Test func liveDocumentationSearchServiceRepairerSelectsClosestSameMajorAsset()

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1259,6 +1259,66 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
     }
 
+    @Test func repairedDocumentationProviderKeepsReopenedRouteForSearch()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 118, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"repaired\"}")
+                    ),
+                ],
+            ]
+        )
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "26.5",
+                    osVersion: "26.2",
+                    documentationRelease: 900339,
+                    changedDefault: true
+                )
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            serviceRepairer: repairer
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-26.6")
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 118, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"repaired\"}")
+        #expect(await repairer.repairedPIDs() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 1)
+        #expect(await factory.documentationQueries(for: target.processID) == ["UIView"])
+    }
+
     @Test func documentationProviderUsesInstalledAssetFallbackWhenRepairDoesNotRestoreDescriptor()
         async throws
     {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -235,6 +235,58 @@ extension RuntimeCoordinatorTests {
         #expect(await upstream.sentCount() == 2)
     }
 
+    @Test func runtimeDocumentationTransportDoesNotOpenFallbackForReusedRouteToolsListFailure()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = ToggleableOverloadUpstreamClient()
+        await upstream.overloadNextSend()
+        let target = documentationProviderTarget(processID: 741, xcodeVersion: "27.0")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let openStarted = TestSignal()
+        let openGate = AsyncGate()
+        let fallback = BlockingFallbackDocumentationProviderTransport(
+            openStarted: openStarted,
+            openGate: openGate
+        )
+        let providerManager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: RuntimeDocumentationProviderTransport(
+                runtimeBox: runtimeBox,
+                fallback: fallback
+            ),
+            providerSelectionTimeout: .seconds(1)
+        )
+        let route = DocumentationProviderRoute(
+            id: "upstream-0-pid-\(target.processID)",
+            target: target,
+            upstreamIndex: 0
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [route],
+            documentationProviderManager: providerManager,
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let update = await providerManager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(
+            update,
+            to: try jsonValue(["tools": []])
+        )
+
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: result) == nil)
+        #expect(await upstream.sentCount() == 1)
+        #expect(await fallback.openCount() == 0)
+    }
+
     @Test func runtimeDocumentationTransportFallsBackWhenReusedUpstreamRouteFails()
         async throws
     {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -788,6 +788,61 @@ extension RuntimeCoordinatorTests {
         #expect(await documentationProvider.toolListUpdateCount() == 1)
     }
 
+    @Test func sharedToolsListDoesNotWaitPastTimeoutForStartupDocumentationPrewarm()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let prewarmStarted = TestSignal()
+        let prewarmGate = AsyncGate()
+        let documentationProvider = StubDocumentationProviderManager(
+            toolListUpdate: .available(documentationDescriptor(version: "27.0")),
+            prewarmStarted: prewarmStarted,
+            prewarmBlocker: prewarmGate
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderManager: documentationProvider,
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.setCachedToolsListResult(
+            try jsonValue([
+                "tools": [
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ]),
+            sourceUpstream: 0
+        )
+
+        manager.prewarmDocumentationProvider()
+        try await prewarmStarted.wait(description: "documentation prewarm started")
+
+        let result = try await waitWithTimeout(
+            "tools/list should not wait for the blocked documentation prewarm",
+            timeout: .milliseconds(500)
+        ) {
+            try await manager.sharedToolsList(
+                sessionID: "session-docs-tools-prewarm-timeout",
+                requestTimeoutOverride: .milliseconds(20)
+            )
+        }
+
+        #expect(toolNames(in: result) == ["XcodeRead"])
+        #expect(await documentationProvider.toolListUpdateCount() == 0)
+        await prewarmGate.signal()
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            await documentationProvider.prewarmCount() == 1
+        })
+    }
+
     @Test func sharedToolsListRemovesStaleDocumentationSearchWhenProviderUnavailable() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -1472,6 +1527,47 @@ extension RuntimeCoordinatorTests {
         #expect(requests.first?.arguments.joined(separator: " ").contains(
             "xcode-26-5.asset/AssetData/documentation-db/index.sql"
         ) == true)
+    }
+
+    @Test func liveDocumentationAssetSearchProviderHonorsSearchTimeout()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        let runner = StubProcessRunner(
+            output: ProcessOutput(terminationStatus: 0, stdout: "[]", stderr: ""),
+            delayNanoseconds: 300_000_000
+        )
+        let provider = LiveDocumentationAssetSearchProvider(
+            assetRoot: root,
+            currentOSVersion: { "26.5.1" },
+            processRunner: runner
+        )
+        let target = documentationProviderTarget(processID: 125, xcodeVersion: "26.6")
+
+        await #expect(throws: TimeoutError.self) {
+            _ = try await waitWithTimeout(
+                "local DocumentationSearch should honor the caller timeout",
+                timeout: .milliseconds(500)
+            ) {
+                try await provider.callDocumentationSearch(
+                    requestData: makeDocumentationSearchRequest(id: 125, query: "UIView"),
+                    for: target,
+                    timeout: .milliseconds(20)
+                )
+            }
+        }
+        let requests = await runner.recordedRequests()
+        #expect(requests.count == 1)
     }
 
     @Test func documentationProviderBackgroundDiscoveryKeepsBaseCatalogWhenDescriptorIsAbsent()

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1861,6 +1861,64 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
     }
 
+    @Test func documentationProviderKeepsLiveProviderAfterInitialAssetFallbackRequestTimeout()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 129, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled,
+                        userCallResponses: [.notEnabled]
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 131,
+                text: "{\"answer\":\"asset\"}"
+            ),
+            timeoutOnceAfterSuccessfulCallCount: 0
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let timeoutOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 131, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .failed(let error, let timeoutInvalidatedProvider) = timeoutOutcome else {
+            Issue.record("expected failed timeout outcome, got \(timeoutOutcome)")
+            return
+        }
+        #expect(error is TimeoutError)
+        #expect(timeoutInvalidatedProvider == false)
+
+        let retryOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 132, query: "UIKit"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let retryData, let retryInvalidatedProvider) = retryOutcome else {
+            Issue.record("expected retry handled outcome, got \(retryOutcome)")
+            return
+        }
+        #expect(retryInvalidatedProvider)
+        #expect(try toolContentText(in: retryData) == "{\"answer\":\"asset\"}")
+        #expect(await localProvider.requestedCallPIDs() == [target.processID, target.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI", "UIKit"])
+        #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI", "UIKit"])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 2)
+    }
+
     @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeConfigIsBroken()
         async throws
     {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1319,6 +1319,62 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.documentationQueries(for: target.processID) == ["UIView"])
     }
 
+    @Test func documentationProviderRepairDoesNotWaitPastRequestTimeout()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 120, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "26.5",
+                    osVersion: "26.2",
+                    documentationRelease: 900339,
+                    changedDefault: true
+                )
+            ),
+            delayNanoseconds: 300_000_000
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            serviceRepairer: repairer
+        )
+
+        let update = try await waitWithTimeout(
+            "documentation repair should not exceed the caller timeout",
+            timeout: .milliseconds(500)
+        ) {
+            await manager.startBackgroundDiscovery(requestTimeout: .milliseconds(20))
+        }
+        if case .available = update {
+            Issue.record("expected repair timeout to avoid advertising DocumentationSearch")
+        }
+        #expect(await repairer.repairedPIDs() == [target.processID])
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            await repairer.cancelledPIDs() == [target.processID]
+        })
+        #expect(await factory.startedPIDs() == [target.processID])
+    }
+
     @Test func documentationProviderUsesInstalledAssetFallbackWhenRepairDoesNotRestoreDescriptor()
         async throws
     {
@@ -1628,6 +1684,7 @@ extension RuntimeCoordinatorTests {
         }
         let requests = await runner.recordedRequests()
         #expect(requests.count == 1)
+        #expect(requests.first?.timeoutNanoseconds == 20_000_000)
         #expect(await waitUntil(timeout: .seconds(2)) {
             await runner.cancelledRunCount() == 1
         })

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1553,6 +1553,62 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.documentationQueries(for: target.processID) == ["First", "Second"])
     }
 
+    @Test func backgroundDiscoveryKeepsReopenedRouteWhenRepairDoesNotRestoreDescriptor()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 125, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .successText("{\"answer\":\"closed\"}")
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .successText("{\"answer\":\"reopened\"}")
+                    ),
+                ],
+            ]
+        )
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "26.5",
+                    osVersion: "26.2",
+                    documentationRelease: 900339,
+                    changedDefault: true
+                )
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            serviceRepairer: repairer
+        )
+
+        _ = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 125, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"reopened\"}")
+        #expect(await repairer.repairedPIDs() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
+        #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
+    }
+
     @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeReturnsNotEnabled()
         async throws
     {
@@ -2412,6 +2468,54 @@ extension RuntimeCoordinatorTests {
         #expect(invalidatedProvider)
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"fallback\"}")
         #expect(await localProvider.requestedCallPIDs() == [xcode27.processID])
+        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
+        #expect(await factory.documentationQueries(for: xcode27.processID) == ["UIView"])
+        #expect(await factory.documentationQueries(for: xcode26.processID) == ["UIView"])
+    }
+
+    @Test func documentationProviderManagerRetriesProviderFailureOnNextCandidate()
+        async throws
+    {
+        let xcode26 = documentationProviderTarget(processID: 424, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 427, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"fallback\"}")
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .toolErrorText(
+                            "The file “config.json” couldn’t be opened because there is no such file."
+                        )
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 77, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"fallback\"}")
         #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
         #expect(await factory.documentationQueries(for: xcode27.processID) == ["UIView"])
         #expect(await factory.documentationQueries(for: xcode26.processID) == ["UIView"])

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1790,6 +1790,77 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
     }
 
+    @Test func documentationProviderKeepsCachedAssetFallbackAfterRequestTimeout()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 128, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 128,
+                text: "{\"answer\":\"asset\"}"
+            ),
+            timeoutOnceAfterSuccessfulCallCount: 1
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let firstOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 128, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let firstData, let firstInvalidatedProvider) = firstOutcome else {
+            Issue.record("expected first handled outcome, got \(firstOutcome)")
+            return
+        }
+        #expect(firstInvalidatedProvider)
+        #expect(try toolContentText(in: firstData) == "{\"answer\":\"asset\"}")
+
+        let timeoutOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 129, query: "UIKit"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .failed(let error, let timeoutInvalidatedProvider) = timeoutOutcome else {
+            Issue.record("expected failed timeout outcome, got \(timeoutOutcome)")
+            return
+        }
+        #expect(error is TimeoutError)
+        #expect(timeoutInvalidatedProvider == false)
+
+        let retryOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 130, query: "AppKit"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let retryData, let retryInvalidatedProvider) = retryOutcome else {
+            Issue.record("expected retry handled outcome, got \(retryOutcome)")
+            return
+        }
+        #expect(retryInvalidatedProvider == false)
+        #expect(try toolContentText(in: retryData) == "{\"answer\":\"asset\"}")
+        #expect(await localProvider.requestedCallPIDs() == [
+            target.processID,
+            target.processID,
+            target.processID,
+        ])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI", "UIKit", "AppKit"])
+        #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
+    }
+
     @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeConfigIsBroken()
         async throws
     {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1718,6 +1718,78 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 1)
     }
 
+    @Test func documentationProviderInvalidatesCachedAssetFallbackWhenLocalSearchFails()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 126, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 21,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 126,
+                text: "{\"answer\":\"asset\"}"
+            ),
+            failAfterSuccessfulCallCount: 1
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let firstOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 126, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let firstData, let firstInvalidatedProvider) = firstOutcome else {
+            Issue.record("expected first handled outcome, got \(firstOutcome)")
+            return
+        }
+        #expect(firstInvalidatedProvider)
+        #expect(try toolContentText(in: firstData) == "{\"answer\":\"asset\"}")
+
+        let secondOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 127, query: "UIKit"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .unavailable(let reason) = secondOutcome else {
+            Issue.record("expected unavailable outcome, got \(secondOutcome)")
+            return
+        }
+        #expect(reason.message == DocumentationProvider.UnavailableReason.userFacingMessage)
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(
+            update,
+            to: try jsonValue([
+                "tools": [
+                    documentationDescriptor(version: "asset-fallback").foundationObject,
+                    [
+                        "name": "XcodeRead",
+                        "description": "read",
+                    ],
+                ],
+            ])
+        )
+
+        #expect(toolNames(in: result) == ["XcodeRead"])
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: result) == nil)
+        #expect(await localProvider.requestedCallPIDs() == [target.processID, target.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI", "UIKit"])
+        #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
+    }
+
     @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeConfigIsBroken()
         async throws
     {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1628,6 +1628,9 @@ extension RuntimeCoordinatorTests {
         }
         let requests = await runner.recordedRequests()
         #expect(requests.count == 1)
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            await runner.cancelledRunCount() == 1
+        })
     }
 
     @Test func documentationProviderBackgroundDiscoveryKeepsBaseCatalogWhenDescriptorIsAbsent()
@@ -2164,6 +2167,59 @@ extension RuntimeCoordinatorTests {
         }
         #expect(invalidatedProvider)
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"fallback\"}")
+        #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
+        #expect(await factory.documentationQueries(for: xcode27.processID) == ["UIView"])
+        #expect(await factory.documentationQueries(for: xcode26.processID) == ["UIView"])
+    }
+
+    @Test func documentationProviderManagerContinuesFailoverWhenAssetFallbackFails()
+        async throws
+    {
+        let xcode26 = documentationProviderTarget(processID: 422, xcodeVersion: "26.6")
+        let xcode27 = documentationProviderTarget(processID: 423, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                xcode26.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"fallback\"}")
+                    ),
+                ],
+                xcode27.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(id: 423, text: "{\"unused\":true}"),
+            failsCalls: true
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 75, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"fallback\"}")
+        #expect(await localProvider.requestedCallPIDs() == [xcode27.processID])
         #expect(await factory.startedPIDs() == [xcode27.processID, xcode26.processID])
         #expect(await factory.documentationQueries(for: xcode27.processID) == ["UIView"])
         #expect(await factory.documentationQueries(for: xcode26.processID) == ["UIView"])

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1444,6 +1444,73 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
     }
 
+    @Test func activeDocumentationProviderKeepsReopenedRouteWhenRepairDoesNotRestoreDescriptor()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 122, xcodeVersion: "26.6")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .successText("{\"answer\":\"first\"}")
+                    ),
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .successText("{\"answer\":\"second\"}")
+                    ),
+                ],
+            ]
+        )
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "26.5",
+                    osVersion: "26.2",
+                    documentationRelease: 900339,
+                    changedDefault: true
+                )
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            serviceRepairer: repairer
+        )
+
+        let firstOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 122, query: "First"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let firstData, _) = firstOutcome else {
+            Issue.record("expected first handled outcome, got \(firstOutcome)")
+            return
+        }
+        #expect(try toolContentText(in: firstData) == "{\"answer\":\"first\"}")
+
+        _ = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+
+        let secondOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 123, query: "Second"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let secondData, _) = secondOutcome else {
+            Issue.record("expected second handled outcome, got \(secondOutcome)")
+            return
+        }
+        #expect(try toolContentText(in: secondData) == "{\"answer\":\"second\"}")
+        #expect(await repairer.repairedPIDs() == [target.processID])
+        #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
+        #expect(await factory.documentationQueries(for: target.processID) == ["First", "Second"])
+    }
+
     @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeReturnsNotEnabled()
         async throws
     {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1994,6 +1994,48 @@ extension RuntimeCoordinatorTests {
         ) == true)
     }
 
+    @Test func liveDocumentationAssetSearchProviderTreatsEmptySQLiteOutputAsNoResults()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        let runner = StubProcessRunner(output: ProcessOutput(
+            terminationStatus: 0,
+            stdout: "",
+            stderr: ""
+        ))
+        let provider = LiveDocumentationAssetSearchProvider(
+            assetRoot: root,
+            currentOSVersion: { "26.5.1" },
+            processRunner: runner
+        )
+        let target = documentationProviderTarget(processID: 127, xcodeVersion: "26.6")
+
+        let response = try await provider.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 127, query: "NoMatch"),
+            for: target,
+            timeout: .seconds(1)
+        )
+
+        let maybeText = try toolContentText(in: response)
+        let text = try #require(maybeText)
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
+        )
+        let documents = try #require(payload["documents"] as? [[String: Any]])
+        #expect(documents.isEmpty)
+        #expect(payload["source"] as? String == "installed-documentation-asset")
+    }
+
     @Test func liveDocumentationAssetSearchProviderHonorsSearchTimeout()
         async throws
     {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1319,6 +1319,48 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.documentationQueries(for: target.processID) == ["UIView"])
     }
 
+    @Test func repairedDocumentationProviderDoesNotCloseReusedRuntimeRoute()
+        async throws
+    {
+        let target = documentationProviderTarget(processID: 123, xcodeVersion: "26.6")
+        let transport = ReusedRouteRepairTransport()
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "26.5",
+                    osVersion: "26.2",
+                    documentationRelease: 900339,
+                    changedDefault: true
+                )
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: transport,
+            serviceRepairer: repairer
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-reused")
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 123, query: "UIView"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"reused\"}")
+        #expect(await repairer.repairedPIDs() == [target.processID])
+        #expect(await transport.openCount() == 2)
+        #expect(await transport.toolsListCount() == 2)
+        #expect(await transport.closedRoutes().isEmpty)
+    }
+
     @Test func documentationProviderRepairDoesNotWaitPastRequestTimeout()
         async throws
     {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -519,6 +519,85 @@ actor TransientUnavailableDescriptorTransport: DocumentationProviderRouting {
     }
 }
 
+actor ReusedRouteRepairTransport: DocumentationProviderRouting {
+    private var openCountValue = 0
+    private var toolsListCountValue = 0
+    private var closedRouteIDs: [String] = []
+
+    func openRoute(
+        for target: DocumentationProviderTarget,
+        requestTimeout _: TimeAmount?,
+        initializeParams _: [String: JSONValue]
+    ) async throws -> DocumentationProviderRoute {
+        openCountValue += 1
+        return DocumentationProviderRoute(
+            id: "reused-\(target.processID)",
+            target: target,
+            upstreamIndex: 0,
+            serverVersion: target.xcodeVersion
+        )
+    }
+
+    func toolsList(
+        route _: DocumentationProviderRoute,
+        timeout _: TimeAmount?
+    ) async throws -> JSONValue {
+        toolsListCountValue += 1
+        let tools: [Any]
+        if toolsListCountValue == 1 {
+            tools = []
+        } else {
+            tools = [documentationDescriptor(version: "reused").foundationObject]
+        }
+        return try jsonValue(["tools": tools])
+    }
+
+    func callDocumentationSearch(
+        route: DocumentationProviderRoute,
+        requestData: Data,
+        timeout _: TimeAmount?
+    ) async throws -> Data {
+        guard closedRouteIDs.contains(route.id) == false else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        let object = try JSONSerialization.jsonObject(with: requestData, options: [])
+            as? [String: Any]
+        let id = object?["id"] ?? 0
+        return try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": [
+                    "content": [
+                        [
+                            "type": "text",
+                            "text": "{\"answer\":\"reused\"}",
+                        ],
+                    ],
+                    "isError": false,
+                ],
+            ],
+            options: []
+        )
+    }
+
+    func close(route: DocumentationProviderRoute) async {
+        closedRouteIDs.append(route.id)
+    }
+
+    func openCount() -> Int {
+        openCountValue
+    }
+
+    func toolsListCount() -> Int {
+        toolsListCountValue
+    }
+
+    func closedRoutes() -> [String] {
+        closedRouteIDs
+    }
+}
+
 final class SequencedXcodeTargetDiscovery: XcodeTargetDiscovering, @unchecked Sendable {
     private let lock = NSLock()
     private var remainingSequences: [[DocumentationProviderTarget]]

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -380,13 +380,15 @@ actor StubDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairin
 actor StubDocumentationSearchProvider: DocumentationSearchProviding {
     private let descriptorValue: JSONValue?
     private let responseData: Data
+    private let failsCalls: Bool
     private var descriptorPIDs: [pid_t] = []
     private var callPIDs: [pid_t] = []
     private var queries: [String] = []
 
-    init(descriptor: JSONValue?, responseData: Data) {
+    init(descriptor: JSONValue?, responseData: Data, failsCalls: Bool = false) {
         self.descriptorValue = descriptor
         self.responseData = responseData
+        self.failsCalls = failsCalls
     }
 
     func descriptor(for target: DocumentationProviderTarget) async -> JSONValue? {
@@ -402,6 +404,9 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
         callPIDs.append(target.processID)
         if let query = try documentationSearchQuery(in: requestData) {
             queries.append(query)
+        }
+        if failsCalls {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
         return responseData
     }
@@ -423,6 +428,7 @@ actor StubProcessRunner: ProcessRunning {
     private let output: ProcessOutput
     private let delayNanoseconds: UInt64?
     private var requests: [ProcessRequest] = []
+    private var cancelledRunCountValue = 0
 
     init(output: ProcessOutput, delayNanoseconds: UInt64? = nil) {
         self.output = output
@@ -432,13 +438,22 @@ actor StubProcessRunner: ProcessRunning {
     func run(_ request: ProcessRequest) async throws -> ProcessOutput {
         requests.append(request)
         if let delayNanoseconds {
-            try await Task.sleep(nanoseconds: delayNanoseconds)
+            do {
+                try await Task.sleep(nanoseconds: delayNanoseconds)
+            } catch is CancellationError {
+                cancelledRunCountValue += 1
+                throw CancellationError()
+            }
         }
         return output
     }
 
     func recordedRequests() -> [ProcessRequest] {
         requests
+    }
+
+    func cancelledRunCount() -> Int {
+        cancelledRunCountValue
     }
 }
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -399,14 +399,22 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
     private let descriptorValue: JSONValue?
     private let responseData: Data
     private let failsCalls: Bool
+    private let failAfterSuccessfulCallCount: Int?
     private var descriptorPIDs: [pid_t] = []
     private var callPIDs: [pid_t] = []
     private var queries: [String] = []
+    private var successfulCallCount = 0
 
-    init(descriptor: JSONValue?, responseData: Data, failsCalls: Bool = false) {
+    init(
+        descriptor: JSONValue?,
+        responseData: Data,
+        failsCalls: Bool = false,
+        failAfterSuccessfulCallCount: Int? = nil
+    ) {
         self.descriptorValue = descriptor
         self.responseData = responseData
         self.failsCalls = failsCalls
+        self.failAfterSuccessfulCallCount = failAfterSuccessfulCallCount
     }
 
     func descriptor(for target: DocumentationProviderTarget) async -> JSONValue? {
@@ -426,6 +434,12 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
         if failsCalls {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
+        if let failAfterSuccessfulCallCount,
+           successfulCallCount >= failAfterSuccessfulCallCount
+        {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        successfulCallCount += 1
         return responseData
     }
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -77,6 +77,58 @@ func documentationDescriptorDescription(in result: JSONValue) -> String? {
     return description
 }
 
+private struct TestDocumentationAssetInfoPlist: Encodable {
+    let properties: TestDocumentationAssetProperties
+
+    private enum CodingKeys: String, CodingKey {
+        case properties = "MobileAssetProperties"
+    }
+}
+
+private struct TestDocumentationAssetProperties: Encodable {
+    let documentationRelease: String
+    let xcodeVersion: String
+    let osVersion: String
+
+    private enum CodingKeys: String, CodingKey {
+        case documentationRelease = "DocumentationRelease"
+        case xcodeVersion = "XcodeVersion"
+        case osVersion = "OSVersion"
+    }
+}
+
+func makeInstalledDocumentationAsset(
+    root: URL,
+    name: String,
+    xcodeVersion: String,
+    osVersion: String,
+    documentationRelease: Int
+) throws {
+    let assetURL = root.appendingPathComponent("\(name).asset", isDirectory: true)
+    let assetDataURL = assetURL.appendingPathComponent("AssetData", isDirectory: true)
+    let databaseURL = assetDataURL.appendingPathComponent("documentation-db", isDirectory: true)
+    try FileManager.default.createDirectory(
+        at: databaseURL,
+        withIntermediateDirectories: true
+    )
+    let plist = TestDocumentationAssetInfoPlist(
+        properties: TestDocumentationAssetProperties(
+            documentationRelease: String(documentationRelease),
+            xcodeVersion: xcodeVersion,
+            osVersion: osVersion
+        )
+    )
+    try PropertyListEncoder().encode(plist).write(
+        to: assetURL.appendingPathComponent("Info.plist", isDirectory: false)
+    )
+    try Data("{}".utf8).write(
+        to: assetDataURL.appendingPathComponent("config.json", isDirectory: false)
+    )
+    try Data("-- sqlite index placeholder".utf8).write(
+        to: databaseURL.appendingPathComponent("index.sql", isDirectory: false)
+    )
+}
+
 func makeDocumentationSearchRequest(id: Int64, query: String) throws -> Data {
     try JSONSerialization.data(
         withJSONObject: [
@@ -302,6 +354,130 @@ struct UnavailableDocumentationProviderTransport: DocumentationProviderRouting {
         timeout _: TimeAmount?
     ) async throws -> Data {
         throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+}
+
+actor StubDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairing {
+    private let result: DocumentationSearchServiceRepairResult
+    private var repairedProcessIDs: [pid_t] = []
+
+    init(result: DocumentationSearchServiceRepairResult) {
+        self.result = result
+    }
+
+    func repairDocumentationSearch(
+        for target: DocumentationProviderTarget
+    ) async -> DocumentationSearchServiceRepairResult {
+        repairedProcessIDs.append(target.processID)
+        return result
+    }
+
+    func repairedPIDs() -> [pid_t] {
+        repairedProcessIDs
+    }
+}
+
+actor StubDocumentationSearchProvider: DocumentationSearchProviding {
+    private let descriptorValue: JSONValue?
+    private let responseData: Data
+    private var descriptorPIDs: [pid_t] = []
+    private var callPIDs: [pid_t] = []
+    private var queries: [String] = []
+
+    init(descriptor: JSONValue?, responseData: Data) {
+        self.descriptorValue = descriptor
+        self.responseData = responseData
+    }
+
+    func descriptor(for target: DocumentationProviderTarget) async -> JSONValue? {
+        descriptorPIDs.append(target.processID)
+        return descriptorValue
+    }
+
+    func callDocumentationSearch(
+        requestData: Data,
+        for target: DocumentationProviderTarget,
+        timeout _: TimeAmount?
+    ) async throws -> Data {
+        callPIDs.append(target.processID)
+        if let query = try documentationSearchQuery(in: requestData) {
+            queries.append(query)
+        }
+        return responseData
+    }
+
+    func requestedDescriptorPIDs() -> [pid_t] {
+        descriptorPIDs
+    }
+
+    func requestedCallPIDs() -> [pid_t] {
+        callPIDs
+    }
+
+    func requestedQueries() -> [String] {
+        queries
+    }
+}
+
+actor StubProcessRunner: ProcessRunning {
+    private let output: ProcessOutput
+    private var requests: [ProcessRequest] = []
+
+    init(output: ProcessOutput) {
+        self.output = output
+    }
+
+    func run(_ request: ProcessRequest) async throws -> ProcessOutput {
+        requests.append(request)
+        return output
+    }
+
+    func recordedRequests() -> [ProcessRequest] {
+        requests
+    }
+}
+
+actor TransientUnavailableDescriptorTransport: DocumentationProviderRouting {
+    private var toolsListCountValue = 0
+
+    func openRoute(
+        for target: DocumentationProviderTarget,
+        requestTimeout _: TimeAmount?,
+        initializeParams _: [String: JSONValue]
+    ) async throws -> DocumentationProviderRoute {
+        DocumentationProviderRoute(
+            id: "transient-\(target.processID)",
+            target: target,
+            upstreamIndex: nil,
+            serverVersion: target.xcodeVersion
+        )
+    }
+
+    func toolsList(
+        route _: DocumentationProviderRoute,
+        timeout _: TimeAmount?
+    ) async throws -> JSONValue {
+        toolsListCountValue += 1
+        if toolsListCountValue == 1 {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        return try jsonValue([
+            "tools": [
+                documentationDescriptor(version: "transient").foundationObject,
+            ],
+        ])
+    }
+
+    func callDocumentationSearch(
+        route _: DocumentationProviderRoute,
+        requestData _: Data,
+        timeout _: TimeAmount?
+    ) async throws -> Data {
+        throw UpstreamSlotScheduler.AcquisitionError.unavailable
+    }
+
+    func toolsListCount() -> Int {
+        toolsListCountValue
     }
 }
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -421,14 +421,19 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
 
 actor StubProcessRunner: ProcessRunning {
     private let output: ProcessOutput
+    private let delayNanoseconds: UInt64?
     private var requests: [ProcessRequest] = []
 
-    init(output: ProcessOutput) {
+    init(output: ProcessOutput, delayNanoseconds: UInt64? = nil) {
         self.output = output
+        self.delayNanoseconds = delayNanoseconds
     }
 
     func run(_ request: ProcessRequest) async throws -> ProcessOutput {
         requests.append(request)
+        if let delayNanoseconds {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        }
         return output
     }
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -400,21 +400,25 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
     private let responseData: Data
     private let failsCalls: Bool
     private let failAfterSuccessfulCallCount: Int?
+    private let timeoutOnceAfterSuccessfulCallCount: Int?
     private var descriptorPIDs: [pid_t] = []
     private var callPIDs: [pid_t] = []
     private var queries: [String] = []
     private var successfulCallCount = 0
+    private var didThrowTimeout = false
 
     init(
         descriptor: JSONValue?,
         responseData: Data,
         failsCalls: Bool = false,
-        failAfterSuccessfulCallCount: Int? = nil
+        failAfterSuccessfulCallCount: Int? = nil,
+        timeoutOnceAfterSuccessfulCallCount: Int? = nil
     ) {
         self.descriptorValue = descriptor
         self.responseData = responseData
         self.failsCalls = failsCalls
         self.failAfterSuccessfulCallCount = failAfterSuccessfulCallCount
+        self.timeoutOnceAfterSuccessfulCallCount = timeoutOnceAfterSuccessfulCallCount
     }
 
     func descriptor(for target: DocumentationProviderTarget) async -> JSONValue? {
@@ -433,6 +437,13 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
         }
         if failsCalls {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        if let timeoutOnceAfterSuccessfulCallCount,
+           successfulCallCount >= timeoutOnceAfterSuccessfulCallCount,
+           didThrowTimeout == false
+        {
+            didThrowTimeout = true
+            throw TimeoutError()
         }
         if let failAfterSuccessfulCallCount,
            successfulCallCount >= failAfterSuccessfulCallCount

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -359,21 +359,39 @@ struct UnavailableDocumentationProviderTransport: DocumentationProviderRouting {
 
 actor StubDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairing {
     private let result: DocumentationSearchServiceRepairResult
+    private let delayNanoseconds: UInt64?
     private var repairedProcessIDs: [pid_t] = []
+    private var cancelledProcessIDs: [pid_t] = []
 
-    init(result: DocumentationSearchServiceRepairResult) {
+    init(
+        result: DocumentationSearchServiceRepairResult,
+        delayNanoseconds: UInt64? = nil
+    ) {
         self.result = result
+        self.delayNanoseconds = delayNanoseconds
     }
 
     func repairDocumentationSearch(
         for target: DocumentationProviderTarget
     ) async -> DocumentationSearchServiceRepairResult {
         repairedProcessIDs.append(target.processID)
+        if let delayNanoseconds {
+            do {
+                try await Task.sleep(nanoseconds: delayNanoseconds)
+            } catch is CancellationError {
+                cancelledProcessIDs.append(target.processID)
+            } catch {
+            }
+        }
         return result
     }
 
     func repairedPIDs() -> [pid_t] {
         repairedProcessIDs
+    }
+
+    func cancelledPIDs() -> [pid_t] {
+        cancelledProcessIDs
     }
 }
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -274,6 +274,10 @@ actor BlockingFallbackDocumentationProviderTransport: DocumentationProviderRouti
     func closeCount() -> Int {
         closedRouteIDs.count
     }
+
+    func openCount() -> Int {
+        openCountValue
+    }
 }
 
 struct UnavailableDocumentationProviderTransport: DocumentationProviderRouting {

--- a/Tests/ProxySessionTests/ToolCatalogStartupLogFormatterTests.swift
+++ b/Tests/ProxySessionTests/ToolCatalogStartupLogFormatterTests.swift
@@ -1,0 +1,47 @@
+import ProxyMCP
+import Testing
+
+@testable import ProxySession
+
+@Suite
+struct ToolCatalogStartupLogFormatterTests {
+    @Test func summaryListsAvailableToolsOnePerLine() throws {
+        let result = try #require(JSONValue(any: [
+            "tools": [
+                ["name": "XcodeRead"],
+                ["name": "DocumentationSearch"],
+                ["name": "BuildProject"],
+            ],
+        ]))
+
+        let summary = ToolCatalogStartupLogFormatter.summary(from: result)
+
+        #expect(summary == """
+        Tools
+          DocumentationSearch: available
+          Count: 3
+          Available:
+            - BuildProject
+            - DocumentationSearch
+            - XcodeRead
+        """)
+    }
+
+    @Test func summaryMarksDocumentationSearchUnavailable() throws {
+        let result = try #require(JSONValue(any: [
+            "tools": [
+                ["name": "XcodeRead"],
+            ],
+        ]))
+
+        let summary = ToolCatalogStartupLogFormatter.summary(from: result)
+
+        #expect(summary == """
+        Tools
+          DocumentationSearch: unavailable
+          Count: 1
+          Available:
+            - XcodeRead
+        """)
+    }
+}


### PR DESCRIPTION
## Purpose
Fix DocumentationSearch availability and recovery when Xcode stops advertising or serving the tool, without requiring users to restart Xcode manually.

## Changes
- Avoid duplicate eager DocumentationSearch prewarm bridge launches.
- Treat numeric-equal installed documentation asset versions as equal.
- Add installed documentation asset fallback and cache it when Xcode returns not-enabled or provider-failure responses.
- Invalidate failed installed-asset fallback providers while preserving request-scoped fallback failures.
- Try remaining documentation provider candidates after candidate-scoped installed-asset fallback timeouts.
- Handle empty local sqlite output as an empty DocumentationSearch result set.
- Open installed documentation asset SQLite indexes read-only.
- Terminate local sqlite subprocesses promptly when the caller cancels.
- Return timed-out subprocess results without waiting for child-held stdout/stderr pipe EOF.
- Release scheduled timeout actions after successful process completion so timed runs do not retain process resources until their original deadline.
- Bound DocumentationSearch fallback, repair, and subprocess timeouts to the caller deadline.
- Preserve reopened documentation routes, including reused runtime routes, after service repair.
- Consume completed startup DocumentationSearch prewarm results so public tools/list refreshes current provider state.
- Improve startup tool logging so available tools are listed line by line.

## Testing
- swift test -Xswiftc -strict-concurrency=minimal
- XCODE_MCP_RUN_PROCESS_TESTS=1 swift test --no-parallel --filter ProxyProcessTests -Xswiftc -strict-concurrency=minimal
- scripts/check.sh
- codex-review --base refs/pr-fix/base/75/e0b3465641f18a45c933aa356d0449c0b3d78381