### PR TITLE
Make async tests deterministic

### DIFF
--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -800,7 +800,8 @@ private final class ProcessOutputTimeoutWaiter: @unchecked Sendable {
 
     func wait(
         for task: Task<ProcessOutput, Error>,
-        timeout: TimeAmount
+        timeout: TimeAmount,
+        clock: ClockClient
     ) async throws -> ProcessOutput {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
@@ -814,7 +815,7 @@ private final class ProcessOutputTimeoutWaiter: @unchecked Sendable {
                     }
                 })
                 addTask(Task {
-                    try? await Task.sleep(nanoseconds: UInt64(timeout.nanoseconds))
+                    await clock.sleep(.nanoseconds(timeout.nanoseconds))
                     guard Task.isCancelled == false else {
                         return
                     }
@@ -888,7 +889,8 @@ private final class DocumentationSearchServiceRepairWaiter: @unchecked Sendable 
 
     func wait(
         for task: Task<DocumentationSearchServiceRepairResult, Never>,
-        timeout: TimeAmount
+        timeout: TimeAmount,
+        clock: ClockClient
     ) async -> Result {
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
@@ -898,7 +900,7 @@ private final class DocumentationSearchServiceRepairWaiter: @unchecked Sendable 
                     self.resume(Result(repairResult: result, timedOut: false))
                 })
                 addTask(Task {
-                    try? await Task.sleep(nanoseconds: UInt64(timeout.nanoseconds))
+                    await clock.sleep(.nanoseconds(timeout.nanoseconds))
                     guard Task.isCancelled == false else {
                         return
                     }
@@ -981,16 +983,19 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
     private let assetRoot: URL
     private let currentOSVersion: @Sendable () -> String
     private let processRunner: any ProcessRunning
+    private let clock: ClockClient
 
     package init(
         assetRoot: URL = DocumentationSearchAssetLocator.defaultAssetRoot,
         currentOSVersion: @escaping @Sendable () -> String =
             DocumentationSearchAssetLocator.currentOperatingSystemVersionString,
-        processRunner: any ProcessRunning = ProcessRunner()
+        processRunner: any ProcessRunning = ProcessRunner(),
+        clock: ClockClient = .liveValue
     ) {
         self.assetRoot = assetRoot
         self.currentOSVersion = currentOSVersion
         self.processRunner = processRunner
+        self.clock = clock
     }
 
     package func descriptor(for target: DocumentationProviderTarget) async -> JSONValue? {
@@ -1063,7 +1068,8 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
                     for: Task {
                         try await processRunner.run(request)
                     },
-                    timeout: timeout
+                    timeout: timeout,
+                    clock: clock
                 )
             } else {
                 output = try await processRunner.run(request)
@@ -1552,6 +1558,24 @@ package actor SessionBackedDocumentationProviderTransport: DocumentationProvider
     }
 }
 
+package struct DocumentationProviderManagerTestHooks: Sendable {
+    package var providerPreparationStarted: @Sendable (pid_t) -> Void
+    package var providerPreparationReused: @Sendable (pid_t) -> Void
+    package var providerPreparationWaitTimedOut: @Sendable (pid_t) -> Void
+
+    package init(
+        providerPreparationStarted: @escaping @Sendable (pid_t) -> Void = { _ in },
+        providerPreparationReused: @escaping @Sendable (pid_t) -> Void = { _ in },
+        providerPreparationWaitTimedOut: @escaping @Sendable (pid_t) -> Void = { _ in }
+    ) {
+        self.providerPreparationStarted = providerPreparationStarted
+        self.providerPreparationReused = providerPreparationReused
+        self.providerPreparationWaitTimedOut = providerPreparationWaitTimedOut
+    }
+
+    package static let noop = Self()
+}
+
 package actor DocumentationProviderManager: DocumentationProviderManaging {
     private enum CandidateBackend: Sendable {
         case xcode(route: DocumentationProviderRoute, descriptor: JSONValue?)
@@ -1676,6 +1700,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
     private let serviceRepairer: any DocumentationSearchServiceRepairing
     private let localSearchProvider: any DocumentationSearchProviding
     private let clock: ClockClient
+    private let testHooks: DocumentationProviderManagerTestHooks
     private let logger: Logger
     private let descriptorRefreshRetryDelayNanoseconds: Int64 = 250_000_000
     private var activeProvider: ActiveProvider?
@@ -1694,6 +1719,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         serviceRepairer: any DocumentationSearchServiceRepairing = NoopDocumentationSearchServiceRepairer(),
         localSearchProvider: any DocumentationSearchProviding = UnavailableDocumentationSearchProvider(),
         clock: ClockClient = .liveValue,
+        testHooks: DocumentationProviderManagerTestHooks = .noop,
         logger: Logger = ProxyLogging.make("documentation.provider")
     ) {
         self.discovery = discovery
@@ -1704,6 +1730,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         self.serviceRepairer = serviceRepairer
         self.localSearchProvider = localSearchProvider
         self.clock = clock
+        self.testHooks = testHooks
         self.logger = logger
     }
 
@@ -1716,6 +1743,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         serviceRepairer: any DocumentationSearchServiceRepairing = NoopDocumentationSearchServiceRepairer(),
         localSearchProvider: any DocumentationSearchProviding = UnavailableDocumentationSearchProvider(),
         clock: ClockClient = .liveValue,
+        testHooks: DocumentationProviderManagerTestHooks = .noop,
         logger: Logger = ProxyLogging.make("documentation.provider")
     ) {
         self.init(
@@ -1730,6 +1758,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             serviceRepairer: serviceRepairer,
             localSearchProvider: localSearchProvider,
             clock: clock,
+            testHooks: testHooks,
             logger: logger
         )
     }
@@ -2352,6 +2381,7 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
         let preparation: ProviderPreparation
         if let existing = providerPreparations[target.processID] {
             preparation = existing
+            testHooks.providerPreparationReused(target.processID)
         } else {
             let timeout = providerSelectionTimeout
             preparation = ProviderPreparation(
@@ -2363,11 +2393,13 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 }
             )
             providerPreparations[target.processID] = preparation
+            testHooks.providerPreparationStarted(target.processID)
         }
         let profile: CandidateProfile
         do {
             profile = try await waitForPreparation(preparation, requestTimeout: requestTimeout)
         } catch is PreparationWaitTimedOut {
+            testHooks.providerPreparationWaitTimedOut(target.processID)
             throw TimeoutError()
         } catch is CancellationError {
             throw CancellationError()
@@ -2768,7 +2800,8 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
             for: Task {
                 await serviceRepairer.repairDocumentationSearch(for: target)
             },
-            timeout: timeout
+            timeout: timeout,
+            clock: clock
         )
         return result.repairResult
     }

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1559,16 +1559,13 @@ package actor SessionBackedDocumentationProviderTransport: DocumentationProvider
 }
 
 package struct DocumentationProviderManagerTestHooks: Sendable {
-    package var providerPreparationStarted: @Sendable (pid_t) -> Void
     package var providerPreparationReused: @Sendable (pid_t) -> Void
     package var providerPreparationWaitTimedOut: @Sendable (pid_t) -> Void
 
     package init(
-        providerPreparationStarted: @escaping @Sendable (pid_t) -> Void = { _ in },
         providerPreparationReused: @escaping @Sendable (pid_t) -> Void = { _ in },
         providerPreparationWaitTimedOut: @escaping @Sendable (pid_t) -> Void = { _ in }
     ) {
-        self.providerPreparationStarted = providerPreparationStarted
         self.providerPreparationReused = providerPreparationReused
         self.providerPreparationWaitTimedOut = providerPreparationWaitTimedOut
     }
@@ -2393,7 +2390,6 @@ package actor DocumentationProviderManager: DocumentationProviderManaging {
                 }
             )
             providerPreparations[target.processID] = preparation
-            testHooks.providerPreparationStarted(target.processID)
         }
         let profile: CandidateProfile
         do {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
@@ -146,6 +146,7 @@ extension RuntimeCoordinator {
 
     func markToolsListRefreshSucceeded(upstreamIndex: Int, nowUptimeNs: UInt64) {
         upstreamHealthManager.markToolsListRefreshSucceeded(upstreamIndex: upstreamIndex, nowUptimeNs: nowUptimeNs)
+        testHooks.toolsListRefreshCompleted?(upstreamIndex, true)
     }
 
     func markToolsListRefreshFailed(upstreamIndex: Int, nowUptimeNs: UInt64, reason: String)
@@ -167,6 +168,7 @@ extension RuntimeCoordinator {
                 "uptime_ns": .string("\(nowUptimeNs)"),
             ]
         )
+        testHooks.toolsListRefreshCompleted?(upstreamIndex, false)
     }
 
     func isValidToolsListResult(_ value: JSONValue) -> Bool {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -41,13 +41,19 @@ package final class WeakRuntimeCoordinatorBox: @unchecked Sendable {
 package struct RuntimeCoordinatorTestHooks: Sendable {
     package var documentationPrewarmWaitStarted: (@Sendable () -> Void)?
     package var initializedNotificationStaleIgnored: (@Sendable (_ upstreamIndex: Int) -> Void)?
+    package var upstreamEventHandled: (@Sendable (_ upstreamIndex: Int) -> Void)?
+    package var toolsListRefreshCompleted: (@Sendable (_ upstreamIndex: Int, _ succeeded: Bool) -> Void)?
 
     package init(
         documentationPrewarmWaitStarted: (@Sendable () -> Void)? = nil,
-        initializedNotificationStaleIgnored: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil
+        initializedNotificationStaleIgnored: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil,
+        upstreamEventHandled: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil,
+        toolsListRefreshCompleted: (@Sendable (_ upstreamIndex: Int, _ succeeded: Bool) -> Void)? = nil
     ) {
         self.documentationPrewarmWaitStarted = documentationPrewarmWaitStarted
         self.initializedNotificationStaleIgnored = initializedNotificationStaleIgnored
+        self.upstreamEventHandled = upstreamEventHandled
+        self.toolsListRefreshCompleted = toolsListRefreshCompleted
     }
 }
 
@@ -577,6 +583,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                     case .exit(let status):
                         self.handleUpstreamExit(status, upstreamIndex: upstreamIndex)
                     }
+                    self.testHooks.upstreamEventHandled?(upstreamIndex)
                 }
             }
         }

--- a/Sources/ProxySessionControlPlane/ControlPlaneSupport.swift
+++ b/Sources/ProxySessionControlPlane/ControlPlaneSupport.swift
@@ -55,18 +55,92 @@ extension ControlPlane {
 
 extension ControlPlane {
     package final class DebugMirror: Sendable {
-        private let state = NIOLockedValueBox<ControlPlane.DebugSnapshot?>(nil)
+        private struct Waiter {
+            let id: UUID
+            let predicate: @Sendable (ControlPlane.DebugSnapshot) -> Bool
+            let continuation: CheckedContinuation<ControlPlane.DebugSnapshot, Error>
+        }
+
+        private struct State {
+            var snapshot: ControlPlane.DebugSnapshot?
+            var waiters: [Waiter] = []
+        }
+
+        private let state = NIOLockedValueBox(State())
 
         package init() {}
 
         package func snapshot() -> ControlPlane.DebugSnapshot? {
-            state.withLockedValue { $0 }
+            state.withLockedValue { $0.snapshot }
         }
 
         package func overwrite(_ snapshot: ControlPlane.DebugSnapshot?) {
-            state.withLockedValue { state in
-                state = snapshot
+            let resumptions = state.withLockedValue { state -> [Waiter] in
+                state.snapshot = snapshot
+                guard let snapshot else {
+                    return []
+                }
+                var ready: [Waiter] = []
+                var remaining: [Waiter] = []
+                for waiter in state.waiters {
+                    if waiter.predicate(snapshot) {
+                        ready.append(waiter)
+                    } else {
+                        remaining.append(waiter)
+                    }
+                }
+                state.waiters = remaining
+                return ready
             }
+
+            if let snapshot {
+                for waiter in resumptions {
+                    waiter.continuation.resume(returning: snapshot)
+                }
+            }
+        }
+
+        package func waitForSnapshot(
+            matching predicate: @escaping @Sendable (ControlPlane.DebugSnapshot) -> Bool
+        ) async throws -> ControlPlane.DebugSnapshot {
+            if let snapshot = self.snapshot(), predicate(snapshot) {
+                return snapshot
+            }
+
+            let waiterID = UUID()
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    let immediate = state.withLockedValue {
+                        state -> ControlPlane.DebugSnapshot? in
+                        if let snapshot = state.snapshot, predicate(snapshot) {
+                            return snapshot
+                        }
+                        state.waiters.append(
+                            Waiter(
+                                id: waiterID,
+                                predicate: predicate,
+                                continuation: continuation
+                            )
+                        )
+                        return nil
+                    }
+                    if let immediate {
+                        continuation.resume(returning: immediate)
+                    }
+                }
+            } onCancel: {
+                cancelWaiter(id: waiterID)
+            }
+        }
+
+        private func cancelWaiter(id: UUID) {
+            let waiter = state.withLockedValue { state -> Waiter? in
+                guard let index = state.waiters.firstIndex(where: { $0.id == id }) else {
+                    return nil
+                }
+                return state.waiters.remove(at: index)
+            }
+            waiter?.continuation.resume(throwing: CancellationError())
         }
     }
 }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesCoordinator.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesCoordinator.swift
@@ -18,14 +18,11 @@ extension RefreshCodeIssues {
     }
 
     package struct TestHooks: Sendable {
-        package var permitAcquired: @Sendable (_ key: String, _ permit: Permit) -> Void
         package var waiterQueued: @Sendable (_ key: String, _ permit: Permit) -> Void
 
         package init(
-            permitAcquired: @escaping @Sendable (_ key: String, _ permit: Permit) -> Void = { _, _ in },
             waiterQueued: @escaping @Sendable (_ key: String, _ permit: Permit) -> Void = { _, _ in }
         ) {
-            self.permitAcquired = permitAcquired
             self.waiterQueued = waiterQueued
         }
 
@@ -148,7 +145,6 @@ extension RefreshCodeIssues {
                 pendingForKey: 0,
                 pendingTotal: pendingWaiterCount
             )
-            testHooks.permitAcquired(key, permit)
             return permit
         }
 
@@ -298,7 +294,6 @@ extension RefreshCodeIssues {
             } else {
                 waitersByKey[key] = waiters
             }
