### PR TITLE
Add public XcodeMCP client library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
         .macOS("15.4")
     ],
     products: [
+        .library(
+            name: "XcodeMCPKit",
+            targets: ["XcodeMCPKit"]
+        ),
         .executable(
             name: "xcode-mcp-proxy",
             targets: ["XcodeMCPProxyCLI"]
@@ -269,6 +273,14 @@ let package = Package(
             name: "ProxyBuildInfoPlugin",
             capability: .buildTool(),
             dependencies: ["ProxyBuildInfoTool"]
+        ),
+        .testTarget(
+            name: "XcodeMCPKitTests",
+            dependencies: [
+                "XcodeMCPKit",
+            ],
+            path: "Tests/XcodeMCPKitTests",
+            swiftSettings: strictSwiftSettings
         ),
         .testTarget(
             name: "ProxyContractTests",

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [English](README.md)
 
-XcodeMCPKitは、Xcode MCPのためのローカルプロキシです。MCPクライアントに安定したendpointを提供し、`mcpbridge`の承認フローを自動化します。
+XcodeMCPKitは、Xcode MCPのためのSwiftライブラリ兼ローカルプロキシです。アプリはSwift APIからローカル`mcpbridge`を直接操作でき、MCPクライアントはproxy経由で安定したendpointと承認フローの自動化を利用できます。
 
 ## 要件
 
@@ -55,6 +55,24 @@ source ~/.zshrc
 ```
 
 </details>
+
+## Swiftから使う
+
+Swift packageまたはXcode targetに`XcodeMCPKit` library productを追加し、top-level clientを作成します。async initializerがローカル`mcpbridge`の起動とMCP initialize handshakeを行い、利用可能なclientを返します。
+
+```swift
+import XcodeMCPKit
+
+let xcode = try await XcodeMCP(config: .init())
+let tools = try await xcode.listTools()
+let result = try await xcode.callTool(
+    "DocumentationSearch",
+    arguments: ["query": .string("SwiftData")]
+)
+await xcode.close()
+```
+
+public APIは`MCPJSONValue`、`MCPTool`、`MCPToolResult`、`MCPContent`、`MCPProgress`などのMCP domain valueを公開します。process launch、JSON-RPC framing、session transportはinternal implementation detailです。
 
 ## MCPクライアント設定
 
@@ -170,8 +188,6 @@ Codex/Claude Codeから利用している場合は、移行作業はありませ
   `MCP-Protocol-Version: 2025-06-18`を送り、`POST /mcp`には
   `Accept: application/json, text/event-stream`を付けてください。
   JSON-RPC batch requestは送らないでください。
-- SwiftPM library productに依存している場合:
-  `v0.10.2`に固定するか、executable productに移行してください。
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [日本語](README.ja.md)
 
-XcodeMCPKit is a local proxy for Xcode MCP. It gives your MCP clients one stable
-endpoint and automates the `mcpbridge` approval flow.
+XcodeMCPKit is a Swift library and local proxy for Xcode MCP. Apps can use the
+Swift API to operate a local `mcpbridge` process directly, while MCP clients can
+use the proxy for one stable endpoint and automated approval flow.
 
 ## Requirements
 
@@ -56,6 +57,28 @@ source ~/.zshrc
 ```
 
 </details>
+
+## Use From Swift
+
+Add the `XcodeMCPKit` library product to your Swift package or Xcode target, then
+create a top-level client. The async initializer launches local `mcpbridge`,
+performs the MCP initialize handshake, and returns a ready client.
+
+```swift
+import XcodeMCPKit
+
+let xcode = try await XcodeMCP(config: .init())
+let tools = try await xcode.listTools()
+let result = try await xcode.callTool(
+    "DocumentationSearch",
+    arguments: ["query": .string("SwiftData")]
+)
+await xcode.close()
+```
+
+The public API exposes MCP domain values such as `MCPJSONValue`, `MCPTool`,
+`MCPToolResult`, `MCPContent`, and `MCPProgress`. Process launch, JSON-RPC
+framing, and session transport are internal implementation details.
 
 ## Set Up Your MCP Client
 
@@ -172,8 +195,6 @@ Only the following cases need changes:
   `MCP-Protocol-Version: 2025-06-18`. Include
   `Accept: application/json, text/event-stream` on `POST /mcp`, and do not send
   JSON-RPC batch requests.
-- SwiftPM library users:
-  pin to `v0.10.2` or migrate to the executable products.
 
 ## Troubleshooting
 

--- a/Sources/XcodeMCPKit/MCPDomainTypes.swift
+++ b/Sources/XcodeMCPKit/MCPDomainTypes.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+public struct MCPTool: Codable, Equatable, Sendable {
+    public var name: String
+    public var description: String?
+    public var inputSchema: MCPJSONValue?
+    public var raw: MCPJSONValue
+
+    public init(
+        name: String,
+        description: String? = nil,
+        inputSchema: MCPJSONValue? = nil,
+        raw: MCPJSONValue? = nil
+    ) {
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+        self.raw = raw ?? .object([
+            "name": .string(name)
+        ])
+    }
+}
+
+public enum MCPContent: Codable, Equatable, Sendable {
+    case text(String, raw: MCPJSONValue)
+    case image(data: String, mimeType: String?, raw: MCPJSONValue)
+    case resource(uri: String?, text: String?, mimeType: String?, raw: MCPJSONValue)
+    case raw(MCPJSONValue)
+
+    public init(from decoder: Decoder) throws {
+        let value = try MCPJSONValue(from: decoder)
+        self = try MCPContent(json: value)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try rawValue.encode(to: encoder)
+    }
+
+    public var rawValue: MCPJSONValue {
+        switch self {
+        case .text(_, let raw),
+             .image(_, _, let raw),
+             .resource(_, _, _, let raw),
+             .raw(let raw):
+            return raw
+        }
+    }
+}
+
+public struct MCPToolResult: Codable, Equatable, Sendable {
+    public var content: [MCPContent]
+    public var structuredContent: MCPJSONValue?
+    public var isError: Bool
+    public var raw: MCPJSONValue
+
+    public init(
+        content: [MCPContent],
+        structuredContent: MCPJSONValue? = nil,
+        isError: Bool = false,
+        raw: MCPJSONValue? = nil
+    ) {
+        self.content = content
+        self.structuredContent = structuredContent
+        self.isError = isError
+        self.raw = raw ?? .object([
+            "content": .array(content.map(\.rawValue)),
+            "isError": .bool(isError),
+        ])
+    }
+}
+
+public struct MCPProgress: Codable, Equatable, Sendable {
+    public var progressToken: String
+    public var progress: Double?
+    public var total: Double?
+    public var message: String?
+    public var raw: MCPJSONValue
+
+    public init(
+        progressToken: String,
+        progress: Double? = nil,
+        total: Double? = nil,
+        message: String? = nil,
+        raw: MCPJSONValue? = nil
+    ) {
+        self.progressToken = progressToken
+        self.progress = progress
+        self.total = total
+        self.message = message
+        self.raw = raw ?? .object([
+            "progressToken": .string(progressToken)
+        ])
+    }
+}
+
+extension MCPTool {
+    package init(json value: MCPJSONValue) throws {
+        guard let object = value.objectValue else {
+            throw XcodeMCPError.invalidResponse("tool entry is not an object")
+        }
+        guard let name = object["name"]?.stringValue, name.isEmpty == false else {
+            throw XcodeMCPError.invalidResponse("tool entry is missing name")
+        }
+        self.init(
+            name: name,
+            description: object["description"]?.stringValue,
+            inputSchema: object["inputSchema"],
+            raw: value
+        )
+    }
+}
+
+extension MCPContent {
+    package init(json value: MCPJSONValue) throws {
+        guard let object = value.objectValue else {
+            self = .raw(value)
+            return
+        }
+        guard let type = object["type"]?.stringValue, type.isEmpty == false else {
+            self = .raw(value)
+            return
+        }
+
+        switch type {
+        case "text":
+            if let text = object["text"]?.stringValue {
+                self = .text(text, raw: value)
+            } else {
+                self = .raw(value)
+            }
+        case "image":
+            if let data = object["data"]?.stringValue {
+                self = .image(
+                    data: data,
+                    mimeType: object["mimeType"]?.stringValue,
+                    raw: value
+                )
+            } else {
+                self = .raw(value)
+            }
+        case "resource", "embeddedResource":
+            let uri = object["uri"]?.stringValue
+                ?? object["resource"]?.objectValue?["uri"]?.stringValue
+            let text = object["text"]?.stringValue
+                ?? object["resource"]?.objectValue?["text"]?.stringValue
+            let mimeType = object["mimeType"]?.stringValue
+                ?? object["resource"]?.objectValue?["mimeType"]?.stringValue
+            self = .resource(uri: uri, text: text, mimeType: mimeType, raw: value)
+        default:
+            self = .raw(value)
+        }
+    }
+}
+
+extension MCPToolResult {
+    package init(json value: MCPJSONValue) throws {
+        guard let object = value.objectValue else {
+            throw XcodeMCPError.invalidResponse("tools/call result is not an object")
+        }
+        let contentValues = object["content"]?.arrayValue ?? []
+        let content = try contentValues.map { try MCPContent(json: $0) }
+        let isError: Bool
+        if case .bool(let value) = object["isError"] {
+            isError = value
+        } else {
+            isError = false
+        }
+        self.init(
+            content: content,
+            structuredContent: object["structuredContent"],
+            isError: isError,
+            raw: value
+        )
+    }
+}
+
+extension MCPProgress {
+    package init?(json value: MCPJSONValue) {
+        guard let object = value.objectValue,
+              let progressToken = object["progressToken"]?.stringValue
+        else {
+            return nil
+        }
+        self.init(
+            progressToken: progressToken,
+            progress: object["progress"]?.doubleValue,
+            total: object["total"]?.doubleValue,
+            message: object["message"]?.stringValue,
+            raw: value
+        )
+    }
+}

--- a/Sources/XcodeMCPKit/MCPDomainTypes.swift
+++ b/Sources/XcodeMCPKit/MCPDomainTypes.swift
@@ -19,6 +19,15 @@ public struct MCPTool: Codable, Equatable, Sendable {
             "name": .string(name)
         ])
     }
+
+    public init(from decoder: Decoder) throws {
+        let value = try MCPJSONValue(from: decoder)
+        self = try MCPTool(json: value)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try MCPJSONValue.object(toolObject()).encode(to: encoder)
+    }
 }
 
 public enum MCPContent: Codable, Equatable, Sendable {
@@ -67,6 +76,15 @@ public struct MCPToolResult: Codable, Equatable, Sendable {
             "isError": .bool(isError),
         ])
     }
