### PR TITLE
Make proxy CI timeout tests deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,12 @@ jobs:
           xcodebuild -version
           swift --version
 
-      - name: Run package checks
-        run: scripts/check.sh
+      - name: Run package tests
+        run: swift test -Xswiftc -strict-concurrency=minimal
+
+      - name: Run process tests
+        run: |
+          XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
+            --no-parallel \
+            --filter ProxyProcessTests \
+            -Xswiftc -strict-concurrency=minimal

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -371,6 +371,7 @@ extension RuntimeCoordinator {
                     upstreamIndex: upstreamIndex,
                     expectedUpstreamID: expectedUpstreamID
                 ) else {
+                    self.testHooks.initializedNotificationStaleIgnored?(upstreamIndex)
                     return
                 }
                 self.recordTraffic(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -38,6 +38,19 @@ package final class WeakRuntimeCoordinatorBox: @unchecked Sendable {
     package init() {}
 }
 
+package struct RuntimeCoordinatorTestHooks: Sendable {
+    package var documentationPrewarmWaitStarted: (@Sendable () -> Void)?
+    package var initializedNotificationStaleIgnored: (@Sendable (_ upstreamIndex: Int) -> Void)?
+
+    package init(
+        documentationPrewarmWaitStarted: (@Sendable () -> Void)? = nil,
+        initializedNotificationStaleIgnored: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil
+    ) {
+        self.documentationPrewarmWaitStarted = documentationPrewarmWaitStarted
+        self.initializedNotificationStaleIgnored = initializedNotificationStaleIgnored
+    }
+}
+
 private final class DocumentationToolListUpdateWaiter: @unchecked Sendable {
     struct Result: Sendable {
         let update: DocumentationProvider.ToolListUpdate
@@ -51,7 +64,8 @@ private final class DocumentationToolListUpdateWaiter: @unchecked Sendable {
 
     func wait(
         for task: Task<DocumentationProvider.ToolListUpdate, Never>,
-        timeout: TimeAmount
+        timeout: TimeAmount,
+        clock: ClockClient
     ) async -> Result {
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
@@ -61,7 +75,7 @@ private final class DocumentationToolListUpdateWaiter: @unchecked Sendable {
                     self.resume(Result(update: update, timedOut: false))
                 })
                 addTask(Task {
-                    try? await Task.sleep(nanoseconds: UInt64(timeout.nanoseconds))
+                    await clock.sleep(.nanoseconds(timeout.nanoseconds))
                     guard Task.isCancelled == false else {
                         return
                     }
@@ -320,6 +334,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     package let documentationProviderManager: (any DocumentationProviderManaging)?
     package let documentationProviderRoutes: [DocumentationProviderRoute]
     package let prewarmDocumentationProviderOnStartup: Bool
+    package let testHooks: RuntimeCoordinatorTestHooks
     private let lifecycleStartedBox = NIOLockedValueBox(false)
 
     /// Composition-root entry point: the Xcode-specific readiness gate and
@@ -425,6 +440,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         documentationProviderRoutes: [DocumentationProviderRoute] = [],
         documentationProviderManager: (any DocumentationProviderManaging)? = nil,
         prewarmDocumentationProviderOnStartup: Bool = false,
+        testHooks: RuntimeCoordinatorTestHooks = RuntimeCoordinatorTestHooks(),
         startImmediately: Bool = true,
         runtimeBox providedRuntimeBox: WeakRuntimeCoordinatorBox? = nil
     ) {
@@ -463,6 +479,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.documentationProviderManager = documentationProviderManager
         self.documentationProviderRoutes = documentationProviderRoutes
         self.prewarmDocumentationProviderOnStartup = prewarmDocumentationProviderOnStartup
+        self.testHooks = testHooks
         let resolvedReadinessGate =
             upstreamReadinessGate
             ?? .alwaysReady(uptimeNanoseconds: runtimeClock.uptimeNanoseconds)
@@ -1164,9 +1181,11 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 timedOut: false
             )
         }
+        testHooks.documentationPrewarmWaitStarted?()
         let result = await DocumentationToolListUpdateWaiter().wait(
             for: task,
-            timeout: requestTimeout
+            timeout: requestTimeout,
+            clock: clock
         )
         if result.timedOut {
             logger.debug(
@@ -1216,8 +1235,9 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 group.addTask {
                     await manager.toolListUpdate(requestTimeout: requestTimeout)
                 }
+                let clock = self.clock
                 group.addTask {
-                    try await Task.sleep(nanoseconds: UInt64(requestTimeout.nanoseconds))
+                    await clock.sleep(.nanoseconds(requestTimeout.nanoseconds))
                     throw TimeoutError()
                 }
                 guard let update = try await group.next() else {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -1027,6 +1027,7 @@ extension RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let prewarmStarted = TestSignal()
+        let prewarmWaitStarted = TestSignal()
         let prewarmGate = AsyncGate()
         let documentationProvider = StubDocumentationProviderManager(
             toolListUpdate: .available(documentationDescriptor(version: "27.0")),
@@ -1038,6 +1039,11 @@ extension RuntimeCoordinatorTests {
             eventLoop: eventLoop,
             upstreams: [upstream],
             documentationProviderManager: documentationProvider,
+            testHooks: RuntimeCoordinatorTestHooks(
+                documentationPrewarmWaitStarted: {
+                    prewarmWaitStarted.signal()
+                }
+            ),
             startImmediately: false
         )
         defer { manager.shutdownAndWait() }
@@ -1062,11 +1068,10 @@ extension RuntimeCoordinatorTests {
                 requestTimeoutOverride: .seconds(1)
             )
         }
-        #expect(
-            await staysTrue(for: .milliseconds(100)) {
-                await documentationProvider.toolListUpdateCount() == 0
-            }
+        try await prewarmWaitStarted.wait(
+            description: "tools/list should join the startup documentation prewarm"
         )
+        #expect(await documentationProvider.toolListUpdateCount() == 0)
 
         await prewarmGate.signal()
         let result = try await resultTask.value
@@ -1074,7 +1079,7 @@ extension RuntimeCoordinatorTests {
         #expect(toolNames(in: result) == ["XcodeRead", "DocumentationSearch"])
         #expect(documentationDescriptorDescription(in: result) == "docs-27.0")
         #expect(await documentationProvider.prewarmCount() == 1)
-        #expect(await documentationProvider.toolListUpdateCount() == 1)
+        #expect(await documentationProvider.toolListUpdateCount() == 0)
     }
 
     @Test func sharedToolsListRefreshesAfterConsumingStartupDocumentationPrewarm() async throws {
@@ -1125,7 +1130,7 @@ extension RuntimeCoordinatorTests {
 
         #expect(toolNames(in: refreshedResult) == ["XcodeRead"])
         #expect(DocumentationProvider.ToolCatalog.descriptor(in: refreshedResult) == nil)
-        #expect(await documentationProvider.toolListUpdateCount() == 2)
+        #expect(await documentationProvider.toolListUpdateCount() == 1)
     }
 
     @Test func sharedToolsListDoesNotWaitPastTimeoutForStartupDocumentationPrewarm()
@@ -1134,8 +1139,10 @@ extension RuntimeCoordinatorTests {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
+        let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
         let upstream = TestUpstreamClient()
         let prewarmStarted = TestSignal()
+        let prewarmWaitStarted = TestSignal()
         let prewarmGate = AsyncGate()
         let documentationProvider = StubDocumentationProviderManager(
             toolListUpdate: .available(documentationDescriptor(version: "27.0")),
@@ -1146,7 +1153,13 @@ extension RuntimeCoordinatorTests {
             config: makeConfig(requestTimeout: 5),
             eventLoop: eventLoop,
             upstreams: [upstream],
+            clock: clock,
             documentationProviderManager: documentationProvider,
+            testHooks: RuntimeCoordinatorTestHooks(
+                documentationPrewarmWaitStarted: {
+                    prewarmWaitStarted.signal()
+                }
+            ),
             startImmediately: false
         )
         defer { manager.shutdownAndWait() }
@@ -1165,22 +1178,32 @@ extension RuntimeCoordinatorTests {
         manager.prewarmDocumentationProvider()
         try await prewarmStarted.wait(description: "documentation prewarm started")
 
-        let result = try await waitWithTimeout(
-            "tools/list should not wait for the blocked documentation prewarm",
-            timeout: .milliseconds(500)
-        ) {
+        let resultTask = Task {
             try await manager.sharedToolsList(
                 sessionID: "session-docs-tools-prewarm-timeout",
                 requestTimeoutOverride: .milliseconds(20)
             )
         }
+        try await prewarmWaitStarted.wait(
+            description: "tools/list should join the startup documentation prewarm"
+        )
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: timeoutClock,
+            uptimeClock: uptimeClock,
+            by: .milliseconds(20)
+        )
+        let result = try await waitWithTimeout(
+            "tools/list should not wait for the blocked documentation prewarm"
+        ) {
+            try await resultTask.value
+        }
 
         #expect(toolNames(in: result) == ["XcodeRead"])
         #expect(await documentationProvider.toolListUpdateCount() == 0)
         await prewarmGate.signal()
-        #expect(await waitUntil(timeout: .seconds(2)) {
+        try await spinUntil("waiting for documentation prewarm to finish") {
             await documentationProvider.prewarmCount() == 1
-        })
+        }
     }
 
     @Test func sharedToolsListRemovesStaleDocumentationSearchWhenProviderUnavailable() async throws {
@@ -1224,15 +1247,20 @@ extension RuntimeCoordinatorTests {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
+        let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
         let upstream = TestUpstreamClient()
+        let toolListStarted = TestSignal()
+        let toolListGate = AsyncGate()
         let documentationProvider = StubDocumentationProviderManager(
             toolListUpdate: .available(documentationDescriptor(version: "27.0")),
-            toolListDelayNanoseconds: 50_000_000
+            toolListStarted: toolListStarted,
+            toolListBlocker: toolListGate
         )
         let manager = RuntimeCoordinator(
             config: makeConfig(requestTimeout: 5),
             eventLoop: eventLoop,
             upstreams: [upstream],
+            clock: clock,
             documentationProviderManager: documentationProvider
         )
         defer { manager.shutdownAndWait() }
@@ -1250,14 +1278,28 @@ extension RuntimeCoordinatorTests {
             sourceUpstream: 0
         )
 
-        let result = try await manager.sharedToolsList(
-            sessionID: "session-docs-timeout",
-            requestTimeoutOverride: .milliseconds(1)
+        let resultTask = Task {
+            try await manager.sharedToolsList(
+                sessionID: "session-docs-timeout",
+                requestTimeoutOverride: .milliseconds(1)
+            )
+        }
+        try await toolListStarted.wait(description: "documentation tools/list update started")
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: timeoutClock,
+            uptimeClock: uptimeClock,
+            by: .milliseconds(1)
         )
+        let result = try await waitWithTimeout(
+            "documentation tools/list should honor the caller timeout"
+        ) {
+            try await resultTask.value
+        }
 
         #expect(toolNames(in: result) == ["XcodeRead"])
         #expect(manager.cachedToolsListResult() != nil)
         #expect(await documentationProvider.recordedInvalidateReasons().isEmpty)
+        await toolListGate.signal()
     }
 
     @Test func documentationSearchKeepsCanonicalToolsCatalogWhenProviderRecoversAfterInvalidation() async throws {
@@ -1439,7 +1481,7 @@ extension RuntimeCoordinatorTests {
 
         let observedTimeout = try #require(await documentationProvider.lastPrewarmTimeout())
         #expect(observedTimeout.nanoseconds == TimeAmount.seconds(30).nanoseconds)
-        #expect(await documentationProvider.toolListUpdateCount() == 1)
+        #expect(await documentationProvider.toolListUpdateCount() == 0)
     }
 
     @Test func shutdownCancelsPendingDocumentationProviderStartupPrewarm() async throws {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -1632,6 +1632,29 @@ func makeDeterministicClockClient(
     )
 }
 
+func makeRuntimeCoordinatorDeterministicClocks()
+    -> (clock: ClockClient, timeoutClock: TestClock, uptimeClock: TestUptimeClock)
+{
+    let timeoutClock = TestClock()
+    let uptimeClock = TestUptimeClock()
+    return (
+        makeDeterministicClockClient(timeoutClock: timeoutClock, uptimeClock: uptimeClock),
+        timeoutClock,
+        uptimeClock
+    )
+}
+
+func advanceRuntimeCoordinatorTimeout(
+    timeoutClock: TestClock,
+    uptimeClock: TestUptimeClock,
+    by duration: Duration,
+    suspendedSleepers: Int = 1
+) async {
+    await timeoutClock.sleep(untilSuspendedBy: suspendedSleepers)
+    uptimeClock.advance(by: duration)
+    timeoutClock.advance(by: duration)
+}
+
 func spinUntilSentCount(
     _ upstream: TestUpstreamClient,
     count: Int,

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -1005,35 +1005,31 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
     private var prewarmTimeouts: [TimeAmount?] = []
     private var toolListTimeouts: [TimeAmount?] = []
     private var callTimeouts: [TimeAmount?] = []
-    private let prewarmDelayNanoseconds: UInt64?
-    private let toolListDelayNanoseconds: UInt64?
     private let prewarmStarted: TestSignal?
     private let prewarmBlocker: AsyncGate?
+    private let toolListStarted: TestSignal?
+    private let toolListBlocker: AsyncGate?
 
     init(
         toolListUpdate: DocumentationProvider.ToolListUpdate,
         callOutcomes: [DocumentationProvider.CallOutcome] = [],
-        prewarmDelayNanoseconds: UInt64? = nil,
-        toolListDelayNanoseconds: UInt64? = nil,
         prewarmStarted: TestSignal? = nil,
-        prewarmBlocker: AsyncGate? = nil
+        prewarmBlocker: AsyncGate? = nil,
+        toolListStarted: TestSignal? = nil,
+        toolListBlocker: AsyncGate? = nil
     ) {
         self.update = toolListUpdate
         self.callOutcomes = callOutcomes
-        self.prewarmDelayNanoseconds = prewarmDelayNanoseconds
-        self.toolListDelayNanoseconds = toolListDelayNanoseconds
         self.prewarmStarted = prewarmStarted
         self.prewarmBlocker = prewarmBlocker
+        self.toolListStarted = toolListStarted
+        self.toolListBlocker = toolListBlocker
     }
 
     func startBackgroundDiscovery(requestTimeout: TimeAmount?) async
         -> DocumentationProvider.ToolListUpdate
     {
         prewarmStarted?.signal()
-        if let prewarmDelayNanoseconds {
-            try? await Task.sleep(nanoseconds: prewarmDelayNanoseconds)
-            guard !Task.isCancelled else { return .unavailable }
-        }
         if let prewarmBlocker {
             do {
                 try await prewarmBlocker.wait()
@@ -1043,13 +1039,18 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
             guard !Task.isCancelled else { return .unavailable }
         }
         prewarmTimeouts.append(requestTimeout)
-        return await toolListUpdate(requestTimeout: requestTimeout)
+        return update
     }
 
     func toolListUpdate(requestTimeout: TimeAmount?) async -> DocumentationProvider.ToolListUpdate {
         toolListTimeouts.append(requestTimeout)
-        if let toolListDelayNanoseconds {
-            try? await Task.sleep(nanoseconds: toolListDelayNanoseconds)
+        toolListStarted?.signal()
+        if let toolListBlocker {
+            do {
+                try await toolListBlocker.wait()
+            } catch {
+                return .unavailable
+            }
             guard !Task.isCancelled else { return .unavailable }
         }
         return update

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -876,12 +876,8 @@ struct RuntimeCoordinatorTests {
         #expect(received.first == notification)
 
         manager.markNotificationClientConnected(sessionID: sessionID)
-        await upstream.yield(.message(notification))
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                session.router.drainBufferedNotifications().isEmpty
-            }
-        )
+        manager.routeUpstreamMessage(notification, upstreamIndex: 0)
+        #expect(session.router.drainBufferedNotifications().isEmpty)
     }
 
     @Test func sessionManagerRoutesUnmappedNotificationsDuringInitializeHandshake() async throws {
@@ -974,12 +970,8 @@ struct RuntimeCoordinatorTests {
         #expect(received.first == notification)
 
         manager.markNotificationClientConnected(sessionID: sessionID)
-        await upstream.yield(.message(notification))
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                session.router.drainBufferedNotifications().isEmpty
-            }
-        )
+        manager.routeUpstreamMessage(notification, upstreamIndex: 0)
+        #expect(session.router.drainBufferedNotifications().isEmpty)
     }
 
     @Test func sessionManagerDoesNotRecreateRemovedSessionWhenInitializeCompletes() async throws {
@@ -1046,14 +1038,9 @@ struct RuntimeCoordinatorTests {
             ],
             options: []
         )
-        await upstream.yield(.message(notification))
-
         _ = try await future.get()
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                replacement.router.drainBufferedNotifications().isEmpty
-            }
-        )
+        manager.routeUpstreamMessage(notification, upstreamIndex: 0)
+        #expect(replacement.router.drainBufferedNotifications().isEmpty)
     }
 
     @Test func sessionManagerRoutesUnmappedNotificationsToCachedInitializeSessionsUntilClientConnects()
@@ -1129,13 +1116,9 @@ struct RuntimeCoordinatorTests {
         #expect(Set(received) == Set([notification0, notification1]))
 
         manager.markNotificationClientConnected(sessionID: sessionID)
-        await upstream0.yield(.message(notification0))
-        await upstream1.yield(.message(notification1))
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                session.router.drainBufferedNotifications().isEmpty
-            }
-        )
+        manager.routeUpstreamMessage(notification0, upstreamIndex: 0)
+        manager.routeUpstreamMessage(notification1, upstreamIndex: 1)
+        #expect(session.router.drainBufferedNotifications().isEmpty)
     }
 
     @Test func sessionManagerTimeoutResetsInitState() async throws {
@@ -1302,7 +1285,13 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let clocks = makeRuntimeCoordinatorDeterministicClocks()
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            clock: clocks.clock
+        )
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
@@ -1322,31 +1311,39 @@ struct RuntimeCoordinatorTests {
         let firstTask = Task {
             try await manager.sharedToolsList(
                 sessionID: sessionID,
-                requestTimeoutOverride: .milliseconds(50)
+                requestTimeoutOverride: .seconds(5)
             )
         }
         try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
         let firstRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: firstRequest) == "tools/list")
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: clocks.timeoutClock,
+            uptimeClock: clocks.uptimeClock,
+            by: .seconds(5)
+        )
         await #expect(throws: TimeoutError.self) {
             _ = try await firstTask.value
         }
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-            }
-        )
+        try await spinUntil("waiting for first timed-out tools/list to release its lease") {
+            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
+        }
 
         let secondTask = Task {
             try await manager.sharedToolsList(
                 sessionID: sessionID,
-                requestTimeoutOverride: .milliseconds(50)
+                requestTimeoutOverride: .seconds(5)
             )
         }
         try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
         let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/list")
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: clocks.timeoutClock,
+            uptimeClock: clocks.uptimeClock,
+            by: .seconds(5)
+        )
         await #expect(throws: TimeoutError.self) {
             _ = try await secondTask.value
         }
