### PR TITLE
Add upstream topology identities

### DIFF
--- a/Sources/ProxySession/Session/UpstreamRouter.swift
+++ b/Sources/ProxySession/Session/UpstreamRouter.swift
@@ -8,13 +8,26 @@ extension RuntimeCoordinator {
     package struct DefaultUpstreamPlan: Sendable {
         package let upstreams: [ManagedUpstreamSlot]
         package let xcodeProcessRoutes: [XcodeProcessRoute]
+        package let topology: UpstreamTopologySnapshot
 
         package init(
             upstreams: [ManagedUpstreamSlot],
-            xcodeProcessRoutes: [XcodeProcessRoute] = []
+            xcodeProcessRoutes: [XcodeProcessRoute] = [],
+            topology: UpstreamTopologySnapshot? = nil
         ) {
             self.upstreams = upstreams
-            self.xcodeProcessRoutes = xcodeProcessRoutes
+            self.topology = topology ?? UpstreamTopologySnapshot(
+                slotCount: upstreams.count,
+                xcodeProcessBindings: xcodeProcessRoutes.map { route in
+                    XcodeProcessBinding(
+                        target: route.target,
+                        slotIDs: route.upstreamIndices.map { UpstreamSlotID(rawValue: $0) }
+                    )
+                }
+            )
+            self.xcodeProcessRoutes = xcodeProcessRoutes.isEmpty
+                ? self.topology.xcodeProcessRoutes()
+                : xcodeProcessRoutes
         }
     }
 
@@ -42,16 +55,16 @@ extension RuntimeCoordinator {
             orderedXcodeTargets.isEmpty == false
             && XcrunArguments.isDefaultMCPBridgeInvocation(config: config)
         var upstreams: [ManagedUpstreamSlot] = []
-        var xcodeProcessRoutes: [XcodeProcessRoute] = []
+        var xcodeProcessBindings: [XcodeProcessBinding] = []
         let upstreamCount = max(1, count)
 
         if canUseProcessBoundXcodeUpstreams {
             upstreams.reserveCapacity(orderedXcodeTargets.count * upstreamCount)
-            xcodeProcessRoutes.reserveCapacity(orderedXcodeTargets.count)
+            xcodeProcessBindings.reserveCapacity(orderedXcodeTargets.count)
 
             for target in orderedXcodeTargets {
-                var upstreamIndices: [Int] = []
-                upstreamIndices.reserveCapacity(upstreamCount)
+                var slotIDs: [UpstreamSlotID] = []
+                slotIDs.reserveCapacity(upstreamCount)
                 for _ in 0..<upstreamCount {
                     let upstreamIndex = upstreams.count
                     let upstreamConfig = makeDefaultUpstreamConfig(
@@ -62,11 +75,12 @@ extension RuntimeCoordinator {
                     upstreams.append(
                         ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig))
                     )
-                    upstreamIndices.append(upstreamIndex)
+                    slotIDs.append(UpstreamSlotID(rawValue: upstreamIndex))
                 }
 
-                let route = XcodeProcessRoute(target: target, upstreamIndices: upstreamIndices)
-                xcodeProcessRoutes.append(route)
+                xcodeProcessBindings.append(
+                    XcodeProcessBinding(target: target, slotIDs: slotIDs)
+                )
             }
         } else {
             upstreams.reserveCapacity(upstreamCount)
@@ -81,10 +95,15 @@ extension RuntimeCoordinator {
                 )
             }
         }
+        let topology = UpstreamTopologySnapshot(
+            slotCount: upstreams.count,
+            xcodeProcessBindings: xcodeProcessBindings
+        )
 
         return DefaultUpstreamPlan(
             upstreams: upstreams,
-            xcodeProcessRoutes: xcodeProcessRoutes
+            xcodeProcessRoutes: topology.xcodeProcessRoutes(),
+            topology: topology
         )
     }
 