+
+    public init(from decoder: Decoder) throws {
+        let value = try MCPJSONValue(from: decoder)
+        self = try MCPToolResult(json: value)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try MCPJSONValue.object(resultObject()).encode(to: encoder)
+    }
 }
 
 public struct MCPProgress: Codable, Equatable, Sendable {
@@ -90,6 +108,18 @@ public struct MCPProgress: Codable, Equatable, Sendable {
         self.raw = raw ?? .object([
             "progressToken": .string(progressToken)
         ])
+    }
+
+    public init(from decoder: Decoder) throws {
+        let value = try MCPJSONValue(from: decoder)
+        guard let progress = MCPProgress(json: value) else {
+            throw XcodeMCPError.invalidResponse("progress notification is missing progressToken")
+        }
+        self = progress
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try MCPJSONValue.object(progressObject()).encode(to: encoder)
     }
 }
 
@@ -188,5 +218,60 @@ extension MCPProgress {
             message: object["message"]?.stringValue,
             raw: value
         )
+    }
+}
+
+private extension MCPTool {
+    func toolObject() -> [String: MCPJSONValue] {
+        var object = raw.objectValue ?? [:]
+        object["name"] = .string(name)
+        if let description {
+            object["description"] = .string(description)
+        } else {
+            object.removeValue(forKey: "description")
+        }
+        if let inputSchema {
+            object["inputSchema"] = inputSchema
+        } else {
+            object.removeValue(forKey: "inputSchema")
+        }
+        return object
+    }
+}
+
+private extension MCPToolResult {
+    func resultObject() -> [String: MCPJSONValue] {
+        var object = raw.objectValue ?? [:]
+        object["content"] = .array(content.map(\.rawValue))
+        if let structuredContent {
+            object["structuredContent"] = structuredContent
+        } else {
+            object.removeValue(forKey: "structuredContent")
+        }
+        object["isError"] = .bool(isError)
+        return object
+    }
+}
+
+private extension MCPProgress {
+    func progressObject() -> [String: MCPJSONValue] {
+        var object = raw.objectValue ?? [:]
+        object["progressToken"] = .string(progressToken)
+        if let progress {
+            object["progress"] = .double(progress)
+        } else {
+            object.removeValue(forKey: "progress")
+        }
+        if let total {
+            object["total"] = .double(total)
+        } else {
+            object.removeValue(forKey: "total")
+        }
+        if let message {
+            object["message"] = .string(message)
+        } else {
+            object.removeValue(forKey: "message")
+        }
+        return object
     }
 }