@@ -1386,11 +1383,10 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                await upstream.sentCount() == 3
-            }
-        )
+        try await spinUntil("waiting for foreground tools/list waiter to reuse prewarm load") {
+            manager.debugSnapshot().controlPlane?.waiterCounts.toolsCatalog == 1
+        }
+        #expect(await upstream.sentCount() == 3)
 
         let prewarmUpstreamID = try extractUpstreamID(from: prewarmRequest)
         let response: [String: Any] = [
@@ -1520,11 +1516,9 @@ struct RuntimeCoordinatorTests {
         await #expect(throws: CancellationError.self) {
             _ = try await task.value
         }
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-            }
-        )
+        try await spinUntil("waiting for cancelled tools/list to release its lease") {
+            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
+        }
     }
 
     @Test func sessionManagerSharedToolsListStopsPromotingAfterLoadBecomesShared() async throws {
@@ -1583,11 +1577,10 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        #expect(
-            await staysTrue(for: .milliseconds(250)) {
-                await upstream.sentCount() == 4
-            }
-        )
+        try await spinUntil("waiting for third tools/list waiter to share the in-flight load") {
+            manager.debugSnapshot().controlPlane?.waiterCounts.toolsCatalog == 3
+        }
+        #expect(await upstream.sentCount() == 4)
 
         firstTask.cancel()
         secondTask.cancel()
