### PR TITLE
Extract RuntimeCoordinator test fixture

### DIFF
--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -450,9 +450,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportReusesPrewarmedUpstreamRouteForSearch()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 740, xcodeVersion: "27.0")
         let runtimeBox = WeakRuntimeCoordinatorBox()
@@ -461,16 +458,15 @@ extension RuntimeCoordinatorTests {
             transport: RuntimeDocumentationProviderTransport(runtimeBox: runtimeBox),
             providerSelectionTimeout: .seconds(1)
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             documentationProviderManager: providerManager,
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         async let prewarmUpdate = providerManager.startBackgroundDiscovery(
@@ -520,9 +516,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportFallsBackForReusedRouteToolsListFailure()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = ToggleableOverloadUpstreamClient()
         await upstream.overloadNextSend()
         let target = xcodeProcessTarget(processID: 741, xcodeVersion: "27.0")
@@ -541,16 +534,15 @@ extension RuntimeCoordinatorTests {
             ),
             providerSelectionTimeout: .seconds(1)
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             documentationProviderManager: providerManager,
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         let discoveryTask = Task {
@@ -573,9 +565,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportFallsBackWhenReusedUpstreamRouteFails()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = ToggleableOverloadUpstreamClient()
         await upstream.overloadNextSend()
         let target = xcodeProcessTarget(processID: 742, xcodeVersion: "27.0")
@@ -601,16 +590,15 @@ extension RuntimeCoordinatorTests {
             ),
             providerSelectionTimeout: .seconds(1)
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             documentationProviderManager: providerManager,
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         let firstOutcome = try await providerManager.callDocumentationSearch(
@@ -648,9 +636,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportCachesInstalledAssetFallbackWithoutOwningBorrowedRoute()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 747, xcodeVersion: "26.6")
         let runtimeBox = WeakRuntimeCoordinatorBox()
@@ -667,16 +652,15 @@ extension RuntimeCoordinatorTests {
             providerSelectionTimeout: .seconds(1),
             localSearchProvider: localProvider
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             documentationProviderManager: providerManager,
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         let firstTask = Task {
@@ -727,9 +711,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportKeepsBorrowedRouteAfterInitialAssetFallbackTimeout()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 748, xcodeVersion: "26.6")
         let runtimeBox = WeakRuntimeCoordinatorBox()
@@ -747,16 +728,15 @@ extension RuntimeCoordinatorTests {
             providerSelectionTimeout: .seconds(1),
             localSearchProvider: localProvider
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             documentationProviderManager: providerManager,
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         let timeoutTask = Task {
@@ -809,9 +789,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportUsesInstalledAssetFallbackWhenBorrowedRouteRepairDoesNotRestoreDescriptor()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 749, xcodeVersion: "26.6")
         let runtimeBox = WeakRuntimeCoordinatorBox()
@@ -840,16 +817,15 @@ extension RuntimeCoordinatorTests {
             serviceRepairer: repairer,
             localSearchProvider: localProvider
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             documentationProviderManager: providerManager,
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         let prewarmTask = Task {
@@ -900,9 +876,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportTimesOutQueuedPinnedRouteBeforeDispatch()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 746, xcodeVersion: "27.0")
         let runtimeBox = WeakRuntimeCoordinatorBox()
@@ -911,16 +884,16 @@ extension RuntimeCoordinatorTests {
             transport: RuntimeDocumentationProviderTransport(runtimeBox: runtimeBox),
             providerSelectionTimeout: .seconds(1)
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             documentationProviderManager: providerManager,
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let eventLoop = fixture.eventLoop
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         let activeDescriptor = SessionRequestPipeline.Descriptor(
@@ -979,9 +952,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportClosesFallbackOpenedAfterRouteInvalidation()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = ToggleableOverloadUpstreamClient()
         await upstream.overloadNextSend()
         let target = xcodeProcessTarget(processID: 743, xcodeVersion: "27.0")
@@ -1000,16 +970,15 @@ extension RuntimeCoordinatorTests {
             ),
             providerSelectionTimeout: .seconds(1)
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             documentationProviderManager: providerManager,
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         let searchTask = Task {
@@ -1088,9 +1057,6 @@ extension RuntimeCoordinatorTests {
     @Test func runtimeDocumentationTransportCancellationReleasesControlPlaneLease()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 745, xcodeVersion: "27.0")
         let runtimeBox = WeakRuntimeCoordinatorBox()
@@ -1099,15 +1065,15 @@ extension RuntimeCoordinatorTests {
             target: target,
             upstreamIndex: 0
         )
-        let manager = RuntimeCoordinator(
+        let fixture = RuntimeCoordinatorFixture(
             config: makeConfig(requestTimeout: 30),
-            eventLoop: eventLoop,
             upstreams: [upstream],
             xcodeProcessRoutes: [xcodeProcessRoute(target: target)],
             startImmediately: false,
             runtimeBox: runtimeBox
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
         let toolsListTask = Task {
@@ -1269,20 +1235,16 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func sharedToolsListAdvertisesProxyOwnedDocumentationSearchDescriptor() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let documentationProvider = StubDocumentationProviderManager(
             toolListUpdate: .available(documentationDescriptor(version: "27.0"))
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             documentationProviderManager: documentationProvider
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         manager.setCachedToolsListResult(
             try jsonValue([
@@ -1310,9 +1272,6 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func sharedToolsListDoesNotWaitForStartupDocumentationPrewarm() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let prewarmStarted = TestSignal()
         let prewarmGate = AsyncGate()
@@ -1321,14 +1280,13 @@ extension RuntimeCoordinatorTests {
             prewarmStarted: prewarmStarted,
             prewarmBlocker: prewarmGate
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             documentationProviderManager: documentationProvider,
             startImmediately: false
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.setCachedToolsListResult(
             try jsonValue([
                 "tools": [
@@ -1368,21 +1326,17 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func sharedToolsListSurfaceDoesNotDependOnProviderInvalidation() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let documentationProvider = StubDocumentationProviderManager(
             toolListUpdate: .available(documentationDescriptor(version: "27.0"))
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             documentationProviderManager: documentationProvider,
             startImmediately: false
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
         manager.setCachedToolsListResult(
             try jsonValue([
                 "tools": [
@@ -1425,18 +1379,14 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func sharedToolsListReplacesStaleDocumentationSearchWhenProviderUnavailable() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let documentationProvider = StubDocumentationProviderManager(toolListUpdate: .unavailable)
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             documentationProviderManager: documentationProvider
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         manager.setCachedToolsListResult(
             try jsonValue([
@@ -1466,22 +1416,18 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func sharedToolsListDoesNotProbeDocumentationProvider() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let toolListGate = AsyncGate()
         let documentationProvider = StubDocumentationProviderManager(
             toolListUpdate: .available(documentationDescriptor(version: "27.0")),
             toolListBlocker: toolListGate
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             documentationProviderManager: documentationProvider
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         manager.setCachedToolsListResult(
             try jsonValue([
@@ -1517,9 +1463,6 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func documentationSearchKeepsCanonicalToolsCatalogWhenProviderRecoversAfterInvalidation() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let providerResponse = try makeJSONRPCResponse(
             id: 41,
@@ -1537,13 +1480,12 @@ extension RuntimeCoordinatorTests {
             toolListUpdate: .available(documentationDescriptor(version: "27.0")),
             callOutcomes: [.handled(providerResponse, invalidatedProvider: true)]
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             documentationProviderManager: documentationProvider
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         manager.setCachedToolsListResult(
             try jsonValue([
@@ -1574,9 +1516,6 @@ extension RuntimeCoordinatorTests {
     @Test func documentationSearchDoesNotInvalidateWhenSuccessfulAnswerMentionsNotEnabled()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let providerResponse = try makeJSONRPCResponse(
             id: 43,
@@ -1594,13 +1533,12 @@ extension RuntimeCoordinatorTests {
             toolListUpdate: .available(documentationDescriptor(version: "27.0")),
             callOutcomes: [.handled(providerResponse, invalidatedProvider: false)]
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             documentationProviderManager: documentationProvider
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         let cachedTools = try jsonValue([
             "tools": [
@@ -1626,21 +1564,17 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func documentationSearchReportsUnavailableWhenNoProviderAvailable() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let documentationProvider = StubDocumentationProviderManager(
             toolListUpdate: .available(documentationDescriptor(version: "27.0")),
             callOutcomes: [.unavailable(.noAvailableProvider)]
         )
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             documentationProviderManager: documentationProvider
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         manager.setCachedToolsListResult(
             try jsonValue([
@@ -1673,21 +1607,17 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func startupPrewarmsDocumentationProviderWhenEnabled() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let documentationProvider = StubDocumentationProviderManager(
             toolListUpdate: .available(documentationDescriptor(version: "27.0"))
         )
-        let manager = RuntimeCoordinator(
+        let fixture = RuntimeCoordinatorFixture(
             config: makeConfig(requestTimeout: 300),
-            eventLoop: eventLoop,
             upstreams: [upstream],
             documentationProviderManager: documentationProvider,
             prewarmDocumentationProviderOnStartup: true
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
 
         try await waitWithTimeout("waiting for documentation provider startup prewarm") {
             try await documentationProvider.waitForPrewarmCount(1)
@@ -1699,21 +1629,17 @@ extension RuntimeCoordinatorTests {
     }
 
     @Test func startupPollsDocumentationProviderUntilAvailable() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
         let upstream = TestUpstreamClient()
         let documentationProvider = StubDocumentationProviderManager(toolListUpdate: .unavailable)
-        let manager = RuntimeCoordinator(
+        let fixture = RuntimeCoordinatorFixture(
             config: makeConfig(requestTimeout: 300),
-            eventLoop: eventLoop,
             upstreams: [upstream],
             clock: clock,
             documentationProviderManager: documentationProvider,
             prewarmDocumentationProviderOnStartup: true
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
 
         try await waitWithTimeout("waiting for initial documentation provider prewarm") {
             try await documentationProvider.waitForPrewarmCount(1)

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -1833,6 +1833,126 @@ func makeInitializeErrorResponse(id: Int64, message: String = "initialize failed
     return try JSONSerialization.data(withJSONObject: response, options: [])
 }
 
+protocol InitializableTestUpstream: AnyObject, Sendable {
+    func nextSent(at index: Int) async throws -> Data
+    func yield(_ event: Upstream.Event) async
+}
+
+extension TestUpstreamClient: InitializableTestUpstream {}
+extension ToggleableOverloadUpstreamClient: InitializableTestUpstream {}
+extension BlockingInitializedNotificationUpstreamClient: InitializableTestUpstream {}
+
+struct RuntimeCoordinatorFixture {
+    let group: MultiThreadedEventLoopGroup
+    let eventLoop: EventLoop
+    let manager: RuntimeCoordinator
+
+    init(
+        config: ProxyConfig = makeConfig(requestTimeout: 5),
+        upstreams: [any UpstreamSlotControlling],
+        clock: ClockClient = .liveValue,
+        upstreamReadinessGate: UpstreamReadinessGate? = nil,
+        nowUptimeNanoseconds: (@Sendable () -> UInt64)? = nil,
+        scheduleRuntimeTimeout: (
+            @Sendable (TimeAmount, @escaping @Sendable () -> Void) ->
+                RuntimeScheduledTimeout
+        )? = nil,
+        xcodeProcessRoutes: [XcodeProcessRoute] = [],
+        documentationProviderManager: (any DocumentationProviderManaging)? = nil,
+        prewarmDocumentationProviderOnStartup: Bool = false,
+        testHooks: RuntimeCoordinatorTestHooks = RuntimeCoordinatorTestHooks(),
+        startImmediately: Bool = true,
+        runtimeBox: WeakRuntimeCoordinatorBox? = nil
+    ) {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let eventLoop = group.next()
+        self.group = group
+        self.eventLoop = eventLoop
+        self.manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: upstreams,
+            clock: clock,
+            upstreamReadinessGate: upstreamReadinessGate,
+            nowUptimeNanoseconds: nowUptimeNanoseconds,
+            scheduleRuntimeTimeout: scheduleRuntimeTimeout,
+            xcodeProcessRoutes: xcodeProcessRoutes,
+            documentationProviderManager: documentationProviderManager,
+            prewarmDocumentationProviderOnStartup: prewarmDocumentationProviderOnStartup,
+            testHooks: testHooks,
+            startImmediately: startImmediately,
+            runtimeBox: runtimeBox
+        )
+    }
+
+    func shutdownAndWait() {
+        manager.shutdownAndWait()
+        XcodeMCPTestSupport.shutdownAndWait(group)
+    }
+
+    func registerInitialize(
+        requestID: Int,
+        sessionID: String? = nil,
+        requestObject: [String: Any]? = nil
+    ) -> EventLoopFuture<ByteBuffer> {
+        let originalID = JSONRPC.ID(any: NSNumber(value: requestID))!
+        let requestObject = requestObject ?? makeInitializeRequest(id: requestID)
+        if let sessionID {
+            return manager.registerInitialize(
+                sessionID: sessionID,
+                originalID: originalID,
+                requestObject: requestObject,
+                on: eventLoop
+            )
+        }
+        return manager.registerInitialize(
+            originalID: originalID,
+            requestObject: requestObject,
+            on: eventLoop
+        )
+    }
+
+    @discardableResult
+    func completeInitialize<UpstreamClient: InitializableTestUpstream>(
+        on upstream: UpstreamClient,
+        at sentIndex: Int = 0,
+        serverName: String? = nil,
+        timeout: Duration = .seconds(2)
+    ) async throws -> Data {
+        let initializeRequest = try await waitWithTimeout(
+            "waiting for sent message \(sentIndex + 1)",
+            timeout: timeout
+        ) {
+            try await upstream.nextSent(at: sentIndex)
+        }
+        let upstreamID = try extractUpstreamID(from: initializeRequest)
+        await upstream.yield(.message(try makeInitializeResponse(
+            id: upstreamID,
+            serverName: serverName
+        )))
+        return initializeRequest
+    }
+
+    @discardableResult
+    func initializePrimary<UpstreamClient: InitializableTestUpstream>(
+        on upstream: UpstreamClient,
+        requestID: Int = 1,
+        sessionID: String? = nil,
+        sentIndex: Int = 0,
+        serverName: String? = nil,
+        timeout: Duration = .seconds(2)
+    ) async throws -> ByteBuffer {
+        let future = registerInitialize(requestID: requestID, sessionID: sessionID)
+        try await completeInitialize(
+            on: upstream,
+            at: sentIndex,
+            serverName: serverName,
+            timeout: timeout
+        )
+        return try await future.get()
+    }
+}
+
 func extractUpstreamID(from data: Data) throws -> Int64 {
     let object = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
     return (object?["id"] as? NSNumber)?.int64Value ?? 0

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -81,21 +81,16 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func upstreamStderrStillRecordsInDebugSnapshotWhenRateLimited() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let upstreamEvents = LockedRecordedValues<Int>()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(
-            config: config,
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             testHooks: RuntimeCoordinatorTestHooks(
                 upstreamEventHandled: { upstreamEvents.append($0) }
             )
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         manager.handleUpstreamStderr("repeated stderr", upstreamIndex: 0)
         manager.handleUpstreamStderr("repeated stderr", upstreamIndex: 0)
@@ -105,34 +100,18 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func sessionManagerQueuesInitializeRequests() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let upstreamEvents = LockedRecordedValues<Int>()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(
-            config: config,
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             testHooks: RuntimeCoordinatorTestHooks(
                 upstreamEventHandled: { upstreamEvents.append($0) }
             )
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
 
-        let request1 = makeInitializeRequest(id: 1)
-        let request2 = makeInitializeRequest(id: 2)
-        let future1 = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: request1,
-            on: eventLoop
-        )
-        let future2 = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
-            requestObject: request2,
-            on: eventLoop
-        )
+        let future1 = fixture.registerInitialize(requestID: 1)
+        let future2 = fixture.registerInitialize(requestID: 2)
 
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
         let sent = await upstream.sent()
@@ -166,28 +145,19 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func sessionManagerJoinsEagerProcessInitializeInFlight() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 27001, xcodeVersion: "27.0")
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: target, upstreamIndices: [0]),
             ]
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
 
         let eagerInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
         let eagerUpstreamID = try extractUpstreamID(from: eagerInitialize)
-        let future = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
+        let future = fixture.registerInitialize(requestID: 1)
         #expect(await upstream.sentCount() == 1)
 
         await upstream.yield(.message(try makeInitializeResponse(id: eagerUpstreamID)))
@@ -199,16 +169,11 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerRetriesProcessPrimaryInitializeOnNextXcodeProcessAfterError()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
         let newerTarget = xcodeProcessTarget(processID: 27100, xcodeVersion: "27.0")
         let olderTarget = xcodeProcessTarget(processID: 26600, xcodeVersion: "26.6")
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream0, upstream1],
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: newerTarget, upstreamIndices: [0]),
@@ -216,13 +181,10 @@ struct RuntimeCoordinatorTests {
             ],
             startImmediately: false
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
-        let future = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
+        let future = fixture.registerInitialize(requestID: 1)
         let failedInitialize = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
         let failedUpstreamID = try extractUpstreamID(from: failedInitialize)
         await upstream0.yield(.message(try makeInitializeErrorResponse(id: failedUpstreamID)))
@@ -251,17 +213,12 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerRoutesInitializeHandshakeNotificationsFromRetriedPrimaryProcess()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
         let upstreamEvents = LockedRecordedValues<Int>()
         let newerTarget = xcodeProcessTarget(processID: 27104, xcodeVersion: "27.0")
         let olderTarget = xcodeProcessTarget(processID: 26604, xcodeVersion: "26.6")
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream0, upstream1],
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: newerTarget, upstreamIndices: [0]),
@@ -272,18 +229,14 @@ struct RuntimeCoordinatorTests {
             ),
             startImmediately: false
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         let sessionID = "session-retried-primary-handshake"
         let session = manager.session(id: sessionID)
         _ = session.router.drainBufferedNotifications()
 
-        let future = manager.registerInitialize(
-            sessionID: sessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
+        let future = fixture.registerInitialize(requestID: 1, sessionID: sessionID)
         let failedInitialize = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
         let failedUpstreamID = try extractUpstreamID(from: failedInitialize)
         await upstream0.yield(.message(try makeInitializeErrorResponse(id: failedUpstreamID)))
@@ -316,28 +269,20 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerRetriesProcessPrimaryInitializeOnSiblingBeforeDroppingProcessAfterError()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 27103, xcodeVersion: "27.0")
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream0, upstream1],
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: target, upstreamIndices: [0, 1]),
             ],
             startImmediately: false
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
-        let future = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
+        let future = fixture.registerInitialize(requestID: 1)
         let failedInitialize = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
         let failedUpstreamID = try extractUpstreamID(from: failedInitialize)
         await upstream0.yield(.message(try makeInitializeErrorResponse(id: failedUpstreamID)))
@@ -356,17 +301,12 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerRetriesProcessPrimaryInitializeOnNextXcodeProcessAfterExit()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream0 = TestUpstreamClient()
         let upstream1 = TestUpstreamClient()
         let upstreamEvents = LockedRecordedValues<Int>()
         let newerTarget = xcodeProcessTarget(processID: 27101, xcodeVersion: "27.0")
         let olderTarget = xcodeProcessTarget(processID: 26601, xcodeVersion: "26.6")
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream0, upstream1],
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: newerTarget, upstreamIndices: [0]),
@@ -377,13 +317,10 @@ struct RuntimeCoordinatorTests {
             ),
             startImmediately: false
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
-        let future = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
+        let future = fixture.registerInitialize(requestID: 1)
         _ = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
         let exitEventIndex = upstreamEvents.count()
         await upstream0.yield(.exit(1))
@@ -405,16 +342,11 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerRetriesProcessPrimaryInitializeWhenSendIsUnavailable()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let unavailableUpstream = AlwaysUnavailableUpstreamClient(reason: .startFailed)
         let retryUpstream = TestUpstreamClient()
         let newerTarget = xcodeProcessTarget(processID: 27102, xcodeVersion: "27.0")
         let olderTarget = xcodeProcessTarget(processID: 26602, xcodeVersion: "26.6")
-        let manager = RuntimeCoordinator(
-            config: makeConfig(requestTimeout: 5),
-            eventLoop: eventLoop,
+        let fixture = RuntimeCoordinatorFixture(
             upstreams: [unavailableUpstream, retryUpstream],
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: newerTarget, upstreamIndices: [0]),
@@ -422,13 +354,10 @@ struct RuntimeCoordinatorTests {
             ],
             startImmediately: false
         )
-        defer { manager.shutdownAndWait() }
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
-        let future = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
+        let future = fixture.registerInitialize(requestID: 1)
 
         try await waitForSentCount(unavailableUpstream, count: 1, timeoutSeconds: 2)
         let retriedInitialize = try await sentValue(from: retryUpstream, at: 0, timeout: .seconds(2))
@@ -442,45 +371,25 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func sessionManagerMarksPrimaryUsableBeforeInitializeReturns() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
-        let future = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
-        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
-        let upstreamID = try extractUpstreamID(from: sent)
-        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
-
-        _ = try await future.get()
+        _ = try await fixture.initializePrimary(on: upstream)
         #expect(manager.chooseUpstreamIndex() == 0)
     }
 
     @Test func sessionManagerRejectsUnsupportedInitializeProtocolBeforeIssuingSession()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         let sessionID = "session-unsupported-protocol"
-        let future = manager.registerInitialize(
-            sessionID: sessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
+        let future = fixture.registerInitialize(requestID: 1, sessionID: sessionID)
         let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
         let upstreamID = try extractUpstreamID(from: sent)
         let response: [String: Any] = [
@@ -509,21 +418,13 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func sessionManagerRemovesPendingInitializeSessionOnFailure() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         let sessionID = "session-failed-initialize"
-        let future = manager.registerInitialize(
-            sessionID: sessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
+        let future = fixture.registerInitialize(requestID: 1, sessionID: sessionID)
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
 
         manager.failInitPending(error: TimeoutError())
@@ -539,26 +440,14 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerRecordsServerInitiatedRequestUpstreamForClientResponses()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         let sessionID = "session-server-request"
         let session = manager.session(id: sessionID)
-        let future = manager.registerInitialize(
-            sessionID: sessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
-        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
-        let upstreamID = try extractUpstreamID(from: sent)
-        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
-        _ = try await future.get()
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: sessionID)
 
         let serverRequest: [String: Any] = [
             "jsonrpc": "2.0",
@@ -582,26 +471,15 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerDoesNotTreatServerRequestIDAsPendingResponseID()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let eventLoop = fixture.eventLoop
+        let manager = fixture.manager
 
         let sessionID = "session-server-request-id-collision"
         let session = manager.session(id: sessionID)
-        let initializeFuture = manager.registerInitialize(
-            sessionID: sessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
-        let sentInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
-        let initializeUpstreamID = try extractUpstreamID(from: sentInitialize)
-        await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
-        _ = try await initializeFuture.get()
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: sessionID)
 
         let originalID = JSONRPC.ID(any: NSNumber(value: 42))!
         let responseFuture = session.router.registerRequest(
@@ -637,26 +515,15 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerRoutesServerRequestFromMixedUpstreamBatchThroughTracker()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let eventLoop = fixture.eventLoop
+        let manager = fixture.manager
 
         let sessionID = "session-mixed-upstream-batch"
         let session = manager.session(id: sessionID)
-        let initializeFuture = manager.registerInitialize(
-            sessionID: sessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
-        let sentInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
-        let initializeUpstreamID = try extractUpstreamID(from: sentInitialize)
-        await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
-        _ = try await initializeFuture.get()
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: sessionID)
 
         let originalID = JSONRPC.ID(any: NSNumber(value: 42))!
         let responseFuture = session.router.registerRequest(
@@ -721,26 +588,15 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerCompletesMalformedMappedUpstreamResponseWithError()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let eventLoop = fixture.eventLoop
+        let manager = fixture.manager
 
         let sessionID = "session-malformed-mapped-response"
         let session = manager.session(id: sessionID)
-        let initializeFuture = manager.registerInitialize(
-            sessionID: sessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
-        let sentInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
-        let initializeUpstreamID = try extractUpstreamID(from: sentInitialize)
-        await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
-        _ = try await initializeFuture.get()
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: sessionID)
 
         let originalID = JSONRPC.ID(any: NSNumber(value: 42))!
         let responseFuture = session.router.registerRequest(
@@ -772,26 +628,15 @@ struct RuntimeCoordinatorTests {
     @Test func sessionManagerPreservesServerRequestRouteUntilForwardingSendAccepted()
         async throws
     {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = ToggleableOverloadUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let eventLoop = fixture.eventLoop
+        let manager = fixture.manager
 
         let sessionID = "session-server-response-retry"
         let session = manager.session(id: sessionID)
-        let initializeFuture = manager.registerInitialize(
-            sessionID: sessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
-        let sentInitialize = try await upstream.nextSent(at: 0)
-        let initializeUpstreamID = try extractUpstreamID(from: sentInitialize)
-        await upstream.yield(.message(try makeInitializeResponse(id: initializeUpstreamID)))
-        _ = try await initializeFuture.get()
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: sessionID)
 
         let serverRequest: [String: Any] = [
             "jsonrpc": "2.0",
@@ -904,35 +749,18 @@ struct RuntimeCoordinatorTests {
     }
 
     @Test func sessionManagerRoutesServerInitiatedRequestToOwningSession() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
 
         let firstSessionID = "session-server-request-a"
         let firstSession = manager.session(id: firstSessionID)
-        let firstFuture = manager.registerInitialize(
-            sessionID: firstSessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
-        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
-        let upstreamID = try extractUpstreamID(from: sent)
-        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
-        _ = try await firstFuture.get()
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: firstSessionID)
 
         let secondSessionID = "session-server-request-b"
         let secondSession = manager.session(id: secondSessionID)
-        let secondFuture = manager.registerInitialize(
-            sessionID: secondSessionID,
-            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
-            requestObject: makeInitializeRequest(id: 2),
-            on: eventLoop
-        )
+        let secondFuture = fixture.registerInitialize(requestID: 2, sessionID: secondSessionID)
         _ = try await secondFuture.get()
 
         let ownerLeaseID = manager.createRequestLease(


### PR DESCRIPTION
## Purpose
Reduce ProxySession test ceremony around RuntimeCoordinator setup, teardown, and initialize handshakes without changing session behavior.

## Changes
- Added a focused RuntimeCoordinatorFixture in ProxySession test support for EventLoopGroup ownership, coordinator construction, teardown, and primary initialize handshakes.
- Refactored repeated RuntimeCoordinator setup in RuntimeCoordinatorTests and DocumentationProviderTests.
- Kept initialize request IDs, protocol version generation, explicit session IDs, event loop usage, and documentation provider assertions intact.

## Validation
- swift test --filter ProxySessionTests -Xswiftc -strict-concurrency=minimal
- git diff --check
- codex-review against codex/refactor-layered-runtime-integration: no findings