### PR TITLE
Split runtime gateway ports

### DIFF
--- a/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPControlService.swift
@@ -46,12 +46,12 @@ package final class HTTPControlService: Sendable {
         }
     }
 
-    private let runtimeCoordinator: any RuntimeCoordinating
+    private let runtimeCoordinator: any RuntimeHTTPControlPort
     private let refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator?
     private let refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState?
 
     package init(
-        runtimeCoordinator: any RuntimeCoordinating,
+        runtimeCoordinator: any RuntimeHTTPControlPort,
         refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
         refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil
     ) {

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -39,7 +39,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     package init(
         config: ProxyConfig,
-        sessionManager: any RuntimeCoordinating,
+        sessionManager: any RuntimeHTTPGatewayPort,
         refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
         refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
         refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil,

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -22,7 +22,7 @@ package enum LocalPostHandling {
 package struct LocalMCPResponder {
     private struct EmbeddedTestResolutionError: Error {}
 
-    private let sessionManager: any RuntimeCoordinating
+    private let sessionManager: any RuntimeLocalMCPResponderPort
     private let refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode
     private let disabledToolNames: Set<String>
     /// EmbeddedChannel-based tests cannot complete promises from another
@@ -32,7 +32,7 @@ package struct LocalMCPResponder {
     private let logger: Logger
 
     package init(
-        sessionManager: any RuntimeCoordinating,
+        sessionManager: any RuntimeLocalMCPResponderPort,
         refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode,
         disabledToolNames: Set<String>,
         usesSynchronousLocalResolution: Bool = false,

--- a/Sources/ProxyHTTPGateway/MCP/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPGateway/MCP/MCPForwardingService.swift
@@ -26,10 +26,10 @@ package struct MCPForwardingService: Sendable {
     }
 
     private let config: ProxyConfig
-    private let sessionManager: any RuntimeCoordinating
+    private let sessionManager: any RuntimeMCPForwardingPort
     private let toolSurface: ToolSurface
 
-    package init(config: ProxyConfig, sessionManager: any RuntimeCoordinating) {
+    package init(config: ProxyConfig, sessionManager: any RuntimeMCPForwardingPort) {
         self.config = config
         self.sessionManager = sessionManager
         self.toolSurface = ToolSurface(config: config, sessionManager: sessionManager)

--- a/Sources/ProxyHTTPGateway/MCP/ToolCallNormalizer.swift
+++ b/Sources/ProxyHTTPGateway/MCP/ToolCallNormalizer.swift
@@ -7,9 +7,9 @@ package struct ToolCallNormalizer: Sendable {
         "DocumentationSearch"
     ]
 
-    private let sessionManager: any RuntimeCoordinating
+    private let sessionManager: any RuntimeToolsCatalogPort
 
-    package init(sessionManager: any RuntimeCoordinating) {
+    package init(sessionManager: any RuntimeToolsCatalogPort) {
         self.sessionManager = sessionManager
     }
 

--- a/Sources/ProxyHTTPGateway/MCP/ToolSurface.swift
+++ b/Sources/ProxyHTTPGateway/MCP/ToolSurface.swift
@@ -16,7 +16,7 @@ package struct ToolSurface: Sendable {
 
     package init(
         config: ProxyConfig,
-        sessionManager: any RuntimeCoordinating
+        sessionManager: any RuntimeToolsCatalogPort
     ) {
         self.refreshCodeIssuesMode = config.refreshCodeIssuesMode
         self.callNormalizer = ToolCallNormalizer(sessionManager: sessionManager)

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -33,7 +33,7 @@ package final class HTTPPostService: Sendable {
         let deadline: Date?
     }
 
-    package let sessionManager: any RuntimeCoordinating
+    package let sessionManager: any RuntimeHTTPPostPort
     package let disabledToolNames: Set<String>
     package let usesSynchronousLocalResolution: Bool
     package let localResponder: LocalMCPResponder
@@ -44,7 +44,7 @@ package final class HTTPPostService: Sendable {
 
     package init(
         config: ProxyConfig,
-        sessionManager: any RuntimeCoordinating,
+        sessionManager: any RuntimeHTTPPostPort,
         refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator,
         refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
         refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState,

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostTypes.swift
@@ -144,7 +144,7 @@ extension HTTPPostService {
             }
         }
 
-        package func cancel(using runtime: any RuntimeCoordinating) {
+        package func cancel(using runtime: any RuntimeSessionRegistryPort & RuntimeRequestLeasePort) {
             let snapshot = state.withLockedValue {
                 state -> (
                     Int?, UUID?, Task<Void, Never>?, [HTTPPostService.CancellationHandle], [String]

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -69,19 +69,30 @@ package enum ServerRequestResponseForwardingResult: Sendable, Equatable {
     case upstreamUnavailable
 }
 
-package protocol RuntimeCoordinating: Sendable {
+package protocol RuntimeSessionLifecyclePort: Sendable {
     func start()
+    func debugReset()
+    func shutdown() async
+}
+
+package protocol RuntimeSessionRegistryPort: Sendable {
     func session(id: String) -> SessionContext
     func hasSession(id: String) -> Bool
     func negotiatedProtocolVersion(id: String) -> String?
     func markNotificationClientConnected(sessionID: String)
     func removeSession(id: String)
-    func debugReset()
-    func shutdown() async
     func isInitialized() -> Bool
+}
+
+package protocol RuntimeToolsCatalogPort: Sendable {
     func cachedToolsListResult() -> JSONValue?
     func cachedToolsListResult(forUpstreamIndex upstreamIndex: Int) -> JSONValue?
     func setCachedToolsListResult(_ result: JSONValue, sourceUpstream: Int)
+}
+
+package protocol RuntimeInitializeToolsPort: Sendable {
+    func session(id: String) -> SessionContext
+    func isInitialized() -> Bool
     func registerInitialize(
         sessionID: String,
         originalID: JSONRPC.ID,
@@ -101,14 +112,25 @@ package protocol RuntimeCoordinating: Sendable {
         requestTimeoutOverride: TimeAmount?
     ) async throws -> DocumentationSearchOutcome
     func hasDocumentationSearchService() -> Bool
+}
+
+package protocol RuntimeToolRoutingPort: Sendable {
     func toolRoutingDecision(
         for requestJSON: Any,
         requestTimeoutOverride: TimeAmount?
     ) async -> ToolRoutingDecision
     func immediateToolRoutingDecision(for requestJSON: Any) -> ToolRoutingDecision?
-    func chooseUpstreamIndex() -> Int?
     func preferredUpstreamIndex(for requestJSON: Any) -> Int?
     func primaryUpstreamIndex(forXcodeProcessID processID: pid_t) -> Int?
+    func liveXcodeListWindowsResult(
+        route: ControlPlane.Route,
+        requestTimeoutOverride: TimeAmount?
+    ) async throws -> JSONValue
+}
+
+package protocol RuntimeUpstreamForwardingPort: Sendable {
+    func session(id: String) -> SessionContext
+    func chooseUpstreamIndex() -> Int?
     func enqueueOnUpstreamSlot<Output: Sendable>(
         leaseID: LeaseManager.ID,
         descriptor: SessionRequestPipeline.Descriptor,
@@ -134,8 +156,14 @@ package protocol RuntimeCoordinating: Sendable {
         responseID: JSONRPC.ID,
         on eventLoop: EventLoop
     ) -> EventLoopFuture<ServerRequestResponseForwardingResult>
+}
+
+package protocol RuntimeDebugSnapshotPort: Sendable {
     func debugSnapshot() -> ProxyDebug.Snapshot
     func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebug.Snapshot
+}
+
+package protocol RuntimeRequestLeasePort: Sendable {
     func createRequestLease(descriptor: SessionRequestPipeline.Descriptor) -> LeaseManager.ID
     func activateRequestLease(
         _ leaseID: LeaseManager.ID,
@@ -164,23 +192,67 @@ package protocol RuntimeCoordinating: Sendable {
     )
 }
 
-extension RuntimeCoordinating {
-    package func start() {}
+package protocol RuntimeHTTPControlPort:
+    RuntimeSessionLifecyclePort,
+    RuntimeSessionRegistryPort,
+    RuntimeDebugSnapshotPort {}
 
+package protocol RuntimeLocalMCPResponderPort:
+    RuntimeSessionRegistryPort,
+    RuntimeInitializeToolsPort {}
+
+package protocol RuntimeMCPForwardingPort:
+    RuntimeSessionRegistryPort,
+    RuntimeToolsCatalogPort,
+    RuntimeInitializeToolsPort,
+    RuntimeToolRoutingPort,
+    RuntimeUpstreamForwardingPort,
+    RuntimeRequestLeasePort {}
+
+package protocol RuntimeHTTPPostPort:
+    RuntimeSessionRegistryPort,
+    RuntimeLocalMCPResponderPort,
+    RuntimeMCPForwardingPort {}
+
+package protocol RuntimeHTTPGatewayPort:
+    RuntimeHTTPControlPort,
+    RuntimeHTTPPostPort {}
+
+package protocol RuntimeCoordinating:
+    RuntimeHTTPGatewayPort {}
+
+extension RuntimeSessionLifecyclePort {
+    package func start() {}
+}
+
+extension RuntimeSessionRegistryPort {
     package func negotiatedProtocolVersion(id _: String) -> String? {
         nil
     }
 
     package func markNotificationClientConnected(sessionID _: String) {}
+}
 
+extension RuntimeToolsCatalogPort {
+    package func cachedToolsListResult(forUpstreamIndex _: Int) -> JSONValue? {
+        cachedToolsListResult()
+    }
+}
+
+extension RuntimeInitializeToolsPort {
     package func hasDocumentationSearchService() -> Bool {
         false
     }
 
-    package func cachedToolsListResult(forUpstreamIndex _: Int) -> JSONValue? {
-        cachedToolsListResult()
+    package func callDocumentationSearch(
+        requestData _: Data,
+        requestTimeoutOverride _: TimeAmount?
+    ) async throws -> DocumentationSearchOutcome {
+        .unavailable(.noAvailableProvider)
     }
+}
 
+extension RuntimeToolRoutingPort {
     package func toolRoutingDecision(
         for requestJSON: Any,
         requestTimeoutOverride _: TimeAmount?
@@ -199,7 +271,9 @@ extension RuntimeCoordinating {
     package func primaryUpstreamIndex(forXcodeProcessID _: pid_t) -> Int? {
         nil
     }
+}
 
+extension RuntimeUpstreamForwardingPort {
     func sendUpstream(_ data: Data, upstreamIndex: Int) {
         sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: false)
     }
@@ -243,16 +317,11 @@ extension RuntimeCoordinating {
             starter: starter
         )
     }
+}
 
+extension RuntimeDebugSnapshotPort {
     func debugSnapshot() -> ProxyDebug.Snapshot {
         debugSnapshot(includeSensitiveDebugPayloads: false)
-    }
-
-    package func callDocumentationSearch(
-        requestData _: Data,
-        requestTimeoutOverride _: TimeAmount?
-    ) async throws -> DocumentationSearchOutcome {
-        .unavailable(.noAvailableProvider)
     }
 }
 


### PR DESCRIPTION
## Purpose

Split the monolithic `RuntimeCoordinating` HTTP gateway surface into smaller package-level runtime ports while preserving existing HTTP/MCP behavior.

## Changes

- Added responsibility-focused runtime port protocols in `ProxySession`, with `RuntimeCoordinating` retained as the composed compatibility surface.
- Narrowed HTTP control, local MCP response, forwarding, tool normalization, post handling, cancellation, and tool surface dependencies to the smallest practical runtime ports.
- Kept existing coordinator and test fake conformance paths intact without changing routing, scheduling, lease, or wire behavior.

## Testing

- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyArchitectureTests -Xswiftc -strict-concurrency=minimal`
- `codex-review` baseBranch against `codex/refactor-layered-runtime-integration`: no findings