@@ -1661,11 +1654,9 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError for promoted waiter but received \(error)")
         }
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-            }
-        )
+        try await spinUntil("waiting for promoted tools/list cancellation to release its lease") {
+            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
+        }
     }
 
     @Test func sessionManagerSharedToolsListTimeoutCancelsStalePrewarmLoad() async throws {
@@ -1675,7 +1666,13 @@ struct RuntimeCoordinatorTests {
         let upstream = TestUpstreamClient()
         var config = makeConfig(requestTimeout: 5)
         config.prewarmToolsList = true
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let clocks = makeRuntimeCoordinatorDeterministicClocks()
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            clock: clocks.clock
+        )
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
@@ -1698,28 +1695,40 @@ struct RuntimeCoordinatorTests {
         let firstTask = Task {
             try await manager.sharedToolsList(
                 sessionID: sessionID,
-                requestTimeoutOverride: .milliseconds(50)
+                requestTimeoutOverride: .seconds(5)
             )
         }
 
+        try await spinUntil("waiting for foreground tools/list waiter to attach to prewarm load") {
+            manager.debugSnapshot().controlPlane?.waiterCounts.toolsCatalog == 1
+        }
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: clocks.timeoutClock,
+            uptimeClock: clocks.uptimeClock,
+            by: .seconds(5),
+            suspendedSleepers: 2
+        )
         await #expect(throws: TimeoutError.self) {
             _ = try await firstTask.value
         }
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-            }
-        )
+        try await spinUntil("waiting for timed-out prewarm tools/list to release its lease") {
+            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
+        }
 
         let secondTask = Task {
             try await manager.sharedToolsList(
                 sessionID: sessionID,
-                requestTimeoutOverride: .milliseconds(50)
+                requestTimeoutOverride: .seconds(5)
             )
         }
         try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
         let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/list")
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: clocks.timeoutClock,
+            uptimeClock: clocks.uptimeClock,
+            by: .seconds(5)
+        )
         await #expect(throws: TimeoutError.self) {
             _ = try await secondTask.value
         }