-            testHooks.permitAcquired(key, next.permit)
             next.continuation.resume(returning: next.permit)
             return
         }

--- a/Sources/ProxyXcodeFeatures/RefreshCodeIssuesCoordinator.swift
+++ b/Sources/ProxyXcodeFeatures/RefreshCodeIssuesCoordinator.swift
@@ -17,6 +17,21 @@ extension RefreshCodeIssues {
         package let pendingTotal: Int
     }
 
+    package struct TestHooks: Sendable {
+        package var permitAcquired: @Sendable (_ key: String, _ permit: Permit) -> Void
+        package var waiterQueued: @Sendable (_ key: String, _ permit: Permit) -> Void
+
+        package init(
+            permitAcquired: @escaping @Sendable (_ key: String, _ permit: Permit) -> Void = { _, _ in },
+            waiterQueued: @escaping @Sendable (_ key: String, _ permit: Permit) -> Void = { _, _ in }
+        ) {
+            self.permitAcquired = permitAcquired
+            self.waiterQueued = waiterQueued
+        }
+
+        package static let noop = Self()
+    }
+
     package enum AcquireError: Error {
         case queueWaitTimedOut
     }
@@ -42,15 +57,18 @@ extension RefreshCodeIssues {
     private var pendingWaiterCount = 0
     private var activeExecutionsByKey: [String: ActiveExecution] = [:]
     private var waitersByKey: [String: [Waiter]] = [:]
+    private let testHooks: TestHooks
 
     package static func makeDefault() -> RefreshCodeIssues.Coordinator {
         RefreshCodeIssues.Coordinator()
     }
 
     package init(
-        waitClock: any Clock<Duration> & Sendable = ContinuousClock()
+        waitClock: any Clock<Duration> & Sendable = ContinuousClock(),
+        testHooks: TestHooks = .noop
     ) {
         self.waitClock = waitClock
+        self.testHooks = testHooks
     }
 
     package nonisolated func scheduleReset() {
@@ -125,11 +143,13 @@ extension RefreshCodeIssues {
     private func acquire(key: String, requestTimeout: TimeAmount?) async throws -> Permit {
         if busyKeys.contains(key) == false {
             busyKeys.insert(key)
-            return Permit(
+            let permit = Permit(
                 queuePosition: 0,
                 pendingForKey: 0,
                 pendingTotal: pendingWaiterCount
             )
+            testHooks.permitAcquired(key, permit)
+            return permit
         }
 
         let waiterCountForKey = waitersByKey[key]?.count ?? 0
@@ -164,6 +184,7 @@ extension RefreshCodeIssues {
                         }
                         waitersByKey[key, default: []].append(waiter)
                         pendingWaiterCount += 1
+                        testHooks.waiterQueued(key, permit)
 
                         if Task.isCancelled {
                             failWaiter(
@@ -277,6 +298,7 @@ extension RefreshCodeIssues {
             } else {
                 waitersByKey[key] = waiters
             }
+            testHooks.permitAcquired(key, next.permit)
             next.continuation.resume(returning: next.permit)
             return
         }

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -1595,6 +1595,9 @@ private func waitUntil(
     interval: Duration = .milliseconds(20),
     condition: @escaping @Sendable () async -> Bool
 ) async -> Bool {
+    // These HTTP tests cross URLSession and NIO channel scheduling boundaries.
+    // Polling here is only a bounded eventual-I/O guard, not an intra-actor
+    // synchronization primitive.
     let intervalNanos = interval.components.seconds * 1_000_000_000
         + Int64(interval.components.attoseconds / 1_000_000_000)
     let deadline = ContinuousClock.now + timeout

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesCoordinatorTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesCoordinatorTests.swift
@@ -8,10 +8,10 @@ import XcodeMCPTestSupport
 struct RefreshCodeIssuesCoordinatorTests {
     @Test func refreshCoordinatorSerializesRequestsForSameKey() async throws {
         let clock = TestClock()
-        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let queuedKeys = LockedRecordedValues<String>()
         let coordinator = RefreshCodeIssues.Coordinator(
             waitClock: clock,
-            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+            testHooks: refreshCoordinatorHooks(recording: queuedKeys)
         )
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
@@ -36,9 +36,8 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        let queued = try await nextHookEvent(hookEvents, at: 1, "waiting for second waiter to queue")
-        #expect(queued.kind == .waiterQueued)
-        #expect(queued.key == "windowtab-same")
+        let queuedKey = try await nextQueuedKey(queuedKeys, at: 0, "waiting for second waiter to queue")
+        #expect(queuedKey == "windowtab-same")
         #expect(await acquisitions.snapshot() == ["first"])
         await releaseFirst.signal()
 
@@ -82,10 +81,10 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorAcceptsManyQueuedWaitersForSameKey() async throws {
         let clock = TestClock()
-        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let queuedKeys = LockedRecordedValues<String>()
         let coordinator = RefreshCodeIssues.Coordinator(
             waitClock: clock,
-            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+            testHooks: refreshCoordinatorHooks(recording: queuedKeys)
         )
         let releaseFirst = AsyncGate()
         let completionCount = RecordedValues<String>()
@@ -117,7 +116,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        _ = try await nextHookEvent(hookEvents, at: 100, "waiting for queued waiters")
+        _ = try await nextQueuedKey(queuedKeys, at: 99, "waiting for queued waiters")
         #expect(await completionCount.count() == 1)
 
         await releaseFirst.signal()
@@ -131,10 +130,10 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorTimeoutRemovesQueuedWaiterDeterministically() async throws {
         let clock = TestClock()
-        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let queuedKeys = LockedRecordedValues<String>()
         let coordinator = RefreshCodeIssues.Coordinator(
             waitClock: clock,
-            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+            testHooks: refreshCoordinatorHooks(recording: queuedKeys)
         )
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
@@ -167,7 +166,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for timed waiter to queue")
+        _ = try await nextQueuedKey(queuedKeys, at: 0, "waiting for timed waiter to queue")
         await clock.sleep(untilSuspendedBy: 1)
         clock.advance(by: .milliseconds(50))
         _ = try await nextRecorded(outcomes, at: 0, "waiting for timed-out waiter to finish")
@@ -191,10 +190,10 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorNilRequestTimeoutKeepsQueuedWaiterWaiting() async throws {
         let clock = TestClock()
-        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let queuedKeys = LockedRecordedValues<String>()
         let coordinator = RefreshCodeIssues.Coordinator(
             waitClock: clock,
-            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+            testHooks: refreshCoordinatorHooks(recording: queuedKeys)
         )
         let releaseFirst = AsyncGate()
         let firstAcquired = AsyncGate()
@@ -224,7 +223,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for unbounded waiter to queue")
+        _ = try await nextQueuedKey(queuedKeys, at: 0, "waiting for unbounded waiter to queue")
         clock.advance(by: .seconds(10))
         #expect(await outcomes.count() == 0)
 
@@ -236,10 +235,10 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorCancellationRemovesQueuedWaiterDeterministically() async throws {
         let clock = TestClock()
-        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let queuedKeys = LockedRecordedValues<String>()
         let coordinator = RefreshCodeIssues.Coordinator(
             waitClock: clock,
-            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+            testHooks: refreshCoordinatorHooks(recording: queuedKeys)
         )
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
@@ -271,7 +270,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for cancellable waiter to queue")
+        _ = try await nextQueuedKey(queuedKeys, at: 0, "waiting for cancellable waiter to queue")
         cancelledTask.cancel()
         _ = try await nextRecorded(outcomes, at: 0, "waiting for cancelled waiter to finish")
         #expect(await outcomes.snapshot() == ["cancelled"])
@@ -294,10 +293,10 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorResetCancelsQueuedWaiters() async throws {
         let clock = TestClock()
-        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let queuedKeys = LockedRecordedValues<String>()
         let coordinator = RefreshCodeIssues.Coordinator(
             waitClock: clock,
-            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+            testHooks: refreshCoordinatorHooks(recording: queuedKeys)
         )
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
@@ -328,7 +327,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for reset waiter to queue")
+        _ = try await nextQueuedKey(queuedKeys, at: 0, "waiting for reset waiter to queue")
         await coordinator.reset()
 
         _ = try await nextRecorded(outcomes, at: 0, "waiting for queued waiter to cancel")
@@ -383,9 +382,9 @@ struct RefreshCodeIssuesCoordinatorTests {
     @Test func refreshCoordinatorResetKeepsSameKeySerializedUntilCancelledExecutionExits()
         async throws
     {
-        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let queuedKeys = LockedRecordedValues<String>()
         let coordinator = RefreshCodeIssues.Coordinator(
-            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+            testHooks: refreshCoordinatorHooks(recording: queuedKeys)
         )
         let activeStarted = TestSignal()
         let activeCancellationObserved = TestSignal()
@@ -438,7 +437,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for second execution to queue")
+        _ = try await nextQueuedKey(queuedKeys, at: 0, "waiting for second execution to queue")
         #expect(await acquisitions.snapshot() == ["first", "first-cancelling"])
 
         await allowActiveExit.signal()
@@ -456,44 +455,12 @@ struct RefreshCodeIssuesCoordinatorTests {
     }
 }
 
-private struct RefreshCoordinatorHookEvent: Sendable {
-    enum Kind: Sendable {
-        case permitAcquired
-        case waiterQueued
-    }
-
-    let kind: Kind
-    let key: String
-    let queuePosition: Int
-    let pendingForKey: Int
-    let pendingTotal: Int
-}
-
 private func refreshCoordinatorHooks(
-    recording events: LockedRecordedValues<RefreshCoordinatorHookEvent>
+    recording queuedKeys: LockedRecordedValues<String>
 ) -> RefreshCodeIssues.Coordinator.TestHooks {
     RefreshCodeIssues.Coordinator.TestHooks(
-        permitAcquired: { key, permit in
-            events.append(
-                RefreshCoordinatorHookEvent(
-                    kind: .permitAcquired,
-                    key: key,
-                    queuePosition: permit.queuePosition,
-                    pendingForKey: permit.pendingForKey,
-                    pendingTotal: permit.pendingTotal
-                )
-            )
-        },
-        waiterQueued: { key, permit in
-            events.append(
-                RefreshCoordinatorHookEvent(
-                    kind: .waiterQueued,
-                    key: key,
-                    queuePosition: permit.queuePosition,
-                    pendingForKey: permit.pendingForKey,
-                    pendingTotal: permit.pendingTotal
-                )
-            )
+        waiterQueued: { key, _ in
+            queuedKeys.append(key)
         }
     )
 }
@@ -508,12 +475,12 @@ private func nextRecorded<Value: Sendable>(
     }
 }
 
-private func nextHookEvent(
-    _ events: LockedRecordedValues<RefreshCoordinatorHookEvent>,
+private func nextQueuedKey(
+    _ queuedKeys: LockedRecordedValues<String>,
     at index: Int,
     _ description: String
-) async throws -> RefreshCoordinatorHookEvent {
+) async throws -> String {
     try await waitWithTimeout(description) {
-        try await events.nextValue(at: index)
+        try await queuedKeys.nextValue(at: index)
     }
 }

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesCoordinatorTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesCoordinatorTests.swift
@@ -8,7 +8,11 @@ import XcodeMCPTestSupport
 struct RefreshCodeIssuesCoordinatorTests {
     @Test func refreshCoordinatorSerializesRequestsForSameKey() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
+        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let coordinator = RefreshCodeIssues.Coordinator(
+            waitClock: clock,
+            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+        )
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
 
@@ -21,9 +25,7 @@ struct RefreshCodeIssuesCoordinatorTests {
                 try await releaseFirst.wait()
             }
         }
-        try await spinUntil("waiting for first acquisition") {
-            await acquisitions.count() == 1
-        }
+        _ = try await nextRecorded(acquisitions, at: 0, "waiting for first acquisition")
 
         let secondTask = Task<Void, Never> {
             _ = try? await coordinator.withPermit(
@@ -34,7 +36,9 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        await clock.sleep(untilSuspendedBy: 1)
+        let queued = try await nextHookEvent(hookEvents, at: 1, "waiting for second waiter to queue")
+        #expect(queued.kind == .waiterQueued)
+        #expect(queued.key == "windowtab-same")
         #expect(await acquisitions.snapshot() == ["first"])
         await releaseFirst.signal()
 
@@ -57,9 +61,7 @@ struct RefreshCodeIssuesCoordinatorTests {
                 try await releaseFirst.wait()
             }
         }
-        try await spinUntil("waiting for first acquisition") {
-            await acquisitions.count() == 1
-        }
+        _ = try await nextRecorded(acquisitions, at: 0, "waiting for first acquisition")
 
         let secondTask = Task<Void, Never> {
             _ = try? await coordinator.withPermit(
@@ -70,9 +72,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        try await spinUntil("waiting for second acquisition") {
-            await acquisitions.count() == 2
-        }
+        _ = try await nextRecorded(acquisitions, at: 1, "waiting for second acquisition")
 
         await releaseFirst.signal()
         _ = await firstTask.value
@@ -82,7 +82,11 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorAcceptsManyQueuedWaitersForSameKey() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
+        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let coordinator = RefreshCodeIssues.Coordinator(
+            waitClock: clock,
+            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+        )
         let releaseFirst = AsyncGate()
         let completionCount = RecordedValues<String>()
 
@@ -95,9 +99,7 @@ struct RefreshCodeIssuesCoordinatorTests {
                 try await releaseFirst.wait()
             }
         }
-        try await spinUntil("waiting for first acquisition") {
-            await completionCount.count() == 1
-        }
+        _ = try await nextRecorded(completionCount, at: 0, "waiting for first acquisition")
 
         let queuedTasks = (0..<100).map { index in
             Task<String, Never> {
@@ -115,8 +117,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        await Task.yield()
-        await Task.yield()
+        _ = try await nextHookEvent(hookEvents, at: 100, "waiting for queued waiters")
         #expect(await completionCount.count() == 1)
 
         await releaseFirst.signal()
@@ -125,14 +126,16 @@ struct RefreshCodeIssuesCoordinatorTests {
             #expect(await task.value == "success")
         }
 
-        try await spinUntil("waiting for queued completions") {
-            await completionCount.count() == 101
-        }
+        #expect(await completionCount.count() == 101)
     }
 
     @Test func refreshCoordinatorTimeoutRemovesQueuedWaiterDeterministically() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
+        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let coordinator = RefreshCodeIssues.Coordinator(
+            waitClock: clock,
+            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+        )
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
         let outcomes = RecordedValues<String>()
@@ -146,9 +149,7 @@ struct RefreshCodeIssuesCoordinatorTests {
                 try await releaseFirst.wait()
             }
         }
-        try await spinUntil("waiting for first acquisition") {
-            await acquisitions.count() == 1
-        }
+        _ = try await nextRecorded(acquisitions, at: 0, "waiting for first acquisition")
 
         let secondTask = Task<Void, Never> {
             do {
@@ -166,11 +167,10 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
+        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for timed waiter to queue")
         await clock.sleep(untilSuspendedBy: 1)
         clock.advance(by: .milliseconds(50))
-        try await spinUntil("waiting for timed-out waiter to finish") {
-            await outcomes.count() == 1
-        }
+        _ = try await nextRecorded(outcomes, at: 0, "waiting for timed-out waiter to finish")
         #expect(await outcomes.snapshot() == ["timed-out"])
 
         let thirdTask = Task<Void, Never> {
@@ -191,7 +191,11 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorNilRequestTimeoutKeepsQueuedWaiterWaiting() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
+        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let coordinator = RefreshCodeIssues.Coordinator(
+            waitClock: clock,
+            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+        )
         let releaseFirst = AsyncGate()
         let firstAcquired = AsyncGate()
         let outcomes = RecordedValues<String>()
@@ -220,10 +224,8 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        await Task.yield()
-        await Task.yield()
+        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for unbounded waiter to queue")
         clock.advance(by: .seconds(10))
-        await Task.yield()
         #expect(await outcomes.count() == 0)
 
         await releaseFirst.signal()
@@ -234,7 +236,11 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorCancellationRemovesQueuedWaiterDeterministically() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
+        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let coordinator = RefreshCodeIssues.Coordinator(
+            waitClock: clock,
+            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+        )
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
         let outcomes = RecordedValues<String>()
@@ -248,9 +254,7 @@ struct RefreshCodeIssuesCoordinatorTests {
                 try await releaseFirst.wait()
             }
         }
-        try await spinUntil("waiting for first acquisition") {
-            await acquisitions.count() == 1
-        }
+        _ = try await nextRecorded(acquisitions, at: 0, "waiting for first acquisition")
 
         let cancelledTask = Task<Void, Never> {
             do {
@@ -267,11 +271,9 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        await clock.sleep(untilSuspendedBy: 1)
+        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for cancellable waiter to queue")
         cancelledTask.cancel()
-        try await spinUntil("waiting for cancelled waiter to finish") {
-            await outcomes.count() == 1
-        }
+        _ = try await nextRecorded(outcomes, at: 0, "waiting for cancelled waiter to finish")
         #expect(await outcomes.snapshot() == ["cancelled"])
 
         let thirdTask = Task<Void, Never> {
@@ -292,7 +294,11 @@ struct RefreshCodeIssuesCoordinatorTests {
 
     @Test func refreshCoordinatorResetCancelsQueuedWaiters() async throws {
         let clock = TestClock()
-        let coordinator = RefreshCodeIssues.Coordinator(waitClock: clock)
+        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let coordinator = RefreshCodeIssues.Coordinator(
+            waitClock: clock,
+            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+        )
         let releaseFirst = AsyncGate()
         let acquisitions = RecordedValues<String>()
         let outcomes = RecordedValues<String>()
@@ -306,9 +312,7 @@ struct RefreshCodeIssuesCoordinatorTests {
                 try await releaseFirst.wait()
             }
         }
-        try await spinUntil("waiting for first acquisition") {
-            await acquisitions.count() == 1
-        }
+        _ = try await nextRecorded(acquisitions, at: 0, "waiting for first acquisition")
 
         let queuedTask = Task<Void, Never> {
             do {
@@ -324,12 +328,10 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        await clock.sleep(untilSuspendedBy: 1)
+        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for reset waiter to queue")
         await coordinator.reset()
 
-        try await spinUntil("waiting for queued waiter to cancel") {
-            await outcomes.count() == 1
-        }
+        _ = try await nextRecorded(outcomes, at: 0, "waiting for queued waiter to cancel")
         #expect(await outcomes.snapshot() == ["cancelled"])
 
         let thirdTask = Task<Void, Never> {
@@ -373,9 +375,7 @@ struct RefreshCodeIssuesCoordinatorTests {
         try await started.wait(description: "waiting for active execution to start")
         await coordinator.reset()
 
-        try await spinUntil("waiting for active execution to cancel") {
-            await outcomes.count() == 1
-        }
+        _ = try await nextRecorded(outcomes, at: 0, "waiting for active execution to cancel")
         #expect(await outcomes.snapshot() == ["cancelled"])
         _ = await activeTask.value
     }
@@ -383,7 +383,10 @@ struct RefreshCodeIssuesCoordinatorTests {
     @Test func refreshCoordinatorResetKeepsSameKeySerializedUntilCancelledExecutionExits()
         async throws
     {
-        let coordinator = RefreshCodeIssues.Coordinator()
+        let hookEvents = LockedRecordedValues<RefreshCoordinatorHookEvent>()
+        let coordinator = RefreshCodeIssues.Coordinator(
+            testHooks: refreshCoordinatorHooks(recording: hookEvents)
+        )
         let activeStarted = TestSignal()
         let activeCancellationObserved = TestSignal()
         let releaseActive = AsyncGate()
@@ -435,8 +438,7 @@ struct RefreshCodeIssuesCoordinatorTests {
             }
         }
 
-        await Task.yield()
-        await Task.yield()
+        _ = try await nextHookEvent(hookEvents, at: 1, "waiting for second execution to queue")
         #expect(await acquisitions.snapshot() == ["first", "first-cancelling"])
 
         await allowActiveExit.signal()
@@ -451,5 +453,67 @@ struct RefreshCodeIssuesCoordinatorTests {
             "first-cancelled",
             "second",
         ])
+    }
+}
+
+private struct RefreshCoordinatorHookEvent: Sendable {
+    enum Kind: Sendable {
+        case permitAcquired
+        case waiterQueued
+    }
+
+    let kind: Kind
+    let key: String
+    let queuePosition: Int
+    let pendingForKey: Int
+    let pendingTotal: Int
+}
+
+private func refreshCoordinatorHooks(
+    recording events: LockedRecordedValues<RefreshCoordinatorHookEvent>
+) -> RefreshCodeIssues.Coordinator.TestHooks {
+    RefreshCodeIssues.Coordinator.TestHooks(
+        permitAcquired: { key, permit in
+            events.append(
+                RefreshCoordinatorHookEvent(
+                    kind: .permitAcquired,
+                    key: key,
+                    queuePosition: permit.queuePosition,
+                    pendingForKey: permit.pendingForKey,
+                    pendingTotal: permit.pendingTotal
+                )
+            )
+        },
+        waiterQueued: { key, permit in
+            events.append(
+                RefreshCoordinatorHookEvent(
+                    kind: .waiterQueued,
+                    key: key,
+                    queuePosition: permit.queuePosition,
+                    pendingForKey: permit.pendingForKey,
+                    pendingTotal: permit.pendingTotal
+                )
+            )
+        }
+    )
+}
+
+private func nextRecorded<Value: Sendable>(
+    _ values: RecordedValues<Value>,
+    at index: Int,
+    _ description: String
+) async throws -> Value {
+    try await waitWithTimeout(description) {
+        try await values.nextValue(at: index)
+    }
+}
+
+private func nextHookEvent(
+    _ events: LockedRecordedValues<RefreshCoordinatorHookEvent>,
+    at index: Int,
+    _ description: String
+) async throws -> RefreshCoordinatorHookEvent {
+    try await waitWithTimeout(description) {
+        try await events.nextValue(at: index)
     }
 }

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -2411,11 +2411,9 @@ extension HTTPHandlerTests {
         }
 
         do {
-            let deadline = ContinuousClock.now + .seconds(2)
-            while sessionManager.sentUpstreamCount() != 2, ContinuousClock.now < deadline {
-                try await Task.sleep(for: .milliseconds(10))
-            }
-            #expect(sessionManager.sentUpstreamCount() == 2)
+            #expect(await waitUntil(timeout: .seconds(2)) {
+                sessionManager.sentUpstreamCount() == 2
+            })
             #expect(sessionManager.requeuedLeaseCount() == 1)
 
             let inFlightLease = try #require(sessionManager.leaseDebugSnapshots().first)

--- a/Tests/ProxyProcessTests/ProcessRunnerTests.swift
+++ b/Tests/ProxyProcessTests/ProcessRunnerTests.swift
@@ -123,6 +123,9 @@ struct ProcessRunnerTests {
             )
         }
 
+        // This is an OS process integration test. Give /bin/sleep time to exec
+        // before asserting cancellation behavior; unit-level timeout tests use
+        // manual clocks instead.
         try await Task.sleep(nanoseconds: 100_000_000)
         task.cancel()
 

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -714,11 +714,17 @@ extension RuntimeCoordinatorTests {
             return activePromise.futureResult
         }
         _ = activeFuture
-        try await waitForCondition(timeoutSeconds: 2) {
+        try await waitWithTimeout(
+            "waiting for active lease registration",
+            timeout: .seconds(2)
+        ) {
+            try await eventLoop.submit { () }.get()
+        }
+        #expect(
             manager.debugSnapshot().leases.contains { lease in
                 lease.leaseID == activeLeaseID.uuidString && lease.state == .active
             }
-        }
+        )
 
         let started = Date()
         let outcome = try await providerManager.callDocumentationSearch(
@@ -733,9 +739,7 @@ extension RuntimeCoordinatorTests {
         }
         #expect(error is TimeoutError)
         #expect(await upstream.sentCount() == 0)
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.debugSnapshot().queuedRequestCount == 0
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 0)
     }
 
     @Test func runtimeDocumentationTransportClosesFallbackOpenedAfterRouteInvalidation()
@@ -896,11 +900,9 @@ extension RuntimeCoordinatorTests {
         } catch {
             Issue.record("expected CancellationError for documentation tools/list, got \(error)")
         }
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            let snapshot = manager.debugSnapshot()
-            return snapshot.queuedRequestCount == 0
-                && snapshot.upstreams[0].activeCorrelatedRequestCount == 0
-        })
+        let toolsListSnapshot = manager.debugSnapshot()
+        #expect(toolsListSnapshot.queuedRequestCount == 0)
+        #expect(toolsListSnapshot.upstreams[0].activeCorrelatedRequestCount == 0)
 
         let searchTask = Task {
             try await manager.documentationProviderCall(
@@ -926,11 +928,9 @@ extension RuntimeCoordinatorTests {
         } catch {
             Issue.record("expected CancellationError for documentation search, got \(error)")
         }
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            let snapshot = manager.debugSnapshot()
-            return snapshot.queuedRequestCount == 0
-                && snapshot.upstreams[0].activeCorrelatedRequestCount == 0
-        })
+        let searchSnapshot = manager.debugSnapshot()
+        #expect(searchSnapshot.queuedRequestCount == 0)
+        #expect(searchSnapshot.upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
     @Test func runtimeDocumentationTransportFallsBackToDirectCandidateWhenNoUpstreamRouteExists()
@@ -1111,8 +1111,8 @@ extension RuntimeCoordinatorTests {
         )
 
         manager.prewarmDocumentationProvider()
-        try await spinUntil("waiting for documentation prewarm") {
-            await documentationProvider.prewarmCount() == 1
+        try await waitWithTimeout("waiting for documentation prewarm") {
+            try await documentationProvider.waitForPrewarmCount(1)
         }
 
         let prewarmedResult = try await manager.sharedToolsList(
@@ -1201,8 +1201,8 @@ extension RuntimeCoordinatorTests {
         #expect(toolNames(in: result) == ["XcodeRead"])
         #expect(await documentationProvider.toolListUpdateCount() == 0)
         await prewarmGate.signal()
-        try await spinUntil("waiting for documentation prewarm to finish") {
-            await documentationProvider.prewarmCount() == 1
+        try await waitWithTimeout("waiting for documentation prewarm to finish") {
+            try await documentationProvider.waitForPrewarmCount(1)
         }
     }
 
@@ -1475,8 +1475,8 @@ extension RuntimeCoordinatorTests {
         )
         defer { manager.shutdownAndWait() }
 
-        try await spinUntil("waiting for documentation provider startup prewarm") {
-            await documentationProvider.prewarmCount() == 1
+        try await waitWithTimeout("waiting for documentation provider startup prewarm") {
+            try await documentationProvider.waitForPrewarmCount(1)
         }
 
         let observedTimeout = try #require(await documentationProvider.lastPrewarmTimeout())
@@ -1580,12 +1580,27 @@ extension RuntimeCoordinatorTests {
     {
         let target = documentationProviderTarget(processID: 116, xcodeVersion: "27.0")
         let transport = TransientUnavailableDescriptorTransport()
+        let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
         let manager = DocumentationProviderManager(
             discovery: StubXcodeTargetDiscovery(targets: [target]),
-            transport: transport
+            transport: transport,
+            clock: clock
         )
 
-        let update = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let updateTask = Task {
+            await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        }
+        try await waitWithTimeout("waiting for first transient descriptor refresh") {
+            try await transport.waitForToolsListCount(1)
+        }
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: timeoutClock,
+            uptimeClock: uptimeClock,
+            by: .milliseconds(250)
+        )
+        let update = try await waitWithTimeout("waiting for descriptor refresh retry") {
+            await updateTask.value
+        }
         let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
 
         #expect(documentationDescriptorDescription(in: result) == "docs-transient")
@@ -1747,6 +1762,8 @@ extension RuntimeCoordinatorTests {
         async throws
     {
         let target = documentationProviderTarget(processID: 120, xcodeVersion: "26.6")
+        let repairGate = OperationGate<pid_t>()
+        let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 target.processID: [
@@ -1775,27 +1792,40 @@ extension RuntimeCoordinatorTests {
                     changedDefault: true
                 )
             ),
-            delayNanoseconds: 300_000_000
+            gate: repairGate
         )
         let manager = DocumentationProviderManager(
             discovery: StubXcodeTargetDiscovery(targets: [target]),
             sessionFactory: factory,
-            serviceRepairer: repairer
+            serviceRepairer: repairer,
+            clock: clock
         )
 
+        let updateTask = Task {
+            await manager.startBackgroundDiscovery(requestTimeout: .milliseconds(20))
+        }
+        try await waitWithTimeout("waiting for documentation repair to suspend") {
+            try await repairGate.waitUntilWaiting(for: target.processID, count: 1)
+        }
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: timeoutClock,
+            uptimeClock: uptimeClock,
+            by: .milliseconds(20)
+        )
         let update = try await waitWithTimeout(
             "documentation repair should not exceed the caller timeout",
             timeout: .milliseconds(500)
         ) {
-            await manager.startBackgroundDiscovery(requestTimeout: .milliseconds(20))
+            await updateTask.value
         }
         if case .available = update {
             Issue.record("expected repair timeout to avoid advertising DocumentationSearch")
         }
         #expect(await repairer.repairedPIDs() == [target.processID])
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            await repairer.cancelledPIDs() == [target.processID]
-        })
+        _ = try await waitWithTimeout("waiting for repair cancellation") {
+            try await repairer.nextCancelledPID(at: 0)
+        }
+        #expect(await repairer.cancelledPIDs() == [target.processID])
         #expect(await factory.startedPIDs() == [target.processID])
     }
 
@@ -2571,35 +2601,50 @@ extension RuntimeCoordinatorTests {
             osVersion: "26.2",
             documentationRelease: 900339
         )
+        let runGate = OperationGate<Int>()
+        let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
         let runner = StubProcessRunner(
             output: ProcessOutput(terminationStatus: 0, stdout: "[]", stderr: ""),
-            delayNanoseconds: 300_000_000
+            gate: runGate
         )
         let provider = LiveDocumentationAssetSearchProvider(
             assetRoot: root,
             currentOSVersion: { "26.5.1" },
-            processRunner: runner
+            processRunner: runner,
+            clock: clock
         )
         let target = documentationProviderTarget(processID: 125, xcodeVersion: "26.6")
 
+        let searchTask = Task {
+            try await provider.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 125, query: "UIView"),
+                for: target,
+                timeout: .milliseconds(20)
+            )
+        }
+        try await waitWithTimeout("waiting for local DocumentationSearch process to suspend") {
+            try await runGate.waitUntilWaiting(for: 1, count: 1)
+        }
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: timeoutClock,
+            uptimeClock: uptimeClock,
+            by: .milliseconds(20)
+        )
         await #expect(throws: TimeoutError.self) {
             _ = try await waitWithTimeout(
                 "local DocumentationSearch should honor the caller timeout",
                 timeout: .milliseconds(500)
             ) {
-                try await provider.callDocumentationSearch(
-                    requestData: makeDocumentationSearchRequest(id: 125, query: "UIView"),
-                    for: target,
-                    timeout: .milliseconds(20)
-                )
+                try await searchTask.value
             }
         }
         let requests = await runner.recordedRequests()
         #expect(requests.count == 1)
         #expect(requests.first?.timeoutNanoseconds == 20_000_000)
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            await runner.cancelledRunCount() == 1
-        })
+        _ = try await waitWithTimeout("waiting for local search process cancellation") {
+            try await runner.nextCancelledRunCount(at: 0)
+        }
+        #expect(await runner.cancelledRunCount() == 1)
     }
 
     @Test func documentationProviderBackgroundDiscoveryKeepsBaseCatalogWhenDescriptorIsAbsent()
@@ -3248,6 +3293,7 @@ extension RuntimeCoordinatorTests {
     @Test func documentationProviderManagerPreservesTimeForFallbackWhenNewestHangs() async throws {
         let xcode26 = documentationProviderTarget(processID: 425, xcodeVersion: "26.6")
         let xcode27 = documentationProviderTarget(processID: 426, xcodeVersion: "27.0")
+        let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 xcode26.processID: [
@@ -3270,13 +3316,31 @@ extension RuntimeCoordinatorTests {
         )
         let manager = DocumentationProviderManager(
             discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
-            sessionFactory: factory
+            sessionFactory: factory,
+            clock: clock
         )
 
-        let outcome = try await manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 88, query: "UIView"),
-            requestTimeoutOverride: .milliseconds(200)
+        let outcomeTask = Task {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 88, query: "UIView"),
+                requestTimeoutOverride: .milliseconds(200)
+            )
+        }
+        try await waitWithTimeout("waiting for newest candidate documentation search") {
+            try await factory.waitForRequestCount(
+                1,
+                processID: xcode27.processID,
+                method: "tools/call"
+            )
+        }
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: timeoutClock,
+            uptimeClock: uptimeClock,
+            by: .milliseconds(100)
         )
+        let outcome = try await waitWithTimeout("waiting for fallback candidate response") {
+            try await outcomeTask.value
+        }
 
         guard case .handled(let responseData, let invalidatedProvider) = outcome else {
             Issue.record("expected handled outcome, got \(outcome)")
@@ -3482,6 +3546,8 @@ extension RuntimeCoordinatorTests {
 
     @Test func documentationProviderManagerCoalescesConcurrentBackgroundDiscovery() async throws {
         let target = documentationProviderTarget(processID: 470, xcodeVersion: "27.0")
+        let startGate = OperationGate<pid_t>()
+        let preparationReused = TestSignal()
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 target.processID: [
@@ -3493,16 +3559,38 @@ extension RuntimeCoordinatorTests {
                     ),
                 ],
             ],
-            startDelayNanoseconds: 100_000_000
+            startGate: startGate
         )
         let manager = DocumentationProviderManager(
             discovery: StubXcodeTargetDiscovery(targets: [target]),
-            sessionFactory: factory
+            sessionFactory: factory,
+            testHooks: DocumentationProviderManagerTestHooks(
+                providerPreparationReused: { processID in
+                    if processID == target.processID {
+                        preparationReused.signal()
+                    }
+                }
+            )
         )
 
-        async let firstUpdate = manager.startBackgroundDiscovery(requestTimeout: .seconds(2))
-        async let secondUpdate = manager.startBackgroundDiscovery(requestTimeout: .seconds(2))
-        let results = await [firstUpdate, secondUpdate]
+        let firstUpdate = Task {
+            await manager.startBackgroundDiscovery(requestTimeout: .seconds(2))
+        }
+        try await waitWithTimeout("waiting for first documentation provider preparation") {
+            try await startGate.waitUntilWaiting(for: target.processID, count: 1)
+        }
+        let secondUpdate = Task {
+            await manager.startBackgroundDiscovery(requestTimeout: .seconds(2))
+        }
+        try await preparationReused.wait(
+            description: "waiting for second discovery to reuse the in-flight preparation"
+        )
+        #expect(await factory.startAttempts() == [target.processID])
+        await startGate.release(target.processID)
+
+        let results = try await waitWithTimeout("waiting for coalesced background discovery") {
+            await [firstUpdate.value, secondUpdate.value]
+        }
 
         for update in results {
             let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
@@ -3515,6 +3603,8 @@ extension RuntimeCoordinatorTests {
 
     @Test func documentationProviderManagerCoalescesConcurrentInitialDocumentationSearch() async throws {
         let target = documentationProviderTarget(processID: 480, xcodeVersion: "27.0")
+        let startGate = OperationGate<pid_t>()
+        let preparationReused = TestSignal()
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 target.processID: [
@@ -3527,22 +3617,44 @@ extension RuntimeCoordinatorTests {
                     ),
                 ],
             ],
-            startDelayNanoseconds: 100_000_000
+            startGate: startGate
         )
         let manager = DocumentationProviderManager(
             discovery: StubXcodeTargetDiscovery(targets: [target]),
-            sessionFactory: factory
+            sessionFactory: factory,
+            testHooks: DocumentationProviderManagerTestHooks(
+                providerPreparationReused: { processID in
+                    if processID == target.processID {
+                        preparationReused.signal()
+                    }
+                }
+            )
         )
 
-        async let firstOutcome = manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 101, query: "UIView"),
-            requestTimeoutOverride: .seconds(2)
+        let firstOutcome = Task {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 101, query: "UIView"),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        try await waitWithTimeout("waiting for first documentation search preparation") {
+            try await startGate.waitUntilWaiting(for: target.processID, count: 1)
+        }
+        let secondOutcome = Task {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 102, query: "SwiftUI"),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        try await preparationReused.wait(
+            description: "waiting for second search to reuse the in-flight preparation"
         )
-        async let secondOutcome = manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 102, query: "SwiftUI"),
-            requestTimeoutOverride: .seconds(2)
-        )
-        let outcomes = try await [firstOutcome, secondOutcome]
+        #expect(await factory.startAttempts() == [target.processID])
+        await startGate.release(target.processID)
+
+        let outcomes = try await waitWithTimeout("waiting for coalesced documentation searches") {
+            try await [firstOutcome.value, secondOutcome.value]
+        }
 
         var ids: [Int64] = []
         for outcome in outcomes {
@@ -3562,6 +3674,10 @@ extension RuntimeCoordinatorTests {
         async throws
     {
         let target = documentationProviderTarget(processID: 485, xcodeVersion: "27.0")
+        let startGate = OperationGate<pid_t>()
+        let preparationReused = TestSignal()
+        let preparationTimedOut = TestSignal()
+        let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
         let factory = ScriptedDocumentationSessionFactory(
             plansByPID: [
                 target.processID: [
@@ -3573,29 +3689,66 @@ extension RuntimeCoordinatorTests {
                     ),
                 ],
             ],
-            startDelayNanoseconds: 500_000_000
+            startGate: startGate
         )
         let manager = DocumentationProviderManager(
             discovery: StubXcodeTargetDiscovery(targets: [target]),
-            sessionFactory: factory
+            sessionFactory: factory,
+            clock: clock,
+            testHooks: DocumentationProviderManagerTestHooks(
+                providerPreparationReused: { processID in
+                    if processID == target.processID {
+                        preparationReused.signal()
+                    }
+                },
+                providerPreparationWaitTimedOut: { processID in
+                    if processID == target.processID {
+                        preparationTimedOut.signal()
+                    }
+                }
+            )
         )
 
-        let shortStart = Date()
-        let shortOutcome = try await manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 85, query: "too soon"),
-            requestTimeoutOverride: .milliseconds(1)
+        let shortRequest = Task {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 85, query: "too soon"),
+                requestTimeoutOverride: .milliseconds(1)
+            )
+        }
+        try await waitWithTimeout("waiting for shared preparation to suspend") {
+            try await startGate.waitUntilWaiting(for: target.processID, count: 1)
+        }
+        await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: timeoutClock,
+            uptimeClock: uptimeClock,
+            by: .milliseconds(1)
         )
-        #expect(Date().timeIntervalSince(shortStart) < 0.1)
+        try await preparationTimedOut.wait(
+            description: "waiting for short preparation wait timeout"
+        )
+        let shortOutcome = try await waitWithTimeout("waiting for short request outcome") {
+            try await shortRequest.value
+        }
         guard case .failed(let error, _) = shortOutcome else {
             Issue.record("expected timeout outcome, got \(shortOutcome)")
             return
         }
         #expect(error is TimeoutError)
 
-        let followUpOutcome = try await manager.callDocumentationSearch(
-            requestData: makeDocumentationSearchRequest(id: 86, query: "SwiftUI"),
-            requestTimeoutOverride: .seconds(2)
+        let followUpRequest = Task {
+            try await manager.callDocumentationSearch(
+                requestData: makeDocumentationSearchRequest(id: 86, query: "SwiftUI"),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        try await preparationReused.wait(
+            description: "waiting for follow-up request to reuse the in-flight preparation"
         )
+        #expect(await factory.startAttempts() == [target.processID])
+        await startGate.release(target.processID)
+        let followUpOutcome = try await waitWithTimeout("waiting for follow-up request outcome") {
+            try await followUpRequest.value
+        }
         guard case .handled(let responseData, _) = followUpOutcome else {
             Issue.record("expected handled outcome, got \(followUpOutcome)")
             return

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -1326,6 +1326,13 @@ actor ToggleableOverloadUpstreamClient: UpstreamSlotControlling {
     func nextSent(at index: Int) async throws -> Data {
         try await sentMessages.nextValue(at: index)
     }
+
+    func nextSent(
+        startingAt index: Int,
+        matching predicate: @escaping @Sendable (Data) -> Bool
+    ) async throws -> Data {
+        try await sentMessages.nextValue(startingAt: index, matching: predicate)
+    }
 }
 
 actor ReadinessFlag {
@@ -1427,11 +1434,16 @@ actor AvailabilityFlag {
 actor ControlledReadinessSleep {
     private var sleeps: [UInt64] = []
     private var sleepContinuations: [CheckedContinuation<Void, Never>] = []
+    private var releaseCredits = 0
     private var waiters: [(index: Int, continuation: CheckedContinuation<UInt64, Error>)] = []
 
     func sleep(nanoseconds: UInt64) async {
         sleeps.append(nanoseconds)
         resumeReadyWaiters()
+        if releaseCredits > 0 {
+            releaseCredits -= 1
+            return
+        }
         await withCheckedContinuation { continuation in
             sleepContinuations.append(continuation)
         }
@@ -1447,7 +1459,10 @@ actor ControlledReadinessSleep {
     }
 
     func resumeNext() {
-        guard !sleepContinuations.isEmpty else { return }
+        guard !sleepContinuations.isEmpty else {
+            releaseCredits += 1
+            return
+        }
         sleepContinuations.removeFirst().resume()
     }
 
@@ -1846,11 +1861,11 @@ func sentValue(
     at index: Int,
     timeout: Duration = .seconds(5)
 ) async throws -> Data {
-    try await nextValue(
+    try await waitWithTimeout(
         "waiting for sent message \(index + 1)",
         timeout: timeout
     ) {
-        await upstream.sentValue(at: index)
+        try await upstream.nextSent(at: index)
     }
 }
 
@@ -1859,11 +1874,11 @@ func sentValue(
     at index: Int,
     timeout: Duration = .seconds(5)
 ) async throws -> Data {
-    try await nextValue(
+    try await waitWithTimeout(
         "waiting for sent message \(index + 1)",
         timeout: timeout
     ) {
-        await upstream.sentValue(at: index)
+        try await upstream.nextSent(at: index)
     }
 }
 
@@ -1872,11 +1887,11 @@ func sentValue(
     at index: Int,
     timeout: Duration = .seconds(5)
 ) async throws -> Data {
-    try await nextValue(
+    try await waitWithTimeout(
         "waiting for sent message \(index + 1)",
         timeout: timeout
     ) {
-        await upstream.sentValue(at: index)
+        try await upstream.nextSent(at: index)
     }
 }
 
@@ -1885,12 +1900,10 @@ func sentMessage(
     matching predicate: @escaping @Sendable (Data) -> Bool,
     timeout: Duration = .seconds(5)
 ) async throws -> Data {
-    try await nextValue(
+    try await waitWithTimeout(
         "waiting for matching sent message",
         timeout: timeout
     ) {
-        try Task.checkCancellation()
-        let sent = await upstream.sent()
-        return sent.first(where: predicate)
+        try await upstream.nextSent(matching: predicate)
     }
 }

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -361,27 +361,29 @@ struct UnavailableDocumentationProviderTransport: DocumentationProviderRouting {
 
 actor StubDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairing {
     private let result: DocumentationSearchServiceRepairResult
-    private let delayNanoseconds: UInt64?
+    private let gate: OperationGate<pid_t>?
     private var repairedProcessIDs: [pid_t] = []
     private var cancelledProcessIDs: [pid_t] = []
+    private let cancelledPIDValues = RecordedValues<pid_t>()
 
     init(
         result: DocumentationSearchServiceRepairResult,
-        delayNanoseconds: UInt64? = nil
+        gate: OperationGate<pid_t>? = nil
     ) {
         self.result = result
-        self.delayNanoseconds = delayNanoseconds
+        self.gate = gate
     }
 
     func repairDocumentationSearch(
         for target: DocumentationProviderTarget
     ) async -> DocumentationSearchServiceRepairResult {
         repairedProcessIDs.append(target.processID)
-        if let delayNanoseconds {
+        if let gate {
             do {
-                try await Task.sleep(nanoseconds: delayNanoseconds)
+                try await gate.wait(for: target.processID)
             } catch is CancellationError {
                 cancelledProcessIDs.append(target.processID)
+                await cancelledPIDValues.append(target.processID)
             } catch {
             }
         }
@@ -394,6 +396,10 @@ actor StubDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairin
 
     func cancelledPIDs() -> [pid_t] {
         cancelledProcessIDs
+    }
+
+    func nextCancelledPID(at index: Int) async throws -> pid_t {
+        try await cancelledPIDValues.nextValue(at: index)
     }
 }
 
@@ -471,22 +477,25 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
 
 actor StubProcessRunner: ProcessRunning {
     private let output: ProcessOutput
-    private let delayNanoseconds: UInt64?
+    private let gate: OperationGate<Int>?
     private var requests: [ProcessRequest] = []
     private var cancelledRunCountValue = 0
+    private let cancelledRunValues = RecordedValues<Int>()
 
-    init(output: ProcessOutput, delayNanoseconds: UInt64? = nil) {
+    init(output: ProcessOutput, gate: OperationGate<Int>? = nil) {
         self.output = output
-        self.delayNanoseconds = delayNanoseconds
+        self.gate = gate
     }
 
     func run(_ request: ProcessRequest) async throws -> ProcessOutput {
         requests.append(request)
-        if let delayNanoseconds {
+        let runIndex = requests.count
+        if let gate {
             do {
-                try await Task.sleep(nanoseconds: delayNanoseconds)
+                try await gate.wait(for: runIndex)
             } catch is CancellationError {
                 cancelledRunCountValue += 1
+                await cancelledRunValues.append(cancelledRunCountValue)
                 throw CancellationError()
             }
         }
@@ -500,10 +509,15 @@ actor StubProcessRunner: ProcessRunning {
     func cancelledRunCount() -> Int {
         cancelledRunCountValue
     }
+
+    func nextCancelledRunCount(at index: Int) async throws -> Int {
+        try await cancelledRunValues.nextValue(at: index)
+    }
 }
 
 actor TransientUnavailableDescriptorTransport: DocumentationProviderRouting {
     private var toolsListCountValue = 0
+    private let toolsListCountValues = RecordedValues<Int>()
 
     func openRoute(
         for target: DocumentationProviderTarget,
@@ -523,6 +537,7 @@ actor TransientUnavailableDescriptorTransport: DocumentationProviderRouting {
         timeout _: TimeAmount?
     ) async throws -> JSONValue {
         toolsListCountValue += 1
+        await toolsListCountValues.append(toolsListCountValue)
         if toolsListCountValue == 1 {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
@@ -543,6 +558,13 @@ actor TransientUnavailableDescriptorTransport: DocumentationProviderRouting {
 
     func toolsListCount() -> Int {
         toolsListCountValue
+    }
+
+    func waitForToolsListCount(_ count: Int) async throws {
+        guard count > 0 else {
+            return
+        }
+        _ = try await toolsListCountValues.nextValue(at: count - 1)
     }
 }
 
@@ -702,20 +724,20 @@ actor ScriptedDocumentationSessionFactory: DocumentationProviderSessionMaking {
     private var requestCountsByPID: [pid_t: [String: Int]] = [:]
     private var documentationQueriesByPID: [pid_t: [String]] = [:]
     private var requestCountWaiters: [RequestCountWaiter] = []
-    private let startDelayNanoseconds: UInt64?
+    private let startGate: OperationGate<pid_t>?
 
     init(
         plansByPID: [pid_t: [ScriptedDocumentationSessionPlan]],
-        startDelayNanoseconds: UInt64? = nil
+        startGate: OperationGate<pid_t>? = nil
     ) {
         self.plansByPID = plansByPID
-        self.startDelayNanoseconds = startDelayNanoseconds
+        self.startGate = startGate
     }
 
     func startSession(for target: DocumentationProviderTarget) async throws -> any UpstreamSession {
         startAttemptProcessIDs.append(target.processID)
-        if let startDelayNanoseconds {
-            try await Task.sleep(nanoseconds: startDelayNanoseconds)
+        if let startGate {
+            try await startGate.wait(for: target.processID)
         }
         guard var plans = plansByPID[target.processID],
               plans.isEmpty == false else {
@@ -1005,6 +1027,7 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
     private var prewarmTimeouts: [TimeAmount?] = []
     private var toolListTimeouts: [TimeAmount?] = []
     private var callTimeouts: [TimeAmount?] = []
+    private let prewarmCountValues = RecordedValues<Int>()
     private let prewarmStarted: TestSignal?
     private let prewarmBlocker: AsyncGate?
     private let toolListStarted: TestSignal?
@@ -1039,6 +1062,7 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
             guard !Task.isCancelled else { return .unavailable }
         }
         prewarmTimeouts.append(requestTimeout)
+        await prewarmCountValues.append(prewarmTimeouts.count)
         return update
     }
 
@@ -1083,6 +1107,13 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
 
     func prewarmCount() -> Int {
         prewarmTimeouts.count
+    }
+
+    func waitForPrewarmCount(_ count: Int) async throws {
+        guard count > 0 else {
+            return
+        }
+        _ = try await prewarmCountValues.nextValue(at: count - 1)
     }
 
     func toolListUpdateCount() -> Int {
@@ -1436,6 +1467,7 @@ actor ControlledReadinessSleep {
 actor XcodeLaunchRecorder {
     private var count = 0
     private var outcomes: [Bool]
+    private let launches = LockedRecordedValues<Int>()
 
     init(outcomes: [Bool] = []) {
         self.outcomes = outcomes
@@ -1443,6 +1475,8 @@ actor XcodeLaunchRecorder {
 
     func launch() -> Bool {
         count += 1
+        let currentCount = count
+        launches.append(currentCount)
         guard outcomes.isEmpty == false else {
             return true
         }
@@ -1452,12 +1486,17 @@ actor XcodeLaunchRecorder {
     func launchCount() -> Int {
         count
     }
+
+    func nextLaunch(at index: Int) async throws -> Int {
+        try await launches.nextValue(at: index)
+    }
 }
 
 func makeTestReadinessGate(
     readiness: ReadinessFlag,
     availability: AvailabilityFlag? = nil,
     sleepRecorder: ControlledReadinessSleep? = nil,
+    recordPollSleeps: Bool = false,
     launchRetryIntervalNanoseconds: UInt64 = 5_000_000_000,
     launchRecorder: XcodeLaunchRecorder? = nil
 ) -> UpstreamReadinessGate {
@@ -1491,9 +1530,11 @@ func makeTestReadinessGate(
             DispatchTime.now().uptimeNanoseconds
         },
         sleepNanoseconds: { nanoseconds in
-            if let sleepRecorder, nanoseconds >= 1_000_000_000 {
+            if let sleepRecorder, recordPollSleeps || nanoseconds >= 1_000_000_000 {
                 await sleepRecorder.sleep(nanoseconds: nanoseconds)
             } else {
+                // Readiness polling models OS process availability. Tests that
+                // need to assert a poll point pass sleepRecorder instead.
                 try? await Task.sleep(nanoseconds: nanoseconds)
             }
         },
@@ -1686,22 +1727,15 @@ enum WaitForSentCountError: Error {
     case timeout(expected: Int, actual: Int)
 }
 
-func waitForCondition(
-    timeoutSeconds: UInt64,
-    pollNanoseconds: UInt64 = 50_000_000,
-    _ condition: @escaping @Sendable () -> Bool
-) async throws {
-    _ = pollNanoseconds
-    let reached = await waitUntil(timeout: .seconds(Int64(timeoutSeconds))) {
-        condition()
+func waitForRecordedValue<Value: Sendable>(
+    _ values: LockedRecordedValues<Value>,
+    at index: Int,
+    description: String,
+    timeout: Duration = .seconds(2)
+) async throws -> Value {
+    try await waitWithTimeout(description, timeout: timeout) {
+        try await values.nextValue(at: index)
     }
-    if !reached {
-        throw WaitForConditionError.timeout
-    }
-}
-
-enum WaitForConditionError: Error {
-    case timeout
 }
 
 func methodName(from data: Data) -> String? {
@@ -1858,24 +1892,5 @@ func sentMessage(
         try Task.checkCancellation()
         let sent = await upstream.sent()
         return sent.first(where: predicate)
-    }
-}
-
-func nextBufferedNotifications(
-    from router: ProxyRouter,
-    timeout: Duration = .seconds(5)
-) async throws -> [Data] {
-    try await waitWithTimeout(
-        "waiting for buffered notifications",
-        timeout: timeout
-    ) {
-        while true {
-            try Task.checkCancellation()
-            let drained = router.drainBufferedNotifications()
-            if !drained.isEmpty {
-                return drained
-            }
-            await Task.yield()
-        }
     }
 }

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -85,8 +85,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         manager.handleUpstreamStderr("repeated stderr", upstreamIndex: 0)
@@ -101,8 +109,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         let request1 = makeInitializeRequest(id: 1)
@@ -841,8 +857,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         let sessionID = "session-A"
@@ -870,8 +894,14 @@ struct RuntimeCoordinatorTests {
             options: []
         )
         _ = try await future.get()
+        let notificationEventIndex = upstreamEvents.count()
         await upstream.yield(.message(notification))
-        let received = try await nextBufferedNotifications(from: session.router)
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: notificationEventIndex,
+            description: "waiting for cached initialize notification"
+        )
+        let received = session.router.drainBufferedNotifications()
         #expect(received.count == 1)
         #expect(received.first == notification)
 
@@ -885,8 +915,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         let sessionID = "session-handshake"
@@ -909,9 +947,15 @@ struct RuntimeCoordinatorTests {
             ],
             options: []
         )
+        let notificationEventIndex = upstreamEvents.count()
         await upstream.yield(.message(notification))
 
-        let received = try await nextBufferedNotifications(from: session.router)
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: notificationEventIndex,
+            description: "waiting for initialize-handshake notification"
+        )
+        let received = session.router.drainBufferedNotifications()
         #expect(received.count == 1)
         #expect(received.first == notification)
 
@@ -928,8 +972,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         let firstFuture = manager.registerInitialize(
@@ -962,10 +1014,16 @@ struct RuntimeCoordinatorTests {
             ],
             options: []
         )
+        let notificationEventIndex = upstreamEvents.count()
         await upstream.yield(.message(notification))
 
         _ = try await cachedFuture.get()
-        let received = try await nextBufferedNotifications(from: session.router)
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: notificationEventIndex,
+            description: "waiting for cached initialize session notification"
+        )
+        let received = session.router.drainBufferedNotifications()
         #expect(received.count == 1)
         #expect(received.first == notification)
 
@@ -1051,8 +1109,16 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         try await waitForSentCount(upstream0, count: 1, timeoutSeconds: 2)
@@ -1096,23 +1162,21 @@ struct RuntimeCoordinatorTests {
             ],
             options: []
         )
+        let eventIndex = upstreamEvents.count()
         await upstream0.yield(.message(notification0))
         await upstream1.yield(.message(notification1))
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: eventIndex,
+            description: "waiting for first cached initialize notification"
+        )
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: eventIndex + 1,
+            description: "waiting for second cached initialize notification"
+        )
 
-        let received = try await waitWithTimeout(
-            "waiting for cached initialize notifications",
-            timeout: .seconds(5)
-        ) {
-            var notifications: [Data] = []
-            while notifications.count < 2 {
-                notifications.append(contentsOf: session.router.drainBufferedNotifications())
-                if notifications.count >= 2 {
-                    return notifications
-                }
-                await Task.yield()
-            }
-            return notifications
-        }
+        let received = session.router.drainBufferedNotifications()
         #expect(Set(received) == Set([notification0, notification1]))
 
         manager.markNotificationClientConnected(sessionID: sessionID)
@@ -1326,9 +1390,7 @@ struct RuntimeCoordinatorTests {
             _ = try await firstTask.value
         }
 
-        try await spinUntil("waiting for first timed-out tools/list to release its lease") {
-            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-        }
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
 
         let secondTask = Task {
             try await manager.sharedToolsList(
@@ -1383,8 +1445,10 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        try await spinUntil("waiting for foreground tools/list waiter to reuse prewarm load") {
-            manager.debugSnapshot().controlPlane?.waiterCounts.toolsCatalog == 1
+        try await waitWithTimeout("waiting for foreground tools/list waiter to reuse prewarm load") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.toolsCatalog == 1
+            }
         }
         #expect(await upstream.sentCount() == 3)
 
@@ -1453,11 +1517,7 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                await upstream.sentCount() >= 4
-            }
-        )
+        try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
         let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/list")
 
@@ -1516,9 +1576,7 @@ struct RuntimeCoordinatorTests {
         await #expect(throws: CancellationError.self) {
             _ = try await task.value
         }
-        try await spinUntil("waiting for cancelled tools/list to release its lease") {
-            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-        }
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
     @Test func sessionManagerSharedToolsListStopsPromotingAfterLoadBecomesShared() async throws {
@@ -1577,8 +1635,10 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        try await spinUntil("waiting for third tools/list waiter to share the in-flight load") {
-            manager.debugSnapshot().controlPlane?.waiterCounts.toolsCatalog == 3
+        try await waitWithTimeout("waiting for third tools/list waiter to share the in-flight load") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.toolsCatalog == 3
+            }
         }
         #expect(await upstream.sentCount() == 4)
 
@@ -1654,9 +1714,7 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError for promoted waiter but received \(error)")
         }
 
-        try await spinUntil("waiting for promoted tools/list cancellation to release its lease") {
-            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-        }
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
     @Test func sessionManagerSharedToolsListTimeoutCancelsStalePrewarmLoad() async throws {
@@ -1699,8 +1757,10 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        try await spinUntil("waiting for foreground tools/list waiter to attach to prewarm load") {
-            manager.debugSnapshot().controlPlane?.waiterCounts.toolsCatalog == 1
+        try await waitWithTimeout("waiting for foreground tools/list waiter to attach to prewarm load") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.toolsCatalog == 1
+            }
         }
         await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
@@ -1711,9 +1771,7 @@ struct RuntimeCoordinatorTests {
         await #expect(throws: TimeoutError.self) {
             _ = try await firstTask.value
         }
-        try await spinUntil("waiting for timed-out prewarm tools/list to release its lease") {
-            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-        }
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
 
         let secondTask = Task {
             try await manager.sharedToolsList(
@@ -1832,9 +1890,7 @@ struct RuntimeCoordinatorTests {
             _ = try await firstTask.value
         }
 
-        try await spinUntil("waiting for first timed-out list-windows call to release its lease") {
-            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-        }
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
 
         let secondTask = Task {
             try await manager.liveXcodeListWindowsResult(
@@ -1897,9 +1953,7 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError but received \(error)")
         }
 
-        try await spinUntil("waiting for cancelled list-windows call to release its lease") {
-            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-        }
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
     @Test func sessionManagerPromotedLiveXcodeListWindowsCancellationRemovesMigratedWaiter()
@@ -1966,9 +2020,7 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError for promoted XcodeListWindows waiter but received \(error)")
         }
 
-        try await spinUntil("waiting for promoted list-windows cancellation to release its lease") {
-            manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0
-        }
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
     @Test func controlPlaneRPCHandleCancelBeforeQueueStartCapturesQueuedState() {
@@ -2110,9 +2162,9 @@ struct RuntimeCoordinatorTests {
             try await coordinator.toolsCatalog(deadlineUptimeNs: nil)
         }
         try await loadStarted.wait(description: "waiting for tools catalog load")
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            debugMirror.snapshot()?.waiterCounts.toolsCatalog == 1
-        })
+        _ = try await waitWithTimeout("waiting for tools catalog waiter") {
+            try await debugMirror.waitForSnapshot { $0.waiterCounts.toolsCatalog == 1 }
+        }
 
         brokerState.clearToolsCatalog()
         await releaseLoad.signal()
@@ -2151,9 +2203,9 @@ struct RuntimeCoordinatorTests {
             try await coordinator.listWindows(route: .anyHealthy, deadlineUptimeNs: nil)
         }
         try await loadStarted.wait(description: "waiting for window load")
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            debugMirror.snapshot()?.waiterCounts.windows == 1
-        })
+        _ = try await waitWithTimeout("waiting for window waiter") {
+            try await debugMirror.waitForSnapshot { $0.waiterCounts.windows == 1 }
+        }
 
         brokerState.clearInitialize()
         await releaseLoad.signal()
@@ -2208,9 +2260,9 @@ struct RuntimeCoordinatorTests {
             try await coordinator.toolsCatalog(deadlineUptimeNs: nil)
         }
         try await firstLoadStarted.wait(description: "waiting for stale tools catalog load")
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            debugMirror.snapshot()?.waiterCounts.toolsCatalog == 1
-        })
+        _ = try await waitWithTimeout("waiting for stale tools catalog waiter") {
+            try await debugMirror.waitForSnapshot { $0.waiterCounts.toolsCatalog == 1 }
+        }
 
         brokerState.clearToolsCatalog()
         let invalidatedGeneration = brokerState.generation()
@@ -2218,9 +2270,9 @@ struct RuntimeCoordinatorTests {
             try await coordinator.toolsCatalog(deadlineUptimeNs: nil)
         }
         try await secondLoadStarted.wait(description: "waiting for fresh tools catalog load")
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            debugMirror.snapshot()?.waiterCounts.toolsCatalog == 1
-        })
+        _ = try await waitWithTimeout("waiting for fresh tools catalog waiter") {
+            try await debugMirror.waitForSnapshot { $0.waiterCounts.toolsCatalog == 1 }
+        }
 
         await coordinator.cancelLoadsStartedBeforeGeneration(
             invalidatedGeneration,
@@ -2403,10 +2455,6 @@ struct RuntimeCoordinatorTests {
         )
         await timeoutClock.sleep(untilSuspendedBy: 1)
         timeoutClock.advance(by: .milliseconds(100))
-        try await spinUntil("waiting for eager initialize timeout", maxIterations: 1_000) {
-            let snapshot = manager.testStateSnapshot()
-            return snapshot.initInFlight == false && snapshot.hasInitResult == false
-        }
 
         _ = manager.registerInitialize(
             originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
@@ -2557,9 +2605,7 @@ struct RuntimeCoordinatorTests {
             return eventLoop.makeSucceededFuture(())
         }
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.debugSnapshot().queuedRequestCount == 1
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
 
         await upstream1.yield(.message(try makeInitializeResponse(id: init1ID)))
         _ = try await queuedFuture.get()
@@ -2577,8 +2623,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         // First init establishes the cached init result.
@@ -2596,10 +2650,14 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
 
         // Simulate primary upstream dying after init succeeded.
+        let exitEventIndex = upstreamEvents.count()
         await upstream.yield(.exit(1))
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.testStateSnapshot().hasInitResult == false
-        }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: exitEventIndex,
+            description: "waiting for primary upstream exit"
+        )
+        #expect(manager.testStateSnapshot().hasInitResult == false)
 
         // A new downstream initialize must trigger a new upstream initialize (no cached response).
         let init2 = manager.registerInitialize(
@@ -2716,17 +2774,13 @@ struct RuntimeCoordinatorTests {
             return eventLoop.makeSucceededFuture(())
         }
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.debugSnapshot().queuedRequestCount == 1
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
 
         await upstream.yield(.exit(1))
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.testStateSnapshot().upstreams[0].initInFlight
-                && manager.debugSnapshot().queuedRequestCount == 1
-        }
 
         let reinitRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        #expect(manager.testStateSnapshot().upstreams[0].initInFlight)
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
         let reinitUpstreamID = try extractUpstreamID(from: reinitRequest)
         await upstream.yield(.message(try makeInitializeResponse(id: reinitUpstreamID)))
         _ = try await queuedFuture.get()
@@ -2747,9 +2801,16 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
-            config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         // First init establishes the cached init result (primary only).
@@ -2774,27 +2835,29 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream1, count: 2, timeoutSeconds: 2)
 
         // Simulate primary dying first (cached init result should remain because upstream1 is still initialized).
+        let primaryExitEventIndex = upstreamEvents.count()
         await upstream0.yield(.exit(1))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.testStateSnapshot().upstreams[0].isInitialized == false
-            }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: primaryExitEventIndex,
+            description: "waiting for primary upstream exit"
         )
+        #expect(manager.testStateSnapshot().upstreams[0].isInitialized == false)
 
         // Now simulate the last initialized upstream dying too.
+        let secondaryExitEventIndex = upstreamEvents.count()
         await upstream1.yield(.exit(1))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.testStateSnapshot().upstreams[1].isInitialized == false
-            }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: secondaryExitEventIndex,
+            description: "waiting for secondary upstream exit"
         )
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized == false)
 
         // Ensure the cached init result is cleared before asserting that a new downstream initialize
         // triggers a fresh upstream initialize. This avoids race/flakiness where the exit event hasn't
         // been processed yet on the event loop.
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.testStateSnapshot().hasInitResult == false
-        }
+        #expect(manager.testStateSnapshot().hasInitResult == false)
 
         // A new downstream initialize must trigger a new upstream initialize (no cached response).
         let init2 = manager.registerInitialize(
@@ -2818,9 +2881,16 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 0.3)
         let manager = RuntimeCoordinator(
-            config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         // Initialize both upstreams.
@@ -2854,16 +2924,24 @@ struct RuntimeCoordinatorTests {
                 "message": "warm init failed",
             ],
         ]
+        let errorEventIndex = upstreamEvents.count()
         await upstream0.yield(
             .message(try JSONSerialization.data(withJSONObject: errorResponse, options: [])))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.testStateSnapshot().upstreams[0].initInFlight == false
-            }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: errorEventIndex,
+            description: "waiting for primary warm init failure"
         )
+        #expect(manager.testStateSnapshot().upstreams[0].initInFlight == false)
 
         // Now simulate the last initialized upstream dying too. Eager init should kick the global init path again.
+        let secondaryExitEventIndex = upstreamEvents.count()
         await upstream1.yield(.exit(1))
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: secondaryExitEventIndex,
+            description: "waiting for secondary upstream exit"
+        )
         _ = try await sentValue(from: upstream0, at: 3, timeout: .seconds(2))
         _ = manager
     }
@@ -2878,9 +2956,16 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 0.3)
         let manager = RuntimeCoordinator(
-            config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         // Initialize both upstreams.
@@ -2902,12 +2987,14 @@ struct RuntimeCoordinatorTests {
         let retryID = try extractUpstreamID(from: retry)
 
         // While primary warm init is in flight, last initialized upstream exits.
+        let secondaryExitEventIndex = upstreamEvents.count()
         await upstream1.yield(.exit(1))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.testStateSnapshot().upstreams[1].isInitialized == false
-            }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: secondaryExitEventIndex,
+            description: "waiting for secondary upstream exit"
         )
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized == false)
 
         // Warm init fails with JSON-RPC error.
         let errorResponse: [String: Any] = [
@@ -2932,9 +3019,16 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(
-            config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         // Eager init -> upstream0
@@ -3105,8 +3199,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 2)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         let sessionID = "session-A"
@@ -3125,8 +3227,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 2)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
@@ -3151,6 +3261,7 @@ struct RuntimeCoordinatorTests {
         await upstream.yield(.message(try makeToolListResponse(id: upstreamID)))
         _ = try await future.get()
 
+        let debugEventIndex = upstreamEvents.count()
         await upstream.yield(.message(try makeToolListResponse(id: 9_999_999)))
         await upstream.yield(
             .stderr("Could not decode agent message: Error Domain=mcpbridge.DecodeError Code=1"))
@@ -3168,13 +3279,10 @@ struct RuntimeCoordinatorTests {
             )
         )
         await upstream.yield(.stdoutBufferSize(2048))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                let snapshot = manager.debugSnapshot()
-                return snapshot.upstreams[0].bufferedStdoutBytes == 2048
-                    && snapshot.upstreams[0].protocolViolationCount == 1
-                    && snapshot.upstreams[0].recentStderr.count == 2
-            }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: debugEventIndex + 4,
+            description: "waiting for upstream debug events"
         )
 
         let snapshot = manager.debugSnapshot()
@@ -3199,19 +3307,12 @@ struct RuntimeCoordinatorTests {
             })
         #expect(snapshot.upstreams[0].recentStderr.allSatisfy { $0.message == "<redacted>" })
 
+        let exitEventIndex = upstreamEvents.count()
         await upstream.yield(.exit(1))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                let snapshot = manager.debugSnapshot()
-                return snapshot.upstreams[0].recentStderr.isEmpty
-                    && snapshot.upstreams[0].lastDecodeError == nil
-                    && snapshot.upstreams[0].lastBridgeError == nil
-                    && snapshot.upstreams[0].protocolViolationCount == 0
-                    && snapshot.upstreams[0].lastProtocolViolationPreview == nil
-                    && snapshot.upstreams[0].lastProtocolViolationPreviewHex == nil
-                    && snapshot.upstreams[0].lastProtocolViolationLeadingByteHex == nil
-                    && snapshot.upstreams[0].bufferedStdoutBytes == 0
-            }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: exitEventIndex,
+            description: "waiting for upstream exit debug reset"
         )
 
         let clearedSnapshot = manager.debugSnapshot()
@@ -3231,10 +3332,19 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
+        let toolsListRefreshes = LockedRecordedValues<(Int, Bool)>()
         var config = makeConfig(requestTimeout: 2)
         config.prewarmToolsList = true
         let manager = RuntimeCoordinator(
-            config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) },
+                toolsListRefreshCompleted: { toolsListRefreshes.append(($0, $1)) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         // Initialize primary upstream0.
@@ -3266,18 +3376,20 @@ struct RuntimeCoordinatorTests {
             "id": warmup0ID,
             "result": [:],  // invalid (no `tools` array) -> marks upstream unhealthy
         ]
+        let warmup0RefreshIndex = toolsListRefreshes.count()
         await upstream0.yield(
             .message(try JSONSerialization.data(withJSONObject: warmup0Response, options: [])))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                switch manager.testStateSnapshot().upstreams[0].healthState {
-                case .healthy:
-                    return false
-                case .degraded, .quarantined:
-                    return true
-                }
-            }
+        _ = try await waitForRecordedValue(
+            toolsListRefreshes,
+            at: warmup0RefreshIndex,
+            description: "waiting for first tools/list warmup failure"
         )
+        switch manager.testStateSnapshot().upstreams[0].healthState {
+        case .healthy:
+            Issue.record("upstream0 should be degraded after invalid tools/list warmup")
+        case .degraded, .quarantined:
+            break
+        }
 
         // Trigger another warmup; it should prefer upstream1 and fail there too so no healthy upstream exists.
         manager.refreshToolsListIfNeeded()
@@ -3292,12 +3404,13 @@ struct RuntimeCoordinatorTests {
             "id": warmup1ID,
             "result": [:],
         ]
+        let warmup1RefreshIndex = toolsListRefreshes.count()
         await upstream1.yield(
             .message(try JSONSerialization.data(withJSONObject: warmup1Response, options: [])))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.chooseUpstreamIndex() == nil
-            }
+        _ = try await waitForRecordedValue(
+            toolsListRefreshes,
+            at: warmup1RefreshIndex,
+            description: "waiting for second tools/list warmup failure"
         )
 
         let chosen = manager.chooseUpstreamIndex()
@@ -3484,9 +3597,7 @@ struct RuntimeCoordinatorTests {
             return eventLoop.makeSucceededFuture(())
         }
 
-        try await spinUntil("waiting for queued request to be visible") {
-            manager.debugSnapshot().queuedRequestCount == 1
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
 
         try await spinUntilSentCount(
             upstream1,
@@ -3596,9 +3707,7 @@ struct RuntimeCoordinatorTests {
             return eventLoop.makeSucceededFuture(())
         }
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.debugSnapshot().queuedRequestCount == 1
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
 
         let genericDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-generic",
@@ -3635,9 +3744,16 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 2)
         let manager = RuntimeCoordinator(
-            config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         // Initialize both upstreams.
@@ -3666,12 +3782,14 @@ struct RuntimeCoordinatorTests {
             manager.chooseUpstreamIndex())
         #expect(upstreamIndexA != upstreamIndexB)
 
+        let exitEventIndex = upstreamEvents.count()
         await upstream1.yield(.exit(1))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.testStateSnapshot().upstreams[1].isInitialized == false
-            }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: exitEventIndex,
+            description: "waiting for secondary upstream exit"
         )
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized == false)
 
         let repinned = try #require(
             manager.chooseUpstreamIndex())
@@ -3725,9 +3843,16 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 0.3)
         let manager = RuntimeCoordinator(
-            config: config, eventLoop: eventLoop, upstreams: [upstream0, upstream1])
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         // Initialize both upstreams.
@@ -3754,12 +3879,14 @@ struct RuntimeCoordinatorTests {
             sessionID: sessionID, originalID: originalA, upstreamIndex: 1)
         manager.sendUpstream(try makeToolListRequest(id: upstreamIDA), upstreamIndex: 1)
 
+        let exitEventIndex = upstreamEvents.count()
         await upstream1.yield(.exit(1))
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.testStateSnapshot().upstreams[1].isInitialized == false
-            }
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: exitEventIndex,
+            description: "waiting for secondary upstream exit"
         )
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized == false)
 
         // The proxy should continue serving on upstream0.
         let originalB = JSONRPC.ID(any: NSNumber(value: 201))!
@@ -3818,12 +3945,6 @@ struct RuntimeCoordinatorTests {
         #expect((error?["code"] as? NSNumber)?.intValue == -32002)
         #expect((error?["message"] as? String) == "upstream overloaded")
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().recentTraffic.contains { $0.direction == "outbound" }
-                    == false
-            }
-        )
         let snapshot = manager.debugSnapshot()
         #expect(snapshot.recentTraffic.contains { $0.direction == "outbound" } == false)
     }
@@ -3948,12 +4069,7 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
         let retriedInitialize = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: retriedInitialize) == "initialize")
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                let snapshot = manager.testStateSnapshot()
-                return snapshot.hasInitResult == false
-            }
-        )
+        #expect(manager.testStateSnapshot().hasInitResult == false)
     }
 
     @Test func sessionManagerPrimaryInitializedNotificationOverloadClearsSecondaryStateAndToolsCache()
