### PR TITLE
Fix control-plane timeout cleanup race

### DIFF
--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -26,6 +26,11 @@ extension ControlPlane {
     }
 }
 
+private enum EventLoopFutureWaitResult<Output: Sendable>: Sendable {
+    case value(Output)
+    case timedOut
+}
+
 /// The one place that decides which JSON-RPC error a control-plane or
 /// upstream-acquisition failure surfaces as.
 extension ControlPlane {
@@ -535,20 +540,28 @@ extension RuntimeCoordinator {
         onTimeout: @escaping @Sendable () -> Void = {}
     ) async throws -> Output {
         if let deadlineUptimeNs, let timeout = timeAmount(until: deadlineUptimeNs) {
-            return try await withThrowingTaskGroup(of: Output.self) { group in
+            return try await withThrowingTaskGroup(
+                of: EventLoopFutureWaitResult<Output>.self
+            ) { group in
                 group.addTask {
-                    try await future.get()
+                    .value(try await future.get())
                 }
                 group.addTask {
                     try await Task.sleep(
                         nanoseconds: UInt64(max(0, timeout.nanoseconds))
                     )
-                    onTimeout()
-                    throw TimeoutError()
+                    return .timedOut
                 }
                 let result = try await group.next()!
-                group.cancelAll()
-                return result
+                switch result {
+                case .value(let output):
+                    group.cancelAll()
+                    return output
+                case .timedOut:
+                    onTimeout()
+                    group.cancelAll()
+                    throw TimeoutError()
+                }
             }
         }
         return try await future.get()

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -407,6 +407,7 @@ extension RuntimeCoordinatorTests {
         )
         let activeLeaseID = manager.createRequestLease(descriptor: activeDescriptor)
         let activePromise = eventLoop.makePromise(of: Void.self)
+        defer { activePromise.fail(CancellationError()) }
         let activeFuture: EventLoopFuture<Void> = manager.enqueueOnUpstreamSlot(
             leaseID: activeLeaseID,
             descriptor: activeDescriptor,
@@ -437,7 +438,6 @@ extension RuntimeCoordinatorTests {
         #expect(Date().timeIntervalSince(started) < 0.5)
         guard case .failed(let error, _) = outcome else {
             Issue.record("expected timed-out outcome, got \(outcome)")
-            activePromise.fail(CancellationError())
             return
         }
         #expect(error is TimeoutError)
@@ -445,8 +445,6 @@ extension RuntimeCoordinatorTests {
         try await waitForCondition(timeoutSeconds: 2) {
             manager.debugSnapshot().queuedRequestCount == 0
         }
-
-        activePromise.fail(CancellationError())
     }
 
     @Test func runtimeDocumentationTransportClosesFallbackOpenedAfterRouteInvalidation()


### PR DESCRIPTION
## Purpose
Fix a control-plane timeout race where cleanup cancellation could surface as `CancellationError` instead of the caller deadline `TimeoutError`, leaving CI vulnerable to a stuck Swift Testing process after failure.

## Changes
- Make `waitForEventLoopFuture` resolve timeout as an internal result before running cleanup cancellation, preserving `TimeoutError` for caller deadlines.
- Add test cleanup so the manually occupied upstream slot is released even when the timeout assertion path throws.

## Testing
- `swift test --filter runtimeDocumentationTransportTimesOutQueuedPinnedRouteBeforeDispatch -Xswiftc -strict-concurrency=minimal`
- `swift test --filter runtimeDocumentationTransportCancellationReleasesControlPlaneLease -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`
- Codex review: no findings