@@ -1785,7 +1794,13 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let clocks = makeRuntimeCoordinatorDeterministicClocks()
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            clock: clocks.clock
+        )
         defer { manager.shutdownAndWait() }
 
         let initFuture = manager.registerInitialize(
@@ -1802,31 +1817,39 @@ struct RuntimeCoordinatorTests {
         let firstTask = Task {
             try await manager.liveXcodeListWindowsResult(
                 route: .anyHealthy,
-                requestTimeoutOverride: .milliseconds(50)
+                requestTimeoutOverride: .seconds(5)
             )
         }
         try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
         let firstRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: firstRequest) == "tools/call")
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: clocks.timeoutClock,
+            uptimeClock: clocks.uptimeClock,
+            by: .seconds(5)
+        )
         await #expect(throws: TimeoutError.self) {
             _ = try await firstTask.value
         }
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-            }
-        )
+        try await spinUntil("waiting for first timed-out list-windows call to release its lease") {
+            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
+        }
 
         let secondTask = Task {
             try await manager.liveXcodeListWindowsResult(
                 route: .anyHealthy,
-                requestTimeoutOverride: .milliseconds(50)
+                requestTimeoutOverride: .seconds(5)
             )
         }
         try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
         let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/call")
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: clocks.timeoutClock,
+            uptimeClock: clocks.uptimeClock,
+            by: .seconds(5)
+        )
         await #expect(throws: TimeoutError.self) {
             _ = try await secondTask.value
         }