@@ -4136,11 +4252,9 @@ struct RuntimeCoordinatorTests {
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            if case .quarantined = manager.testStateSnapshot().upstreams[1].healthState {
-                return true
-            }
-            return false
+        guard case .quarantined = manager.testStateSnapshot().upstreams[1].healthState else {
+            Issue.record("expected upstream1 to be quarantined")
+            return
         }
 
         await upstream0.yield(.exit(1))
@@ -4287,11 +4401,15 @@ struct RuntimeCoordinatorTests {
         let eventLoop = group.next()
         let upstream0 = ToggleableOverloadUpstreamClient()
         let upstream1 = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
             config: config,
             eventLoop: eventLoop,
-            upstreams: [upstream0, upstream1]
+            upstreams: [upstream0, upstream1],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
         )
         defer { manager.shutdownAndWait() }
 
@@ -4325,16 +4443,20 @@ struct RuntimeCoordinatorTests {
                 "message": "warm init failed",
             ],
         ]
+        let errorEventIndex = upstreamEvents.count()
         await upstream0.yield(
             .message(try JSONSerialization.data(withJSONObject: errorResponse, options: []))
         )
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: errorEventIndex,
+            description: "waiting for warm init failure"
+        )
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            let snapshot = manager.testStateSnapshot()
-            return snapshot.shouldRetryEagerInitializePrimaryAfterWarmInitFailure
-                && snapshot.upstreams[0].isInitialized == false
-                && snapshot.upstreams[0].initInFlight == false
-        }
+        let snapshot = manager.testStateSnapshot()
+        #expect(snapshot.shouldRetryEagerInitializePrimaryAfterWarmInitFailure)
+        #expect(snapshot.upstreams[0].isInitialized == false)
+        #expect(snapshot.upstreams[0].initInFlight == false)
 
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
@@ -4440,9 +4562,7 @@ struct RuntimeCoordinatorTests {
             eventLoop.makeSucceededFuture(())
         }
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.debugSnapshot().queuedRequestCount == 1
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
 
         manager.abandonRequestLease(
             queuedLeaseID,
@@ -4782,11 +4902,7 @@ struct RuntimeCoordinatorTests {
             upstreamIndex: 0
         )
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                await upstream.sentCount() >= 3
-            }
-        )
+        try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
 
         let restartedInitRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         let object = try #require(
