### PR TITLE
[codex] Route proxy server CLI through public kit API

### DIFF
--- a/Sources/ProxyCLI/Server/ProxyServerCommandRuntime.swift
+++ b/Sources/ProxyCLI/Server/ProxyServerCommandRuntime.swift
@@ -31,37 +31,38 @@ extension XcodeMCPProxyServerCommand {
             try XcodeMCPProxyServerCommand.applyDefaults(from: environment, to: &options)
 
             let proxyArgs = ["xcode-mcp-proxy"] + options.forwardedArgs
-            let config = try CLIParser.parse(args: proxyArgs, environment: environment)
-            try config.validateModernProtocolConfiguration()
+            let proxyConfig = try CLIParser.parse(args: proxyArgs, environment: environment)
+            try proxyConfig.validateModernProtocolConfiguration()
+            let serverConfig = XcodeMCPProxyServer.Configuration(serverProxyConfig: proxyConfig)
 
             let isDryRun = options.dryRun || XcodeMCPProxyServerCommand.isTruthy(environment["DRY_RUN"])
             if isDryRun {
                 dependencies.stdout(
-                    XcodeMCPProxyServerCommand.dryRunCommandLine(options: options, config: config)
+                    XcodeMCPProxyServerCommand.dryRunCommandLine(options: options, config: serverConfig)
                 )
                 return 0
             }
-            if options.forceRestart, config.listenPort > 0 {
+            if options.forceRestart, serverConfig.listenPort > 0 {
                 _ = dependencies.existingProxyServerClient.terminateExistingServer(
-                    config.listenHost,
-                    config.listenPort,
+                    serverConfig.listenHost,
+                    serverConfig.listenPort,
                     dependencies.stderr
                 )
             }
 
             do {
-                let server = dependencies.makeServer(config)
+                let server = dependencies.makeServer(serverConfig)
                 _ = try server.startAndWriteDiscovery()
                 try await server.wait()
                 return 0
             } catch {
-                if config.listenPort > 0, dependencies.isAddressAlreadyInUse(error) {
+                if serverConfig.listenPort > 0, dependencies.isAddressAlreadyInUse(error) {
                     let message = XcodeMCPProxyServerCommand.portInUseMessage(
-                        host: config.listenHost,
-                        port: config.listenPort,
+                        host: serverConfig.listenHost,
+                        port: serverConfig.listenPort,
                         pids: dependencies.existingProxyServerClient.detectExistingProxyServerPIDs(
-                            config.listenHost,
-                            config.listenPort
+                            serverConfig.listenHost,
+                            serverConfig.listenPort
                         )
                     )
                     dependencies.stderr(message)

--- a/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand+Parsing.swift
+++ b/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand+Parsing.swift
@@ -64,7 +64,7 @@ extension XcodeMCPProxyServerCommand {
     /// never existed as argv flags.
     package static func dryRunCommandLine(
         options: XcodeMCPProxyServerCommand.Options,
-        config: ProxyConfig
+        config: XcodeMCPProxyServer.Configuration
     ) -> String {
         var parts = ["xcode-mcp-proxy-server"] + options.forwardedArgs
         if options.hasConfigFlag == false, let configPath = config.configPath {

--- a/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand+ProcessControl.swift
+++ b/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand+ProcessControl.swift
@@ -1,7 +1,3 @@
-import ProxyCLICommon
-import ProxyCore
-import XcodeMCPProxyKit
-
 extension XcodeMCPProxyServerCommand {
     package static func hostMatches(requestedHost: String, actualHost: String) -> Bool {
         ExistingProxyServerClient.hostMatches(

--- a/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand.swift
+++ b/Sources/ProxyCLI/Server/XcodeMCPProxyServerCommand.swift
@@ -62,7 +62,7 @@ package struct XcodeMCPProxyServerCommand {
         package var bootstrapLogging: ([String: String]) -> Void
         package var stdout: (String) -> Void
         package var stderr: (String) -> Void
-        package var makeServer: (ProxyConfig) -> any ProxyServerCommandServer
+        package var makeServer: (XcodeMCPProxyServer.Configuration) -> any ProxyServerCommandServer
         package var isAddressAlreadyInUse: (Swift.Error) -> Bool
         package var existingProxyServerClient: ExistingProxyServerClient
 
@@ -70,7 +70,7 @@ package struct XcodeMCPProxyServerCommand {
             bootstrapLogging: @escaping ([String: String]) -> Void,
             stdout: @escaping (String) -> Void,
             stderr: @escaping (String) -> Void,
-            makeServer: @escaping (ProxyConfig) -> any ProxyServerCommandServer,
+            makeServer: @escaping (XcodeMCPProxyServer.Configuration) -> any ProxyServerCommandServer,
             isAddressAlreadyInUse: @escaping (Swift.Error) -> Bool,
             existingProxyServerClient: ExistingProxyServerClient = .liveValue
         ) {
@@ -87,7 +87,7 @@ package struct XcodeMCPProxyServerCommand {
             stdout: @escaping (String) -> Void,
             stderr: @escaping (String) -> Void,
             terminateExistingServer: @escaping @Sendable (String, Int) -> Bool,
-            makeServer: @escaping (ProxyConfig) -> any ProxyServerCommandServer,
+            makeServer: @escaping (XcodeMCPProxyServer.Configuration) -> any ProxyServerCommandServer,
             isAddressAlreadyInUse: @escaping (Swift.Error) -> Bool,
             detectExistingProxyServerPIDs: @escaping @Sendable (String, Int) -> [Int]
         ) {
@@ -112,7 +112,7 @@ package struct XcodeMCPProxyServerCommand {
                 stdout: { print($0) },
                 stderr: { FileHandle.writeLine($0, to: .standardError) },
                 makeServer: { config in
-                    XcodeMCPProxyServer(proxyConfig: config, dependencies: .live(config: config))
+                    XcodeMCPProxyServer(config: config)
                 },
                 isAddressAlreadyInUse: XcodeMCPProxyServerCommand.isAddressAlreadyInUse,
                 existingProxyServerClient: .liveValue

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -135,6 +135,24 @@ public final class XcodeMCPProxyServer {
             self.autoApproveXcodeDialog = autoApproveXcodeDialog
             self.refreshCodeIssuesMode = refreshCodeIssuesMode
         }
+
+        package init(serverProxyConfig proxyConfig: ProxyConfig) {
+            self.init(
+                listenHost: proxyConfig.listenHost,
+                listenPort: proxyConfig.listenPort,
+                upstreamCommand: proxyConfig.upstreamCommand,
+                upstreamArguments: proxyConfig.upstreamArgs,
+                upstreamProcessCount: proxyConfig.upstreamProcessCount,
+                upstreamSessionID: proxyConfig.upstreamSessionID,
+                maxBodyBytes: proxyConfig.maxBodyBytes,
+                requestTimeout: proxyConfig.requestTimeout,
+                configPath: proxyConfig.configPath,
+                discoveryFileURL: proxyConfig.discoveryFileURL,
+                prewarmToolsList: proxyConfig.prewarmToolsList,
+                autoApproveXcodeDialog: proxyConfig.autoApproveXcodeDialog,
+                refreshCodeIssuesMode: RefreshCodeIssuesMode(proxyConfig.refreshCodeIssuesMode)
+            )
+        }
     }
 
     package struct Dependencies: Sendable {
@@ -587,6 +605,17 @@ private extension ProxyConfig {
 
 private extension ProxyConfig.RefreshCodeIssuesMode {
     init(_ mode: XcodeMCPProxyServer.Configuration.RefreshCodeIssuesMode) {
+        switch mode {
+        case .proxy:
+            self = .proxy
+        case .upstream:
+            self = .upstream
+        }
+    }
+}
+
+private extension XcodeMCPProxyServer.Configuration.RefreshCodeIssuesMode {
+    init(_ mode: ProxyConfig.RefreshCodeIssuesMode) {
         switch mode {
         case .proxy:
             self = .proxy

--- a/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandIntegrationTests.swift
@@ -1,8 +1,8 @@
-import ProxyCore
 import Foundation
 import Testing
 import ProxyCLICommon
 import ProxyServerCLI
+import XcodeMCPProxyKit
 
 @Suite(.serialized)
 struct ServerCommandIntegrationTests {
@@ -77,11 +77,11 @@ struct ServerCommandIntegrationTests {
 
 private final class IntegrationRecordingProxyServer: ProxyServerCommandServer {
     private let lock = NSLock()
-    private var config: ProxyConfig?
+    private var config: XcodeMCPProxyServer.Configuration?
     private var started = 0
     private var waited = 0
 
-    func record(config: ProxyConfig) {
+    func record(config: XcodeMCPProxyServer.Configuration) {
         withLock {
             self.config = config
         }
@@ -98,7 +98,7 @@ private final class IntegrationRecordingProxyServer: ProxyServerCommandServer {
         incrementWaitCount()
     }
 
-    func recordedConfig() -> ProxyConfig? {
+    func recordedConfig() -> XcodeMCPProxyServer.Configuration? {
         withLock { config }
     }
 

--- a/Tests/ProxyCLITests/ServerCommandTests.swift
+++ b/Tests/ProxyCLITests/ServerCommandTests.swift
@@ -4,6 +4,7 @@ import Testing
 import ProxyBuildInfo
 import ProxyCLICommon
 import ProxyServerCLI
+import XcodeMCPProxyKit
 
 @Suite
 struct ServerCommandTests {
@@ -603,10 +604,10 @@ struct ServerCommandTests {
 
 private final class RecordingProxyServer: ProxyServerCommandServer {
     private let state = LockedBox(
-        (config: Optional<ProxyConfig>.none, startCount: 0, waitCount: 0)
+        (config: Optional<XcodeMCPProxyServer.Configuration>.none, startCount: 0, waitCount: 0)
     )
 
-    func record(config: ProxyConfig) {
+    func record(config: XcodeMCPProxyServer.Configuration) {
         state.withValue { value in
             value.config = config
         }
@@ -625,7 +626,7 @@ private final class RecordingProxyServer: ProxyServerCommandServer {
         }
     }
 
-    func recordedConfig() -> ProxyConfig? {
+    func recordedConfig() -> XcodeMCPProxyServer.Configuration? {
         state.snapshot().config
     }
 

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -98,6 +98,56 @@ struct XcodeMCPProxyServerTests {
         )
     }
 
+    @Test func configurationMirrorsHTTPProxyConfigForCLIBoundary() throws {
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("xcode-mcp-proxy-config-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directoryURL) }
+
+        let configURL = directoryURL.appendingPathComponent("proxy.toml")
+        try """
+        [upstream_handshake]
+        clientName = "XcodeMCPKit"
+
+        [tools]
+        disabled = []
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let discoveryURL = URL(fileURLWithPath: "/tmp/xcode-mcp-proxy-discovery.json")
+        let proxyConfig = ProxyConfig(
+            listenHost: "127.0.0.1",
+            listenPort: 9876,
+            upstreamCommand: "/usr/bin/xcrun",
+            upstreamArgs: ["--sdk", "macosx", "mcpbridge"],
+            upstreamProcessCount: 3,
+            upstreamSessionID: "session-1",
+            maxBodyBytes: 2048,
+            requestTimeout: 12,
+            configPath: configURL.path,
+            discoveryFileURL: discoveryURL,
+            prewarmToolsList: false,
+            autoApproveXcodeDialog: true,
+            refreshCodeIssuesMode: .upstream
+        )
+
+        let config = XcodeMCPProxyServer.Configuration(serverProxyConfig: proxyConfig)
+
+        #expect(config.listenHost == "127.0.0.1")
+        #expect(config.listenPort == 9876)
+        #expect(config.upstreamCommand == "/usr/bin/xcrun")
+        #expect(config.upstreamArguments == ["--sdk", "macosx", "mcpbridge"])
+        #expect(config.upstreamProcessCount == 3)
+        #expect(config.upstreamSessionID == "session-1")
+        #expect(config.maxBodyBytes == 2048)
+        #expect(config.requestTimeout == 12)
+        #expect(config.configPath == configURL.path)
+        #expect(config.discoveryFileURL == discoveryURL)
+        #expect(config.prewarmToolsList == false)
+        #expect(config.autoApproveXcodeDialog == true)
+        #expect(config.refreshCodeIssuesMode == .upstream)
+    }
+
     @Test func startDoesNotLaunchRuntimeLifecycleWhenBindFails() async throws {
         let blockerGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let blocker = try await ServerBootstrap(group: blockerGroup)


### PR DESCRIPTION
## Purpose

Make `xcode-mcp-proxy-server` construct its runtime through the public `XcodeMCPProxyKit` server API instead of depending on the low-level `ProxyConfig` server initializer path.

## Changes

- Changed `ProxyServerCLI` server construction dependencies to accept `XcodeMCPProxyServer.Configuration`.
- Added a package-only Kit conversion initializer from parsed server `ProxyConfig` into public-facing `XcodeMCPProxyServer.Configuration` without exposing `ProxyConfig` publicly.
- Switched the live CLI path to call `XcodeMCPProxyServer(config:)`.
- Updated CLI tests to record the public configuration and added a Kit boundary mapping test.

## Validation

- `swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPProxyServerTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `codex-review` against `codex/refactor-layered-runtime-integration`: no findings

## Notes

`ProxyServerCLI` still imports `ProxyCore` for shared CLI parsing/config validation and existing proxy process discovery helpers. The server construction/lifecycle path no longer uses `ProxyConfig` or the package-only server initializer.