@@ -1874,11 +1897,9 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError but received \(error)")
         }
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-            }
-        )
+        try await spinUntil("waiting for cancelled list-windows call to release its lease") {
+            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
+        }
     }
 
     @Test func sessionManagerPromotedLiveXcodeListWindowsCancellationRemovesMigratedWaiter()
@@ -1945,11 +1966,9 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError for promoted XcodeListWindows waiter but received \(error)")
         }
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-            }
-        )
+        try await spinUntil("waiting for promoted list-windows cancellation to release its lease") {
+            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
+        }
     }
 
     @Test func controlPlaneRPCHandleCancelBeforeQueueStartCapturesQueuedState() {
@@ -3027,12 +3046,10 @@ struct RuntimeCoordinatorTests {
             options: []
         )
 
-        await yieldMessage(notification, to: upstream0)
+        manager.routeUpstreamMessage(notification, upstreamIndex: 0)
         #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                sessionA.router.drainBufferedNotifications().isEmpty
-                    && sessionB.router.drainBufferedNotifications().isEmpty
-            }
+            sessionA.router.drainBufferedNotifications().isEmpty
+                && sessionB.router.drainBufferedNotifications().isEmpty
         )
     }
 
@@ -3079,13 +3096,8 @@ struct RuntimeCoordinatorTests {
             options: []
         )
 
