### PR TITLE
Fix documentation provider release hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,16 @@ concurrency:
 jobs:
   package-tests:
     name: Package Tests (macOS)
-    runs-on: macos-15
-    timeout-minutes: 20
+    runs-on: macos-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Setup Swift 6.2
+      - name: Setup Swift 6.3
         uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2
         with:
-          swift-version: "6.2"
+          swift-version: "6.3"
 
       - name: Run package checks
         run: scripts/check.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,17 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Setup Swift 6.3
-        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2
-        with:
-          swift-version: "6.3"
+      - name: Select latest Xcode
+        run: |
+          set -euo pipefail
+          xcode_path="$(
+            ruby -e 'paths = Dir["/Applications/Xcode_*.app"]; abort "No versioned Xcode apps found" if paths.empty?; puts paths.max_by { |path| path[/Xcode_(\d+(?:\.\d+)*)\.app\z/, 1].split(".").map(&:to_i) }'
+          )"
+          sudo xcode-select -s "${xcode_path}/Contents/Developer"
+          xcodebuild -version
+          swift --version
 
       - name: Run package checks
         run: scripts/check.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   package-tests:
     name: Package Tests (macOS)
-    runs-on: macos-latest
+    runs-on: macos-26-arm64
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   package-tests:
     name: Package Tests (macOS)
-    runs-on: macos-26-arm64
+    runs-on: macos-26
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.sha }}
 
@@ -75,10 +75,15 @@ jobs:
             echo "Existing draft release will be repaired: ${RELEASE_VERSION}"
           fi
 
-      - name: Setup Swift 6.3
-        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2
-        with:
-          swift-version: "6.3"
+      - name: Select latest Xcode
+        run: |
+          set -euo pipefail
+          xcode_path="$(
+            ruby -e 'paths = Dir["/Applications/Xcode_*.app"]; abort "No versioned Xcode apps found" if paths.empty?; puts paths.max_by { |path| path[/Xcode_(\d+(?:\.\d+)*)\.app\z/, 1].split(".").map(&:to_i) }'
+          )"
+          sudo xcode-select -s "${xcode_path}/Contents/Developer"
+          xcodebuild -version
+          swift --version
 
       - name: Run package checks
         run: scripts/check.sh
@@ -165,7 +170,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ concurrency:
 jobs:
   build-release:
     name: Build Release
-    runs-on: macos-15
-    timeout-minutes: 30
+    runs-on: macos-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -75,10 +75,10 @@ jobs:
             echo "Existing draft release will be repaired: ${RELEASE_VERSION}"
           fi
 
-      - name: Setup Swift 6.2
+      - name: Setup Swift 6.3
         uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2
         with:
-          swift-version: "6.2"
+          swift-version: "6.3"
 
       - name: Run package checks
         run: scripts/check.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-release:
     name: Build Release
-    runs-on: macos-latest
+    runs-on: macos-26-arm64
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-release:
     name: Build Release
