### PR TITLE
Document public kits and rename proxy server type

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,6 +97,7 @@ let package = Package(
                 "ProxySessionUpstream",
             ],
             path: "Sources/XcodeMCPKit",
+            exclude: ["README.md"],
             swiftSettings: strictSwiftSettings
         ),
         .target(
@@ -194,6 +195,7 @@ let package = Package(
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
             ],
+            exclude: ["README.md"],
             swiftSettings: strictSwiftSettings
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,14 @@ let package = Package(
             name: "XcodeMCPKit",
             targets: ["XcodeMCPKit"]
         ),
+        .library(
+            name: "XcodeMCPProxyKit",
+            targets: ["XcodeMCPProxyKit"]
+        ),
+        .library(
+            name: "ProxyCore",
+            targets: ["ProxyCore"]
+        ),
         .executable(
             name: "xcode-mcp-proxy",
             targets: ["XcodeMCPProxyCLI"]

--- a/Package.swift
+++ b/Package.swift
@@ -23,10 +23,6 @@ let package = Package(
             name: "XcodeMCPProxyKit",
             targets: ["XcodeMCPProxyKit"]
         ),
-        .library(
-            name: "ProxyCore",
-            targets: ["ProxyCore"]
-        ),
         .executable(
             name: "xcode-mcp-proxy",
             targets: ["XcodeMCPProxyCLI"]

--- a/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand.swift
@@ -111,7 +111,9 @@ package struct XcodeMCPProxyServerCommand {
                 bootstrapLogging: ProxyLogging.bootstrap,
                 stdout: { print($0) },
                 stderr: { FileHandle.writeLine($0, to: .standardError) },
-                makeServer: { XcodeMCPProxyServer(config: $0) },
+                makeServer: { config in
+                    XcodeMCPProxyServer(proxyConfig: config, dependencies: .live(config: config))
+                },
                 isAddressAlreadyInUse: XcodeMCPProxyServerCommand.isAddressAlreadyInUse,
                 existingProxyServerClient: .liveValue
             )

--- a/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand.swift
@@ -4,7 +4,7 @@ import Foundation
 import ProxyCLICommon
 import XcodeMCPProxyKit
 
-extension ProxyServer: ProxyServerCommandServer {}
+extension XcodeMCPProxyServer: ProxyServerCommandServer {}
 
 package struct XcodeMCPProxyServerCommand {
     package struct Options {
@@ -111,7 +111,7 @@ package struct XcodeMCPProxyServerCommand {
                 bootstrapLogging: ProxyLogging.bootstrap,
                 stdout: { print($0) },
                 stderr: { FileHandle.writeLine($0, to: .standardError) },
-                makeServer: { ProxyServer(config: $0) },
+                makeServer: { XcodeMCPProxyServer(config: $0) },
                 isAddressAlreadyInUse: XcodeMCPProxyServerCommand.isAddressAlreadyInUse,
                 existingProxyServerClient: .liveValue
             )

--- a/Sources/XcodeMCPKit/MCPDomainTypes.swift
+++ b/Sources/XcodeMCPKit/MCPDomainTypes.swift
@@ -1,11 +1,34 @@
 import Foundation
 
+/// A tool advertised by the running Xcode MCP server.
+///
+/// Tool availability and schemas are dynamic. Use ``name`` with
+/// ``XcodeMCP/callTool(_:arguments:onProgress:)`` and inspect ``inputSchema``
+/// or ``raw`` when building arguments for a tool.
 public struct MCPTool: Codable, Equatable, Sendable {
+    /// The server-defined tool name.
     public var name: String
+
+    /// The server-provided human-readable description, when available.
     public var description: String?
+
+    /// The server-provided JSON schema for tool arguments, when available.
     public var inputSchema: MCPJSONValue?
+
+    /// The complete raw MCP tool object.
+    ///
+    /// This preserves dynamic fields and future MCP extensions that are not
+    /// modeled as first-class properties.
     public var raw: MCPJSONValue
 
+    /// Creates a tool value.
+    ///
+    /// - Parameters:
+    ///   - name: Server-defined tool name.
+    ///   - description: Optional human-readable description.
+    ///   - inputSchema: Optional JSON schema for tool arguments.
+    ///   - raw: Complete raw MCP tool object. When omitted, a minimal object is
+    ///     synthesized from `name`.
     public init(
         name: String,
         description: String? = nil,
@@ -20,31 +43,55 @@ public struct MCPTool: Codable, Equatable, Sendable {
         ])
     }
 
+    /// Decodes a tool from its raw MCP JSON object.
     public init(from decoder: Decoder) throws {
         let value = try MCPJSONValue(from: decoder)
         self = try MCPTool(json: value)
     }
 
+    /// Encodes the tool as an MCP JSON object, preserving raw fields where
+    /// possible.
     public func encode(to encoder: Encoder) throws {
         try MCPJSONValue.object(toolObject()).encode(to: encoder)
     }
 }
 
+/// A content item returned by an MCP tool call.
+///
+/// Known MCP content shapes are projected into typed cases. Unknown or
+/// malformed content is preserved as ``raw(_:)`` so clients can still inspect
+/// the original server response.
 public enum MCPContent: Codable, Equatable, Sendable {
+    /// Text content.
+    ///
+    /// The associated `raw` value contains the original MCP content object.
     case text(String, raw: MCPJSONValue)
+
+    /// Base64-encoded image content.
+    ///
+    /// The associated `raw` value contains the original MCP content object.
     case image(data: String, mimeType: String?, raw: MCPJSONValue)
+
+    /// Embedded resource content.
+    ///
+    /// The associated `raw` value contains the original MCP content object.
     case resource(uri: String?, text: String?, mimeType: String?, raw: MCPJSONValue)
+
+    /// Content that is not recognized by this package.
     case raw(MCPJSONValue)
 
+    /// Decodes a content item from raw MCP JSON.
     public init(from decoder: Decoder) throws {
         let value = try MCPJSONValue(from: decoder)
         self = try MCPContent(json: value)
     }
 
+    /// Encodes the original MCP content JSON.
     public func encode(to encoder: Encoder) throws {
         try rawValue.encode(to: encoder)
     }
 
+    /// The original MCP content JSON.
     public var rawValue: MCPJSONValue {
         switch self {
         case .text(_, let raw),
@@ -56,12 +103,40 @@ public enum MCPContent: Codable, Equatable, Sendable {
     }
 }
 
+/// The final result returned by an MCP `tools/call` request.
+///
+/// `XcodeMCP` returns only this final result from
+/// ``XcodeMCP/callTool(_:arguments:onProgress:)``. Progress notifications are
+/// delivered through the call's callback and are not stored here.
 public struct MCPToolResult: Codable, Equatable, Sendable {
+    /// Content items returned by the tool.
     public var content: [MCPContent]
+
+    /// Optional structured content returned by the tool.
+    ///
+    /// This value is raw MCP JSON because each tool may define its own shape.
     public var structuredContent: MCPJSONValue?
+
+    /// Whether the tool reported an error result.
+    ///
+    /// This is the MCP `isError` flag from the final tool response, not a Swift
+    /// transport error. Transport, timeout, and protocol failures are thrown.
     public var isError: Bool
+
+    /// The complete raw MCP tool result object.
+    ///
+    /// This preserves dynamic fields and future MCP extensions that are not
+    /// modeled as first-class properties.
     public var raw: MCPJSONValue
 
+    /// Creates a tool result value.
+    ///
+    /// - Parameters:
+    ///   - content: Content items returned by the tool.
+    ///   - structuredContent: Optional structured content returned by the tool.
+    ///   - isError: Whether the tool reported an error result.
+    ///   - raw: Complete raw MCP result object. When omitted, a minimal object
+    ///     is synthesized from the modeled properties.
     public init(
         content: [MCPContent],
         structuredContent: MCPJSONValue? = nil,
@@ -77,23 +152,53 @@ public struct MCPToolResult: Codable, Equatable, Sendable {
         ])
     }
 
+    /// Decodes a tool result from its raw MCP JSON object.
     public init(from decoder: Decoder) throws {
         let value = try MCPJSONValue(from: decoder)
         self = try MCPToolResult(json: value)
     }
 
+    /// Encodes the result as an MCP JSON object, preserving raw fields where
+    /// possible.
     public func encode(to encoder: Encoder) throws {
         try MCPJSONValue.object(resultObject()).encode(to: encoder)
     }
 }
 
+/// A progress notification associated with a tool call.
+///
+/// Progress values are delivered only through the `onProgress` callback passed
+/// to ``XcodeMCP/callTool(_:arguments:onProgress:)``. They are not exposed as a
+/// public stream and are not included in ``MCPToolResult``.
 public struct MCPProgress: Codable, Equatable, Sendable {
+    /// Token that associates the notification with a specific tool call.
     public var progressToken: String
+
+    /// Current progress value, when provided by the server.
     public var progress: Double?
+
+    /// Total progress value, when provided by the server.
     public var total: Double?
+
+    /// Optional server-provided progress message.
     public var message: String?
+
+    /// The complete raw MCP progress notification payload.
+    ///
+    /// This preserves dynamic fields and future MCP extensions that are not
+    /// modeled as first-class properties.
     public var raw: MCPJSONValue
 
+    /// Creates a progress notification value.
+    ///
+    /// - Parameters:
+    ///   - progressToken: Token that associates the notification with a tool
+    ///     call.
+    ///   - progress: Optional current progress value.
+    ///   - total: Optional total progress value.
+    ///   - message: Optional progress message.
+    ///   - raw: Complete raw MCP progress payload. When omitted, a minimal
+    ///     object is synthesized from `progressToken`.
     public init(
         progressToken: String,
         progress: Double? = nil,
@@ -110,6 +215,7 @@ public struct MCPProgress: Codable, Equatable, Sendable {
         ])
     }
 
+    /// Decodes a progress notification from raw MCP JSON.
     public init(from decoder: Decoder) throws {
         let value = try MCPJSONValue(from: decoder)
         guard let progress = MCPProgress(json: value) else {
@@ -118,6 +224,8 @@ public struct MCPProgress: Codable, Equatable, Sendable {
         self = progress
     }
 
+    /// Encodes the progress notification as MCP JSON, preserving raw fields
+    /// where possible.
     public func encode(to encoder: Encoder) throws {
         try MCPJSONValue.object(progressObject()).encode(to: encoder)
     }

--- a/Sources/XcodeMCPKit/MCPJSONValue.swift
+++ b/Sources/XcodeMCPKit/MCPJSONValue.swift
@@ -1,14 +1,43 @@
 import Foundation
 
+/// A JSON value used by MCP requests, responses, and dynamic metadata.
+///
+/// Xcode MCP tools are discovered at runtime, so this package preserves tool
+/// arguments, input schemas, structured content, and unknown fields as raw JSON
+/// instead of projecting every value into tool-specific Swift types.
+///
+/// Literal conformances make small argument dictionaries concise:
+///
+/// ```swift
+/// let arguments: [String: MCPJSONValue] = [
+///     "query": "SwiftUI toolbar",
+///     "includeBeta": true,
+///     "limit": 5
+/// ]
+/// ```
 public enum MCPJSONValue: Codable, Equatable, Sendable {
+    /// A JSON object with string keys.
     case object([String: MCPJSONValue])
+
+    /// A JSON array.
     case array([MCPJSONValue])
+
+    /// A JSON string.
     case string(String)
+
+    /// A JSON number represented as an integer.
     case integer(Int64)
+
+    /// A JSON number represented as a floating-point value.
     case double(Double)
+
+    /// A JSON boolean.
     case bool(Bool)
+
+    /// A JSON null value.
     case null
 
+    /// Decodes a JSON value while preserving its dynamic shape.
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if container.decodeNil() {
@@ -28,6 +57,7 @@ public enum MCPJSONValue: Codable, Equatable, Sendable {
         }
     }
 
+    /// Encodes the value as JSON.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
@@ -50,36 +80,42 @@ public enum MCPJSONValue: Codable, Equatable, Sendable {
 }
 
 extension MCPJSONValue: ExpressibleByStringLiteral {
+    /// Creates a JSON string from a Swift string literal.
     public init(stringLiteral value: String) {
         self = .string(value)
     }
 }
 
 extension MCPJSONValue: ExpressibleByBooleanLiteral {
+    /// Creates a JSON boolean from a Swift boolean literal.
     public init(booleanLiteral value: Bool) {
         self = .bool(value)
     }
 }
 
 extension MCPJSONValue: ExpressibleByIntegerLiteral {
+    /// Creates a JSON integer from a Swift integer literal.
     public init(integerLiteral value: Int64) {
         self = .integer(value)
     }
 }
 
 extension MCPJSONValue: ExpressibleByFloatLiteral {
+    /// Creates a JSON floating-point number from a Swift float literal.
     public init(floatLiteral value: Double) {
         self = .double(value)
     }
 }
 
 extension MCPJSONValue: ExpressibleByArrayLiteral {
+    /// Creates a JSON array from a Swift array literal.
     public init(arrayLiteral elements: MCPJSONValue...) {
         self = .array(elements)
     }
 }
 
 extension MCPJSONValue: ExpressibleByDictionaryLiteral {
+    /// Creates a JSON object from a Swift dictionary literal.
     public init(dictionaryLiteral elements: (String, MCPJSONValue)...) {
         self = .object(Dictionary(uniqueKeysWithValues: elements))
     }

--- a/Sources/XcodeMCPKit/README.md
+++ b/Sources/XcodeMCPKit/README.md
@@ -1,0 +1,89 @@
+# XcodeMCPKit
+
+Swift client API for talking to Xcode's local MCP bridge from an app or tool.
+
+## Status
+
+`XcodeMCPKit` is the public client-side library target. It launches the
+configured `mcpbridge` process, performs the MCP initialize handshake, and
+exposes the dynamic Xcode MCP tool catalog through a small Swift API.
+
+This target owns:
+
+- `XcodeMCP`, the top-level async client
+- `MCPJSONValue`, the raw JSON value used for dynamic MCP payloads
+- `MCPTool`, `MCPToolResult`, `MCPContent`, and `MCPProgress`
+- `XcodeMCPError`
+
+It intentionally does not expose tool-specific Swift wrappers, JSON-RPC framing,
+transport streams, or server-to-client handlers such as roots, sampling, and
+elicitation.
+
+## Quickstart
+
+Add the `XcodeMCPKit` product to your target, then construct a client:
+
+```swift
+import XcodeMCPKit
+
+let config = XcodeMCP.Configuration(
+    command: "/usr/bin/xcrun",
+    arguments: ["mcpbridge"],
+    clientName: "MyApp",
+    clientVersion: "1.0"
+)
+
+let xcode = try await XcodeMCP(config: config)
+let tools = try await xcode.listTools()
+
+if tools.contains(where: { $0.name == "DocumentationSearch" }) {
+    let result = try await xcode.callTool(
+        "DocumentationSearch",
+        arguments: ["query": "NavigationStack"]
+    ) { progress in
+        if let message = progress.message {
+            print(message)
+        }
+    }
+
+    for item in result.content {
+        if case .text(let text, _) = item {
+            print(text)
+        }
+    }
+}
+
+await xcode.close()
+```
+
+## Dynamic Tools And Raw Values
+
+The Xcode MCP server decides which tools are available at runtime. Call
+`listTools()` to discover names, descriptions, and input schemas, then pass the
+selected tool name to `callTool(_:arguments:onProgress:)`.
+
+Arguments and dynamic response fields use `MCPJSONValue` so clients can send and
+inspect MCP data that this package does not model as a fixed Swift type. Domain
+models keep raw values for unknown fields and future MCP extensions.
+
+## Configuration
+
+`XcodeMCP.Configuration` controls process launch and MCP initialization:
+
+- `command` and `arguments` choose the upstream process. The default is
+  `/usr/bin/xcrun mcpbridge`.
+- `environment` is passed to the process.
+- `clientName`, `clientVersion`, and `capabilities` are sent in `initialize`.
+- `requestTimeout` bounds requests when non-`nil`.
+- `maxQueuedWriteBytes` limits queued outbound transport data.
+
+Capabilities that require server-to-client handlers are filtered because this
+v1 API does not expose those handlers.
+
+## Lifecycle
+
+Create one `XcodeMCP` per bridge session. The async initializer starts the
+process and completes initialization before returning. `callTool` returns the
+final MCP result; progress is callback-only and the underlying event stream is
+not public API. Call `close()` when finished. Closing is idempotent and rejects
+future requests.

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -45,17 +45,98 @@ private final class XcodeMCPPendingRequests: @unchecked Sendable {
     }
 }
 
+/// A high-level client for the local Xcode MCP bridge.
+///
+/// `XcodeMCP` starts an `mcpbridge` process, performs the MCP initialize
+/// handshake, and exposes the dynamic Xcode tool catalog through
+/// ``listTools()`` and ``callTool(_:arguments:onProgress:)``.
+///
+/// The tool catalog is discovered at runtime. This package intentionally does
+/// not promise tool-specific Swift methods or typed request/response models for
+/// individual Xcode tools. Pass tool arguments as ``MCPJSONValue`` and inspect
+/// the returned ``MCPToolResult`` for the final MCP response.
+///
+/// Server-to-client handlers such as roots, sampling, and elicitation are not
+/// exposed by this v1 API. Progress notifications are delivered only through
+/// the callback supplied to ``callTool(_:arguments:onProgress:)``; the streaming
+/// transport itself is an implementation detail.
+///
+/// ```swift
+/// import XcodeMCPKit
+///
+/// let xcode = try await XcodeMCP()
+///
+/// let tools = try await xcode.listTools()
+/// guard tools.contains(where: { $0.name == "DocumentationSearch" }) else {
+///     throw XcodeMCPError.invalidResponse("DocumentationSearch is unavailable")
+/// }
+///
+/// _ = try await xcode.callTool(
+///     "DocumentationSearch",
+///     arguments: ["query": "NavigationStack"]
+/// )
+///
+/// await xcode.close()
+/// ```
 public actor XcodeMCP {
+    /// Settings used to launch and initialize the local MCP bridge.
+    ///
+    /// The default configuration starts `xcrun mcpbridge` with the current
+    /// process environment and a conservative per-request timeout.
     public struct Configuration: Equatable, Sendable {
+        /// The executable used to start the upstream bridge process.
+        ///
+        /// The default is `/usr/bin/xcrun`, which allows `arguments` to select
+        /// Xcode's `mcpbridge` tool.
         public var command: String
+
+        /// Command-line arguments passed to ``command``.
+        ///
+        /// The default value is `["mcpbridge"]`.
         public var arguments: [String]
+
+        /// Environment variables passed to the upstream process.
+        ///
+        /// The default inherits `ProcessInfo.processInfo.environment`.
         public var environment: [String: String]
+
+        /// Client name sent in the MCP `initialize` request.
         public var clientName: String
+
+        /// Client version sent in the MCP `initialize` request.
         public var clientVersion: String
+
+        /// Additional MCP client capabilities sent during initialization.
+        ///
+        /// Values are encoded as raw MCP JSON. Capabilities that require
+        /// server-to-client handlers, such as `roots`, `sampling`, and
+        /// `elicitation`, are intentionally not exposed by this API.
         public var capabilities: [String: MCPJSONValue]
+
+        /// Maximum duration to wait for each request.
+        ///
+        /// Set this to `nil` to disable client-side request timeouts.
         public var requestTimeout: Duration?
+
+        /// Maximum number of outbound bytes that may be queued for the bridge.
         public var maxQueuedWriteBytes: Int
 
+        /// Creates a bridge configuration.
+        ///
+        /// - Parameters:
+        ///   - command: Executable used to start the upstream bridge process.
+        ///   - arguments: Command-line arguments passed to `command`.
+        ///   - environment: Environment variables passed to the upstream
+        ///     process.
+        ///   - clientName: Client name sent in the MCP `initialize` request.
+        ///   - clientVersion: Client version sent in the MCP `initialize`
+        ///     request.
+        ///   - capabilities: Additional MCP client capabilities encoded as raw
+        ///     MCP JSON.
+        ///   - requestTimeout: Maximum duration to wait for each request, or
+        ///     `nil` to disable client-side request timeouts.
+        ///   - maxQueuedWriteBytes: Maximum number of outbound bytes that may
+        ///     be queued for the bridge.
         public init(
             command: String = "/usr/bin/xcrun",
             arguments: [String] = ["mcpbridge"],
@@ -85,6 +166,13 @@ public actor XcodeMCP {
     private var eventTask: Task<Void, Never>?
     private var progressHandlers: [String: @Sendable (MCPProgress) async -> Void] = [:]
 
+    /// Starts the local MCP bridge and returns an initialized client.
+    ///
+    /// The initializer launches the configured process, sends MCP
+    /// `initialize`, then sends `notifications/initialized`. If initialization
+    /// fails, the process is closed before the error is rethrown.
+    ///
+    /// - Parameter config: Launch and initialization settings for the bridge.
     public init(config: Configuration = Configuration()) async throws {
         let transport = try await UpstreamProcessXcodeMCPTransport.start(
             config: UpstreamProcess.Config(
@@ -120,6 +208,11 @@ public actor XcodeMCP {
         eventTask?.cancel()
     }
 
+    /// Returns the currently available Xcode MCP tools.
+    ///
+    /// The returned catalog is dynamic and comes from the running Xcode MCP
+    /// server. Use the tool `name` with ``callTool(_:arguments:onProgress:)``
+    /// and treat `inputSchema` and `raw` as MCP JSON supplied by the server.
     public func listTools() async throws -> [MCPTool] {
         let result = try await request("tools/list")
         guard let tools = result.objectValue?["tools"]?.arrayValue else {
@@ -128,6 +221,21 @@ public actor XcodeMCP {
         return try tools.map { try MCPTool(json: $0) }
     }
 
+    /// Calls an Xcode MCP tool and returns its final result.
+    ///
+    /// This method sends an MCP `tools/call` request using the supplied raw JSON
+    /// arguments. It waits for the final `tools/call` response and returns it as
+    /// ``MCPToolResult``. Incremental transport events are not exposed as a
+    /// public stream; progress notifications are delivered through
+    /// `onProgress` when the server emits them.
+    ///
+    /// - Parameters:
+    ///   - name: Tool name from ``listTools()``.
+    ///   - arguments: Tool arguments encoded as MCP JSON.
+    ///   - onProgress: Optional callback for MCP progress notifications
+    ///     associated with this call.
+    /// - Returns: The final tool result, including content, structured content,
+    ///   error status, and the raw MCP JSON response.
     public func callTool(
         _ name: String,
         arguments: [String: MCPJSONValue] = [:],
@@ -163,6 +271,11 @@ public actor XcodeMCP {
         return try MCPToolResult(json: result)
     }
 
+    /// Closes the client and terminates the underlying transport.
+    ///
+    /// Closing is idempotent. Pending requests fail with ``XcodeMCPError/closed``,
+    /// registered progress callbacks are discarded, and no further requests may
+    /// be sent through this client.
     public func close() async {
         guard isClosed == false else {
             return

--- a/Sources/XcodeMCPKit/XcodeMCPError.swift
+++ b/Sources/XcodeMCPKit/XcodeMCPError.swift
@@ -1,10 +1,36 @@
 import Foundation
 
+/// Errors thrown by the public Xcode MCP client API.
+///
+/// Tool-level failures that arrive as a successful MCP `tools/call` response
+/// are represented by ``MCPToolResult/isError``. This error type is used for
+/// client-side validation, transport failures, protocol-shape failures,
+/// timeouts, and JSON-RPC server errors.
 public enum XcodeMCPError: Error, Equatable, Sendable {
+    /// The client was closed before or during a request.
     case closed
+
+    /// The client rejected a request before sending it.
+    ///
+    /// The associated string describes the invalid input.
     case invalidRequest(String)
+
+    /// The server response did not match the expected MCP shape.
+    ///
+    /// The associated string describes the missing or invalid response field.
     case invalidResponse(String)
+
+    /// A request exceeded the configured timeout.
     case requestTimedOut(method: String)
+
+    /// The MCP server returned a JSON-RPC error response.
+    ///
+    /// `data` preserves the raw JSON-RPC error data value when the server
+    /// includes one.
     case serverError(code: Int, message: String, data: MCPJSONValue?)
+
+    /// The underlying bridge process or transport was unavailable.
+    ///
+    /// The associated string describes the transport failure.
     case transportUnavailable(String)
 }

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -25,8 +25,8 @@ router.
 
 ## Quickstart
 
-Depend on the `XcodeMCPProxyKit` and `ProxyCore` targets, then construct the
-server directly:
+Depend on the `XcodeMCPProxyKit` and `ProxyCore` library products, then
+construct the server directly:
 
 ```swift
 import ProxyCore

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -15,9 +15,10 @@ This target owns:
 - HTTP channel setup and request handling integration
 - startup, discovery writing, waiting, and shutdown entry points
 
-Configuration lives in `ProxyCore.ProxyConfig`. Lower-level session routing,
-upstream process management, Xcode support, and MCP HTTP behavior stay in their
-own internal targets behind this kit boundary.
+External embedders configure the server through
+`XcodeMCPProxyServer.Configuration`. Lower-level session routing, upstream
+process management, Xcode support, and MCP HTTP behavior stay in their own
+internal targets behind this kit boundary.
 
 This target intentionally does not expose the executable CLI parser, the STDIO
 adapter, per-tool typed wrappers, or direct access to the internal session
@@ -25,18 +26,17 @@ router.
 
 ## Quickstart
 
-Depend on the `XcodeMCPProxyKit` and `ProxyCore` library products, then
-construct the server directly:
+Depend on the `XcodeMCPProxyKit` library product, then construct the server
+directly:
 
 ```swift
-import ProxyCore
 import XcodeMCPProxyKit
 
-let config = ProxyConfig(
+let config = XcodeMCPProxyServer.Configuration(
     listenHost: "localhost",
     listenPort: 8765,
     upstreamCommand: "xcrun",
-    upstreamArgs: ["mcpbridge"],
+    upstreamArguments: ["mcpbridge"],
     upstreamProcessCount: 1,
     maxBodyBytes: 1_048_576,
     requestTimeout: 300,
@@ -63,10 +63,11 @@ look up the running HTTP endpoint.
 
 ## Configuration
 
-Use `ProxyConfig` from `ProxyCore` to configure the server:
+Use `XcodeMCPProxyServer.Configuration` to configure the server:
 
 - `listenHost` and `listenPort` choose the HTTP bind address.
-- `upstreamCommand` and `upstreamArgs` choose the upstream MCP bridge process.
+- `upstreamCommand` and `upstreamArguments` choose the upstream MCP bridge
+  process.
 - `upstreamProcessCount` controls the number of upstream bridge processes.
 - `requestTimeout` and `maxBodyBytes` bound request handling.
 - `discoveryFileURL` overrides the endpoint discovery file.
@@ -75,7 +76,7 @@ Use `ProxyConfig` from `ProxyCore` to configure the server:
 - `refreshCodeIssuesMode` selects proxy diagnostics or upstream forwarding for
   `XcodeRefreshCodeIssuesInFile`.
 
-`ProxyConfig` can also load TOML-backed initialize overrides and disabled tools
+The server can also load TOML-backed initialize overrides and disabled tools
 when `configPath` is set.
 
 ## Lifecycle

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -81,11 +81,12 @@ when `configPath` is set.
 
 ## Lifecycle
 
-`start()` binds HTTP channels and starts the proxy runtime.
-`startAndWriteDiscovery()` additionally writes the endpoint discovery file and
-logs a startup summary. `wait()` suspends until the listening channels close.
-`shutdown()` stops permission automation, closes listening and accepted
-channels, shuts down the runtime, and terminates the event loop group.
+`start()` binds HTTP channels, starts the proxy runtime, and returns the
+resolved listening address. `startAndWriteDiscovery()` does the same startup
+work, then writes the endpoint discovery file and logs a startup summary.
+`wait()` suspends until the listening channels close. `shutdown()` stops
+permission automation, closes listening and accepted channels, shuts down the
+runtime, and terminates the event loop group.
 
 Use one `XcodeMCPProxyServer` per proxy server instance. Create a new instance
 after shutdown instead of restarting the same object.

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -1,0 +1,90 @@
+# XcodeMCPProxyKit
+
+Swift library API for embedding the Xcode MCP Streamable HTTP proxy server.
+
+## Status
+
+`XcodeMCPProxyKit` is the public server-side kit used by the
+`xcode-mcp-proxy-server` executable. The CLI parses command-line options and
+then constructs `XcodeMCPProxyServer(config:)` from this target, so the package
+boundary is real and does not rely on a private server wrapper.
+
+This target owns:
+
+- `XcodeMCPProxyServer`, the embeddable proxy server lifecycle object
+- HTTP channel setup and request handling integration
+- startup, discovery writing, waiting, and shutdown entry points
+
+Configuration lives in `ProxyCore.ProxyConfig`. Lower-level session routing,
+upstream process management, Xcode support, and MCP HTTP behavior stay in their
+own internal targets behind this kit boundary.
+
+This target intentionally does not expose the executable CLI parser, the STDIO
+adapter, per-tool typed wrappers, or direct access to the internal session
+router.
+
+## Quickstart
+
+Depend on the `XcodeMCPProxyKit` and `ProxyCore` targets, then construct the
+server directly:
+
+```swift
+import ProxyCore
+import XcodeMCPProxyKit
+
+let config = ProxyConfig(
+    listenHost: "localhost",
+    listenPort: 8765,
+    upstreamCommand: "xcrun",
+    upstreamArgs: ["mcpbridge"],
+    upstreamProcessCount: 1,
+    maxBodyBytes: 1_048_576,
+    requestTimeout: 300,
+    discoveryFileURL: URL(fileURLWithPath: "/tmp/xcode-mcp-proxy.json"),
+    autoApproveXcodeDialog: false
+)
+
+let server = XcodeMCPProxyServer(config: config)
+let address = try server.startAndWriteDiscovery()
+print("Listening on \(address.host):\(address.port)")
+
+let waiter = Task {
+    try await server.wait()
+}
+
+// Keep your application alive here, then shut down on your own signal.
+try await server.shutdown()
+try await waiter.value
+```
+
+After startup, MCP clients can connect to `http://<host>:<port>/mcp`. The
+discovery file is written by `startAndWriteDiscovery()` for local adapters that
+look up the running HTTP endpoint.
+
+## Configuration
+
+Use `ProxyConfig` from `ProxyCore` to configure the server:
+
+- `listenHost` and `listenPort` choose the HTTP bind address.
+- `upstreamCommand` and `upstreamArgs` choose the upstream MCP bridge process.
+- `upstreamProcessCount` controls the number of upstream bridge processes.
+- `requestTimeout` and `maxBodyBytes` bound request handling.
+- `discoveryFileURL` overrides the endpoint discovery file.
+- `autoApproveXcodeDialog` enables Xcode permission dialog automation when the
+  host app has the required Accessibility permission.
+- `refreshCodeIssuesMode` selects proxy diagnostics or upstream forwarding for
+  `XcodeRefreshCodeIssuesInFile`.
+
+`ProxyConfig` can also load TOML-backed initialize overrides and disabled tools
+when `configPath` is set.
+
+## Lifecycle
+
+`start()` binds HTTP channels and starts the proxy runtime.
+`startAndWriteDiscovery()` additionally writes the endpoint discovery file and
+logs a startup summary. `wait()` suspends until the listening channels close.
+`shutdown()` stops permission automation, closes listening and accepted
+channels, shuts down the runtime, and terminates the event loop group.
+
+Use one `XcodeMCPProxyServer` per proxy server instance. Create a new instance
+after shutdown instead of restarting the same object.

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Startup.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Startup.swift
@@ -3,7 +3,11 @@ import NIO
 import NIOHTTP1
 import ProxySession
 
-extension ProxyServer {
+extension XcodeMCPProxyServer {
+    /// Starts the proxy server without writing discovery information.
+    ///
+    /// Prefer ``startAndWriteDiscovery()`` when local clients or adapters need
+    /// to discover the HTTP endpoint automatically.
     public func start() throws -> Channel {
         try config.validateModernProtocolConfiguration()
         let preparedRuntime = try prepareRuntimeForStart()

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Startup.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Startup.swift
@@ -8,7 +8,14 @@ extension XcodeMCPProxyServer {
     ///
     /// Prefer ``startAndWriteDiscovery()`` when local clients or adapters need
     /// to discover the HTTP endpoint automatically.
-    public func start() throws -> Channel {
+    ///
+    /// - Returns: The resolved listening address.
+    public func start() throws -> (host: String, port: Int) {
+        let channel = try startListening()
+        return resolvedListenAddress(for: channel)
+    }
+
+    package func startListening() throws -> NIO.Channel {
         try config.validateModernProtocolConfiguration()
         let preparedRuntime = try prepareRuntimeForStart()
         let sessionManager = preparedRuntime.sessionManager

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -9,7 +9,17 @@ import ProxyHTTPGateway
 import ProxyXcodeFeatures
 import ProxyXcodeSupport
 
-public final class ProxyServer {
+/// Embeddable Streamable HTTP proxy server for Xcode MCP.
+///
+/// `XcodeMCPProxyServer` is the library boundary used by the
+/// `xcode-mcp-proxy-server` executable. Construct it with a ``ProxyConfig``,
+/// call ``startAndWriteDiscovery()`` or ``start()``, then keep the process alive
+/// with ``wait()`` until your application decides to call ``shutdown()``.
+///
+/// The server exposes the proxy lifecycle. CLI parsing, STDIO adapter behavior,
+/// and internal session routing are intentionally handled outside this public
+/// type.
+public final class XcodeMCPProxyServer {
     package struct Dependencies: Sendable {
         package var discoveryClient: DiscoveryClient
         package var executableLookupClient: ExecutableLookupClient
@@ -47,7 +57,7 @@ public final class ProxyServer {
                     LiveXcodeTargetDiscovery().runningXcodeTargets()
                 },
                 makeAutoApprover: {
-                    let additionalCandidates = ProxyServer.additionalPermissionDialogExecutableCandidates(
+                    let additionalCandidates = XcodeMCPProxyServer.additionalPermissionDialogExecutableCandidates(
                         config: config,
                         executableLookupClient: executableLookupClient
                     )
@@ -59,7 +69,7 @@ public final class ProxyServer {
                                 )
                             },
                             assistantNameCandidates: {
-                                Set(ProxyServer.permissionDialogAssistantNameCandidates(config: config))
+                                Set(XcodeMCPProxyServer.permissionDialogAssistantNameCandidates(config: config))
                             }
                         )
                     )
@@ -91,6 +101,10 @@ public final class ProxyServer {
     package var sessionManager: (any RuntimeCoordinating)?
     package var permissionDialogAutoApprover: (any ProxyServerPermissionDialogAutoApprover)?
 
+    /// Creates a proxy server with live runtime dependencies.
+    ///
+    /// - Parameter config: HTTP, upstream bridge, discovery, and lifecycle
+    ///   settings from `ProxyCore`.
     public convenience init(config: ProxyConfig) {
         self.init(config: config, dependencies: .live(config: config))
     }
@@ -106,6 +120,12 @@ public final class ProxyServer {
         )
     }
 
+    /// Starts the server and writes endpoint discovery information.
+    ///
+    /// This is the usual entry point for embedded users. It binds HTTP
+    /// channels, starts the proxy runtime, writes the discovery file configured
+    /// by `ProxyConfig.discoveryFileURL`, logs a startup summary, and returns
+    /// the resolved listening address.
     public func startAndWriteDiscovery() throws -> (host: String, port: Int) {
         let channel = try start()
         let (host, port) = resolvedListenAddress(for: channel)
@@ -121,10 +141,20 @@ public final class ProxyServer {
         return (host, port)
     }
 
+    /// Waits until the listening HTTP channels close.
+    ///
+    /// Call this after starting the server to keep an async task suspended for
+    /// the server lifetime. Calling ``shutdown()`` closes the channels and lets
+    /// this method return.
     public func wait() async throws {
         try await waitForHTTP()
     }
 
+    /// Shuts down the proxy server and its runtime resources.
+    ///
+    /// Shutdown stops permission automation, closes listening and accepted
+    /// channels, shuts down the runtime coordinator, and terminates the event
+    /// loop group.
     public func shutdown() async throws {
         let shutdownContext = beginShutdown()
         shutdownContext.autoApprover?.stop()

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -15,6 +15,7 @@ import ProxyXcodeSupport
 /// `xcode-mcp-proxy-server` executable. Construct it with ``Configuration``,
 /// call ``startAndWriteDiscovery()`` or ``start()``, then keep the process
 /// alive with ``wait()`` until your application decides to call ``shutdown()``.
+/// Both start methods return the resolved listening address.
 ///
 /// The server exposes the proxy lifecycle. CLI parsing, STDIO adapter behavior,
 /// and internal session routing are intentionally handled outside this public
@@ -244,7 +245,7 @@ public final class XcodeMCPProxyServer {
     /// by ``Configuration/discoveryFileURL``, logs a startup summary, and returns
     /// the resolved listening address.
     public func startAndWriteDiscovery() throws -> (host: String, port: Int) {
-        let channel = try start()
+        let channel = try startListening()
         let (host, port) = resolvedListenAddress(for: channel)
         let displayHost = config.listenHost == "localhost" ? "localhost" : host
         writeDiscovery(resolvedHost: host, port: port)
@@ -328,7 +329,7 @@ public final class XcodeMCPProxyServer {
         }
     }
 
-    private func resolvedListenAddress(for channel: Channel) -> (String, Int) {
+    package func resolvedListenAddress(for channel: Channel) -> (String, Int) {
         if let address = channel.localAddress {
             let host = address.ipAddress ?? config.listenHost
             let port = address.port ?? config.listenPort

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -12,14 +12,130 @@ import ProxyXcodeSupport
 /// Embeddable Streamable HTTP proxy server for Xcode MCP.
 ///
 /// `XcodeMCPProxyServer` is the library boundary used by the
-/// `xcode-mcp-proxy-server` executable. Construct it with a ``ProxyConfig``,
-/// call ``startAndWriteDiscovery()`` or ``start()``, then keep the process alive
-/// with ``wait()`` until your application decides to call ``shutdown()``.
+/// `xcode-mcp-proxy-server` executable. Construct it with ``Configuration``,
+/// call ``startAndWriteDiscovery()`` or ``start()``, then keep the process
+/// alive with ``wait()`` until your application decides to call ``shutdown()``.
 ///
 /// The server exposes the proxy lifecycle. CLI parsing, STDIO adapter behavior,
 /// and internal session routing are intentionally handled outside this public
 /// type.
 public final class XcodeMCPProxyServer {
+    /// Public configuration for an embedded Xcode MCP proxy server.
+    ///
+    /// This type is the stable server configuration surface for
+    /// `XcodeMCPProxyKit`. Lower-level parser, discovery, filesystem, and
+    /// session-routing types stay internal to the package targets that own
+    /// them.
+    public struct Configuration: Equatable, Sendable {
+        /// How `XcodeRefreshCodeIssuesInFile` requests are served.
+        public enum RefreshCodeIssuesMode: String, Equatable, Sendable {
+            /// Serve refresh-code-issues requests through proxy diagnostics.
+            case proxy
+
+            /// Forward refresh-code-issues requests to the upstream Xcode MCP
+            /// bridge.
+            case upstream
+        }
+
+        /// Hostname or IP address for the Streamable HTTP server.
+        public var listenHost: String
+
+        /// TCP port for the Streamable HTTP server.
+        ///
+        /// Use `0` to request an ephemeral port from the operating system.
+        public var listenPort: Int
+
+        /// Executable used to start the upstream MCP bridge.
+        public var upstreamCommand: String
+
+        /// Arguments passed to ``upstreamCommand``.
+        public var upstreamArguments: [String]
+
+        /// Number of upstream bridge processes to run per routed Xcode process.
+        public var upstreamProcessCount: Int
+
+        /// Optional upstream Xcode MCP session identifier.
+        public var upstreamSessionID: String?
+
+        /// Maximum accepted HTTP request body size in bytes.
+        public var maxBodyBytes: Int
+
+        /// Request timeout in seconds.
+        public var requestTimeout: TimeInterval
+
+        /// Optional TOML configuration path for initialize overrides and
+        /// disabled tools.
+        public var configPath: String?
+
+        /// Optional discovery file URL written by ``startAndWriteDiscovery()``.
+        public var discoveryFileURL: URL?
+
+        /// Whether the proxy should prewarm the upstream tools list.
+        public var prewarmToolsList: Bool
+
+        /// Whether to try approving Xcode's permission dialog automatically.
+        ///
+        /// This requires macOS Accessibility permission for the host process.
+        public var autoApproveXcodeDialog: Bool
+
+        /// Refresh-code-issues handling mode.
+        public var refreshCodeIssuesMode: RefreshCodeIssuesMode
+
+        /// Creates a public proxy server configuration.
+        ///
+        /// - Parameters:
+        ///   - listenHost: Hostname or IP address for the Streamable HTTP
+        ///     server.
+        ///   - listenPort: TCP port for the Streamable HTTP server. Use `0` to
+        ///     request an ephemeral port.
+        ///   - upstreamCommand: Executable used to start the upstream MCP
+        ///     bridge.
+        ///   - upstreamArguments: Arguments passed to `upstreamCommand`.
+        ///   - upstreamProcessCount: Number of upstream bridge processes to run
+        ///     per routed Xcode process.
+        ///   - upstreamSessionID: Optional upstream Xcode MCP session
+        ///     identifier.
+        ///   - maxBodyBytes: Maximum accepted HTTP request body size in bytes.
+        ///   - requestTimeout: Request timeout in seconds.
+        ///   - configPath: Optional TOML configuration path.
+        ///   - discoveryFileURL: Optional discovery file URL written by
+        ///     `startAndWriteDiscovery()`.
+        ///   - prewarmToolsList: Whether the proxy should prewarm the upstream
+        ///     tools list.
+        ///   - autoApproveXcodeDialog: Whether to try approving Xcode's
+        ///     permission dialog automatically.
+        ///   - refreshCodeIssuesMode: Refresh-code-issues handling mode.
+        public init(
+            listenHost: String = "localhost",
+            listenPort: Int = 8765,
+            upstreamCommand: String = "xcrun",
+            upstreamArguments: [String] = ["mcpbridge"],
+            upstreamProcessCount: Int = 1,
+            upstreamSessionID: String? = nil,
+            maxBodyBytes: Int = 1_048_576,
+            requestTimeout: TimeInterval = 300,
+            configPath: String? = nil,
+            discoveryFileURL: URL? = nil,
+            prewarmToolsList: Bool = true,
+            autoApproveXcodeDialog: Bool = false,
+            refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy
+        ) {
+            self.listenHost = listenHost
+            self.listenPort = listenPort
+            self.upstreamCommand = upstreamCommand
+            self.upstreamArguments = upstreamArguments
+            self.upstreamProcessCount = upstreamProcessCount
+            self.upstreamSessionID = upstreamSessionID
+            self.maxBodyBytes = maxBodyBytes
+            self.requestTimeout = requestTimeout
+            self.configPath = configPath
+            self.discoveryFileURL = discoveryFileURL
+            self.prewarmToolsList = prewarmToolsList
+            self.autoApproveXcodeDialog = autoApproveXcodeDialog
+            self.refreshCodeIssuesMode = refreshCodeIssuesMode
+        }
+    }
+
     package struct Dependencies: Sendable {
         package var discoveryClient: DiscoveryClient
         package var executableLookupClient: ExecutableLookupClient
@@ -103,20 +219,21 @@ public final class XcodeMCPProxyServer {
 
     /// Creates a proxy server with live runtime dependencies.
     ///
-    /// - Parameter config: HTTP, upstream bridge, discovery, and lifecycle
-    ///   settings from `ProxyCore`.
-    public convenience init(config: ProxyConfig) {
-        self.init(config: config, dependencies: .live(config: config))
+    /// - Parameter config: Public HTTP, upstream bridge, discovery, and
+    ///   lifecycle settings.
+    public convenience init(config: Configuration = Configuration()) {
+        let proxyConfig = ProxyConfig(config)
+        self.init(proxyConfig: proxyConfig, dependencies: .live(config: proxyConfig))
     }
 
-    package init(config: ProxyConfig, dependencies: Dependencies) {
-        self.config = config
+    package init(proxyConfig: ProxyConfig, dependencies: Dependencies) {
+        self.config = proxyConfig
         self.dependencies = dependencies
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.refreshCodeIssuesCoordinator = RefreshCodeIssues.Coordinator.makeDefault()
         self.refreshCodeIssuesTargetResolver = RefreshCodeIssues.TargetResolver()
         self.refreshCodeIssuesDebugState = RefreshCodeIssues.DebugState(
-            defaultRequestTimeoutSeconds: config.requestTimeout
+            defaultRequestTimeoutSeconds: proxyConfig.requestTimeout
         )
     }
 
@@ -124,7 +241,7 @@ public final class XcodeMCPProxyServer {
     ///
     /// This is the usual entry point for embedded users. It binds HTTP
     /// channels, starts the proxy runtime, writes the discovery file configured
-    /// by `ProxyConfig.discoveryFileURL`, logs a startup summary, and returns
+    /// by ``Configuration/discoveryFileURL``, logs a startup summary, and returns
     /// the resolved listening address.
     public func startAndWriteDiscovery() throws -> (host: String, port: Int) {
         let channel = try start()
@@ -444,6 +561,37 @@ public final class XcodeMCPProxyServer {
 
     package func setChannelsForStartedServer(_ startedChannels: [Channel]) {
         channels = startedChannels
+    }
+}
+
+private extension ProxyConfig {
+    init(_ config: XcodeMCPProxyServer.Configuration) {
+        self.init(
+            listenHost: config.listenHost,
+            listenPort: config.listenPort,
+            upstreamCommand: config.upstreamCommand,
+            upstreamArgs: config.upstreamArguments,
+            upstreamProcessCount: config.upstreamProcessCount,
+            upstreamSessionID: config.upstreamSessionID,
+            maxBodyBytes: config.maxBodyBytes,
+            requestTimeout: config.requestTimeout,
+            configPath: config.configPath,
+            discoveryFileURL: config.discoveryFileURL,
+            prewarmToolsList: config.prewarmToolsList,
+            autoApproveXcodeDialog: config.autoApproveXcodeDialog,
+            refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode(config.refreshCodeIssuesMode)
+        )
+    }
+}
+
+private extension ProxyConfig.RefreshCodeIssuesMode {
+    init(_ mode: XcodeMCPProxyServer.Configuration.RefreshCodeIssuesMode) {
+        switch mode {
+        case .proxy:
+            self = .proxy
+        case .upstream:
+            self = .upstream
+        }
     }
 }
 

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
@@ -5,7 +5,7 @@ import Testing
 @testable import XcodeMCPProxyKit
 
 @Suite
-struct ProxyServerBuildInfoTests {
+struct XcodeMCPProxyServerBuildInfoTests {
     @Test func proxyServerStartupSummaryUsesReadableSections() throws {
         let config = ProxyConfig(
             listenHost: "localhost",
@@ -25,7 +25,7 @@ struct ProxyServerBuildInfoTests {
             xcodeVersion: "26.0"
         )
 
-        let summary = ProxyServer.startupSummary(
+        let summary = XcodeMCPProxyServer.startupSummary(
             displayHost: "localhost",
             port: 8765,
             config: config,

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -118,7 +118,7 @@ struct XcodeMCPProxyServerTests {
             autoApproveXcodeDialog: true
         )
         let server = XcodeMCPProxyServer(
-            config: config,
+            proxyConfig: config,
             dependencies: .init(
                 makeAutoApprover: { autoApprover },
                 makeRuntimeCoordinator: { config, eventLoop in

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -9,7 +9,7 @@ import XcodeMCPTestSupport
 
 @testable import XcodeMCPProxyKit
 
-struct ProxyServerTests {
+struct XcodeMCPProxyServerTests {
     @Test func firstXcrunToolSelectionTreatsLogAsFlagWithoutValue() {
         let selection = XcrunArguments.firstToolSelection(
             from: ["--sdk", "macosx", "--log", "mcpbridge", "--some-flag"]
@@ -29,7 +29,7 @@ struct ProxyServerTests {
             requestTimeout: 300
         )
 
-        let candidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
+        let candidates = XcodeMCPProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
 
         #expect(candidates.contains("/usr/bin/xcrun"))
     }
@@ -47,7 +47,7 @@ struct ProxyServerTests {
             requestTimeout: 300
         )
 
-        let candidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
+        let candidates = XcodeMCPProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
 
         #expect(candidates.contains(fixture.wrapperPath))
         #expect(candidates.contains(fixture.toolPath))
@@ -66,7 +66,7 @@ struct ProxyServerTests {
             requestTimeout: 300
         )
 
-        let candidates = ProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
+        let candidates = XcodeMCPProxyServer.additionalPermissionDialogExecutableCandidates(config: config)
 
         #expect(candidates.contains(fixture.wrapperPath))
         #expect(candidates.contains(fixture.toolPath))
@@ -117,7 +117,7 @@ struct ProxyServerTests {
             requestTimeout: 300,
             autoApproveXcodeDialog: true
         )
-        let server = ProxyServer(
+        let server = XcodeMCPProxyServer(
             config: config,
             dependencies: .init(
                 makeAutoApprover: { autoApprover },

--- a/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
+++ b/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
@@ -125,11 +125,11 @@ struct LiveMCPBridgeTests {
             discoveryFileURL: discoveryFile,
             autoApproveXcodeDialog: true
         )
-        var dependencies = ProxyServer.Dependencies.live(config: config)
+        var dependencies = XcodeMCPProxyServer.Dependencies.live(config: config)
         dependencies.discoveryClient = .live(
             defaultFileURL: { discoveryFile }
         )
-        let server = ProxyServer(config: config, dependencies: dependencies)
+        let server = XcodeMCPProxyServer(config: config, dependencies: dependencies)
         let urlSession = URLSession(configuration: .ephemeral)
         defer {
             urlSession.invalidateAndCancel()

--- a/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
+++ b/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
@@ -129,7 +129,7 @@ struct LiveMCPBridgeTests {
         dependencies.discoveryClient = .live(
             defaultFileURL: { discoveryFile }
         )
-        let server = XcodeMCPProxyServer(config: config, dependencies: dependencies)
+        let server = XcodeMCPProxyServer(proxyConfig: config, dependencies: dependencies)
         let urlSession = URLSession(configuration: .ephemeral)
         defer {
             urlSession.invalidateAndCancel()


### PR DESCRIPTION
## Summary
- Add DocC-friendly comments for the public XcodeMCPKit client API and MCP domain values.
- Add target-local README files for XcodeMCPKit and XcodeMCPProxyKit with status, ownership, quickstarts, lifecycle, and intentional non-goals.
- Rename the public proxy server type from `ProxyServer` to `XcodeMCPProxyServer`, update CLI construction/tests/references, and rename matching source files.
- Export the `XcodeMCPProxyKit` library product and keep `ProxyCore` internal by adding `XcodeMCPProxyServer.Configuration` as the public embeddable server configuration API.
- Keep NIO `Channel` out of the public proxy server lifecycle API: `start()` now returns a listening address.

## Testing
- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPProxyServerTests -Xswiftc -strict-concurrency=minimal`
- `rg -n "public .*Channel|-> Channel" Sources/XcodeMCPProxyKit Sources/XcodeMCPKit` (no matches)
- `swift package diagnose-api-breaking-changes --baseline codex/refactor-layered-runtime-integration` (not supported by local SwiftPM: unknown `--baseline` option)
- `swift package diagnose-api-breaking-changes codex/refactor-layered-runtime-integration` (earlier DocC-only state: no breaking changes; not rerun after intentional public proxy API changes)
- `git diff --check`
- `codex-review` branch-wide against `codex/refactor-layered-runtime-integration`: clean

## Risks
- Intentional breaking API rename: `XcodeMCPProxyKit.ProxyServer` is now `XcodeMCPProxyServer` with no public compatibility typealias.
- Intentional public lifecycle API adjustment: `XcodeMCPProxyServer.start()` returns `(host: String, port: Int)` instead of exposing `NIO.Channel`.
- `XcodeMCPProxyKit` is now an exported library product; `ProxyCore` remains an internal package target rather than an exported product.