-        await yieldMessage(notification, to: upstream0)
-
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                session.router.drainBufferedNotifications().isEmpty
-            }
-        )
+        manager.routeUpstreamMessage(notification, upstreamIndex: 0)
+        #expect(session.router.drainBufferedNotifications().isEmpty)
     }
 
     @Test func sessionManagerDropsUnmappedResponsesEvenWhenPinnedTargetsExist() async throws {
@@ -3104,13 +3116,8 @@ struct RuntimeCoordinatorTests {
         _ = session.router.drainBufferedNotifications()
 
         // Unmapped JSON-RPC response (no `method`) must never be routed to sessions.
-        await yieldMessage(try makeToolListResponse(id: 9_999_999), to: upstream)
-
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                session.router.drainBufferedNotifications().isEmpty
-            }
-        )
+        manager.routeUpstreamMessage(try makeToolListResponse(id: 9_999_999), upstreamIndex: 0)
+        #expect(session.router.drainBufferedNotifications().isEmpty)
     }
 
     @Test func sessionManagerDebugSnapshotCapturesTrafficAndStderr() async throws {
@@ -3975,16 +3982,8 @@ struct RuntimeCoordinatorTests {
 
         try await waitForSentCount(upstream0, count: 3, timeoutSeconds: 2)
         #expect(manager.cachedToolsListResult() == nil)
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                manager.testStateSnapshot().upstreams[1].isInitialized == false
-            }
-        )
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                await upstream1.sentCount() == 0
-            }
-        )
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized == false)
+        #expect(await upstream1.sentCount() == 0)
     }
 
     @Test func sessionManagerPrimaryWarmReinitOverloadKeepsHealthySecondaryAvailable() async throws {
@@ -4026,11 +4025,7 @@ struct RuntimeCoordinatorTests {
         let overloadedInitialized = try await sentValue(from: upstream0, at: 3, timeout: .seconds(2))
         #expect(methodName(from: overloadedInitialized) == "notifications/initialized")
         #expect(manager.cachedToolsListResult() != nil)
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                manager.testStateSnapshot().upstreams[1].isInitialized
-            }
-        )
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized)
         let chosen = manager.chooseUpstreamIndex()
         #expect(chosen == 1)
     }