@@ -4861,9 +4977,7 @@ struct RuntimeCoordinatorTests {
             return eventLoop.makeSucceededFuture(())
         }
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.debugSnapshot().queuedRequestCount == 1
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
 
         manager.handleUpstreamProtocolViolation(
             StdioFramer.ProtocolViolation(
@@ -5002,9 +5116,7 @@ struct RuntimeCoordinatorTests {
             eventLoop.makeSucceededFuture(())
         }
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.debugSnapshot().queuedRequestCount == 1
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
 
         manager.onRequestTimeout(
             sessionID: activeDescriptor.sessionID,
@@ -5023,14 +5135,10 @@ struct RuntimeCoordinatorTests {
             upstreamIndex: 0
         )
 
-        #expect(
-            await waitUntil(timeout: .seconds(2)) {
-                manager.debugSnapshot().queuedRequestCount == 0
-            }
-        )
         await #expect(throws: UpstreamSlotScheduler.AcquisitionError.self) {
             try await queuedFuture.get()
         }
+        #expect(manager.debugSnapshot().queuedRequestCount == 0)
 
         activePromise.fail(CancellationError())
     }
@@ -5131,9 +5239,7 @@ struct RuntimeCoordinatorTests {
             eventLoop.makeSucceededFuture(())
         }
 
