### PR TITLE
Introduce MCP contract target for protocol version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,8 +48,15 @@ let package = Package(
             ]
         ),
         .target(
+            name: "ProxyMCPContract",
+            dependencies: [],
+            path: "Sources/ProxyMCPContract",
+            swiftSettings: strictSwiftSettings
+        ),
+        .target(
             name: "ProxyCore",
             dependencies: [
+                "ProxyMCPContract",
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "NIO", package: "swift-nio"),

--- a/Sources/ProxyCore/MCPProtocolVersion.swift
+++ b/Sources/ProxyCore/MCPProtocolVersion.swift
@@ -1,11 +1,1 @@
-public enum MCP {}
-
-extension MCP {
-    public enum ProtocolVersion {
-        public static let current = "2025-06-18"
-
-        public static func isSupported(_ version: String) -> Bool {
-            version == current
-        }
-    }
-}
+@_exported import ProxyMCPContract

--- a/Sources/ProxyMCPContract/MCPProtocolVersion.swift
+++ b/Sources/ProxyMCPContract/MCPProtocolVersion.swift
@@ -1,0 +1,11 @@
+public enum MCP {}
+
+extension MCP {
+    public enum ProtocolVersion {
+        public static let current = "2025-06-18"
+
+        public static func isSupported(_ version: String) -> Bool {
+            version == current
+        }
+    }
+}

--- a/Tests/ProxyArchitectureTests/ArchitectureTests.swift
+++ b/Tests/ProxyArchitectureTests/ArchitectureTests.swift
@@ -47,6 +47,7 @@ struct ArchitectureTests {
 
 private let requiredSourceDirectories = [
     "Sources/ProxyBuildInfo",
+    "Sources/ProxyMCPContract",
     "Sources/ProxyCore",
     "Sources/ProxyMCP",
     "Sources/ProxySessionControlPlane",
@@ -69,6 +70,16 @@ private struct ForbiddenImportRule {
 }
 
 private let forbiddenImportRules = [
+    ForbiddenImportRule(
+        sourceDirectory: "Sources/ProxyMCPContract",
+        forbiddenModules: [
+            "ProxyBuildInfo", "ProxyCore",
+            "ProxyMCP", "ProxySessionControlPlane", "ProxySessionUpstream", "ProxySession",
+            "ProxyXcodeSupport", "ProxyXcodeFeatures", "ProxyHTTPGateway",
+            "ProxyStdioTransport", "XcodeMCPProxy",
+            "ProxyCLICommon", "ProxyAdapterCLI", "ProxyServerCLI", "ProxyInstallCLI",
+        ]
+    ),
     ForbiddenImportRule(
         sourceDirectory: "Sources/ProxyCore",
         forbiddenModules: [


### PR DESCRIPTION
Purpose

Introduce the first lower-level MCP contract target for protocol-version primitives as part of the layered runtime refactor, while preserving the existing `MCP.ProtocolVersion` source spelling and wire behavior.

Changes

- Added a new `ProxyMCPContract` target below `ProxyCore`.
- Moved the authoritative `MCP.ProtocolVersion` definition into `ProxyMCPContract`.
- Re-exported `ProxyMCPContract` from `ProxyCore` so existing `import ProxyCore` callers keep resolving `MCP.ProtocolVersion`.
- Updated architecture tests to require the new source directory and forbid the contract target from importing higher-level modules.

Testing

- `swift test --filter ProxyArchitectureTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- Codex review against `codex/refactor-layered-runtime-integration`: no findings