### PR TITLE
[codex] Centralize process-bound bridge session config

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -146,7 +146,7 @@ xcode-mcp-proxy --help
 |------|------|
 | `LISTEN` | listen address。例:`127.0.0.1:8765`。 |
 | `HOST` / `PORT` | `LISTEN`未指定時のlisten host / port。 |
-| `MCP_XCODE_PID` | upstream `mcpbridge`へそのまま渡します。proxy自身は解釈しません。 |
+| `MCP_XCODE_PID` | process-bound upstream `mcpbridge` child ではproxyが設定します。process-bound Xcode routingが有効でない場合だけ、継承された値をそのまま渡します。 |
 | `MCP_XCODE_SESSION_ID` | 明示的に指定するupstream Xcode MCP session ID。 |
 | `MCP_XCODE_CONFIG` | TOML config path。`--config`が優先されます。 |
 | `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy`または`upstream`。 |

--- a/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/ProxyHTTPGateway/HTTP/HTTPHandler.swift
@@ -43,6 +43,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
         refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
         refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
         refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil,
+        refreshCodeIssuesClock: ClockClient = .liveValue,
         usesSynchronousLocalResolution: Bool = false
     ) {
         let refreshCoordinator =
@@ -65,6 +66,7 @@ package final class HTTPHandler: ChannelInboundHandler, Sendable {
             refreshCodeIssuesCoordinator: refreshCoordinator,
             refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
             refreshCodeIssuesDebugState: refreshDebugState,
+            refreshCodeIssuesClock: refreshCodeIssuesClock,
             usesSynchronousLocalResolution: usesSynchronousLocalResolution,
             logger: ProxyLogging.make("http")
         )

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -48,6 +48,7 @@ package final class HTTPPostService: Sendable {
         refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator,
         refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
         refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState,
+        refreshCodeIssuesClock: ClockClient = .liveValue,
         usesSynchronousLocalResolution: Bool = false,
         logger: Logger = ProxyLogging.make("http")
     ) {
@@ -72,6 +73,7 @@ package final class HTTPPostService: Sendable {
             coordinator: refreshCodeIssuesCoordinator,
             targetResolver: refreshCodeIssuesTargetResolver,
             debugState: refreshCodeIssuesDebugState,
+            clock: refreshCodeIssuesClock,
             logger: ProxyLogging.make("http.refresh")
         )
         self.logger = logger

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -5,6 +5,7 @@ import ProxySessionControlPlane
 import ProxySessionUpstream
 import ProxyCore
 import ProxyMCP
+import XcodeMCPKit
 
 package enum DocumentationProvider {}
 
@@ -395,26 +396,26 @@ package protocol DocumentationProviderSessionMaking: Sendable {
 }
 
 package struct LiveDocumentationProviderSessionFactory: DocumentationProviderSessionMaking {
+    private let config: ProxyConfig
     private let baseEnvironment: [String: String]
 
-    package init(baseEnvironment: [String: String] = ProcessInfo.processInfo.environment) {
+    package init(
+        config: ProxyConfig,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.config = config
         self.baseEnvironment = baseEnvironment
     }
 
     package func startSession(for target: XcodeProcessTarget) async throws
         -> any UpstreamSession
     {
-        var environment = baseEnvironment
-        environment.removeValue(forKey: "XCODE_PID")
-        environment["MCP_XCODE_PID"] = String(target.processID)
-        environment["DEVELOPER_DIR"] = target.developerDir
-        let config = UpstreamProcess.Config(
-            command: target.mcpbridgePath,
-            args: [],
-            environment: environment,
-            maxQueuedWriteBytes: 4 * 1_048_576
+        try await MCPBridgeRuntime.startProcessBoundSession(
+            config: config,
+            sharedSessionID: config.upstreamSessionID,
+            xcodeTarget: target,
+            baseEnvironment: baseEnvironment
         )
-        return try await UpstreamProcess(config: config).startSession()
     }
 }
 

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -423,6 +423,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             runtimeBox: runtimeBox,
             fallback: SessionBackedDocumentationProviderTransport(
                 sessionFactory: LiveDocumentationProviderSessionFactory(
+                    config: config,
                     baseEnvironment: ProcessInfo.processInfo.environment
                 ),
                 clock: clock

--- a/Sources/XcodeMCPKit/MCPBridgeRuntime.swift
+++ b/Sources/XcodeMCPKit/MCPBridgeRuntime.swift
@@ -70,12 +70,41 @@ package enum MCPBridgeRuntime {
         XcrunArguments.isDefaultMCPBridgeInvocation(config: config)
     }
 
+    package static func makeProcessBoundSessionFactory(
+        config: ProxyConfig,
+        sharedSessionID: String?,
+        xcodeTarget: XcodeProcessTarget,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> any UpstreamSessionFactory {
+        UpstreamProcess(config: makeDefaultUpstreamConfig(
+            config: config,
+            sharedSessionID: sharedSessionID,
+            xcodeTarget: xcodeTarget,
+            baseEnvironment: baseEnvironment
+        ))
+    }
+
+    package static func startProcessBoundSession(
+        config: ProxyConfig,
+        sharedSessionID: String?,
+        xcodeTarget: XcodeProcessTarget,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) async throws -> any UpstreamSession {
+        try await makeProcessBoundSessionFactory(
+            config: config,
+            sharedSessionID: sharedSessionID,
+            xcodeTarget: xcodeTarget,
+            baseEnvironment: baseEnvironment
+        ).startSession()
+    }
+
     private static func makeDefaultUpstreamConfig(
         config: ProxyConfig,
         sharedSessionID: String?,
-        xcodeTarget: XcodeProcessTarget?
+        xcodeTarget: XcodeProcessTarget?,
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
     ) -> UpstreamProcess.Config {
-        var environment = ProcessInfo.processInfo.environment
+        var environment = baseEnvironment
         environment.removeValue(forKey: "XCODE_PID")
         if let sharedSessionID, !sharedSessionID.isEmpty {
             environment["MCP_XCODE_SESSION_ID"] = sharedSessionID

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -1103,7 +1103,8 @@ struct TestHTTPHandlerServer {
         config: ProxyConfig,
         sessionManager: any RuntimeCoordinating,
         refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
-        refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver()
+        refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
+        refreshCodeIssuesClock: ClockClient = .liveValue
     ) throws -> TestHTTPHandlerServer {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let childChannelTracker = HTTPTestServerChannelTracker()
@@ -1124,7 +1125,8 @@ struct TestHTTPHandlerServer {
                             sessionManager: sessionManager,
                             refreshCodeIssuesCoordinator: refreshCoordinator,
                             refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
-                            refreshCodeIssuesDebugState: refreshDebugState
+                            refreshCodeIssuesDebugState: refreshDebugState,
+                            refreshCodeIssuesClock: refreshCodeIssuesClock
                         )
                     )
                 }

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -2542,24 +2542,37 @@ extension HTTPHandlerTests {
     @Test func httpRefreshCodeIssuesCompletesLeaseWhenRetryBudgetExpires() async throws {
         var config = makeConfig(requestTimeout: 0.5)
         config.refreshCodeIssuesMode = .upstream
+        let workflowUptimeClock = TestUptimeClock()
+        let workflowClock = ClockClient(
+            now: {
+                Date(
+                    timeIntervalSince1970:
+                        Double(workflowUptimeClock.now()) / 1_000_000_000
+                )
+            },
+            uptimeNanoseconds: workflowUptimeClock.now,
+            sleep: { _ in },
+            sleepForTimeInterval: { _ in }
+        )
         let sessionManager = TestRuntimeCoordinator(
             config: config,
             upstreamPlanResponder: { method, originalID in
                 #expect(method == "tools/call")
-                return .delayed(
+                workflowUptimeClock.advance(by: .milliseconds(350))
+                return .immediate(
                     try makeToolErrorResponse(
                         id: originalID,
                         text:
                             "Failed to retrieve diagnostics for 'App.swift': The operation couldn’t be completed. (SourceEditor.SourceEditorCallableDiagnosticError error 5.)"
-                    ),
-                    delayNanos: 350_000_000
+                    )
                 )
             }
         )
         sessionManager.setInitialized(true)
         let server = try TestHTTPHandlerServer.start(
             config: config,
-            sessionManager: sessionManager
+            sessionManager: sessionManager,
+            refreshCodeIssuesClock: workflowClock
         )
 
         do {

--- a/Tests/ProxySessionTests/DocumentationProviderTests.swift
+++ b/Tests/ProxySessionTests/DocumentationProviderTests.swift
@@ -343,6 +343,56 @@ extension RuntimeCoordinatorTests {
         }
     }
 
+    @Test func processBoundSessionFactoryShapesBridgeEnvironment() throws {
+        let target = xcodeProcessTarget(processID: 715, xcodeVersion: "27.0")
+        var config = makeConfig(requestTimeout: 5)
+        config.maxBodyBytes = 2_000_000
+        config.upstreamSessionID = "shared-docs-session"
+
+        let factory = MCPBridgeRuntime.makeProcessBoundSessionFactory(
+            config: config,
+            sharedSessionID: config.upstreamSessionID,
+            xcodeTarget: target,
+            baseEnvironment: [
+                "KEEP": "value",
+                "XCODE_PID": "legacy",
+                "MCP_XCODE_PID": "inherited-pid",
+                "MCP_XCODE_SESSION_ID": "inherited-session",
+            ]
+        )
+
+        let environment = try upstreamEnvironment(from: factory)
+        #expect(try upstreamCommand(from: factory) == target.mcpbridgePath)
+        #expect(try upstreamArgs(from: factory).isEmpty)
+        #expect(environment["KEEP"] == "value")
+        #expect(environment["XCODE_PID"] == nil)
+        #expect(environment["MCP_XCODE_PID"] == "\(target.processID)")
+        #expect(environment["DEVELOPER_DIR"] == target.developerDir)
+        #expect(environment["MCP_XCODE_SESSION_ID"] == "shared-docs-session")
+        #expect(try upstreamMaxQueuedWriteBytes(from: factory) == 8_000_000)
+    }
+
+    @Test func processBoundSessionFactoryRemovesInheritedSessionIDWithoutSharedSession()
+        throws
+    {
+        let target = xcodeProcessTarget(processID: 716, xcodeVersion: "27.0")
+        let config = makeConfig(requestTimeout: 5)
+
+        let factory = MCPBridgeRuntime.makeProcessBoundSessionFactory(
+            config: config,
+            sharedSessionID: config.upstreamSessionID,
+            xcodeTarget: target,
+            baseEnvironment: [
+                "MCP_XCODE_SESSION_ID": "inherited-session",
+            ]
+        )
+
+        let environment = try upstreamEnvironment(from: factory)
+        #expect(environment["MCP_XCODE_SESSION_ID"] == nil)
+        #expect(environment["MCP_XCODE_PID"] == "\(target.processID)")
+        #expect(environment["DEVELOPER_DIR"] == target.developerDir)
+    }
+
     @Test func defaultUpstreamPlanScalesWithXcodeProcessCount()
         throws
     {

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTestSupport.swift
@@ -1333,6 +1333,15 @@ func defaultUpstreamEnvironment(sharedSessionID: String?) throws -> [String: Str
 
 func upstreamEnvironment(from upstream: ManagedUpstreamSlot) throws -> [String: String] {
     let configMirror = try upstreamConfigMirror(from: upstream)
+    return try upstreamEnvironment(fromConfigMirror: configMirror)
+}
+
+func upstreamEnvironment(from factory: any UpstreamSessionFactory) throws -> [String: String] {
+    let configMirror = try upstreamConfigMirror(from: factory)
+    return try upstreamEnvironment(fromConfigMirror: configMirror)
+}
+
+private func upstreamEnvironment(fromConfigMirror configMirror: Mirror) throws -> [String: String] {
     return try #require(
         configMirror.children.first(where: { $0.label == "environment" })?.value
             as? [String: String],
@@ -1342,6 +1351,15 @@ func upstreamEnvironment(from upstream: ManagedUpstreamSlot) throws -> [String: 
 
 func upstreamCommand(from upstream: ManagedUpstreamSlot) throws -> String {
     let configMirror = try upstreamConfigMirror(from: upstream)
+    return try upstreamCommand(fromConfigMirror: configMirror)
+}
+
+func upstreamCommand(from factory: any UpstreamSessionFactory) throws -> String {
+    let configMirror = try upstreamConfigMirror(from: factory)
+    return try upstreamCommand(fromConfigMirror: configMirror)
+}
+
+private func upstreamCommand(fromConfigMirror configMirror: Mirror) throws -> String {
     return try #require(
         configMirror.children.first(where: { $0.label == "command" })?.value as? String,
         "UpstreamProcess.Config should include command for tests"
@@ -1350,9 +1368,26 @@ func upstreamCommand(from upstream: ManagedUpstreamSlot) throws -> String {
 
 func upstreamArgs(from upstream: ManagedUpstreamSlot) throws -> [String] {
     let configMirror = try upstreamConfigMirror(from: upstream)
+    return try upstreamArgs(fromConfigMirror: configMirror)
+}
+
+func upstreamArgs(from factory: any UpstreamSessionFactory) throws -> [String] {
+    let configMirror = try upstreamConfigMirror(from: factory)
+    return try upstreamArgs(fromConfigMirror: configMirror)
+}
+
+private func upstreamArgs(fromConfigMirror configMirror: Mirror) throws -> [String] {
     return try #require(
         configMirror.children.first(where: { $0.label == "args" })?.value as? [String],
         "UpstreamProcess.Config should include args for tests"
+    )
+}
+
+func upstreamMaxQueuedWriteBytes(from factory: any UpstreamSessionFactory) throws -> Int {
+    let configMirror = try upstreamConfigMirror(from: factory)
+    return try #require(
+        configMirror.children.first(where: { $0.label == "maxQueuedWriteBytes" })?.value as? Int,
+        "UpstreamProcess.Config should include maxQueuedWriteBytes for tests"
     )
 }
 
@@ -1362,6 +1397,15 @@ private func upstreamConfigMirror(from upstream: ManagedUpstreamSlot) throws -> 
         upstreamMirror.children.first(where: { $0.label == "factory" })?.value,
         "ManagedUpstreamSlot should expose a stored factory for tests"
     )
+    let factoryMirror = Mirror(reflecting: factory)
+    let config = try #require(
+        factoryMirror.children.first(where: { $0.label == "config" })?.value,
+        "UpstreamProcess factory should expose a stored config for tests"
+    )
+    return Mirror(reflecting: config)
+}
+
+private func upstreamConfigMirror(from factory: any UpstreamSessionFactory) throws -> Mirror {
     let factoryMirror = Mirror(reflecting: factory)
     let config = try #require(
         factoryMirror.children.first(where: { $0.label == "config" })?.value,

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -6049,33 +6049,8 @@ struct RuntimeCoordinatorTests {
         )
         defer { manager.shutdownAndWait() }
 
-        let initFuture = manager.registerInitialize(
-            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
-            requestObject: makeInitializeRequest(id: 1),
-            on: eventLoop
-        )
-        try await spinUntilSentCount(
-            upstream0,
-            count: 1,
-            description: "waiting for primary initialize request"
-        )
-        let init0 = try #require(await upstream0.sentValue(at: 0))
-        let init0ID = try extractUpstreamID(from: init0)
-        await upstream0.yield(.message(try makeInitializeResponse(id: init0ID)))
-        _ = try await initFuture.get()
-        try await spinUntilSentCount(
-            upstream0,
-            count: 2,
-            description: "waiting for primary initialized notification"
-        )
-
-        try await spinUntilSentCount(
-            upstream1,
-            count: 1,
-            description: "waiting for secondary warm initialize request"
-        )
-        let warmInitialize = try #require(await upstream1.sentValue(at: 0))
-        let warmInitID = try extractUpstreamID(from: warmInitialize)
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
 
         let activeDescriptor = SessionRequestPipeline.Descriptor(
             sessionID: "session-active",
@@ -6101,18 +6076,13 @@ struct RuntimeCoordinatorTests {
         }
         _ = activeFuture
 
-        await upstream1.yield(.message(try makeInitializeResponse(id: warmInitID)))
-        try await spinUntilSentCount(
-            upstream1,
-            count: 2,
-            description: "waiting for secondary initialized notification"
-        )
-        let initializedNotification = try #require(await upstream1.sentValue(at: 1))
-        #expect(methodName(from: initializedNotification) == "notifications/initialized")
-
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
+        guard case .quarantined = manager.testStateSnapshot().upstreams[1].healthState else {
+            Issue.record("expected upstream1 to be quarantined before queueing request")
+            return
+        }
 
         let queuedRequestData = try JSONSerialization.data(
             withJSONObject: [
@@ -6149,12 +6119,13 @@ struct RuntimeCoordinatorTests {
 
         try await spinUntilSentCount(
             upstream1,
-            count: 3,
+            count: 1,
             description: "waiting for recovery probe request"
         )
-        let probeRequest = try #require(await upstream1.sentValue(at: 2))
+        let probeRequest = try #require(await upstream1.sentValue(at: 0))
         #expect(methodName(from: probeRequest) == "tools/list")
         let probeID = try extractUpstreamID(from: probeRequest)
+        #expect(probeID != 99)
         let probeResponse: [String: Any] = [
             "jsonrpc": "2.0",
             "id": NSNumber(value: probeID),
@@ -6169,10 +6140,10 @@ struct RuntimeCoordinatorTests {
         _ = try await queuedFuture.get()
         try await spinUntilSentCount(
             upstream1,
-            count: 4,
+            count: 2,
             description: "waiting for queued request dispatch after probe recovery"
         )
-        let queuedRequest = try #require(await upstream1.sentValue(at: 3))
+        let queuedRequest = try #require(await upstream1.sentValue(at: 1))
         #expect(methodName(from: queuedRequest) == "tools/list")
         #expect(try extractUpstreamID(from: queuedRequest) == 99)
 

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -203,12 +203,16 @@ struct RuntimeCoordinatorTests {
         let recoveryUpstreamID = try extractUpstreamID(from: recoveryInitialize)
         await upstream0.yield(.message(try makeInitializeResponse(id: recoveryUpstreamID)))
         _ = try await sentValue(from: upstream0, at: 2, timeout: .seconds(2))
-        #expect(manager.testStateSnapshot().upstreams[0].isInitialized == true)
-        #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 1)
-        #expect(manager.documentationCandidateProcessOrder() == [
+        let expectedCandidateProcessOrder = [
             newerTarget.processID,
             olderTarget.processID,
-        ])
+        ]
+        #expect(await waitUntil(timeout: .seconds(2)) {
+            manager.documentationCandidateProcessOrder() == expectedCandidateProcessOrder
+        })
+        #expect(manager.testStateSnapshot().upstreams[0].isInitialized == true)
+        #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 1)
+        #expect(manager.documentationCandidateProcessOrder() == expectedCandidateProcessOrder)
     }
 
     @Test func sessionManagerRoutesInitializeHandshakeNotificationsFromRetriedPrimaryProcess()

--- a/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxySessionTests/RuntimeCoordinatorTests.swift
@@ -3122,16 +3122,23 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
         manager.markUpstreamInitialized(upstreamIndex: 0)
 
+        let firstUpstream0StartIndex = await upstream0.sentCount()
+        let firstUpstream1StartIndex = await upstream1.sentCount()
         let firstTask = Task {
             try await manager.liveXcodeListWindowsResult(
                 route: .anyHealthy,
                 requestTimeoutOverride: .seconds(2)
             )
         }
-        let firstRequest = try await upstream0.nextSent {
-            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        let firstRequest = try await waitWithTimeout(
+            "waiting for first window fanout request on upstream0",
+            timeout: .seconds(2)
+        ) {
+            try await upstream0.nextSent(startingAt: firstUpstream0StartIndex) {
+                methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+            }
         }
-        #expect(await upstream1.sentCount() == 0)
+        #expect(await upstream1.sentCount() == firstUpstream1StartIndex)
         await upstream0.yield(
             .message(
                 try makeXcodeListWindowsResponse(
@@ -3140,20 +3147,38 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
-        _ = try await firstTask.value
+        _ = try await waitWithTimeout(
+            "waiting for first window fanout result",
+            timeout: .seconds(2)
+        ) {
+            try await firstTask.value
+        }
+        #expect(await upstream1.sentCount() == firstUpstream1StartIndex)
 
         manager.markUpstreamInitialized(upstreamIndex: 1)
+        let secondUpstream0StartIndex = await upstream0.sentCount()
+        let secondUpstream1StartIndex = await upstream1.sentCount()
         let secondTask = Task {
             try await manager.liveXcodeListWindowsResult(
                 route: .anyHealthy,
                 requestTimeoutOverride: .seconds(2)
             )
         }
-        let secondRequest0 = try await upstream0.nextSent {
-            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        let secondRequest0 = try await waitWithTimeout(
+            "waiting for second window fanout request on upstream0",
+            timeout: .seconds(2)
+        ) {
+            try await upstream0.nextSent(startingAt: secondUpstream0StartIndex) {
+                methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+            }
         }
-        let secondRequest1 = try await upstream1.nextSent {
-            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        let secondRequest1 = try await waitWithTimeout(
+            "waiting for second window fanout request on upstream1",
+            timeout: .seconds(2)
+        ) {
+            try await upstream1.nextSent(startingAt: secondUpstream1StartIndex) {
+                methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+            }
         }
         await upstream0.yield(
             .message(
@@ -3171,7 +3196,12 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
-        _ = try await secondTask.value
+        _ = try await waitWithTimeout(
+            "waiting for second window fanout result",
+            timeout: .seconds(2)
+        ) {
+            try await secondTask.value
+        }
     }
 
     @Test func mergedXcodeListWindowsPreservesToolErrors() throws {

--- a/Tests/ProxySessionTests/TestUpstreamClient.swift
+++ b/Tests/ProxySessionTests/TestUpstreamClient.swift
@@ -59,6 +59,13 @@ actor TestUpstreamClient: UpstreamSlotControlling {
         try await sentMessages.nextValue(matching: predicate)
     }
 
+    func nextSent(
+        startingAt index: Int,
+        matching predicate: @escaping @Sendable (Data) -> Bool
+    ) async throws -> Data {
+        try await sentMessages.nextValue(startingAt: index, matching: predicate)
+    }
+
     func startCount() async -> Int {
         startCountValue
     }


### PR DESCRIPTION
## Summary

Centralizes process-bound `mcpbridge` session construction in `XcodeMCPKit` so ProxySession documentation fallback code requests a high-level bridge session instead of constructing `UpstreamProcess.Config` and shaping environment variables itself.

## Root Cause

`MCPBridgeRuntime` already owned process-bound upstream env shaping for managed slots, but `LiveDocumentationProviderSessionFactory` duplicated the same `MCP_XCODE_PID`, `DEVELOPER_DIR`, inherited session ID, and write-queue decisions directly in ProxySession.

## Changes

- Added package-level `MCPBridgeRuntime` APIs for process-bound session factory/startup.
- Updated `LiveDocumentationProviderSessionFactory` to delegate bridge process/env/session shaping to `XcodeMCPKit`.
- Added contract tests for process-bound bridge environment shaping and inherited session ID removal.
- Updated stale Japanese README wording for `MCP_XCODE_PID`.

## Validation

- `swift test --filter ProxySessionTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `codex-review` against `codex/refactor-layered-runtime-integration`: no findings