-    runs-on: macos-26-arm64
+    runs-on: macos-26
     timeout-minutes: 10
     permissions:
       contents: read

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -12,7 +12,7 @@ let strictSwiftSettings: [SwiftSetting] = [
 let package = Package(
     name: "XcodeMCPKit",
     platforms: [
-        .macOS(.v15)
+        .macOS("15.4")
     ],
     products: [
         .executable(

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,8 +6,8 @@ XcodeMCPKitは、Xcode MCPのためのローカルプロキシです。MCPクラ
 
 ## 要件
 
-- macOS 15.0+
-- Swift 6.2+
+- macOS 15.4+
+- Swift 6.3+
 
 ## インストール
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ endpoint and automates the `mcpbridge` approval flow.
 
 ## Requirements
 
-- macOS 15.0+
-- Swift 6.2+
+- macOS 15.4+
+- Swift 6.3+
 
 ## Install
 

--- a/Sources/ProxySession/AsyncTaskSupervisor.swift
+++ b/Sources/ProxySession/AsyncTaskSupervisor.swift
@@ -26,7 +26,8 @@ package final class AsyncTaskSupervisor: @unchecked Sendable {
 
     package init() {}
 
-    package func run(_ operation: @escaping @Sendable () async -> Void) {
+    @discardableResult
+    package func run(_ operation: @escaping @Sendable () async -> Void) -> Bool {
         let record = TaskRecord()
         let accepted = state.withLockedValue { state in
             guard state.acceptsNewTasks else {
@@ -39,9 +40,7 @@ package final class AsyncTaskSupervisor: @unchecked Sendable {
             }
             return true
         }
-        if !accepted {
-            record.task?.cancel()
-        }
+        return accepted
     }
 
     package func cancelAll() {

--- a/Sources/ProxySession/AsyncTaskSupervisor.swift
+++ b/Sources/ProxySession/AsyncTaskSupervisor.swift
@@ -1,7 +1,7 @@
 import Foundation
 import NIOConcurrencyHelpers
 
-package final class RuntimeTaskSupervisor: @unchecked Sendable {
+package final class AsyncTaskSupervisor: @unchecked Sendable {
     package struct Drain: Sendable {
         fileprivate let tasks: [Task<Void, Never>]
 

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1253,6 +1253,11 @@ package actor DocumentationProviderConnection {
         self.clock = clock
     }
 
+    isolated deinit {
+        eventTask?.cancel()
+        failAll(CancellationError())
+    }
+
     package func start() {
         guard eventTask == nil else { return }
         let session = session

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1244,6 +1244,7 @@ private final class DocumentationPendingResponse: @unchecked Sendable {
 package actor DocumentationProviderConnection {
     private let session: any UpstreamSession
     private let clock: ClockClient
+    private let tasks = AsyncTaskSupervisor()
     private var eventTask: Task<Void, Never>?
     private var pendingResponses: [String: DocumentationPendingResponse] = [:]
     private var nextID: Int64 = 1
@@ -1255,6 +1256,7 @@ package actor DocumentationProviderConnection {
 
     isolated deinit {
         eventTask?.cancel()
+        tasks.cancelAll()
         failAll(CancellationError())
     }
 
@@ -1270,10 +1272,14 @@ package actor DocumentationProviderConnection {
     }
 
     package func stop() async {
+        let eventTask = self.eventTask
         eventTask?.cancel()
-        eventTask = nil
+        self.eventTask = nil
+        let taskDrain = tasks.beginShutdown()
         failAll(CancellationError())
         await session.stop()
+        await eventTask?.value
+        await taskDrain.wait()
     }
 
     package func sendNotification(_ object: [String: Any]) async throws {
@@ -1314,7 +1320,7 @@ package actor DocumentationProviderConnection {
                 pendingResponses[upstreamIDKey] = pending
                 scheduleTimeoutIfNeeded(id: upstreamIDKey, timeout: timeout, pending: pending)
 
-                Task { [weak self, session] in
+                tasks.run { [weak self, session] in
                     let sendResult = await session.send(upstreamData)
                     guard sendResult == .accepted else {
                         await self?.failPending(
@@ -1325,7 +1331,7 @@ package actor DocumentationProviderConnection {
                 }
             }
         } onCancel: {
-            Task { [weak self] in
+            tasks.run { [weak self] in
                 await self?.failPending(id: upstreamIDKey, error: CancellationError())
             }
         }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -136,11 +136,34 @@ package struct UnavailableDocumentationSearchProvider: DocumentationSearchProvid
     }
 }
 
+package enum DocumentationProviderRouteOwnership: Sendable, Equatable {
+    case transportOwned
+    case runtimeBorrowed(upstreamIndex: Int)
+}
+
 package struct DocumentationProviderRoute: Sendable, Equatable {
     package let id: String
     package let target: DocumentationProviderTarget
-    package let upstreamIndex: Int?
+    package let ownership: DocumentationProviderRouteOwnership
     package let serverVersion: String
+
+    package var upstreamIndex: Int? {
+        switch ownership {
+        case .transportOwned:
+            nil
+        case .runtimeBorrowed(let upstreamIndex):
+            upstreamIndex
+        }
+    }
+
+    package var isRuntimeBorrowed: Bool {
+        switch ownership {
+        case .runtimeBorrowed:
+            true
+        case .transportOwned:
+            false
+        }
+    }
 
     package init(
         id: String,
@@ -150,7 +173,9 @@ package struct DocumentationProviderRoute: Sendable, Equatable {
     ) {
         self.id = id
         self.target = target
-        self.upstreamIndex = upstreamIndex
+        self.ownership = upstreamIndex.map {
+            .runtimeBorrowed(upstreamIndex: $0)
+        } ?? .transportOwned
         self.serverVersion = serverVersion
     }
 }
@@ -1520,18 +1545,51 @@ package actor SessionBackedDocumentationProviderTransport: DocumentationProvider
 }
 
 package actor DocumentationProviderManager: DocumentationProviderManaging {
-    private enum DescriptorSource: Sendable, Equatable {
-        case xcode
-        case installedDocumentationAsset
+    private enum CandidateBackend: Sendable {
+        case xcode(route: DocumentationProviderRoute, descriptor: JSONValue?)
+        case installedDocumentationAsset(descriptor: JSONValue)
+
+        var descriptor: JSONValue? {
+            switch self {
+            case .xcode(_, let descriptor):
+                descriptor
+            case .installedDocumentationAsset(let descriptor):
+                descriptor
+            }
+        }
+
+        var route: DocumentationProviderRoute? {
+            switch self {
+            case .xcode(let route, _):
+                route
+            case .installedDocumentationAsset:
+                nil
+            }
+        }
+
+        var usesInstalledDocumentationAsset: Bool {
+            switch self {
+            case .installedDocumentationAsset:
+                true
+            case .xcode:
+                false
+            }
+        }
     }
 
     private struct CandidateProfile: Sendable {
         let id: UUID
         let target: DocumentationProviderTarget
-        let route: DocumentationProviderRoute
-        var descriptor: JSONValue?
-        var descriptorSource: DescriptorSource?
+        var backend: CandidateBackend
         let serverVersion: String
+
+        var descriptor: JSONValue? {
+            backend.descriptor
+        }
+
+        var route: DocumentationProviderRoute? {
+            backend.route
+        }
     }
 
     private struct ActiveProvider: Sendable {
@@ -1860,6 +1918,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
 
             var progressed = false
             for (index, target) in targets.enumerated() {
+                let hasRemainingCandidate = index + 1 < targets.count
                 if let deadline, deadline.hasExpired {
                     return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
                 }
@@ -1910,6 +1969,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                         if permanentlyUnusable {
                             unusableProcessIDs.insert(processID)
                         }
+                        await discardPreparedProvider(processID: processID)
                         continue
                     case .requestFailed(let error):
                         return .failed(error, invalidatedProvider: invalidatedProvider)
@@ -1917,11 +1977,15 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                         rejectedProcessIDs.insert(target.processID)
                         lastCandidateFailure = error
                         progressed = true
+                        if hasRemainingCandidate {
+                            await discardPreparedProvider(processID: target.processID)
+                        }
                         continue
                     case .failed(let error):
                         rejectedProcessIDs.insert(target.processID)
                         invalidatedProvider = true
                         progressed = true
+                        await discardPreparedProvider(processID: target.processID)
                         if let deadline, deadline.hasExpired {
                             return .failed(error, invalidatedProvider: invalidatedProvider)
                         }
@@ -1934,6 +1998,9 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                     rejectedProcessIDs.insert(target.processID)
                     invalidatedProvider = true
                     progressed = true
+                    if hasRemainingCandidate {
+                        await discardPreparedProvider(processID: target.processID)
+                    }
                     if let deadline, deadline.hasExpired {
                         return .failed(error, invalidatedProvider: invalidatedProvider)
                     }
@@ -1970,7 +2037,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         guard previous.profile.id != profile.id else {
             return false
         }
-        await transport.close(route: previous.profile.route)
+        await closeTransportRouteIfPresent(previous.profile)
         return true
     }
 
@@ -2001,7 +2068,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         deadline: Deadline?
     ) async throws -> DocumentationAttemptResult {
         let processID = provider.profile.target.processID
-        if provider.profile.descriptorSource == .installedDocumentationAsset {
+        if provider.profile.backend.usesInstalledDocumentationAsset {
             do {
                 let response = try await localSearchProvider.callDocumentationSearch(
                     requestData: requestData,
@@ -2024,9 +2091,12 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 return .rejected(processID: processID, permanentlyUnusable: true)
             }
         }
+        guard let route = provider.profile.route else {
+            return .rejected(processID: processID, permanentlyUnusable: true)
+        }
         do {
             let response = try await transport.callDocumentationSearch(
-                route: provider.profile.route,
+                route: route,
                 requestData: requestData,
                 timeout: remainingTimeout(until: deadline)
             )
@@ -2108,7 +2178,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         case .success(let fallback):
             return .success(
                 data: fallback.responseData,
-                replacementProfile: profileByUsingInstalledDocumentationAssetFallback(
+                replacementProfile: await profileByUsingInstalledDocumentationAssetFallback(
                     provider,
                     fallback: fallback
                 )
@@ -2165,11 +2235,29 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let provider = activeProvider
         activeProvider = nil
         for profile in prepared.values where profile.id != provider?.profile.id {
-            await transport.close(route: profile.route)
+            await closeTransportRouteIfPresent(profile)
         }
         if let provider {
-            await transport.close(route: provider.profile.route)
+            await closeTransportRouteIfPresent(provider.profile)
         }
+    }
+
+    private func discardPreparedProvider(processID: pid_t) async {
+        providerPreparations.removeValue(forKey: processID)?.task.cancel()
+        guard let profile = preparedProviders.removeValue(forKey: processID) else {
+            return
+        }
+        guard activeProvider?.profile.id != profile.id else {
+            return
+        }
+        await closeTransportRouteIfPresent(profile)
+    }
+
+    private func closeTransportRouteIfPresent(_ profile: CandidateProfile) async {
+        guard let route = profile.route else {
+            return
+        }
+        await transport.close(route: route)
     }
 
     private func cacheInstalledDocumentationAssetReplacement(
@@ -2185,7 +2273,6 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         {
             preparedProviders[replacedProfile.target.processID] = replacementProfile
         }
-        await transport.close(route: replacedProfile.route)
     }
 
     package func shutdown() async {
@@ -2282,7 +2369,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         }
         providerPreparations.removeValue(forKey: target.processID)
         if isShutdown {
-            await transport.close(route: profile.route)
+            await closeTransportRouteIfPresent(profile)
             throw CancellationError()
         }
         return try await cachePreparedProvider(
@@ -2367,10 +2454,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         guard primary.descriptor == nil, fallback.descriptor != nil else {
             return primary
         }
-        var merged = primary
-        merged.descriptor = fallback.descriptor
-        merged.descriptorSource = fallback.descriptorSource
-        return merged
+        return fallback
     }
 
     private func waitForPreparation(
@@ -2418,7 +2502,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         if let activeProvider, activeProvider.profile.id == provider.profile.id {
             self.activeProvider = nil
         }
-        await transport.close(route: provider.profile.route)
+        await closeTransportRouteIfPresent(provider.profile)
     }
 
     private func orderedTargets(
@@ -2489,9 +2573,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         return CandidateProfile(
             id: UUID(),
             target: target,
-            route: route,
-            descriptor: nil,
-            descriptorSource: nil,
+            backend: .xcode(route: route, descriptor: nil),
             serverVersion: route.serverVersion
         )
     }
@@ -2505,12 +2587,17 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         guard toolsListTimeout?.nanoseconds != 0 else {
             throw TimeoutError()
         }
+        guard let route = profile.route else {
+            return profile
+        }
         let toolsResult = try await transport.toolsList(
-            route: profile.route,
+            route: route,
             timeout: toolsListTimeout
         )
-        updated.descriptor = DocumentationProvider.ToolCatalog.descriptor(in: toolsResult)
-        updated.descriptorSource = updated.descriptor == nil ? nil : .xcode
+        updated.backend = .xcode(
+            route: route,
+            descriptor: DocumentationProvider.ToolCatalog.descriptor(in: toolsResult)
+        )
         return updated
     }
 
@@ -2621,8 +2708,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 target: profile.target,
                 requestTimeout: remainingTimeout(until: deadline)
             )
-            if replacement.route.id != profile.route.id {
-                await transport.close(route: profile.route)
+            if replacement.route?.id != profile.route?.id {
+                await closeTransportRouteIfPresent(profile)
             }
             let updated = await profileByRefreshingDescriptor(
                 replacement,
@@ -2693,18 +2780,18 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             ]
         )
         var updated = profile
-        updated.descriptor = descriptor
-        updated.descriptorSource = .installedDocumentationAsset
+        updated.backend = .installedDocumentationAsset(descriptor: descriptor)
+        await closeTransportRouteIfPresent(profile)
         return updated
     }
 
     private func profileByUsingInstalledDocumentationAssetFallback(
         _ profile: CandidateProfile,
         fallback: InstalledDocumentationAssetFallback
-    ) -> CandidateProfile {
+    ) async -> CandidateProfile {
         var updated = profile
-        updated.descriptor = fallback.descriptor
-        updated.descriptorSource = .installedDocumentationAsset
+        updated.backend = .installedDocumentationAsset(descriptor: fallback.descriptor)
+        await closeTransportRouteIfPresent(profile)
         return updated
     }
 

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1345,7 +1345,7 @@ package actor DocumentationProviderConnection {
                 pendingResponses[upstreamIDKey] = pending
                 scheduleTimeoutIfNeeded(id: upstreamIDKey, timeout: timeout, pending: pending)
 
-                tasks.run { [weak self, session] in
+                let scheduled = tasks.run { [weak self, session] in
                     let sendResult = await session.send(upstreamData)
                     guard sendResult == .accepted else {
                         await self?.failPending(
@@ -1353,6 +1353,12 @@ package actor DocumentationProviderConnection {
                             error: UpstreamSlotScheduler.AcquisitionError.unavailable)
                         return
                     }
+                }
+                if !scheduled {
+                    failPending(
+                        id: upstreamIDKey,
+                        error: UpstreamSlotScheduler.AcquisitionError.unavailable
+                    )
                 }
             }
         } onCancel: {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
@@ -39,7 +39,7 @@ extension RuntimeCoordinator {
         let probeSession = session(id: internalSessionID)
         let probeTimeout: TimeAmount = .seconds(2)
         let originalID = JSONRPC.ID(any: "__probe-\(upstreamIndex)-\(UUID().uuidString)")!
-        let future = probeSession.router.registerRequest(
+        let registration = probeSession.router.registerRequestPending(
             idKey: originalID.key,
             on: eventLoop,
             timeout: probeTimeout
@@ -69,10 +69,15 @@ extension RuntimeCoordinator {
 
         sendUpstream(requestData, upstreamIndex: upstreamIndex)
 
-        Task { [weak self] in
+        addRuntimeTask { [weak self, probeSession, registration] in
             guard let self else { return }
             do {
-                var buffer = try await future.get()
+                var buffer = try await withTaskCancellationHandler {
+                    try await registration.future.get()
+                } onCancel: {
+                    _ = probeSession.router.cancelPending(token: registration.token)
+                    self.upstreamRouter.remove(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
+                }
                 guard let responseData = buffer.readData(length: buffer.readableBytes),
                     let object = try JSONSerialization.jsonObject(with: responseData, options: [])
                         as? [String: Any],
@@ -95,6 +100,10 @@ extension RuntimeCoordinator {
                     reason: "ok"
                 )
             } catch {
+                if error is CancellationError {
+                    self.upstreamRouter.remove(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
+                    return
+                }
                 self.upstreamRouter.remove(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
                 self.finishHealthProbe(
                     upstreamIndex: upstreamIndex,

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -361,7 +361,7 @@ extension RuntimeCoordinator {
             return
         }
 
-        Task { [weak self] in
+        addRuntimeTask { [weak self] in
             guard let self else { return }
             let result = await self.upstreams[upstreamIndex].send(data)
             if result == .accepted {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Readiness.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Readiness.swift
@@ -28,7 +28,7 @@ extension RuntimeCoordinator {
 
     func startAllUpstreamSlots() {
         for upstream in upstreams {
-            Task {
+            addRuntimeTask { [upstream] in
                 await upstream.start()
             }
         }
@@ -36,7 +36,7 @@ extension RuntimeCoordinator {
 
     func startPrimaryUpstreamSlot() {
         guard let primary = upstreams.first else { return }
-        Task {
+        addRuntimeTask { [primary] in
             await primary.start()
         }
     }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -406,7 +406,7 @@ extension RuntimeCoordinator {
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ServerRequestResponseForwardingResult> {
         let promise = eventLoop.makePromise(of: ServerRequestResponseForwardingResult.self)
-        addRuntimeTask { [weak self] in
+        let scheduled = addRuntimeTask { [weak self] in
             guard let self else {
                 promise.succeed(.upstreamUnavailable)
                 return
@@ -417,6 +417,9 @@ extension RuntimeCoordinator {
                 responseID: responseID
             )
             promise.succeed(result)
+        }
+        if !scheduled {
+            promise.succeed(.upstreamUnavailable)
         }
         return promise.futureResult
     }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -366,11 +366,12 @@ extension RuntimeCoordinator {
         guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
             return
         }
-        Task {
+        addRuntimeTask { [weak self] in
+            guard let self else { return }
             if ensureRunning {
-                await upstreams[upstreamIndex].start()
+                await self.upstreams[upstreamIndex].start()
             }
-            switch await upstreams[upstreamIndex].send(data) {
+            switch await self.upstreams[upstreamIndex].send(data) {
             case .accepted:
                 self.recordTraffic(
                     upstreamIndex: upstreamIndex,
@@ -405,7 +406,7 @@ extension RuntimeCoordinator {
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ServerRequestResponseForwardingResult> {
         let promise = eventLoop.makePromise(of: ServerRequestResponseForwardingResult.self)
-        Task { [weak self] in
+        addRuntimeTask { [weak self] in
             guard let self else {
                 promise.succeed(.upstreamUnavailable)
                 return

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -286,7 +286,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     package let sessionRegistry: SessionRegistry
     package let initializeManager: InitializeManager
-    package let upstreamTaskBox = NIOLockedValueBox<[Task<Void, Never>]>([])
+    package let upstreamEventTasks = RuntimeTaskSupervisor()
+    package let runtimeTasks = RuntimeTaskSupervisor()
     package let upstreamStderrLogLimiter = UpstreamStderrLogLimiter()
     package let primaryInitializeReadinessTokenBox =
         NIOLockedValueBox<UpstreamReadinessWaiterToken?>(nil)
@@ -538,10 +539,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         )
         runtimeBox.value = self
 
-        var tasks: [Task<Void, Never>] = []
-        tasks.reserveCapacity(upstreams.count)
         for (upstreamIndex, upstream) in upstreams.enumerated() {
-            let task = Task { [weak self] in
+            upstreamEventTasks.run { [weak self, upstream] in
                 guard let self else { return }
                 for await event in upstream.events {
                     switch event {
@@ -561,10 +560,6 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                     }
                 }
             }
-            tasks.append(task)
-        }
-        upstreamTaskBox.withLockedValue { taskBox in
-            taskBox = tasks
         }
 
         if startImmediately {
@@ -583,6 +578,12 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         if prewarmDocumentationProviderOnStartup {
             prewarmDocumentationProvider()
         }
+    }
+
+    package func addRuntimeTask(
+        _ operation: @escaping @Sendable () async -> Void
+    ) {
+        runtimeTasks.run(operation)
     }
 
     package func session(id: String) -> SessionContext {
@@ -624,6 +625,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         upstreamRouter.resetAll()
         _ = leaseManager.resetAll(reason: .clientDisconnected)
         upstreamSlotScheduler.reset()
+        runtimeTasks.cancelAll()
         resetUpstreamReadinessWaiters()
         cancelPrimaryInitializeReadinessWaiter()
         debugRecorder.resetAll()
@@ -665,14 +667,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             clearToolsCatalog: true
         )
 
-        let tasks = upstreamTaskBox.withLockedValue { taskBox -> [Task<Void, Never>] in
-            let current = taskBox
-            taskBox = []
-            return current
-        }
-        for task in tasks {
-            task.cancel()
-        }
+        let runtimeDrain = runtimeTasks.beginShutdown()
         await withTaskGroup(of: Void.self) { group in
             for upstream in upstreams {
                 group.addTask {
@@ -690,9 +685,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 }
             }
         }
-        for task in tasks {
-            await task.value
-        }
+        await upstreamEventTasks.shutdown()
+        await runtimeDrain.wait()
     }
 
     package func isInitialized() -> Bool {
@@ -718,7 +712,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 defaultSeconds: config.requestTimeout
             )
         )
-        Task { [weak self] in
+        addRuntimeTask { [weak self] in
             guard let self,
                   let baseResult = await self.controlPlaneCoordinator.prewarmToolsCatalogIfNeeded(
                       deadlineUptimeNs: deadline
@@ -1341,7 +1335,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
         let invalidatedGeneration = canonicalBrokerState.generation()
         let coordinator = controlPlaneCoordinator
-        Task {
+        addRuntimeTask {
             await coordinator.cancelLoadsStartedBeforeGeneration(
                 invalidatedGeneration,
                 reason: reason

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -580,9 +580,10 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
     }
 
+    @discardableResult
     package func addRuntimeTask(
         _ operation: @escaping @Sendable () async -> Void
-    ) {
+    ) -> Bool {
         runtimeTasks.run(operation)
     }
 

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -286,8 +286,8 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
 
     package let sessionRegistry: SessionRegistry
     package let initializeManager: InitializeManager
-    package let upstreamEventTasks = RuntimeTaskSupervisor()
-    package let runtimeTasks = RuntimeTaskSupervisor()
+    package let upstreamEventTasks = AsyncTaskSupervisor()
+    package let runtimeTasks = AsyncTaskSupervisor()
     package let upstreamStderrLogLimiter = UpstreamStderrLogLimiter()
     package let primaryInitializeReadinessTokenBox =
         NIOLockedValueBox<UpstreamReadinessWaiterToken?>(nil)

--- a/Sources/ProxySession/Runtime/RuntimeDocumentationProviderTransport.swift
+++ b/Sources/ProxySession/Runtime/RuntimeDocumentationProviderTransport.swift
@@ -52,7 +52,7 @@ package final class RuntimeDocumentationProviderTransport: DocumentationProvider
         if let fallbackRoute = fallbackRouteIfActive(for: route) {
             return try await fallback.toolsList(route: fallbackRoute, timeout: timeout)
         }
-        guard route.upstreamIndex != nil else {
+        guard route.isRuntimeBorrowed else {
             return try await fallback.toolsList(route: route, timeout: timeout)
         }
         let deadline = Deadline.fromNow(timeout, clock: clock)
@@ -75,7 +75,7 @@ package final class RuntimeDocumentationProviderTransport: DocumentationProvider
                 timeout: timeout
             )
         }
-        guard route.upstreamIndex != nil else {
+        guard route.isRuntimeBorrowed else {
             return try await fallback.callDocumentationSearch(
                 route: route,
                 requestData: requestData,
@@ -119,7 +119,7 @@ package final class RuntimeDocumentationProviderTransport: DocumentationProvider
     }
 
     package func close(route: DocumentationProviderRoute) async {
-        if route.upstreamIndex == nil {
+        if !route.isRuntimeBorrowed {
             await fallback.close(route: route)
             return
         }
@@ -148,7 +148,7 @@ package final class RuntimeDocumentationProviderTransport: DocumentationProvider
     private func fallbackRouteIfActive(
         for route: DocumentationProviderRoute
     ) -> DocumentationProviderRoute? {
-        guard route.upstreamIndex != nil else {
+        guard route.isRuntimeBorrowed else {
             return nil
         }
         return state.withLockedValue { state in
@@ -163,7 +163,7 @@ package final class RuntimeDocumentationProviderTransport: DocumentationProvider
         if let fallbackRoute = fallbackRouteIfActive(for: route) {
             return fallbackRoute
         }
-        guard route.upstreamIndex != nil else {
+        guard route.isRuntimeBorrowed else {
             return route
         }
         let initializeParams = state.withLockedValue { state in

--- a/Sources/ProxySession/Runtime/RuntimeTaskSupervisor.swift
+++ b/Sources/ProxySession/Runtime/RuntimeTaskSupervisor.swift
@@ -1,0 +1,81 @@
+import Foundation
+import NIOConcurrencyHelpers
+
+package final class RuntimeTaskSupervisor: @unchecked Sendable {
+    package struct Drain: Sendable {
+        fileprivate let tasks: [Task<Void, Never>]
+
+        package func wait() async {
+            for task in tasks {
+                await task.value
+            }
+        }
+    }
+
+    private final class TaskRecord: @unchecked Sendable {
+        let id = UUID()
+        var task: Task<Void, Never>?
+    }
+
+    private struct State: Sendable {
+        var acceptsNewTasks = true
+        var records: [UUID: TaskRecord] = [:]
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    package init() {}
+
+    package func run(_ operation: @escaping @Sendable () async -> Void) {
+        let record = TaskRecord()
+        let accepted = state.withLockedValue { state in
+            guard state.acceptsNewTasks else {
+                return false
+            }
+            state.records[record.id] = record
+            record.task = Task { [weak self, record] in
+                await operation()
+                self?.finish(record.id)
+            }
+            return true
+        }
+        if !accepted {
+            record.task?.cancel()
+        }
+    }
+
+    package func cancelAll() {
+        let tasks = state.withLockedValue { state -> [Task<Void, Never>] in
+            let tasks = state.records.values.compactMap(\.task)
+            state.records.removeAll()
+            return tasks
+        }
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    package func shutdown() async {
+        let drain = beginShutdown()
+        await drain.wait()
+    }
+
+    package func beginShutdown() -> Drain {
+        let tasks = state.withLockedValue { state -> [Task<Void, Never>] in
+            state.acceptsNewTasks = false
+            let tasks = state.records.values.compactMap(\.task)
+            state.records.removeAll()
+            return tasks
+        }
+        for task in tasks {
+            task.cancel()
+        }
+        return Drain(tasks: tasks)
+    }
+
+    private func finish(_ id: UUID) {
+        _ = state.withLockedValue { state in
+            state.records.removeValue(forKey: id)
+        }
+    }
+}

--- a/Tests/ProxySessionTests/AsyncTaskSupervisorTests.swift
+++ b/Tests/ProxySessionTests/AsyncTaskSupervisorTests.swift
@@ -1,0 +1,28 @@
+import Testing
+import XcodeMCPTestSupport
+@testable import ProxySession
+
+@Suite struct AsyncTaskSupervisorTests {
+    @Test func runReportsAcceptedBeforeShutdown() async throws {
+        let supervisor = AsyncTaskSupervisor()
+        let ran = TestSignal()
+
+        let scheduled = supervisor.run {
+            ran.signal()
+        }
+
+        #expect(scheduled)
+        try await ran.wait(description: "waiting for scheduled task to run")
+        await supervisor.shutdown()
+    }
+
+    @Test func runReportsRejectedAfterShutdownBegins() async {
+        let supervisor = AsyncTaskSupervisor()
+
+        let drain = supervisor.beginShutdown()
+        let scheduled = supervisor.run {}
+
+        #expect(scheduled == false)
+        await drain.wait()
+    }
+}

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -10,6 +10,20 @@ import XcodeMCPTestSupport
 @testable import ProxySession
 
 extension RuntimeCoordinatorTests {
+    @Test func documentationProviderConnectionCancelsEventReaderOnDeinit() async throws {
+        let terminated = TestSignal()
+        var connection: DocumentationProviderConnection? = DocumentationProviderConnection(
+            session: HangingDocumentationEventSession(terminationSignal: terminated)
+        )
+
+        await connection?.start()
+        connection = nil
+
+        try await terminated.wait(
+            description: "waiting for documentation provider event reader termination"
+        )
+    }
+
     @Test func defaultDocumentationProviderIsEnabledOnlyForDefaultMCPBridgeInvocation() {
         var config = makeConfig(requestTimeout: 5)
         let transport = UnavailableDocumentationProviderTransport()
@@ -3354,5 +3368,29 @@ extension RuntimeCoordinatorTests {
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"after-cancel\"}")
         #expect(await factory.startedPIDs() == [xcode.processID])
         #expect(await factory.documentationQueries(for: xcode.processID) == ["UIView", "SwiftUI"])
+    }
+}
+
+private actor HangingDocumentationEventSession: UpstreamSession {
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
+
+    init(terminationSignal: TestSignal) {
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
+        self.events = AsyncStream { continuation in
+            continuation.onTermination = { @Sendable _ in
+                terminationSignal.signal()
+            }
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+    }
+
+    func send(_: Data) async -> Upstream.SendResult {
+        .accepted
+    }
+
+    func stop() async {
+        continuation.finish()
     }
 }

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -381,6 +381,281 @@ extension RuntimeCoordinatorTests {
         #expect(await factory.documentationQueries(for: target.processID) == ["UIView", "SwiftUI"])
     }
 
+    @Test func runtimeDocumentationTransportCachesInstalledAssetFallbackWithoutOwningBorrowedRoute()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = documentationProviderTarget(processID: 747, xcodeVersion: "26.6")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 147,
+                text: "{\"answer\":\"asset\"}"
+            )
+        )
+        let providerManager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: RuntimeDocumentationProviderTransport(runtimeBox: runtimeBox),
+            providerSelectionTimeout: .seconds(1),
+            localSearchProvider: localProvider
+        )
+        let route = DocumentationProviderRoute(
+            id: "upstream-0-pid-\(target.processID)",
+            target: target,
+            upstreamIndex: 0
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [route],
+            documentationProviderManager: providerManager,
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let firstTask = Task {
+            try await providerManager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 147, query: "SwiftUI"),
+                requestTimeoutOverride: .seconds(1)
+            )
+        }
+        let runtimeRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: runtimeRequest) == "tools/call")
+        let runtimeRequestID = try extractUpstreamID(from: runtimeRequest)
+        await yieldMessage(
+            try makeDocumentationSearchToolErrorResponse(
+                id: runtimeRequestID,
+                text: "Tool 'DocumentationSearch' is not enabled."
+            ),
+            to: upstream
+        )
+
+        let firstOutcome = try await firstTask.value
+        guard case .handled(let firstData, let firstInvalidatedProvider) = firstOutcome else {
+            Issue.record("expected handled fallback outcome, got \(firstOutcome)")
+            return
+        }
+        #expect(firstInvalidatedProvider)
+        #expect(try toolContentText(in: firstData) == "{\"answer\":\"asset\"}")
+        #expect(await upstream.stopCount() == 0)
+
+        let secondOutcome = try await providerManager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 148, query: "UIKit"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let secondData, let secondInvalidatedProvider) = secondOutcome else {
+            Issue.record("expected cached asset fallback outcome, got \(secondOutcome)")
+            return
+        }
+        #expect(secondInvalidatedProvider == false)
+        #expect(try toolContentText(in: secondData) == "{\"answer\":\"asset\"}")
+        #expect(await upstream.sentCount() == 1)
+        #expect(await upstream.stopCount() == 0)
+        #expect(await localProvider.requestedCallPIDs() == [
+            target.processID,
+            target.processID,
+        ])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI", "UIKit"])
+    }
+
+    @Test func runtimeDocumentationTransportKeepsBorrowedRouteAfterInitialAssetFallbackTimeout()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = documentationProviderTarget(processID: 748, xcodeVersion: "26.6")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 148,
+                text: "{\"answer\":\"asset\"}"
+            ),
+            timeoutOnceAfterSuccessfulCallCount: 0
+        )
+        let providerManager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: RuntimeDocumentationProviderTransport(runtimeBox: runtimeBox),
+            providerSelectionTimeout: .seconds(1),
+            localSearchProvider: localProvider
+        )
+        let route = DocumentationProviderRoute(
+            id: "upstream-0-pid-\(target.processID)",
+            target: target,
+            upstreamIndex: 0
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [route],
+            documentationProviderManager: providerManager,
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let timeoutTask = Task {
+            try await providerManager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 149, query: "SwiftUI"),
+                requestTimeoutOverride: .seconds(1)
+            )
+        }
+        let firstRuntimeRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let firstRuntimeRequestID = try extractUpstreamID(from: firstRuntimeRequest)
+        await yieldMessage(
+            try makeDocumentationSearchToolErrorResponse(
+                id: firstRuntimeRequestID,
+                text: "Tool 'DocumentationSearch' is not enabled."
+            ),
+            to: upstream
+        )
+        let timeoutOutcome = try await timeoutTask.value
+        guard case .failed(let error, let timeoutInvalidatedProvider) = timeoutOutcome else {
+            Issue.record("expected failed timeout outcome, got \(timeoutOutcome)")
+            return
+        }
+        #expect(error is TimeoutError)
+        #expect(timeoutInvalidatedProvider == false)
+        #expect(await upstream.stopCount() == 0)
+
+        let retryTask = Task {
+            try await providerManager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 150, query: "UIKit"),
+                requestTimeoutOverride: .seconds(1)
+            )
+        }
+        let secondRuntimeRequest = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
+        let secondRuntimeRequestID = try extractUpstreamID(from: secondRuntimeRequest)
+        await yieldMessage(
+            try makeDocumentationSearchToolErrorResponse(
+                id: secondRuntimeRequestID,
+                text: "Tool 'DocumentationSearch' is not enabled."
+            ),
+            to: upstream
+        )
+        let retryOutcome = try await retryTask.value
+        guard case .handled(let retryData, let retryInvalidatedProvider) = retryOutcome else {
+            Issue.record("expected retry fallback outcome, got \(retryOutcome)")
+            return
+        }
+        #expect(retryInvalidatedProvider)
+        #expect(try toolContentText(in: retryData) == "{\"answer\":\"asset\"}")
+        #expect(await upstream.sentCount() == 2)
+        #expect(await upstream.stopCount() == 0)
+        #expect(await localProvider.requestedCallPIDs() == [
+            target.processID,
+            target.processID,
+        ])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI", "UIKit"])
+    }
+
+    @Test func runtimeDocumentationTransportUsesInstalledAssetFallbackWhenBorrowedRouteRepairDoesNotRestoreDescriptor()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = documentationProviderTarget(processID: 749, xcodeVersion: "26.6")
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "26.5",
+                    osVersion: "26.2",
+                    documentationRelease: 900339,
+                    changedDefault: true
+                )
+            )
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 151,
+                text: "{\"answer\":\"asset\"}"
+            )
+        )
+        let providerManager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            transport: RuntimeDocumentationProviderTransport(runtimeBox: runtimeBox),
+            providerSelectionTimeout: .seconds(1),
+            serviceRepairer: repairer,
+            localSearchProvider: localProvider
+        )
+        let route = DocumentationProviderRoute(
+            id: "upstream-0-pid-\(target.processID)",
+            target: target,
+            upstreamIndex: 0
+        )
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            documentationProviderRoutes: [route],
+            documentationProviderManager: providerManager,
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let prewarmTask = Task {
+            await providerManager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        }
+        let firstToolsRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: firstToolsRequest) == "tools/list")
+        await yieldMessage(
+            try makeDocumentationToolsListResponse(
+                id: try extractUpstreamID(from: firstToolsRequest),
+                tools: []
+            ),
+            to: upstream
+        )
+        let secondToolsRequest = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
+        #expect(methodName(from: secondToolsRequest) == "tools/list")
+        await yieldMessage(
+            try makeDocumentationToolsListResponse(
+                id: try extractUpstreamID(from: secondToolsRequest),
+                tools: []
+            ),
+            to: upstream
+        )
+
+        let update = await prewarmTask.value
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-asset-fallback")
+        #expect(await repairer.repairedPIDs() == [target.processID])
+        #expect(await upstream.sentCount() == 2)
+        #expect(await upstream.stopCount() == 0)
+
+        let searchOutcome = try await providerManager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 151, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let responseData, let invalidatedProvider) = searchOutcome else {
+            Issue.record("expected cached asset fallback search, got \(searchOutcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
+        #expect(await upstream.sentCount() == 2)
+        #expect(await upstream.stopCount() == 0)
+        #expect(await localProvider.requestedCallPIDs() == [target.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI"])
+    }
+
     @Test func runtimeDocumentationTransportTimesOutQueuedPinnedRouteBeforeDispatch()
         async throws
     {
@@ -1533,6 +1808,7 @@ extension RuntimeCoordinatorTests {
         #expect(documentationDescriptorDescription(in: result) == "docs-asset-fallback")
         #expect(await repairer.repairedPIDs() == [target.processID])
         #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.stoppedPIDs() == [target.processID, target.processID])
         #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
 
         let outcome = try await manager.callDocumentationSearch(
@@ -1668,6 +1944,7 @@ extension RuntimeCoordinatorTests {
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"reopened\"}")
         #expect(await repairer.repairedPIDs() == [target.processID])
         #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.stoppedPIDs() == [target.processID])
         #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
         #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
     }
@@ -1914,6 +2191,7 @@ extension RuntimeCoordinatorTests {
         }
         #expect(error is TimeoutError)
         #expect(timeoutInvalidatedProvider == false)
+        #expect(await factory.stoppedPIDs().isEmpty)
 
         let retryOutcome = try await manager.callDocumentationSearch(
             requestData: makeDocumentationSearchRequest(id: 132, query: "UIKit"),
@@ -1929,6 +2207,7 @@ extension RuntimeCoordinatorTests {
         #expect(await localProvider.requestedQueries() == ["SwiftUI", "UIKit"])
         #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI", "UIKit"])
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 2)
+        #expect(await factory.stoppedPIDs() == [target.processID])
     }
 
     @Test func documentationProviderTriesNextCandidateAfterInitialAssetFallbackTimeout()
@@ -1985,6 +2264,7 @@ extension RuntimeCoordinatorTests {
         #expect(await localProvider.requestedQueries() == ["SwiftUI"])
         #expect(await factory.documentationQueries(for: newer.processID) == ["SwiftUI"])
         #expect(await factory.documentationQueries(for: older.processID) == ["SwiftUI"])
+        #expect(await factory.stoppedPIDs() == [newer.processID])
     }
 
     @Test func documentationProviderFallsBackToInstalledAssetWhenXcodeConfigIsBroken()
@@ -2358,6 +2638,9 @@ extension RuntimeCoordinatorTests {
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"direct\"}")
         #expect(await factory.startedPIDs() == [target.processID])
         #expect(await factory.documentationQueries(for: target.processID) == ["UIView"])
+
+        discoveryTask.cancel()
+        _ = await discoveryTask.value
     }
 
     @Test func documentationProviderManagerUsesNumericIDsForMCPBridgeStartup() async throws {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -695,6 +695,7 @@ actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
     private var plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]]
     private var startAttemptProcessIDs: [pid_t] = []
     private var startedProcessIDs: [pid_t] = []
+    private var stoppedProcessIDs: [pid_t] = []
     private var initializeParamsByPID: [pid_t: [JSONValue]] = [:]
     private var requestCountsByPID: [pid_t: [String: Int]] = [:]
     private var documentationQueriesByPID: [pid_t: [String]] = [:]
@@ -732,8 +733,16 @@ actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
         startedProcessIDs
     }
 
+    func stoppedPIDs() -> [pid_t] {
+        stoppedProcessIDs
+    }
+
     func startAttempts() -> [pid_t] {
         startAttemptProcessIDs
+    }
+
+    func recordStop(for processID: pid_t) {
+        stoppedProcessIDs.append(processID)
     }
 
     func recordInitializeParams(_ params: JSONValue, for processID: pid_t) {
@@ -898,6 +907,7 @@ actor ScriptedDocumentationSession: UpstreamSession {
 
     func stop() async {
         continuation.finish()
+        await recorder.recordStop(for: processID)
     }
 
     private func toolsList() -> [[String: Any]] {
@@ -1699,14 +1709,21 @@ func makeToolListResponse(id: Int64) throws -> Data {
 }
 
 func makeDocumentationToolsListResponse(id: Int64, version: String) throws -> Data {
+    try makeDocumentationToolsListResponse(
+        id: id,
+        tools: [
+            documentationDescriptor(version: version).foundationObject,
+        ]
+    )
+}
+
+func makeDocumentationToolsListResponse(id: Int64, tools: [Any]) throws -> Data {
     try JSONSerialization.data(
         withJSONObject: [
             "jsonrpc": "2.0",
             "id": id,
             "result": [
-                "tools": [
-                    documentationDescriptor(version: version).foundationObject,
-                ],
+                "tools": tools,
             ],
         ],
         options: []
@@ -1726,6 +1743,25 @@ func makeDocumentationSearchResponse(id: Int64, text: String) throws -> Data {
                     ],
                 ],
                 "isError": false,
+            ],
+        ],
+        options: []
+    )
+}
+
+func makeDocumentationSearchToolErrorResponse(id: Int64, text: String) throws -> Data {
+    try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": text,
+                    ],
+                ],
+                "isError": true,
             ],
         ],
         options: []

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -4212,6 +4212,56 @@ struct RuntimeCoordinatorTests {
         )
     }
 
+    @Test func sessionManagerShutdownStopsUpstreamsBeforeDrainingRuntimeTasks() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = BlockingInitializedNotificationUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1]
+        )
+
+        var didShutdown = false
+        defer {
+            if !didShutdown {
+                manager.shutdownAndWait()
+            }
+        }
+
+        let init0 = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
+        let init0ID = try extractUpstreamID(from: init0)
+        await upstream1.blockNextInitializedNotification()
+        await upstream0.yield(.message(try makeInitializeResponse(id: init0ID)))
+
+        let init1 = try await sentValue(from: upstream1, at: 0, timeout: .seconds(2))
+        let init1ID = try extractUpstreamID(from: init1)
+        await upstream1.yield(.message(try makeInitializeResponse(id: init1ID)))
+        try await upstream1.waitForBlockedInitializedNotification()
+
+        let shutdownFinished = TestSignal()
+        let shutdownTask = Task {
+            await manager.shutdown()
+            shutdownFinished.signal()
+        }
+
+        do {
+            try await shutdownFinished.wait(
+                timeout: .milliseconds(500),
+                description: "shutdown should stop upstreams before draining blocked runtime tasks"
+            )
+        } catch {
+            await upstream1.releaseBlockedInitializedNotification(.backpressure)
+            await shutdownTask.value
+            throw error
+        }
+        await shutdownTask.value
+        didShutdown = true
+    }
+
     @Test func upstreamHealthManagerIgnoresStaleInitializeCompletionAfterStateReset() {
         let manager = UpstreamHealthManager(upstreamCount: 1)
         manager.markInitInFlight(upstreamIndex: 0, upstreamID: 10)

--- a/Tests/XcodeMCPTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPTestSupport/AsyncTestSupport.swift
@@ -225,7 +225,6 @@ package func makeTestURLSession(
     configuration.waitsForConnectivity = waitsForConnectivity
     configuration.timeoutIntervalForRequest = timeout
     configuration.timeoutIntervalForResource = timeout
-    configuration.httpShouldUsePipelining = false
     configuration.httpMaximumConnectionsPerHost = 20
     return URLSession(configuration: configuration)
 }


### PR DESCRIPTION
## Purpose
Fix the documentation-provider release hang by making provider/task ownership explicit and by closing shutdown races that could leave pending work unresolved.

## Changes
- Raise package requirements to Swift 6.3 and macOS 15.4.
- Move macOS CI/release jobs to the supported `macos-26` arm64 runner, select the installed latest Xcode, remove the unsupported `setup-swift` step, and keep job timeouts at 10 minutes.
- Supervise runtime and documentation-provider background tasks so shutdown cancels and drains owned work.
- Model documentation provider backends explicitly as live Xcode routes vs installed documentation assets, including route ownership for runtime-borrowed routes.
- Close/release only owned documentation provider routes when falling back to installed assets, discarding skipped prepared providers without keeping stale routes alive.
- Make task scheduling refusal observable so documentation calls and server-request forwarding complete immediately during shutdown races.
- Add regression coverage for provider fallback ownership, runtime-borrowed routes, cancellation/drain behavior, and supervisor scheduling refusal.

## Testing
- `swift test --filter AsyncTaskSupervisorTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter sessionManagerPreservesServerRequestRouteUntilForwardingSendAccepted -Xswiftc -strict-concurrency=minimal`
- `swift test --filter documentationProviderConnectionCancelsEventReaderOnDeinit -Xswiftc -strict-concurrency=minimal`
- `swift test --filter DocumentationProviderTests -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`
- GitHub Actions CI: `Package Tests (macOS)` passed on `macos-26-arm64` with Xcode 26.5 / Swift 6.3.2
- `codex-review` against `main`: clean, 0 findings