-        try await waitForCondition(timeoutSeconds: 2) {
-            manager.debugSnapshot().queuedRequestCount == 1
-        }
+        #expect(manager.debugSnapshot().queuedRequestCount == 1)
 
         manager.debugReset()
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -4208,12 +4208,14 @@ struct RuntimeCoordinatorTests {
         let serverInfo = try #require(result["serverInfo"] as? [String: Any])
         #expect(serverInfo["name"] as? String == "cached-handshake")
 
-        let secondWarmRetry = try await nextValue(
+        let secondWarmRetry = try await waitWithTimeout(
             "primary should start another warm initialize after overload",
             timeout: .seconds(2)
         ) {
-            let sent = await upstream0.sent()
-            return sent.dropFirst(3).first(where: { methodName(from: $0) == "initialize" })
+            try await upstream0.nextSent(
+                startingAt: 3,
+                matching: { methodName(from: $0) == "initialize" }
+            )
         }
         #expect(methodName(from: secondWarmRetry) == "initialize")
     }

--- a/Tests/ProxySessionTests/TestUpstreamClient.swift
+++ b/Tests/ProxySessionTests/TestUpstreamClient.swift
@@ -53,6 +53,12 @@ actor TestUpstreamClient: UpstreamSlotControlling {
         try await sentMessages.nextValue(at: index)
     }
 
+    func nextSent(
+        matching predicate: @escaping @Sendable (Data) -> Bool
+    ) async throws -> Data {
+        try await sentMessages.nextValue(matching: predicate)
+    }
+
     func startCount() async -> Int {
         startCountValue
     }

--- a/Tests/ProxySessionTests/UpstreamReadinessTests.swift
+++ b/Tests/ProxySessionTests/UpstreamReadinessTests.swift
@@ -108,6 +108,7 @@ extension RuntimeCoordinatorTests {
         let upstream = TestUpstreamClient()
         let readiness = ReadinessFlag(isReady: false)
         let launchRecorder = XcodeLaunchRecorder()
+        let sleepRecorder = ControlledReadinessSleep()
         let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
             config: config,
@@ -115,18 +116,21 @@ extension RuntimeCoordinatorTests {
             upstreams: [upstream],
             upstreamReadinessGate: makeTestReadinessGate(
                 readiness: readiness,
+                sleepRecorder: sleepRecorder,
+                recordPollSleeps: true,
                 launchRecorder: launchRecorder
             )
         )
         defer { manager.shutdownAndWait() }
 
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            await launchRecorder.launchCount() == 1
-        })
+        _ = try await waitWithTimeout("waiting for Xcode launch attempt", timeout: .seconds(2)) {
+            try await launchRecorder.nextLaunch(at: 0)
+        }
         #expect(await upstream.startCount() == 0)
         #expect(await upstream.sentCount() == 0)
 
         await readiness.setReady(true)