@@ -4159,11 +4154,7 @@ struct RuntimeCoordinatorTests {
         let eagerRetry = try await sentValue(from: upstream0, at: 4, timeout: .seconds(2))
         #expect(methodName(from: eagerRetry) == "initialize")
         #expect(manager.cachedToolsListResult() == nil)
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                manager.testStateSnapshot().upstreams[1].isInitialized == false
-            }
-        )
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized == false)
     }
 
     @Test func sessionManagerIgnoresStaleSecondaryInitializedNotificationAfterReset()

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -4165,11 +4165,19 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = BlockingInitializedNotificationUpstreamClient()
+        let staleInitializedIgnored = TestSignal()
         let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
             config: config,
             eventLoop: eventLoop,
-            upstreams: [upstream0, upstream1]
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                initializedNotificationStaleIgnored: { upstreamIndex in
+                    if upstreamIndex == 1 {
+                        staleInitializedIgnored.signal()
+                    }
+                }
+            )
         )
         defer { manager.shutdownAndWait() }
 
@@ -4190,19 +4198,16 @@ struct RuntimeCoordinatorTests {
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
 
         await upstream1.releaseBlockedInitializedNotification(.accepted)
-
-        #expect(
-            await staysTrue(for: .milliseconds(200)) {
-                let snapshot = manager.testStateSnapshot().upstreams[1]
-                if snapshot.isInitialized {
-                    return false
-                }
-                guard case .quarantined = snapshot.healthState else {
-                    return false
-                }
-                return true
-            }
+        try await staleInitializedIgnored.wait(
+            description: "stale initialized notification completion should be ignored"
         )
+
+        let snapshot = manager.testStateSnapshot().upstreams[1]
+        #expect(snapshot.isInitialized == false)
+        guard case .quarantined = snapshot.healthState else {
+            Issue.record("expected upstream to remain quarantined")
+            return
+        }
     }
 
     @Test func sessionManagerShutdownStopsUpstreamsBeforeDrainingRuntimeTasks() async throws {

--- a/Tests/XcodeMCPTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPTestSupport/AsyncTestSupport.swift
@@ -167,26 +167,6 @@ package func nextValue<Value: Sendable>(
     }
 }
 