--- a/Sources/ProxySession/Upstream/UpstreamTopologySnapshot.swift
+++ b/Sources/ProxySession/Upstream/UpstreamTopologySnapshot.swift
@@ -1,0 +1,137 @@
+import Foundation
+import ProxyCore
+
+package struct UpstreamSlotID: Sendable, Hashable, Comparable {
+    package let rawValue: Int
+
+    package init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    package static func < (lhs: UpstreamSlotID, rhs: UpstreamSlotID) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+package struct XcodeProcessID: Sendable, Hashable, Comparable {
+    package let rawValue: pid_t
+
+    package init(rawValue: pid_t) {
+        self.rawValue = rawValue
+    }
+
+    package init(_ target: XcodeProcessTarget) {
+        self.init(rawValue: target.processID)
+    }
+
+    package static func < (lhs: XcodeProcessID, rhs: XcodeProcessID) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+package struct XcodeVersionKey: Sendable, Hashable {
+    package let xcodeVersion: String
+    package let developerDir: String
+    package let mcpbridgePath: String
+
+    package init(
+        xcodeVersion: String,
+        developerDir: String,
+        mcpbridgePath: String
+    ) {
+        self.xcodeVersion = xcodeVersion
+        self.developerDir = developerDir
+        self.mcpbridgePath = mcpbridgePath
+    }
+
+    package init(_ target: XcodeProcessTarget) {
+        self.init(
+            xcodeVersion: target.xcodeVersion,
+            developerDir: target.developerDir,
+            mcpbridgePath: target.mcpbridgePath
+        )
+    }
+}
+
+package enum UpstreamSelectionScope: Sendable, Hashable {
+    case any
+    case xcodeProcess(XcodeProcessID)
+    case xcodeVersion(XcodeVersionKey)
+}
+
+package struct XcodeProcessBinding: Sendable, Equatable {
+    package let processID: XcodeProcessID
+    package let versionKey: XcodeVersionKey
+    package let target: XcodeProcessTarget
+    package let slotIDs: [UpstreamSlotID]
+    package let selectionScope: UpstreamSelectionScope
+
+    package init(
+        processID: XcodeProcessID,
+        versionKey: XcodeVersionKey,
+        target: XcodeProcessTarget,
+        slotIDs: [UpstreamSlotID],
+        selectionScope: UpstreamSelectionScope
+    ) {
+        self.processID = processID
+        self.versionKey = versionKey
+        self.target = target
+        self.slotIDs = slotIDs
+        self.selectionScope = selectionScope
+    }
+
+    package init(target: XcodeProcessTarget, slotIDs: [UpstreamSlotID]) {
+        let processID = XcodeProcessID(target)
+        self.init(
+            processID: processID,
+            versionKey: XcodeVersionKey(target),
+            target: target,
+            slotIDs: slotIDs,
+            selectionScope: .xcodeProcess(processID)
+        )
+    }
+}
+
+package struct UpstreamTopologySnapshot: Sendable, Equatable {
+    package let slotIDs: [UpstreamSlotID]
+    package let xcodeProcessBindings: [XcodeProcessBinding]
+
+    package init(
+        slotIDs: [UpstreamSlotID],
+        xcodeProcessBindings: [XcodeProcessBinding] = []
+    ) {
+        self.slotIDs = slotIDs
+        self.xcodeProcessBindings = xcodeProcessBindings
+    }
+
+    package init(
+        slotCount: Int,
+        xcodeProcessBindings: [XcodeProcessBinding] = []
+    ) {
+        self.init(
+            slotIDs: (0..<max(0, slotCount)).map { UpstreamSlotID(rawValue: $0) },
+            xcodeProcessBindings: xcodeProcessBindings
+        )
+    }
+
+    package static let empty = UpstreamTopologySnapshot(slotIDs: [])
+
+    package func xcodeProcessRoutes() -> [XcodeProcessRoute] {
+        xcodeProcessBindings.map { binding in
+            XcodeProcessRoute(
+                target: binding.target,
+                upstreamIndices: binding.slotIDs.map(\.rawValue)
+            )
+        }
+    }
+
+    package func binding(forSlotID slotID: UpstreamSlotID) -> XcodeProcessBinding? {
+        xcodeProcessBindings.first { binding in
+            binding.slotIDs.contains(slotID)
+        }
+    }
+
+    package func binding(forUpstreamIndex upstreamIndex: Int) -> XcodeProcessBinding? {
+        binding(forSlotID: UpstreamSlotID(rawValue: upstreamIndex))
+    }
+}

--- a/Sources/ProxySession/Upstream/UpstreamTopologySnapshot.swift
+++ b/Sources/ProxySession/Upstream/UpstreamTopologySnapshot.swift
@@ -55,6 +55,7 @@ package struct XcodeVersionKey: Sendable, Hashable {
 
 package enum UpstreamSelectionScope: Sendable, Hashable {
     case any
+    case slots([UpstreamSlotID])
     case xcodeProcess(XcodeProcessID)
     case xcodeVersion(XcodeVersionKey)
 }
@@ -64,30 +65,25 @@ package struct XcodeProcessBinding: Sendable, Equatable {
     package let versionKey: XcodeVersionKey
     package let target: XcodeProcessTarget
     package let slotIDs: [UpstreamSlotID]
-    package let selectionScope: UpstreamSelectionScope
 
     package init(
         processID: XcodeProcessID,
         versionKey: XcodeVersionKey,
         target: XcodeProcessTarget,
-        slotIDs: [UpstreamSlotID],
-        selectionScope: UpstreamSelectionScope
+        slotIDs: [UpstreamSlotID]
     ) {
         self.processID = processID
         self.versionKey = versionKey
         self.target = target
         self.slotIDs = slotIDs
-        self.selectionScope = selectionScope
     }
 
     package init(target: XcodeProcessTarget, slotIDs: [UpstreamSlotID]) {
-        let processID = XcodeProcessID(target)
         self.init(
-            processID: processID,
+            processID: XcodeProcessID(target),
             versionKey: XcodeVersionKey(target),
             target: target,
-            slotIDs: slotIDs,
-            selectionScope: .xcodeProcess(processID)
+            slotIDs: slotIDs
         )
     }
 }
@@ -125,6 +121,23 @@ package struct UpstreamTopologySnapshot: Sendable, Equatable {
         }
     }
 
+    package func slotIDs(matching scope: UpstreamSelectionScope) -> [UpstreamSlotID] {
+        switch scope {
+        case .any:
+            return slotIDs
+        case .slots(let requestedSlotIDs):
+            return validUniqueSlotIDs(requestedSlotIDs)
+        case .xcodeProcess(let processID):
+            return xcodeProcessBindings.first { binding in
+                binding.processID == processID
+            }?.slotIDs ?? []
+        case .xcodeVersion(let versionKey):
+            return xcodeProcessBindings.flatMap { binding -> [UpstreamSlotID] in
+                binding.versionKey == versionKey ? binding.slotIDs : []
+            }
+        }
+    }
+
     package func binding(forSlotID slotID: UpstreamSlotID) -> XcodeProcessBinding? {
         xcodeProcessBindings.first { binding in
             binding.slotIDs.contains(slotID)
@@ -133,5 +146,18 @@ package struct UpstreamTopologySnapshot: Sendable, Equatable {
 
     package func binding(forUpstreamIndex upstreamIndex: Int) -> XcodeProcessBinding? {
         binding(forSlotID: UpstreamSlotID(rawValue: upstreamIndex))
+    }
+
+    private func validUniqueSlotIDs(_ requestedSlotIDs: [UpstreamSlotID]) -> [UpstreamSlotID] {
+        let knownSlotIDs = Set(slotIDs)
+        var seenSlotIDs = Set<UpstreamSlotID>()
+        return requestedSlotIDs.filter { slotID in
+            guard knownSlotIDs.contains(slotID),
+                  seenSlotIDs.contains(slotID) == false else {
+                return false
+            }
+            seenSlotIDs.insert(slotID)
+            return true
+        }
     }
 }

--- a/Sources/ProxySession/Upstream/UpstreamTopologySnapshot.swift
+++ b/Sources/ProxySession/Upstream/UpstreamTopologySnapshot.swift
@@ -128,13 +128,17 @@ package struct UpstreamTopologySnapshot: Sendable, Equatable {
         case .slots(let requestedSlotIDs):
             return validUniqueSlotIDs(requestedSlotIDs)
         case .xcodeProcess(let processID):
-            return xcodeProcessBindings.first { binding in
+            guard let binding = xcodeProcessBindings.first(where: { binding in
                 binding.processID == processID
-            }?.slotIDs ?? []
+            }) else {
+                return []
+            }
+            return topologyOrderedSlotIDs(containedIn: binding.slotIDs)
         case .xcodeVersion(let versionKey):
-            return xcodeProcessBindings.flatMap { binding -> [UpstreamSlotID] in
+            let matchingSlotIDs = xcodeProcessBindings.flatMap { binding -> [UpstreamSlotID] in
                 binding.versionKey == versionKey ? binding.slotIDs : []
             }
+            return topologyOrderedSlotIDs(containedIn: matchingSlotIDs)
         }
     }
 
@@ -159,5 +163,12 @@ package struct UpstreamTopologySnapshot: Sendable, Equatable {
             seenSlotIDs.insert(slotID)
             return true
         }
+    }
+
+    private func topologyOrderedSlotIDs(containedIn candidateSlotIDs: [UpstreamSlotID])
+        -> [UpstreamSlotID]
+    {
+        let candidates = Set(candidateSlotIDs)
+        return slotIDs.filter { candidates.contains($0) }
     }
 }

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -247,16 +247,19 @@ extension RuntimeCoordinatorTests {
             ],
             xcodeProcessBindings: [
                 XcodeProcessBinding(
-                    target: firstSharedVersionTarget,
+                    target: secondSharedVersionTarget,
                     slotIDs: [
-                        UpstreamSlotID(rawValue: 0),
                         UpstreamSlotID(rawValue: 2),
+                        UpstreamSlotID(rawValue: 1),
                     ]
                 ),
                 XcodeProcessBinding(
-                    target: secondSharedVersionTarget,
+                    target: firstSharedVersionTarget,
                     slotIDs: [
-                        UpstreamSlotID(rawValue: 1),
+                        UpstreamSlotID(rawValue: 2),
+                        UpstreamSlotID(rawValue: 99),
+                        UpstreamSlotID(rawValue: 0),
+                        UpstreamSlotID(rawValue: 2),
                     ]
                 ),
                 XcodeProcessBinding(
@@ -293,8 +296,8 @@ extension RuntimeCoordinatorTests {
             firstSharedVersionTarget
         ))) == [
             UpstreamSlotID(rawValue: 0),
-            UpstreamSlotID(rawValue: 2),
             UpstreamSlotID(rawValue: 1),
+            UpstreamSlotID(rawValue: 2),
         ])
     }
 

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -220,6 +220,84 @@ extension RuntimeCoordinatorTests {
         #expect(base != differentMCPBridgePath)
     }
 