+        await sleepRecorder.resumeNext()
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
         #expect(await launchRecorder.launchCount() == 1)
         #expect(await upstream.startCount() > 0)
@@ -139,6 +143,7 @@ extension RuntimeCoordinatorTests {
         let upstream = TestUpstreamClient()
         let readiness = ReadinessFlag(isReady: false)
         let launchRecorder = XcodeLaunchRecorder(outcomes: [false, true])
+        let sleepRecorder = ControlledReadinessSleep()
         let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
             config: config,
@@ -146,17 +151,30 @@ extension RuntimeCoordinatorTests {
             upstreams: [upstream],
             upstreamReadinessGate: makeTestReadinessGate(
                 readiness: readiness,
+                sleepRecorder: sleepRecorder,
+                recordPollSleeps: true,
                 launchRecorder: launchRecorder
             )
         )
         defer { manager.shutdownAndWait() }
 
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            await launchRecorder.launchCount() == 2
-        })
+        _ = try await waitWithTimeout("waiting for first Xcode launch attempt", timeout: .seconds(2)) {
+            try await launchRecorder.nextLaunch(at: 0)
+        }
+        _ = try await waitWithTimeout(
+            "waiting for readiness poll after failed launch",
+            timeout: .seconds(2)
+        ) {
+            try await sleepRecorder.nextSleep(at: 0)
+        }
+        await sleepRecorder.resumeNext()
+        _ = try await waitWithTimeout("waiting for retried Xcode launch attempt", timeout: .seconds(2)) {
+            try await launchRecorder.nextLaunch(at: 1)
+        }
         #expect(await upstream.startCount() == 0)
 
         await readiness.setReady(true)