--- a/Sources/XcodeMCPKit/MCPJSONValue.swift
+++ b/Sources/XcodeMCPKit/MCPJSONValue.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+public enum MCPJSONValue: Codable, Equatable, Sendable {
+    case object([String: MCPJSONValue])
+    case array([MCPJSONValue])
+    case string(String)
+    case integer(Int64)
+    case double(Double)
+    case bool(Bool)
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let integer = try? container.decode(Int64.self) {
+            self = .integer(integer)
+        } else if let double = try? container.decode(Double.self) {
+            self = .double(double)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([MCPJSONValue].self) {
+            self = .array(array)
+        } else {
+            self = .object(try container.decode([String: MCPJSONValue].self))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .integer(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}
+
+extension MCPJSONValue: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension MCPJSONValue: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = .bool(value)
+    }
+}
+
+extension MCPJSONValue: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int64) {
+        self = .integer(value)
+    }
+}
+
+extension MCPJSONValue: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self = .double(value)
+    }
+}
+
+extension MCPJSONValue: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: MCPJSONValue...) {
+        self = .array(elements)
+    }
+}
+
+extension MCPJSONValue: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, MCPJSONValue)...) {
+        self = .object(Dictionary(uniqueKeysWithValues: elements))
+    }
+}
+
+extension MCPJSONValue {
+    package init?(foundationObject value: Any) {
+        switch value {
+        case is NSNull:
+            self = .null
+        case let string as String:
+            self = .string(string)
+        case let number as NSNumber:
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                self = .bool(number.boolValue)
+            } else if CFNumberIsFloatType(number) {
+                self = .double(number.doubleValue)
+            } else {
+                self = .integer(number.int64Value)
+            }
+        case let array as [Any]:
+            var values: [MCPJSONValue] = []
+            values.reserveCapacity(array.count)
+            for item in array {
+                guard let value = MCPJSONValue(foundationObject: item) else {
+                    return nil
+                }
+                values.append(value)
+            }
+            self = .array(values)
+        case let object as [String: Any]:
+            var values: [String: MCPJSONValue] = [:]
+            values.reserveCapacity(object.count)
+            for (key, item) in object {
+                guard let value = MCPJSONValue(foundationObject: item) else {
+                    return nil
+                }
+                values[key] = value
+            }
+            self = .object(values)
+        default:
+            return nil
+        }
+    }
+
+    package var foundationObject: Any {
+        switch self {
+        case .object(let value):
+            return value.mapValues(\.foundationObject)
+        case .array(let value):
+            return value.map(\.foundationObject)
+        case .string(let value):
+            return value
+        case .integer(let value):
+            return NSNumber(value: value)
+        case .double(let value):
+            return NSNumber(value: value)
+        case .bool(let value):
+            return NSNumber(value: value)
+        case .null:
+            return NSNull()
+        }
+    }
+
+    package var objectValue: [String: MCPJSONValue]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+
+    package var arrayValue: [MCPJSONValue]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+
+    package var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    package var doubleValue: Double? {
+        switch self {
+        case .integer(let value):
+            return Double(value)
+        case .double(let value):
+            return value
+        case .object, .array, .string, .bool, .null:
+            return nil
+        }
+    }
+}

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -1,0 +1,390 @@
+import Foundation
+import ProxyMCPContract
+import ProxySessionUpstream
+
+private final class XcodeMCPPendingRequests: @unchecked Sendable {
+    private struct PendingRequest {
+        let continuation: CheckedContinuation<MCPJSONValue, Error>
+    }
+
+    private let lock = NSLock()
+    private var requests: [String: PendingRequest] = [:]
+
+    func add(
+        idKey: String,
+        continuation: CheckedContinuation<MCPJSONValue, Error>
+    ) {
+        lock.withLock {
+            requests[idKey] = PendingRequest(continuation: continuation)
+        }
+    }
+
+    func complete(idKey: String, result: MCPJSONValue) {
+        let request = lock.withLock {
+            requests.removeValue(forKey: idKey)
+        }
+        request?.continuation.resume(returning: result)
+    }
+
+    func fail(idKey: String, error: Error) {
+        let request = lock.withLock {
+            requests.removeValue(forKey: idKey)
+        }
+        request?.continuation.resume(throwing: error)
+    }
+
+    func failAll(error: Error) {
+        let pending = lock.withLock {
+            let current = requests
+            requests.removeAll()
+            return current
+        }
+        for request in pending.values {
+            request.continuation.resume(throwing: error)
+        }
+    }
+}
+
+public actor XcodeMCP {
+    public struct Configuration: Equatable, Sendable {
+        public var command: String
+        public var arguments: [String]
+        public var environment: [String: String]
+        public var clientName: String
+        public var clientVersion: String
+        public var capabilities: [String: MCPJSONValue]
+        public var requestTimeout: Duration?
+        public var maxQueuedWriteBytes: Int
+
+        public init(
+            command: String = "/usr/bin/xcrun",
+            arguments: [String] = ["mcpbridge"],
+            environment: [String: String] = ProcessInfo.processInfo.environment,
+            clientName: String = "XcodeMCPKit",
+            clientVersion: String = "dev",
+            capabilities: [String: MCPJSONValue] = [:],
+            requestTimeout: Duration? = .seconds(60),
+            maxQueuedWriteBytes: Int = 4 * 1024 * 1024
+        ) {
+            self.command = command
+            self.arguments = arguments
+            self.environment = environment
+            self.clientName = clientName
+            self.clientVersion = clientVersion
+            self.capabilities = capabilities
+            self.requestTimeout = requestTimeout
+            self.maxQueuedWriteBytes = maxQueuedWriteBytes
+        }
+    }
+
+    private let config: Configuration
+    private let transport: any XcodeMCPTransport
+    private let pendingRequests = XcodeMCPPendingRequests()
+    private var nextRequestID: Int64 = 1
+    private var isClosed = false
+    private var eventTask: Task<Void, Never>?
+    private var progressHandlers: [String: @Sendable (MCPProgress) async -> Void] = [:]
+
+    public init(config: Configuration = Configuration()) async throws {
+        let transport = try await UpstreamProcessXcodeMCPTransport.start(
+            config: UpstreamProcess.Config(
+                command: config.command,
+                args: config.arguments,
+                environment: config.environment,
+                maxQueuedWriteBytes: config.maxQueuedWriteBytes
+            )
+        )
+        try await self.init(config: config, transport: transport)
+    }
+
+    package init(config: Configuration = Configuration(), transport: any XcodeMCPTransport) async throws {
+        self.config = config
+        self.transport = transport
+        self.eventTask = nil
+        self.eventTask = Task { [weak self, transport] in
+            for await event in transport.events {
+                await self?.handle(event)
+            }
+        }
+
+        do {
+            try await initialize()
+        } catch {
+            eventTask?.cancel()
+            await transport.close()
+            throw error
+        }
+    }
+
+    deinit {
+        eventTask?.cancel()
+    }
+
+    public func listTools() async throws -> [MCPTool] {
+        let result = try await request("tools/list")
+        guard let tools = result.objectValue?["tools"]?.arrayValue else {
+            throw XcodeMCPError.invalidResponse("tools/list result is missing tools")
+        }
+        return try tools.map { try MCPTool(json: $0) }
+    }
+
+    public func callTool(
+        _ name: String,
+        arguments: [String: MCPJSONValue] = [:],
+        onProgress: (@Sendable (MCPProgress) async -> Void)? = nil
+    ) async throws -> MCPToolResult {
+        guard name.isEmpty == false else {
+            throw XcodeMCPError.invalidRequest("tool name must not be empty")
+        }
+
+        var params: [String: MCPJSONValue] = [
+            "name": .string(name),
+            "arguments": .object(arguments),
+        ]
+        let progressToken: String?
+        if let onProgress {
+            let token = "xcode-mcp-\(UUID().uuidString)"
+            progressToken = token
+            progressHandlers[token] = onProgress
+            params["_meta"] = .object([
+                "progressToken": .string(token)
+            ])
+        } else {
+            progressToken = nil
+        }
+
+        defer {
+            if let progressToken {
+                progressHandlers.removeValue(forKey: progressToken)
+            }
+        }
+
+        let result = try await request("tools/call", params: .object(params))
+        return try MCPToolResult(json: result)
+    }
+
+    public func close() async {
+        guard isClosed == false else {
+            return
+        }
+        isClosed = true
+        eventTask?.cancel()
+        eventTask = nil
+        progressHandlers.removeAll()
+        pendingRequests.failAll(error: XcodeMCPError.closed)
+        await transport.close()
+    }
+}
+
+extension XcodeMCP {
+    package func request(_ method: String, params: MCPJSONValue? = nil) async throws -> MCPJSONValue {
+        guard method.isEmpty == false else {
+            throw XcodeMCPError.invalidRequest("method must not be empty")
+        }
+        try ensureOpen()
+
+        let requestID = nextRequestID
+        nextRequestID += 1
+        let idValue = MCPJSONValue.integer(requestID)
+        let idKey = String(requestID)
+        let payload = try makeJSONRPCPayload(id: idValue, method: method, params: params)
+
+        return try await withRequestTimeout(method: method) { [self] in
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    self.pendingRequests.add(idKey: idKey, continuation: continuation)
+                    Task {
+                        do {
+                            try await self.transport.send(payload)
+                        } catch {
+                            self.pendingRequests.fail(idKey: idKey, error: error)
+                        }
+                    }
+                }
+            } onCancel: {
+                self.pendingRequests.fail(idKey: idKey, error: CancellationError())
+            }
+        }
+    }
+
+    package func notify(_ method: String, params: MCPJSONValue? = nil) async throws {
+        guard method.isEmpty == false else {
+            throw XcodeMCPError.invalidRequest("method must not be empty")
+        }
+        try ensureOpen()
+        let payload = try makeJSONRPCPayload(id: nil, method: method, params: params)
+        try await transport.send(payload)
+    }
+}
+
+private extension XcodeMCP {
+    func initialize() async throws {
+        _ = try await request(
+            "initialize",
+            params: .object([
+                "protocolVersion": .string(MCP.ProtocolVersion.current),
+                "clientInfo": .object([
+                    "name": .string(config.clientName),
+                    "version": .string(config.clientVersion),
+                ]),
+                "capabilities": .object(config.capabilities),
+            ])
+        )
+        try await notify("notifications/initialized")
+    }
+
+    func withRequestTimeout<T: Sendable>(
+        method: String,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        guard let requestTimeout = config.requestTimeout else {
+            return try await operation()
+        }
+        return try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(for: requestTimeout)
+                throw XcodeMCPError.requestTimedOut(method: method)
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+
+    func ensureOpen() throws {
+        if isClosed {
+            throw XcodeMCPError.closed
+        }
+    }
+
+    func handle(_ event: XcodeMCPTransportEvent) async {
+        switch event {
+        case .message(let data):
+            await handleMessage(data)
+        case .closed(let reason):
+            isClosed = true
+            progressHandlers.removeAll()
+            pendingRequests.failAll(
+                error: XcodeMCPError.transportUnavailable(reason ?? "mcpbridge closed")
+            )
+        }
+    }
+
+    func handleMessage(_ data: Data) async {
+        do {
+            let object = try parseJSONObject(data)
+            if let id = object["id"], let idKey = jsonRPCIDKey(id) {
+                if let method = object["method"]?.stringValue {
+                    try await respondToUnsupportedServerRequest(id: id, method: method)
+                    return
+                }
+                if let errorValue = object["error"] {
+                    pendingRequests.fail(idKey: idKey, error: parseServerError(errorValue))
+                    return
+                }
+                let result = object["result"] ?? .null
+                pendingRequests.complete(idKey: idKey, result: result)
+                return
+            }
+
+            if object["method"]?.stringValue == "notifications/progress",
+               let params = object["params"],
+               let progress = MCPProgress(json: params),
+               let handler = progressHandlers[progress.progressToken]
+            {
+                await handler(progress)
+            }
+        } catch {
+            pendingRequests.failAll(error: error)
+        }
+    }
+
+    func respondToUnsupportedServerRequest(id: MCPJSONValue, method _: String) async throws {
+        let payload = try makeJSONRPCResponse(
+            id: id,
+            error: .object([
+                "code": .integer(-32601),
+                "message": .string("Unsupported server request"),
+            ])
+        )
+        try await transport.send(payload)
+    }
+
+    func makeJSONRPCPayload(
+        id: MCPJSONValue?,
+        method: String,
+        params: MCPJSONValue?
+    ) throws -> Data {
+        var object: [String: MCPJSONValue] = [
+            "jsonrpc": .string("2.0"),
+            "method": .string(method),
+        ]
+        if let id {
+            object["id"] = id
+        }
+        if let params {
+            object["params"] = params
+        }
+        return try JSONSerialization.data(withJSONObject: MCPJSONValue.object(object).foundationObject)
+    }
+
+    func makeJSONRPCResponse(
+        id: MCPJSONValue,
+        result: MCPJSONValue? = nil,
+        error: MCPJSONValue? = nil
+    ) throws -> Data {
+        var object: [String: MCPJSONValue] = [
+            "jsonrpc": .string("2.0"),
+            "id": id,
+        ]
+        if let error {
+            object["error"] = error
+        } else {
+            object["result"] = result ?? .null
+        }
+        return try JSONSerialization.data(withJSONObject: MCPJSONValue.object(object).foundationObject)
+    }
+
+    func parseJSONObject(_ data: Data) throws -> [String: MCPJSONValue] {
+        let raw = try JSONSerialization.jsonObject(with: data)
+        guard let value = MCPJSONValue(foundationObject: raw),
+              let object = value.objectValue
+        else {
+            throw XcodeMCPError.invalidResponse("JSON-RPC message is not an object")
+        }
+        return object
+    }
+
+    func jsonRPCIDKey(_ value: MCPJSONValue) -> String? {
+        switch value {
+        case .string(let value):
+            return value
+        case .integer(let value):
+            return String(value)
+        case .double(let value):
+            return String(value)
+        case .object, .array, .bool, .null:
+            return nil
+        }
+    }
+
+    func parseServerError(_ value: MCPJSONValue) -> XcodeMCPError {
+        guard let object = value.objectValue else {
+            return .invalidResponse("JSON-RPC error is not an object")
+        }
+        let code: Int
+        switch object["code"] {
+        case .integer(let value):
+            code = Int(value)
+        case .double(let value):
+            code = Int(value)
+        default:
+            code = 0
+        }
+        let message = object["message"]?.stringValue ?? "MCP server error"
+        return .serverError(code: code, message: message, data: object["data"])
+    }
+}

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -227,10 +227,18 @@ private extension XcodeMCP {
                     "name": .string(config.clientName),
                     "version": .string(config.clientVersion),
                 ]),