+    @Test func upstreamTopologyResolvesSelectionScopes() {
+        let sharedDeveloperDir = "/Applications/Xcode.app/Contents/Developer"
+        let sharedMCPBridgePath = "\(sharedDeveloperDir)/usr/bin/mcpbridge"
+        let firstSharedVersionTarget = XcodeProcessTarget(
+            processID: 700,
+            appPath: "/Applications/Xcode.app",
+            developerDir: sharedDeveloperDir,
+            mcpbridgePath: sharedMCPBridgePath,
+            xcodeVersion: "27.0"
+        )
+        let secondSharedVersionTarget = XcodeProcessTarget(
+            processID: 701,
+            appPath: "/Applications/Xcode.app",
+            developerDir: sharedDeveloperDir,
+            mcpbridgePath: sharedMCPBridgePath,
+            xcodeVersion: "27.0"
+        )
+        let otherVersionTarget = xcodeProcessTarget(processID: 702, xcodeVersion: "26.6")
+        let topology = UpstreamTopologySnapshot(
+            slotIDs: [
+                UpstreamSlotID(rawValue: 0),
+                UpstreamSlotID(rawValue: 1),
+                UpstreamSlotID(rawValue: 2),
+                UpstreamSlotID(rawValue: 3),
+            ],
+            xcodeProcessBindings: [
+                XcodeProcessBinding(
+                    target: firstSharedVersionTarget,
+                    slotIDs: [
+                        UpstreamSlotID(rawValue: 0),
+                        UpstreamSlotID(rawValue: 2),
+                    ]
+                ),
+                XcodeProcessBinding(
+                    target: secondSharedVersionTarget,
+                    slotIDs: [
+                        UpstreamSlotID(rawValue: 1),
+                    ]
+                ),
+                XcodeProcessBinding(
+                    target: otherVersionTarget,
+                    slotIDs: [
+                        UpstreamSlotID(rawValue: 3),
+                    ]
+                ),
+            ]
+        )
+
+        #expect(topology.slotIDs(matching: .any) == [
+            UpstreamSlotID(rawValue: 0),
+            UpstreamSlotID(rawValue: 1),
+            UpstreamSlotID(rawValue: 2),
+            UpstreamSlotID(rawValue: 3),
+        ])
+        #expect(topology.slotIDs(matching: .slots([
+            UpstreamSlotID(rawValue: 2),
+            UpstreamSlotID(rawValue: 99),
+            UpstreamSlotID(rawValue: 2),
+            UpstreamSlotID(rawValue: 0),
+        ])) == [
+            UpstreamSlotID(rawValue: 2),
+            UpstreamSlotID(rawValue: 0),
+        ])
+        #expect(topology.slotIDs(
+            matching: .xcodeProcess(XcodeProcessID(rawValue: firstSharedVersionTarget.processID))
+        ) == [
+            UpstreamSlotID(rawValue: 0),
+            UpstreamSlotID(rawValue: 2),
+        ])
+        #expect(topology.slotIDs(matching: .xcodeVersion(XcodeVersionKey(
+            firstSharedVersionTarget
+        ))) == [
+            UpstreamSlotID(rawValue: 0),
+            UpstreamSlotID(rawValue: 2),
+            UpstreamSlotID(rawValue: 1),
+        ])
+    }
+
     @Test func defaultUpstreamPlanBindsEachSlotToSingleXcodeProcess() throws {
         let target = xcodeProcessTarget(processID: 710, xcodeVersion: "27.0")
         var config = makeConfig(requestTimeout: 5)
@@ -250,7 +328,6 @@ extension RuntimeCoordinatorTests {
             UpstreamSlotID(rawValue: 0),
             UpstreamSlotID(rawValue: 1),
         ])