+        await sleepRecorder.resumeNext()
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
     }
 
@@ -168,6 +186,7 @@ extension RuntimeCoordinatorTests {
         let readiness = ReadinessFlag(isReady: false)
         let availability = AvailabilityFlag(isAvailable: false)
         let launchRecorder = XcodeLaunchRecorder()
+        let sleepRecorder = ControlledReadinessSleep()
         let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
             config: config,
@@ -176,19 +195,26 @@ extension RuntimeCoordinatorTests {
             upstreamReadinessGate: makeTestReadinessGate(
                 readiness: readiness,
                 availability: availability,
-                launchRetryIntervalNanoseconds: 2_000_000,
+                sleepRecorder: sleepRecorder,
+                recordPollSleeps: true,
+                launchRetryIntervalNanoseconds: 0,
                 launchRecorder: launchRecorder
             )
         )
         defer { manager.shutdownAndWait() }
 
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            await launchRecorder.launchCount() >= 2
-        })
+        _ = try await waitWithTimeout("waiting for first Xcode launch attempt", timeout: .seconds(2)) {
+            try await launchRecorder.nextLaunch(at: 0)
+        }
+        await sleepRecorder.resumeNext()
+        _ = try await waitWithTimeout("waiting for retried Xcode launch attempt", timeout: .seconds(2)) {
+            try await launchRecorder.nextLaunch(at: 1)
+        }
         #expect(await upstream.startCount() == 0)
 
         await availability.setAvailable(true)
         await readiness.setReady(true)
+        await sleepRecorder.resumeNext()
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
         #expect(await upstream.startCount() > 0)
     }
@@ -201,6 +227,7 @@ extension RuntimeCoordinatorTests {
         let readiness = ReadinessFlag(isReady: false)
         let availability = AvailabilityFlag(isAvailable: true)
         let launchRecorder = XcodeLaunchRecorder()
+        let sleepRecorder = ControlledReadinessSleep()
         let config = makeConfig(requestTimeout: 5)
         let manager = RuntimeCoordinator(
             config: config,
@@ -209,6 +236,8 @@ extension RuntimeCoordinatorTests {
             upstreamReadinessGate: makeTestReadinessGate(
                 readiness: readiness,
                 availability: availability,
+                sleepRecorder: sleepRecorder,
+                recordPollSleeps: true,
                 launchRecorder: launchRecorder
             )
         )
@@ -218,14 +247,22 @@ extension RuntimeCoordinatorTests {
         #expect(await launchRecorder.launchCount() == 0)
         #expect(await upstream.startCount() == 0)
 
+        _ = try await waitWithTimeout(
+            "waiting for readiness poll sleep",
+            timeout: .seconds(2)
+        ) {
+            try await sleepRecorder.nextSleep(at: 0)
+        }
         await availability.setAvailable(false)
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            await launchRecorder.launchCount() == 1
-        })
+        await sleepRecorder.resumeNext()
+        _ = try await waitWithTimeout("waiting for Xcode launch after quit", timeout: .seconds(2)) {
+            try await launchRecorder.nextLaunch(at: 0)
+        }
         #expect(await upstream.startCount() == 0)
 
         await availability.setAvailable(true)
         await readiness.setReady(true)
+        await sleepRecorder.resumeNext()
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
         #expect(await upstream.startCount() > 0)
     }