-package func staysTrue(
-    for duration: Duration,
-    _ condition: @escaping @Sendable () async -> Bool
-) async -> Bool {
-    let clock = ContinuousClock()
-    let deadline = clock.now.advanced(by: duration)
-
-    while clock.now < deadline {
-        if Task.isCancelled {
-            return false
-        }
-        guard await condition() else {
-            return false
-        }
-        await Task.yield()
-    }
-
-    return await condition()
-}
-
 package func shutdown(_ group: EventLoopGroup) async {
     await withCheckedContinuation { continuation in
         group.shutdownGracefully { _ in

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -5,10 +5,38 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$repo_root"
 
-swift test \
+begin_group() {
+  local name="$1"
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    printf '::group::%s\n' "$name"
+  else
+    printf '==> %s\n' "$name"
+  fi
+}
+
+end_group() {
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    printf '::endgroup::\n'
+  fi
+}
+
+run_group() {
+  local name="$1"
+  shift
+
+  begin_group "$name"
+  set +e
+  "$@"
+  local status=$?
+  set -e
+  end_group
+  return "$status"
+}
+
+run_group "swift test" swift test \
   -Xswiftc -strict-concurrency=minimal
 
-XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
+run_group "ProxyProcessTests" env XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
   --no-parallel \
   --filter ProxyProcessTests \
   -Xswiftc -strict-concurrency=minimal


### PR DESCRIPTION
Purpose
Make CI-sensitive proxy tests deterministic after the PR/main check difference exposed timing-dependent behavior in RuntimeCoordinator and documentation-provider paths.

Changes
- Split package checks so regular package tests and process tests run as separate CI/script steps.
- Drive RuntimeCoordinator timeout tests with injected fake clocks instead of wall-clock delays.
- Replace wall-clock negative waits with explicit test hooks, signals, and gates for documentation prewarm and stale initialized-notification handling.
- Route documentation overlay timeouts through the injected clock and remove the unused `staysTrue` helper.

Testing
- `swift test --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`