-                "capabilities": .object(config.capabilities),
+                "capabilities": .object(initializeCapabilities()),
             ])
         )
         try await notify("notifications/initialized")
+    }
+
+    func initializeCapabilities() -> [String: MCPJSONValue] {
+        var capabilities = config.capabilities
+        capabilities.removeValue(forKey: "roots")
+        capabilities.removeValue(forKey: "sampling")
+        capabilities.removeValue(forKey: "elicitation")
+        return capabilities
     }
 
     func withRequestTimeout<T: Sendable>(
@@ -295,7 +303,9 @@ private extension XcodeMCP {
                let progress = MCPProgress(json: params),
                let handler = progressHandlers[progress.progressToken]
             {
-                await handler(progress)
+                Task {
+                    await handler(progress)
+                }
             }
         } catch {
             pendingRequests.failAll(error: error)

--- a/Sources/XcodeMCPKit/XcodeMCPError.swift
+++ b/Sources/XcodeMCPKit/XcodeMCPError.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public enum XcodeMCPError: Error, Equatable, Sendable {
+    case closed
+    case invalidRequest(String)
+    case invalidResponse(String)
+    case requestTimedOut(method: String)
+    case serverError(code: Int, message: String, data: MCPJSONValue?)
+    case transportUnavailable(String)
+}

--- a/Sources/XcodeMCPKit/XcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/XcodeMCPTransport.swift
@@ -1,0 +1,73 @@
+import Foundation
+import ProxySessionUpstream
+
+package enum XcodeMCPTransportEvent: Sendable {
+    case message(Data)
+    case closed(String?)
+}
+
+package protocol XcodeMCPTransport: Sendable {
+    var events: AsyncStream<XcodeMCPTransportEvent> { get }
+
+    func send(_ data: Data) async throws
+    func close() async
+}
+
+package final class UpstreamProcessXcodeMCPTransport: XcodeMCPTransport {
+    package nonisolated let events: AsyncStream<XcodeMCPTransportEvent>
+
+    private let session: any UpstreamSession
+    private let bridgeTask: Task<Void, Never>
+
+    package static func start(config: UpstreamProcess.Config) async throws -> UpstreamProcessXcodeMCPTransport {
+        let session = try await UpstreamProcess(config: config).startSession()
+        return UpstreamProcessXcodeMCPTransport(session: session)
+    }
+
+    private init(session: any UpstreamSession) {
+        self.session = session
+        let sessionEvents = session.events
+        let stream = AsyncStream<XcodeMCPTransportEvent>.makeStream()
+        self.events = stream.stream
+        self.bridgeTask = Task {
+            for await event in sessionEvents {
+                switch event {
+                case .message(let data):
+                    stream.continuation.yield(.message(data))
+                case .stderr, .stdoutBufferSize:
+                    continue
+                case .stdoutProtocolViolation(let violation):
+                    stream.continuation.yield(.closed("protocol violation: \(violation.reason.rawValue)"))
+                    stream.continuation.finish()
+                    return
+                case .exit(let status):
+                    stream.continuation.yield(.closed("process exited with status \(status)"))
+                    stream.continuation.finish()
+                    return
+                }
+            }
+            stream.continuation.yield(.closed(nil))
+            stream.continuation.finish()
+        }
+    }
+
+    deinit {
+        bridgeTask.cancel()
+    }
+
+    package func send(_ data: Data) async throws {
+        switch await session.send(data) {
+        case .accepted:
+            return
+        case .backpressure:
+            throw XcodeMCPError.transportUnavailable("mcpbridge write queue is full")
+        case .unavailable(let reason):
+            throw XcodeMCPError.transportUnavailable("mcpbridge is unavailable: \(reason)")
+        }
+    }
+
+    package func close() async {
+        bridgeTask.cancel()
+        await session.stop()
+    }
+}

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -12,7 +12,10 @@ struct XcodeMCPTests {
                 environment: [:],
                 clientName: "UnitTestClient",
                 clientVersion: "1.2.3",
-                capabilities: ["roots": .object([:])]
+                capabilities: [
+                    "roots": .object([:]),
+                    "experimental": .object(["x-test": .bool(true)]),
+                ]
             ),
             transport: transport
         )
@@ -30,7 +33,7 @@ struct XcodeMCPTests {
             "version": .string("1.2.3"),
         ]))
         #expect(initializeParams["capabilities"] == .object([