@@ -370,9 +407,7 @@ extension RuntimeCoordinatorTests {
         let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
         let upstreamID = try extractUpstreamID(from: sent)
         await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            manager.isInitialized()
-        })
+        _ = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
 
         await readiness.setReady(false)
         await upstream.yield(.exit(1))
@@ -405,9 +440,7 @@ extension RuntimeCoordinatorTests {
         let firstInit = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
         let firstInitID = try extractUpstreamID(from: firstInit)
         await upstream.yield(.message(try makeInitializeResponse(id: firstInitID)))
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            manager.isInitialized()
-        })
+        _ = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
 
         await upstream.yield(.exit(1))
         _ = try await waitWithTimeout(
@@ -423,9 +456,7 @@ extension RuntimeCoordinatorTests {
         let secondInit = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         let secondInitID = try extractUpstreamID(from: secondInit)
         await upstream.yield(.message(try makeInitializeResponse(id: secondInitID)))
-        #expect(await waitUntil(timeout: .seconds(2)) {
-            manager.isInitialized()
-        })
+        _ = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
 
         await upstream.yield(.exit(1))
         let secondDelay = try await waitWithTimeout(

--- a/Tests/XcodeMCPTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPTestSupport/AsyncTestSupport.swift
@@ -80,6 +80,254 @@ package actor RecordedValues<Value: Sendable> {
     }
 }
 
+package final class LockedRecordedValues<Value: Sendable>: @unchecked Sendable {
+    private struct Waiter {
+        let id: UUID
+        let index: Int
+        let continuation: CheckedContinuation<Value, Error>
+    }
+
+    private struct State {
+        var values: [Value] = []
+        var waiters: [Waiter] = []
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    package init() {}
+
+    package func append(_ value: Value) {
+        let waitersToResume = state.withLockedValue { state -> [(Waiter, Value)] in
+            state.values.append(value)
+
+            var remaining: [Waiter] = []
+            var resumptions: [(Waiter, Value)] = []
+            for waiter in state.waiters {
+                if state.values.indices.contains(waiter.index) {
+                    resumptions.append((waiter, state.values[waiter.index]))
+                } else {
+                    remaining.append(waiter)
+                }
+            }
+            state.waiters = remaining
+            return resumptions
+        }
+
+        for (waiter, value) in waitersToResume {
+            waiter.continuation.resume(returning: value)
+        }
+    }
+
+    package func count() -> Int {
+        state.withLockedValue { $0.values.count }
+    }
+
+    package func value(at index: Int) -> Value? {
+        state.withLockedValue { state in
+            guard state.values.indices.contains(index) else {
+                return nil
+            }
+            return state.values[index]
+        }
+    }
+
+    package func nextValue(at index: Int) async throws -> Value {
+        if let existing = value(at: index) {
+            return existing
+        }
+
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let existing = state.withLockedValue { state -> Value? in
+                    if state.values.indices.contains(index) {
+                        return state.values[index]
+                    }
+                    state.waiters.append(
+                        Waiter(id: waiterID, index: index, continuation: continuation)
+                    )
+                    return nil
+                }
+                if let existing {
+                    continuation.resume(returning: existing)
+                }
+            }
+        } onCancel: {
+            self.cancelWaiter(id: waiterID)
+        }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        let waiter = state.withLockedValue { state -> Waiter? in
+            guard let index = state.waiters.firstIndex(where: { $0.id == id }) else {
+                return nil
+            }
+            return state.waiters.remove(at: index)
+        }
+        waiter?.continuation.resume(throwing: CancellationError())
+    }
+}
+
+package actor OperationGate<Key: Hashable & Sendable> {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private struct SuspensionWaiter {
+        let id: UUID
+        let key: Key
+        let minimumWaiters: Int
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private var waitersByKey: [Key: [Waiter]] = [:]
+    private var releaseCreditsByKey: [Key: Int] = [:]
+    private var suspensionWaiters: [SuspensionWaiter] = []
+
+    package init() {}
+
+    package func wait(for key: Key) async throws {
+        if consumeReleaseCredit(for: key) {
+            return
+        }
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if consumeReleaseCredit(for: key) {
+                    continuation.resume(returning: ())
+                    return
+                }
+                waitersByKey[key, default: []].append(
+                    Waiter(id: waiterID, continuation: continuation)
+                )
+                resumeReadySuspensionWaiters()
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(id: waiterID, key: key)
+            }
+        }
+    }
+
+    package func waitUntilWaiting(for key: Key, count minimumWaiters: Int) async throws {
+        guard waitingCount(for: key) < minimumWaiters else {
+            return
+        }
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if waitingCount(for: key) >= minimumWaiters {
+                    continuation.resume(returning: ())
+                    return
+                }
+                suspensionWaiters.append(
+                    SuspensionWaiter(
+                        id: waiterID,
+                        key: key,
+                        minimumWaiters: minimumWaiters,
+                        continuation: continuation
+                    )
+                )
+            }
+        } onCancel: {
+            Task {
+                await self.cancelSuspensionWaiter(id: waiterID)
+            }
+        }
+    }
+
+    package func release(_ key: Key, count: Int = 1) {
+        guard count > 0 else {
+            return
+        }
+
+        var resumptions: [CheckedContinuation<Void, Error>] = []
+        var remainingReleaseCount = count
+        while remainingReleaseCount > 0 {
+            guard var waiters = waitersByKey[key], waiters.isEmpty == false else {
+                releaseCreditsByKey[key, default: 0] += remainingReleaseCount
+                break
+            }
+            let waiter = waiters.removeFirst()
+            if waiters.isEmpty {
+                waitersByKey.removeValue(forKey: key)
+            } else {
+                waitersByKey[key] = waiters
+            }
+            resumptions.append(waiter.continuation)
+            remainingReleaseCount -= 1
+        }
+
+        for continuation in resumptions {
+            continuation.resume(returning: ())
+        }
+    }
+
+    package func releaseAll(for key: Key) {
+        let waiters = waitersByKey.removeValue(forKey: key) ?? []
+        for waiter in waiters {
+            waiter.continuation.resume(returning: ())
+        }
+    }
+
+    package func waitingCount(for key: Key) -> Int {
+        waitersByKey[key]?.count ?? 0
+    }
+
+    private func consumeReleaseCredit(for key: Key) -> Bool {
+        guard let credits = releaseCreditsByKey[key], credits > 0 else {
+            return false
+        }
+        if credits == 1 {
+            releaseCreditsByKey.removeValue(forKey: key)
+        } else {
+            releaseCreditsByKey[key] = credits - 1
+        }
+        return true
+    }
+
+    private func cancelWaiter(id: UUID, key: Key) {
+        guard var waiters = waitersByKey[key],
+              let index = waiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = waiters.remove(at: index)
+        if waiters.isEmpty {
+            waitersByKey.removeValue(forKey: key)
+        } else {
+            waitersByKey[key] = waiters
+        }
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelSuspensionWaiter(id: UUID) {
+        guard let index = suspensionWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = suspensionWaiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func resumeReadySuspensionWaiters() {
+        var ready: [SuspensionWaiter] = []
+        var remaining: [SuspensionWaiter] = []
+        for waiter in suspensionWaiters {
+            if waitingCount(for: waiter.key) >= waiter.minimumWaiters {
+                ready.append(waiter)
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        suspensionWaiters = remaining
+        for waiter in ready {
+            waiter.continuation.resume(returning: ())
+        }
+    }
+}
+
 @discardableResult
 package func waitWithTimeout<T: Sendable>(
     _ description: String = "timed out waiting for async operation",
@@ -111,6 +359,9 @@ package func waitUntil(
     pollInterval: Duration = .milliseconds(10),
     _ condition: @escaping @Sendable () async -> Bool
 ) async -> Bool {
+    // Use this only as a guard around external I/O or OS-driven eventual state.
+    // Intra-process concurrency tests should prefer RecordedValues, OperationGate,
+    // or TestClock so the awaited synchronization point is explicit.
     let clock = ContinuousClock()
     let deadline = clock.now.advanced(by: timeout)
 
@@ -132,6 +383,8 @@ package func spinUntil(
     maxIterations: Int = 200,
     _ condition: @escaping @Sendable () async -> Bool
 ) async throws {
+    // Legacy fallback for places that cannot expose an explicit async event yet.
+    // New deterministic tests should use continuation-backed primitives instead.
     for _ in 0..<maxIterations {
         if await condition() {
             return

--- a/Tests/XcodeMCPTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPTestSupport/AsyncTestSupport.swift
@@ -19,8 +19,16 @@ package actor RecordedValues<Value: Sendable> {
         let continuation: CheckedContinuation<Value, Error>
     }
 
+    private struct MatchingWaiter {
+        let id: UUID
+        let startingAt: Int
+        let predicate: @Sendable (Value) -> Bool
+        let continuation: CheckedContinuation<Value, Error>
+    }
+
     private var values: [Value] = []
     private var waiters: [Waiter] = []
+    private var matchingWaiters: [MatchingWaiter] = []
 
     package init() {}
 
@@ -39,6 +47,16 @@ package actor RecordedValues<Value: Sendable> {
             }
         }
         waiters = remaining
+
+        var remainingMatchingWaiters: [MatchingWaiter] = []
+        for waiter in matchingWaiters {
+            if index >= waiter.startingAt, waiter.predicate(value) {
+                waiter.continuation.resume(returning: value)
+            } else {
+                remainingMatchingWaiters.append(waiter)
+            }
+        }
+        matchingWaiters = remainingMatchingWaiters
     }
 
     package func snapshot() -> [Value] {
@@ -71,12 +89,63 @@ package actor RecordedValues<Value: Sendable> {
         }
     }
 
+    package func nextValue(
+        startingAt startIndex: Int = 0,
+        matching predicate: @escaping @Sendable (Value) -> Bool
+    ) async throws -> Value {
+        let startIndex = max(startIndex, 0)
+        if let existing = firstValue(startingAt: startIndex, matching: predicate) {
+            return existing
+        }
+
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if let existing = firstValue(startingAt: startIndex, matching: predicate) {
+                    continuation.resume(returning: existing)
+                    return
+                }
+                matchingWaiters.append(
+                    MatchingWaiter(
+                        id: waiterID,
+                        startingAt: startIndex,
+                        predicate: predicate,
+                        continuation: continuation
+                    )
+                )
+            }
+        } onCancel: {
+            Task { await self.cancelMatchingWaiter(id: waiterID) }
+        }
+    }
+
     private func cancelWaiter(id: UUID) {
         guard let index = waiters.firstIndex(where: { $0.id == id }) else {
             return
         }
         let waiter = waiters.remove(at: index)
         waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelMatchingWaiter(id: UUID) {
+        guard let index = matchingWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = matchingWaiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func firstValue(
+        startingAt startIndex: Int,
+        matching predicate: @Sendable (Value) -> Bool
+    ) -> Value? {
+        guard startIndex < values.count else {
+            return nil
+        }
+        for index in startIndex..<values.count where predicate(values[index]) {
+            return values[index]
+        }
+        return nil
     }
 }
 
@@ -122,7 +191,7 @@ package final class LockedRecordedValues<Value: Sendable>: @unchecked Sendable {
         state.withLockedValue { $0.values.count }
     }
 
-    package func value(at index: Int) -> Value? {
+    private func value(at index: Int) -> Value? {
         state.withLockedValue { state in
             guard state.values.indices.contains(index) else {
                 return nil
@@ -266,14 +335,7 @@ package actor OperationGate<Key: Hashable & Sendable> {
         }
     }
 
-    package func releaseAll(for key: Key) {
-        let waiters = waitersByKey.removeValue(forKey: key) ?? []
-        for waiter in waiters {
-            waiter.continuation.resume(returning: ())
-        }
-    }
-
-    package func waitingCount(for key: Key) -> Int {
+    private func waitingCount(for key: Key) -> Int {
         waitersByKey[key]?.count ?? 0
     }
 
@@ -376,48 +438,6 @@ package func waitUntil(
     }
 
     return await condition()
-}
-
-package func spinUntil(
-    _ description: String = "condition was not satisfied",
-    maxIterations: Int = 200,
-    _ condition: @escaping @Sendable () async -> Bool
-) async throws {
-    // Legacy fallback for places that cannot expose an explicit async event yet.
-    // New deterministic tests should use continuation-backed primitives instead.
-    for _ in 0..<maxIterations {
-        if await condition() {
-            return
-        }
-        await Task.yield()
-    }
-    throw AsyncTestTimeoutError(description: description)
-}
-
-package func waitUntilCount(
-    _ expectedCount: Int,
-    count: @escaping @Sendable () async -> Int,
-    timeout: Duration = .seconds(5)
-) async -> Bool {
-    await waitUntil(timeout: timeout) {
-        await count() >= expectedCount
-    }
-}
-
-package func nextValue<Value: Sendable>(
-    _ description: String,
-    timeout: Duration = .seconds(5),
-    value: @escaping @Sendable () async throws -> Value?
-) async throws -> Value {
-    try await waitWithTimeout(description, timeout: timeout) {
-        while true {
-            try Task.checkCancellation()
-            if let next = try await value() {
-                return next
-            }
-            await Task.yield()
-        }
-    }
 }
 
 package func shutdown(_ group: EventLoopGroup) async {


### PR DESCRIPTION
## Purpose

Remove scheduler-dependent async test behavior that can hang CI, especially around DocumentationProviderManager shared preparation and related proxy concurrency tests.

## Changes

- Added continuation-backed test primitives for operation gates and recorded synchronous hooks.
- Injected manual-clock-friendly wait paths into documentation provider timeout handling.
- Added package-internal test hooks for provider preparation, runtime event handling, tools/list refreshes, and refresh-code-issues queue events.
- Refactored ProxySession and refresh-code-issues coordinator tests away from Task.sleep, Task.yield, spin loops, and polling for internal state.
- Documented the remaining polling helpers as bounded external I/O guards for URLSession/NIO/process integration tests.

## Testing

- swift test --no-parallel -Xswiftc -strict-concurrency=minimal
- XCODE_MCP_RUN_PROCESS_TESTS=1 swift test --no-parallel --filter ProxyProcessTests -Xswiftc -strict-concurrency=minimal
- scripts/check.sh