-        #expect(binding.selectionScope == .xcodeProcess(XcodeProcessID(rawValue: target.processID)))
         #expect(plan.topology.binding(forUpstreamIndex: 1)?.processID == binding.processID)
         for upstream in plan.upstreams {
             let environment = try upstreamEnvironment(from: upstream)

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -199,6 +199,27 @@ extension RuntimeCoordinatorTests {
         #expect(documentationDescriptorDescription(in: result) == "docs-asset-primary")
     }
 
+    @Test func xcodeVersionKeyDistinguishesDeveloperDirAndMCPBridgePath() {
+        let base = XcodeVersionKey(
+            xcodeVersion: "27.0",
+            developerDir: "/Applications/Xcode.app/Contents/Developer",
+            mcpbridgePath: "/Applications/Xcode.app/Contents/Developer/usr/bin/mcpbridge"
+        )
+        let differentDeveloperDir = XcodeVersionKey(
+            xcodeVersion: "27.0",
+            developerDir: "/Applications/Xcode-Beta.app/Contents/Developer",
+            mcpbridgePath: "/Applications/Xcode.app/Contents/Developer/usr/bin/mcpbridge"
+        )
+        let differentMCPBridgePath = XcodeVersionKey(
+            xcodeVersion: "27.0",
+            developerDir: "/Applications/Xcode.app/Contents/Developer",
+            mcpbridgePath: "/Applications/Xcode-Beta.app/Contents/Developer/usr/bin/mcpbridge"
+        )
+
+        #expect(base != differentDeveloperDir)
+        #expect(base != differentMCPBridgePath)
+    }
+
     @Test func defaultUpstreamPlanBindsEachSlotToSingleXcodeProcess() throws {
         let target = xcodeProcessTarget(processID: 710, xcodeVersion: "27.0")
         var config = makeConfig(requestTimeout: 5)
@@ -217,6 +238,20 @@ extension RuntimeCoordinatorTests {
         #expect(plan.xcodeProcessRoutes.count == 1)
         #expect(plan.xcodeProcessRoutes.first?.target.processID == target.processID)
         #expect(plan.xcodeProcessRoutes.first?.upstreamIndices == [0, 1])
+        #expect(plan.topology.slotIDs == [
+            UpstreamSlotID(rawValue: 0),
+            UpstreamSlotID(rawValue: 1),
+        ])
+        #expect(plan.topology.xcodeProcessRoutes() == plan.xcodeProcessRoutes)
+        let binding = try #require(plan.topology.xcodeProcessBindings.first)
+        #expect(binding.processID == XcodeProcessID(rawValue: target.processID))
+        #expect(binding.versionKey == XcodeVersionKey(target))
+        #expect(binding.slotIDs == [
+            UpstreamSlotID(rawValue: 0),
+            UpstreamSlotID(rawValue: 1),
+        ])
+        #expect(binding.selectionScope == .xcodeProcess(XcodeProcessID(rawValue: target.processID)))
+        #expect(plan.topology.binding(forUpstreamIndex: 1)?.processID == binding.processID)
         for upstream in plan.upstreams {
             let environment = try upstreamEnvironment(from: upstream)
             #expect(try upstreamCommand(from: upstream) == target.mcpbridgePath)
@@ -249,6 +284,11 @@ extension RuntimeCoordinatorTests {
             older.processID,
         ])
         #expect(plan.xcodeProcessRoutes.map(\.upstreamIndices) == [[0], [1]])
+        #expect(plan.topology.xcodeProcessRoutes() == plan.xcodeProcessRoutes)
+        #expect(plan.topology.xcodeProcessBindings.map(\.processID) == [
+            XcodeProcessID(rawValue: newer.processID),
+            XcodeProcessID(rawValue: older.processID),
+        ])
         let firstEnvironment = try upstreamEnvironment(from: try #require(plan.upstreams.first))
         let secondEnvironment = try upstreamEnvironment(from: try #require(plan.upstreams.dropFirst().first))
         #expect(firstEnvironment["MCP_XCODE_PID"] == "\(newer.processID)")


### PR DESCRIPTION
Purpose
- Introduce an adapter-layer topology model for upstream slot, Xcode process, and Xcode version/source identity without changing current routing behavior.

Changes
- Added typed upstream topology identities and process bindings.
- Extended default upstream planning to return both existing xcodeProcessRoutes and the new topology snapshot.
- Added focused tests for version keys, process-bound bindings, and stable compatibility routes.

Testing
- swift test --filter ProxySessionTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyArchitectureTests -Xswiftc -strict-concurrency=minimal
- codex-review baseBranch codex/refactor-layered-runtime-integration: no findings