-            "roots": .object([:])
+            "experimental": .object(["x-test": .bool(true)])
         ]))
     }
 
@@ -96,6 +99,7 @@ struct XcodeMCPTests {
             "DocumentationSearch",
             arguments: ["query": .string("Observation")]
         ) { progress in
+            _ = try? await xcode.listTools()
             await recorder.append(progress)
         }
 

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -140,6 +140,64 @@ struct XcodeMCPTests {
         let tools = try await xcode.listTools()
         #expect(tools.first?.name == "DocumentationSearch")
     }
+
+    @Test func domainTypesCodeToProtocolShapeWithoutRawWrapper() throws {
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+
+        let tool = try decoder.decode(
+            MCPTool.self,
+            from: Data(
+                #"""
+                {
+                  "name": "DynamicTool",
+                  "description": "A dynamic tool",
+                  "inputSchema": { "type": "object", "x-extra": true },
+                  "x-tool": "kept"
+                }
+                """#.utf8
+            )
+        )
+        #expect(tool.inputSchema?.objectValue?["x-extra"] == .bool(true))
+        let encodedTool = try jsonObject(encoder.encode(tool))
+        #expect(encodedTool["raw"] == nil)
+        #expect(encodedTool["x-tool"] == .string("kept"))
+
+        let result = try decoder.decode(
+            MCPToolResult.self,
+            from: Data(
+                #"""
+                {
+                  "content": [{ "type": "text", "text": "done", "x-content": "kept" }],
+                  "structuredContent": { "ok": true },
+                  "isError": false,
+                  "x-result": "kept"
+                }
+                """#.utf8
+            )
+        )
+        let encodedResult = try jsonObject(encoder.encode(result))
+        #expect(encodedResult["raw"] == nil)
+        #expect(encodedResult["x-result"] == .string("kept"))
+
+        let progress = try decoder.decode(
+            MCPProgress.self,
+            from: Data(
+                #"""
+                {
+                  "progressToken": "token",
+                  "progress": 0.25,
+                  "total": 1,
+                  "message": "working",
+                  "x-progress": "kept"
+                }
+                """#.utf8
+            )
+        )
+        let encodedProgress = try jsonObject(encoder.encode(progress))
+        #expect(encodedProgress["raw"] == nil)
+        #expect(encodedProgress["x-progress"] == .string("kept"))
+    }
 }
 
 private struct SentMessage: Sendable, Equatable {
@@ -338,4 +396,14 @@ private func waitForUnsupportedServerResponse(
         try await Task.sleep(for: .milliseconds(50))
     }
     throw XcodeMCPError.invalidResponse("unsupported server request response was not sent")
+}
+
+private func jsonObject(_ data: Data) throws -> [String: MCPJSONValue] {
+    let raw = try JSONSerialization.jsonObject(with: data)
+    guard let value = MCPJSONValue(foundationObject: raw),
+          let object = value.objectValue
+    else {
+        throw XcodeMCPError.invalidResponse("encoded JSON is not an object")
+    }
+    return object
 }

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -1,0 +1,341 @@
+import Foundation
+import Testing
+
+@testable import XcodeMCPKit
+
+@Suite(.serialized)
+struct XcodeMCPTests {
+    @Test func asyncInitializerPerformsMCPHandshake() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let xcode = try await XcodeMCP(
+            config: .init(
+                environment: [:],
+                clientName: "UnitTestClient",
+                clientVersion: "1.2.3",
+                capabilities: ["roots": .object([:])]
+            ),
+            transport: transport
+        )
+        defer {
+            Task { await xcode.close() }
+        }
+
+        let sent = await transport.sentMessages()
+        #expect(sent.compactMap(\.method) == ["initialize", "notifications/initialized"])
+
+        let initializeParams = try #require(sent.first?.params?.objectValue)
+        #expect(initializeParams["protocolVersion"] == .string("2025-06-18"))
+        #expect(initializeParams["clientInfo"] == .object([
+            "name": .string("UnitTestClient"),
+            "version": .string("1.2.3"),
+        ]))
+        #expect(initializeParams["capabilities"] == .object([
+            "roots": .object([:])
+        ]))
+    }
+
+    @Test func listToolsDecodesDescriptorAndPreservesDynamicFields() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let xcode = try await XcodeMCP(config: .init(environment: [:]), transport: transport)
+        defer {
+            Task { await xcode.close() }
+        }
+
+        let tools = try await xcode.listTools()
+        let tool = try #require(tools.first)
+
+        #expect(tool.name == "DocumentationSearch")
+        #expect(tool.description == "Search Apple developer documentation")
+        #expect(tool.inputSchema?.objectValue?["x-dynamic"] == .bool(true))
+        #expect(tool.raw.objectValue?["x-provider"] == .string("fake"))
+    }
+
+    @Test func callToolSendsShapeAndDecodesFinalResult() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let xcode = try await XcodeMCP(config: .init(environment: [:]), transport: transport)
+        defer {
+            Task { await xcode.close() }
+        }
+
+        let result = try await xcode.callTool(
+            "DocumentationSearch",
+            arguments: ["query": .string("SwiftData")]
+        )
+
+        #expect(result.isError)
+        #expect(result.structuredContent == .object([
+            "items": .array([
+                .object(["title": .string("SwiftData")])
+            ])
+        ]))
+        #expect(result.raw.objectValue?["x-result"] == .string("dynamic"))
+        guard case .text(let text, let raw) = try #require(result.content.first) else {
+            Issue.record("expected text content")
+            return
+        }
+        #expect(text == "Result for SwiftData")
+        #expect(raw.objectValue?["x-content"] == .string("kept"))
+
+        let calls = await transport.sentMessages().filter { $0.method == "tools/call" }
+        let params = try #require(calls.last?.params?.objectValue)
+        #expect(params["name"] == .string("DocumentationSearch"))
+        #expect(params["arguments"] == .object([
+            "query": .string("SwiftData")
+        ]))
+    }
+
+    @Test func callToolAddsProgressTokenAndRoutesMatchingProgress() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let recorder = ProgressRecorder()
+        let xcode = try await XcodeMCP(config: .init(environment: [:]), transport: transport)
+        defer {
+            Task { await xcode.close() }
+        }
+
+        _ = try await xcode.callTool(
+            "DocumentationSearch",
+            arguments: ["query": .string("Observation")]
+        ) { progress in
+            await recorder.append(progress)
+        }
+
+        let calls = await transport.sentMessages().filter { $0.method == "tools/call" }
+        let meta = try #require(calls.last?.params?.objectValue?["_meta"]?.objectValue)
+        let progressToken = try #require(meta["progressToken"]?.stringValue)
+        #expect(progressToken.isEmpty == false)
+
+        let progress = try await waitForProgress(recorder)
+        #expect(progress.progressToken == progressToken)
+        #expect(progress.progress == 0.5)
+        #expect(progress.total == 1)
+        #expect(progress.message == "halfway")
+    }
+
+    @Test func closeIsIdempotentAndRejectsFuturePublicCalls() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let xcode = try await XcodeMCP(config: .init(environment: [:]), transport: transport)
+
+        await xcode.close()
+        await xcode.close()
+
+        #expect(await transport.closeCount() == 1)
+        await #expect(throws: XcodeMCPError.closed) {
+            _ = try await xcode.listTools()
+        }
+    }
+
+    @Test func unsupportedServerRequestGetsInternalErrorResponse() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let xcode = try await XcodeMCP(config: .init(environment: [:]), transport: transport)
+        defer {
+            Task { await xcode.close() }
+        }
+
+        await transport.emitServerRequest(method: "sampling/createMessage", id: .integer(99))
+
+        let response = try await waitForUnsupportedServerResponse(transport)
+        #expect(response.id == .integer(99))
+        #expect(response.error?.objectValue?["code"] == .integer(-32601))
+
+        let tools = try await xcode.listTools()
+        #expect(tools.first?.name == "DocumentationSearch")
+    }
+}
+
+private struct SentMessage: Sendable, Equatable {
+    var id: MCPJSONValue?
+    var method: String?
+    var params: MCPJSONValue?
+    var result: MCPJSONValue?
+    var error: MCPJSONValue?
+}
+
+private actor ProgressRecorder {
+    private var values: [MCPProgress] = []
+
+    func append(_ value: MCPProgress) {
+        values.append(value)
+    }
+
+    func snapshot() -> [MCPProgress] {
+        values
+    }
+}
+
+private actor FakeXcodeMCPTransport: XcodeMCPTransport {
+    nonisolated let events: AsyncStream<XcodeMCPTransportEvent>
+
+    private let continuation: AsyncStream<XcodeMCPTransportEvent>.Continuation
+    private var messages: [SentMessage] = []
+    private var closed = false
+    private var closes = 0
+
+    init() {
+        let stream = AsyncStream<XcodeMCPTransportEvent>.makeStream()
+        self.events = stream.stream
+        self.continuation = stream.continuation
+    }
+
+    func send(_ data: Data) async throws {
+        guard closed == false else {
+            throw XcodeMCPError.closed
+        }
+        let object = try parse(data)
+        let sent = SentMessage(
+            id: object["id"],
+            method: object["method"]?.stringValue,
+            params: object["params"],
+            result: object["result"],
+            error: object["error"]
+        )
+        messages.append(sent)
+
+        guard let method = sent.method,
+              let id = sent.id
+        else {
+            return
+        }
+
+        if method == "tools/call",
+           let progressToken = sent.params?.objectValue?["_meta"]?.objectValue?["progressToken"]
+        {
+            try yieldMessage([
+                "jsonrpc": .string("2.0"),
+                "method": .string("notifications/progress"),
+                "params": .object([
+                    "progressToken": progressToken,
+                    "progress": .double(0.5),
+                    "total": .integer(1),
+                    "message": .string("halfway"),
+                ]),
+            ])
+        }
+
+        try yieldMessage([
+            "jsonrpc": .string("2.0"),
+            "id": id,
+            "result": responseResult(method: method, params: sent.params),
+        ])
+    }
+
+    func close() async {
+        guard closed == false else {
+            return
+        }
+        closed = true
+        closes += 1
+        continuation.yield(.closed(nil))
+        continuation.finish()
+    }
+
+    func emitServerRequest(method: String, id: MCPJSONValue) {
+        try? yieldMessage([
+            "jsonrpc": .string("2.0"),
+            "id": id,
+            "method": .string(method),
+            "params": .object([:]),
+        ])
+    }
+
+    func sentMessages() -> [SentMessage] {
+        messages
+    }
+
+    func closeCount() -> Int {
+        closes
+    }
+
+    private func yieldMessage(_ object: [String: MCPJSONValue]) throws {
+        let responseData = try JSONSerialization.data(
+            withJSONObject: MCPJSONValue.object(object).foundationObject
+        )
+        continuation.yield(.message(responseData))
+    }
+
+    private func parse(_ data: Data) throws -> [String: MCPJSONValue] {
+        let raw = try JSONSerialization.jsonObject(with: data)
+        guard let value = MCPJSONValue(foundationObject: raw),
+              let object = value.objectValue
+        else {
+            throw XcodeMCPError.invalidRequest("message is not an object")
+        }
+        return object
+    }
+
+    private func responseResult(method: String, params: MCPJSONValue?) -> MCPJSONValue {
+        switch method {
+        case "initialize":
+            return .object([
+                "protocolVersion": .string("2025-06-18"),
+                "serverInfo": .object([
+                    "name": .string("fake-mcpbridge"),
+                    "version": .string("test"),
+                ]),
+                "capabilities": .object([:]),
+            ])
+        case "tools/list":
+            return .object([
+                "tools": .array([
+                    .object([
+                        "name": .string("DocumentationSearch"),
+                        "description": .string("Search Apple developer documentation"),
+                        "inputSchema": .object([
+                            "type": .string("object"),
+                            "x-dynamic": .bool(true),
+                            "properties": .object([
+                                "query": .object([
+                                    "type": .string("string")
+                                ])
+                            ]),
+                        ]),
+                        "x-provider": .string("fake"),
+                    ])
+                ])
+            ])
+        case "tools/call":
+            let query = params?.objectValue?["arguments"]?.objectValue?["query"]?.stringValue ?? ""
+            return .object([
+                "content": .array([
+                    .object([
+                        "type": .string("text"),
+                        "text": .string("Result for \(query)"),
+                        "x-content": .string("kept"),
+                    ])
+                ]),
+                "structuredContent": .object([
+                    "items": .array([
+                        .object(["title": .string(query)])
+                    ])
+                ]),
+                "isError": .bool(true),
+                "x-result": .string("dynamic"),
+            ])
+        default:
+            return .null
+        }
+    }
+}
+
+private func waitForProgress(_ recorder: ProgressRecorder) async throws -> MCPProgress {
+    for _ in 0..<20 {
+        if let progress = await recorder.snapshot().first {
+            return progress
+        }
+        try await Task.sleep(for: .milliseconds(50))
+    }
+    throw XcodeMCPError.invalidResponse("progress callback was not invoked")
+}
+
+private func waitForUnsupportedServerResponse(
+    _ transport: FakeXcodeMCPTransport
+) async throws -> SentMessage {
+    for _ in 0..<20 {
+        if let response = await transport.sentMessages().first(where: { message in
+            message.method == nil && message.error != nil
+        }) {
+            return response
+        }
+        try await Task.sleep(for: .milliseconds(50))
+    }
+    throw XcodeMCPError.invalidResponse("unsupported server request response was not sent")
+}


### PR DESCRIPTION
## Purpose
Make `XcodeMCPKit` usable as an app-developer-facing Swift library for operating local `mcpbridge` without exposing proxy runtime internals.

## Changes
- Adds the `XcodeMCPKit` library product.
- Adds `public actor XcodeMCP` with async initialization, `listTools`, `callTool`, progress callback routing, and idempotent `close`.
- Adds public MCP domain types: `MCPJSONValue`, `MCPTool`, `MCPToolResult`, `MCPContent`, `MCPProgress`, and `XcodeMCPError`.
- Keeps process launch, JSON-RPC request tracking, framing, unsupported server request responses, and upstream transport behind package/internal boundaries.
- Adds fake-transport contract tests for initialize ordering, tool listing, tool calls, progress, close behavior, unsupported server requests, and Codable protocol JSON shape.
- Updates README usage examples for the new top-level Swift client.

## Validation
- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxySessionTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- Codex review against `codex/refactor-layered-runtime-integration`: clean after fixes

## Risks
- The v1 client intentionally does not expose server-to-client request handling. Configuration capabilities that would require such handlers are not advertised during initialize.