### PR TITLE
Finalize API boundary cleanup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -98,6 +98,7 @@ let package = Package(
             name: "XcodeMCPKit",
             dependencies: [
                 "ProxyCore",
+                "ProxyMCP",
                 "ProxySessionUpstream",
             ],
             path: "Sources/XcodeMCPKit",

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -1,27 +1,27 @@
 import Foundation
 
-public struct ProxyConfig: Sendable {
-    public enum Transport: String, CaseIterable, Sendable {
+package struct ProxyConfig: Sendable {
+    package enum Transport: String, CaseIterable, Sendable {
         case http
         case stdio
     }
 
-    public enum StdioUpstreamSource: String, Sendable {
+    package enum StdioUpstreamSource: String, Sendable {
         case explicit
         case environment
         case discovery
         case fallback
     }
 
-    public enum RefreshCodeIssuesMode: String, Sendable {
+    package enum RefreshCodeIssuesMode: String, Sendable {
         case proxy
         case upstream
     }
 
-    public enum ValidationError: Error, CustomStringConvertible {
+    package enum ValidationError: Error, CustomStringConvertible {
         case unsupportedProtocolVersion(String)
 
-        public var description: String {
+        package var description: String {
             switch self {
             case .unsupportedProtocolVersion(let protocolVersion):
                 return "upstream_handshake.protocolVersion must be \(MCP.ProtocolVersion.current); \(protocolVersion) is not supported"
@@ -31,26 +31,26 @@ public struct ProxyConfig: Sendable {
 
     package enum File {}
 
-    public var listenHost: String
-    public var listenPort: Int
-    public var upstreamCommand: String
-    public var upstreamArgs: [String]
-    public var upstreamProcessCount: Int
-    public var upstreamSessionID: String?
-    public var maxBodyBytes: Int
-    public var requestTimeout: TimeInterval
-    public var configPath: String?
-    public var transport: ProxyConfig.Transport
-    public var stdioUpstreamURL: URL?
-    public var stdioUpstreamSource: ProxyConfig.StdioUpstreamSource?
-    public var discoveryFileURL: URL?
-    public var prewarmToolsList: Bool
-    public var autoApproveXcodeDialog: Bool
-    public var refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode
-    public var disabledToolNames: Set<String>
+    package var listenHost: String
+    package var listenPort: Int
+    package var upstreamCommand: String
+    package var upstreamArgs: [String]
+    package var upstreamProcessCount: Int
+    package var upstreamSessionID: String?
+    package var maxBodyBytes: Int
+    package var requestTimeout: TimeInterval
+    package var configPath: String?
+    package var transport: ProxyConfig.Transport
+    package var stdioUpstreamURL: URL?
+    package var stdioUpstreamSource: ProxyConfig.StdioUpstreamSource?
+    package var discoveryFileURL: URL?
+    package var prewarmToolsList: Bool
+    package var autoApproveXcodeDialog: Bool
+    package var refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode
+    package var disabledToolNames: Set<String>
     package var initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride?
 
-    public init(
+    package init(
         listenHost: String,
         listenPort: Int,
         upstreamCommand: String,
@@ -94,7 +94,7 @@ public struct ProxyConfig: Sendable {
     /// Reads the TOML file config (disabled tools, initialize-params
     /// override) from `configPath` and stores the decoded values. This is
     /// the only place the file is read; consumers use the stored values.
-    public mutating func loadFileConfig() {
+    package mutating func loadFileConfig() {
         loadFileConfig(preserveDisabledToolNames: false)
     }
 
@@ -112,7 +112,7 @@ public struct ProxyConfig: Sendable {
         )
     }
 
-    public func validateModernProtocolConfiguration() throws {
+    package func validateModernProtocolConfiguration() throws {
         guard let protocolVersion = initializeParamsOverride?.protocolVersion else {
             return
         }
@@ -122,10 +122,10 @@ public struct ProxyConfig: Sendable {
     }
 }
 
-public enum CLIError: Error, CustomStringConvertible {
+package enum CLIError: Error, CustomStringConvertible {
     case message(String)
 
-    public var description: String {
+    package var description: String {
         switch self {
         case .message(let text):
             return text
@@ -133,17 +133,17 @@ public enum CLIError: Error, CustomStringConvertible {
     }
 }
 
-public struct CLIParser {
+package struct CLIParser {
     private static let defaultStdioUpstream = "http://localhost:8765/mcp"
     private static let stdioEndpointEnv = "XCODE_MCP_PROXY_ENDPOINT"
     private static let refreshCodeIssuesModeEnv = "MCP_XCODE_REFRESH_CODE_ISSUES_MODE"
-    public static let configPathEnv = "MCP_XCODE_CONFIG"
-    public static let removedLazyInitMessage =
+    package static let configPathEnv = "MCP_XCODE_CONFIG"
+    package static let removedLazyInitMessage =
         "The proxy always uses eager initialization; --lazy-init has been removed."
-    public static let removedXcodePIDMessage =
+    package static let removedXcodePIDMessage =
         "Xcode PID support has been removed; --xcode-pid is no longer supported."
 
-    public static func parse(args: [String], environment: [String: String]) throws -> ProxyConfig {
+    package static func parse(args: [String], environment: [String: String]) throws -> ProxyConfig {
         return try parse(
             args: args,
             environment: environment,

--- a/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/LocalMCPResponder.swift
@@ -121,13 +121,11 @@ package struct LocalMCPResponder {
             let result: [String: Any] = (method == "resources/list")
                 ? ["resources": [Any]()]
                 : ["resourceTemplates": [Any]()]
-            let response: [String: Any] = [
-                "jsonrpc": "2.0",
-                "id": originalID.value.foundationObject,
-                "result": result,
-            ]
-            guard JSONSerialization.isValidJSONObject(response),
-                let data = try? JSONSerialization.data(withJSONObject: response, options: [])
+            guard let resultValue = JSONValue(any: result),
+                let data = try? JSONRPC.Wire.resultResponseData(
+                    id: originalID,
+                    result: resultValue
+                )
             else {
                 return nil
             }
@@ -243,16 +241,7 @@ package struct LocalMCPResponder {
         id: JSONRPC.ID,
         result: JSONValue
     ) throws -> Data {
-        struct EncodingError: Error {}
-        let response: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": id.value.foundationObject,
-            "result": result.foundationObject,
-        ]
-        guard JSONSerialization.isValidJSONObject(response) else {
-            throw EncodingError()
-        }
-        return try JSONSerialization.data(withJSONObject: response, options: [])
+        try JSONRPC.Wire.resultResponseData(id: id, result: result)
     }
 
     private static func encodeResultBuffer(
@@ -280,19 +269,11 @@ package struct LocalMCPResponder {
         error: Error
     ) throws -> Data {
         let mapped = ControlPlane.ErrorMapper.jsonRPCError(for: error)
-        let response: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": id.value.foundationObject,
-            "error": [
-                "code": mapped.code,
-                "message": mapped.message,
-            ],
-        ]
-        guard JSONSerialization.isValidJSONObject(response) else {
-            struct EncodingError: Error {}
-            throw EncodingError()
-        }
-        return try JSONSerialization.data(withJSONObject: response, options: [])
+        return try JSONRPC.Wire.errorResponseData(
+            id: id,
+            code: mapped.code,
+            message: mapped.message
+        )
     }
 
     private static func fallbackLocalError(

--- a/Sources/ProxyHTTPGateway/MCP/MCPErrorResponder.swift
+++ b/Sources/ProxyHTTPGateway/MCP/MCPErrorResponder.swift
@@ -10,17 +10,13 @@ enum MCPErrorResponder {
         data: JSONValue? = nil,
         forceBatchArray: Bool = false
     ) -> Data? {
-        let errorObject = makeErrorObject(code: code, message: message, data: data)
-        let response: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": id?.value.foundationObject ?? NSNull(),
-            "error": errorObject,
-        ]
-        let payload: Any = forceBatchArray ? [response] : response
-        guard JSONSerialization.isValidJSONObject(payload) else {
-            return nil
-        }
-        return try? JSONSerialization.data(withJSONObject: payload, options: [])
+        try? JSONRPC.Wire.errorResponseData(
+            id: id,
+            code: code,
+            message: message,
+            data: data,
+            forceBatchArray: forceBatchArray
+        )
     }
 
     static func errorResponseData(
@@ -48,18 +44,13 @@ enum MCPErrorResponder {
                 forceBatchArray: forceBatchArray
             )
         }
-        let errorObject = makeErrorObject(code: code, message: message, data: data)
-        let responses: [[String: Any]] = ids.map { id in
-            [
-                "jsonrpc": "2.0",
-                "id": id.value.foundationObject,
-                "error": errorObject,
-            ]
-        }
-        guard JSONSerialization.isValidJSONObject(responses) else {
-            return nil
-        }
-        return try? JSONSerialization.data(withJSONObject: responses, options: [])
+        return try? JSONRPC.Wire.errorResponseData(
+            ids: ids,
+            code: code,
+            message: message,
+            data: data,
+            forceBatchArray: forceBatchArray
+        )
     }
 
     static func requestMetadata(from data: Data) -> (ids: [JSONRPC.ID], isBatch: Bool) {
@@ -69,20 +60,5 @@ enum MCPErrorResponder {
     static func requestMetadata(fromParsed json: Any?) -> (ids: [JSONRPC.ID], isBatch: Bool) {
         let metadata = JSONRPC.Message.Inspector.requestMetadata(fromParsed: json)
         return (metadata.ids, metadata.isBatch)
-    }
-
-    private static func makeErrorObject(
-        code: Int,
-        message: String,
-        data: JSONValue?
-    ) -> [String: Any] {
-        var error: [String: Any] = [
-            "code": code,
-            "message": message,
-        ]
-        if let data {
-            error["data"] = data.foundationObject
-        }
-        return error
     }
 }

--- a/Sources/ProxyHTTPGateway/MCP/MCPForwardingService.swift
+++ b/Sources/ProxyHTTPGateway/MCP/MCPForwardingService.swift
@@ -209,18 +209,20 @@ package struct MCPForwardingService: Sendable {
         upstreamIndexOverride: Int? = nil,
         requestTimeoutOverride: TimeAmount? = nil
     ) async -> RefreshCodeIssues.Workflow.InternalToolResult {
-        let requestObject: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": "__internal-\(UUID().uuidString)",
-            "method": "tools/call",
-            "params": [
-                "name": name,
-                "arguments": arguments,
-            ],
-        ]
+        guard let argumentValue = JSONValue(any: arguments) else {
+            return .unavailable
+        }
+        let requestObject = JSONRPC.Wire.requestObject(
+            id: "__internal-\(UUID().uuidString)",
+            method: "tools/call",
+            params: .object([
+                "name": .string(name),
+                "arguments": argumentValue,
+            ])
+        )
         let internalRequestID = JSONRPC.ID(any: requestObject["id"]!)!
 
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: requestObject, options: [])
+        guard let bodyData = try? JSONRPC.Wire.data(from: requestObject)
         else {
             return .unavailable
         }

--- a/Sources/ProxyHTTPGateway/MCP/ToolCallNormalizer.swift
+++ b/Sources/ProxyHTTPGateway/MCP/ToolCallNormalizer.swift
@@ -36,8 +36,7 @@ package struct ToolCallNormalizer: Sendable {
                 toolsCatalogOverride: toolsCatalogOverride
                     ?? upstreamIndex.flatMap(sessionManager.cachedToolsListResult(forUpstreamIndex:))
             ),
-                JSONSerialization.isValidJSONObject(rewritten),
-                let rewrittenData = try? JSONSerialization.data(withJSONObject: rewritten, options: [])
+                let rewrittenData = try? JSONRPC.Wire.data(from: rewritten)
             else {
                 return upstreamData
             }
@@ -68,8 +67,7 @@ package struct ToolCallNormalizer: Sendable {
         }
 
         guard rewroteAny,
-            JSONSerialization.isValidJSONObject(rewrittenArray),
-            let rewrittenData = try? JSONSerialization.data(withJSONObject: rewrittenArray, options: [])
+            let rewrittenData = try? JSONRPC.Wire.data(from: rewrittenArray)
         else {
             return upstreamData
         }

--- a/Sources/ProxyHTTPGateway/MCP/ToolSurface.swift
+++ b/Sources/ProxyHTTPGateway/MCP/ToolSurface.swift
@@ -210,11 +210,10 @@ package struct ToolSurface: Sendable {
         let result: [String: Any] = method == "resources/list"
             ? ["resources": [Any]()]
             : ["resourceTemplates": [Any]()]
-        return [
-            "jsonrpc": "2.0",
-            "id": originalID.value.foundationObject,
-            "result": result,
-        ]
+        return JSONRPC.Wire.resultResponseObject(
+            id: originalID,
+            result: JSONValue(any: result) ?? .object([:])
+        )
     }
 
     private func isNonStandardUnsupportedResourcesResult(_ result: Any, method: String) -> Bool {

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+LocalHandling.swift
@@ -100,12 +100,10 @@ extension HTTPPostService {
         guard let payload = try? JSONSerialization.jsonObject(with: data, options: []) else {
             return data
         }
-        guard payload is [Any] == false,
-            JSONSerialization.isValidJSONObject([payload])
-        else {
+        guard payload is [Any] == false else {
             return data
         }
-        return (try? JSONSerialization.data(withJSONObject: [payload], options: [])) ?? data
+        return (try? JSONRPC.Wire.data(from: [payload])) ?? data
     }
 
     private static func isJSONRPCErrorResponse(_ data: Data) -> Bool {
@@ -308,7 +306,7 @@ extension HTTPPostService {
             forwardedPayload = forwardedObjects[0]
         }
         let forwardedBodyData = forwardedPayload.flatMap {
-            try? JSONSerialization.data(withJSONObject: $0, options: [])
+            try? JSONRPC.Wire.data(from: $0)
         }
         let forwardedResponseIDs = forwardedPayload.map {
             Self.extractResponseIDs(from: $0)
@@ -441,8 +439,7 @@ extension HTTPPostService {
             guard let originalID = JSONRPC.Message.Inspector.requestID(from: request) else {
                 continue
             }
-            guard JSONSerialization.isValidJSONObject(request),
-                  let requestData = try? JSONSerialization.data(withJSONObject: request, options: []) else {
+            guard let requestData = try? JSONRPC.Wire.data(from: request) else {
                 responseObjects.append(
                     Self.makeJSONRPCErrorResponseObject(
                         id: originalID,
@@ -551,7 +548,7 @@ extension HTTPPostService {
         if let object = requestJSON as? [String: Any],
             let refreshRequest = RefreshCodeIssues.Request(requestObject: object),
             Self.extractResponseIDs(from: object).isEmpty == false,
-            let bodyData = try? JSONSerialization.data(withJSONObject: object, options: [])
+            let bodyData = try? JSONRPC.Wire.data(from: object)
         {
             return HTTPPostService.RefreshRouting(
                 refreshRoutes: [
@@ -595,7 +592,7 @@ extension HTTPPostService {
                 continue
             }
             let payload: Any = requests.count == 1 ? requests : object
-            guard let bodyData = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
+            guard let bodyData = try? JSONRPC.Wire.data(from: payload) else {
                 return nil
             }
             refreshRoutes.append(
@@ -622,7 +619,7 @@ extension HTTPPostService {
             return remainingRequestObjects
         }()
         let remainingBodyData = remainingPayload.flatMap {
-            try? JSONSerialization.data(withJSONObject: $0, options: [])
+            try? JSONRPC.Wire.data(from: $0)
         }
         let remainingLocalResponseData = Self.makeToolResponseData(
             from: remainingInvalidResponseObjects,

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService+ResponseUtilities.swift
@@ -248,12 +248,8 @@ extension HTTPPostService {
 
         let mergedObjects =
             localResponseObjects
-            + responseIDs.map { makeJSONRPCErrorResponseObject(id: $0, code: code, message: message) }
-        guard JSONSerialization.isValidJSONObject(mergedObjects),
-            let responseData = try? JSONSerialization.data(
-                withJSONObject: mergedObjects,
-                options: []
-            )
+            + responseIDs.map { JSONRPC.Wire.errorResponseObject(id: $0, code: code, message: message) }
+        guard let responseData = try? JSONRPC.Wire.data(from: mergedObjects)
         else {
             if responseIDs.isEmpty {
                 return .plain(
@@ -315,8 +311,7 @@ extension HTTPPostService {
             return responseData
         }
 
-        return (try? JSONSerialization.data(withJSONObject: mergedObjects, options: []))
-            ?? responseData
+        return (try? JSONRPC.Wire.data(from: mergedObjects)) ?? responseData
     }
 
     package static func mergeLocalToolResponseData(
@@ -370,10 +365,7 @@ extension HTTPPostService {
             return nil
         }
         let payload: Any = (forceBatchArray || objects.count > 1) ? objects : objects[0]
-        guard JSONSerialization.isValidJSONObject(payload) else {
-            return nil
-        }
-        return try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return try? JSONRPC.Wire.data(from: payload)
     }
 
     package static func responseDataForBatchResolution(
@@ -430,19 +422,18 @@ extension HTTPPostService {
         id: JSONRPC.ID,
         message: String
     ) -> [String: Any] {
-        [
-            "jsonrpc": "2.0",
-            "id": id.value.foundationObject,
-            "result": [
-                "content": [
-                    [
-                        "type": "text",
-                        "text": message,
-                    ]
-                ],
-                "isError": true,
-            ],
-        ]
+        JSONRPC.Wire.resultResponseObject(
+            id: id,
+            result: .object([
+                "content": .array([
+                    .object([
+                        "type": .string("text"),
+                        "text": .string(message),
+                    ])
+                ]),
+                "isError": .bool(true),
+            ])
+        )
     }
 
     package static func makeJSONRPCErrorResponseObject(
@@ -450,11 +441,7 @@ extension HTTPPostService {
         code: Int,
         message: String
     ) -> [String: Any] {
-        makeJSONRPCErrorResponseObject(
-            id: id.value.foundationObject,
-            code: code,
-            message: message
-        )
+        JSONRPC.Wire.errorResponseObject(id: id, code: code, message: message)
     }
 
     package static func makeJSONRPCErrorResponseObject(
@@ -462,14 +449,10 @@ extension HTTPPostService {
         code: Int,
         message: String
     ) -> [String: Any] {
-        [
-            "jsonrpc": "2.0",
-            "id": id,
-            "error": [
-                "code": code,
-                "message": message,
-            ],
-        ]
+        JSONRPC.Wire.errorResponseObject(
+            idValue: JSONValue(any: id),
+            error: .init(code: code, message: message)
+        )
     }
 
     package static func makeJSONRPCErrorResponseData(
@@ -478,26 +461,20 @@ extension HTTPPostService {
         message: String,
         forceBatchArray: Bool
     ) -> Data? {
-        let objects = ids.map { makeJSONRPCErrorResponseObject(id: $0, code: code, message: message) }
-        guard !objects.isEmpty else {
-            return nil
-        }
-        let payload: Any = (forceBatchArray || objects.count > 1) ? objects : objects[0]
-        guard JSONSerialization.isValidJSONObject(payload) else {
-            return nil
-        }
-        return try? JSONSerialization.data(withJSONObject: payload, options: [])
+        try? JSONRPC.Wire.errorResponseData(
+            ids: ids,
+            code: code,
+            message: message,
+            forceBatchArray: forceBatchArray,
+            includeNullIDWhenEmpty: false
+        )
     }
 
     package static func makeJSONRPCResultResponseObject(
         id: JSONRPC.ID,
         result: JSONValue
     ) -> [String: Any] {
-        [
-            "jsonrpc": "2.0",
-            "id": id.value.foundationObject,
-            "result": result.foundationObject,
-        ]
+        JSONRPC.Wire.resultResponseObject(id: id, result: result)
     }
 
     package static func makeJSONRPCResultResponseData(
@@ -505,17 +482,11 @@ extension HTTPPostService {
         result: JSONValue,
         forceBatchArray: Bool
     ) -> Data? {
-        let objects = ids.map {
-            makeJSONRPCResultResponseObject(id: $0, result: result)
-        }
-        guard !objects.isEmpty else {
-            return nil
-        }
-        let payload: Any = (forceBatchArray || objects.count > 1) ? objects : objects[0]
-        guard JSONSerialization.isValidJSONObject(payload) else {
-            return nil
-        }
-        return try? JSONSerialization.data(withJSONObject: payload, options: [])
+        try? JSONRPC.Wire.resultResponseData(
+            ids: ids,
+            result: result,
+            forceBatchArray: forceBatchArray
+        )
     }
 
     package static func makeToolResponseData(
@@ -525,13 +496,10 @@ extension HTTPPostService {
         guard responseObjects.isEmpty == false else {
             return nil
         }
-        let payload: Any = (forceBatchArray || responseObjects.count > 1)
-            ? responseObjects
-            : responseObjects[0]
-        guard JSONSerialization.isValidJSONObject(payload) else {
-            return nil
-        }
-        return try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return try? JSONRPC.Wire.responsePayloadData(
+            objects: responseObjects,
+            forceBatchArray: forceBatchArray
+        )
     }
 
     package static func makeToolRoutingErrorResponseData(

--- a/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
+++ b/Sources/ProxyHTTPGateway/Post/HTTPPostService.swift
@@ -733,9 +733,7 @@ package final class HTTPPostService: Sendable {
         responseID: JSONRPC.ID,
         eventLoop: EventLoop
     ) -> HTTPPostService.Operation {
-        guard JSONSerialization.isValidJSONObject(responseObject),
-            let responseData = try? JSONSerialization.data(withJSONObject: responseObject, options: [])
-        else {
+        guard let responseData = try? JSONRPC.Wire.data(from: responseObject) else {
             return HTTPPostService.Operation(
                 future: eventLoop.makeSucceededFuture(
                     .plain(

--- a/Sources/ProxyMCP/JSONRPCWire.swift
+++ b/Sources/ProxyMCP/JSONRPCWire.swift
@@ -1,0 +1,319 @@
+import Foundation
+
+extension JSONRPC {
+    package enum Wire {
+        package enum EncodingFailure: Swift.Error, Equatable {
+            case invalidJSONObject
+        }
+
+        package enum DecodingFailure: Swift.Error, Equatable {
+            case messageWasNotObject
+            case missingResult
+        }
+
+        package struct ErrorPayload: Sendable {
+            package let code: Int
+            package let message: String
+            package let data: JSONValue?
+
+            package init(code: Int, message: String, data: JSONValue? = nil) {
+                self.code = code
+                self.message = message
+                self.data = data
+            }
+        }
+
+        package static let version = "2.0"
+
+        package static func requestObject(
+            id: JSONRPC.ID,
+            method: String,
+            params: JSONValue? = nil
+        ) -> [String: Any] {
+            var object = notificationObject(method: method, params: params)
+            object["id"] = id.value.foundationObject
+            return object
+        }
+
+        package static func requestObject(
+            id: Int64,
+            method: String,
+            params: JSONValue? = nil
+        ) -> [String: Any] {
+            requestObject(
+                id: JSONRPC.ID(any: NSNumber(value: id))!,
+                method: method,
+                params: params
+            )
+        }
+
+        package static func requestObject(
+            id: String,
+            method: String,
+            params: JSONValue? = nil
+        ) -> [String: Any] {
+            requestObject(
+                id: JSONRPC.ID(any: id)!,
+                method: method,
+                params: params
+            )
+        }
+
+        package static func notificationObject(
+            method: String,
+            params: JSONValue? = nil
+        ) -> [String: Any] {
+            var object: [String: Any] = [
+                "jsonrpc": version,
+                "method": method,
+            ]
+            if let params {
+                object["params"] = params.foundationObject
+            }
+            return object
+        }
+
+        package static func resultResponseObject(
+            id: JSONRPC.ID,
+            result: JSONValue
+        ) -> [String: Any] {
+            resultResponseObject(idValue: id.value, result: result)
+        }
+
+        package static func resultResponseObject(
+            idValue: JSONValue?,
+            result: JSONValue
+        ) -> [String: Any] {
+            [
+                "jsonrpc": version,
+                "id": idValue?.foundationObject ?? NSNull(),
+                "result": result.foundationObject,
+            ]
+        }
+
+        package static func errorObject(
+            code: Int,
+            message: String,
+            data: JSONValue? = nil
+        ) -> [String: Any] {
+            var error: [String: Any] = [
+                "code": code,
+                "message": message,
+            ]
+            if let data {
+                error["data"] = data.foundationObject
+            }
+            return error
+        }
+
+        package static func errorResponseObject(
+            id: JSONRPC.ID?,
+            code: Int,
+            message: String,
+            data: JSONValue? = nil
+        ) -> [String: Any] {
+            errorResponseObject(
+                idValue: id?.value,
+                error: ErrorPayload(code: code, message: message, data: data)
+            )
+        }
+
+        package static func errorResponseObject(
+            id: JSONRPC.ID,
+            code: Int,
+            message: String,
+            data: JSONValue? = nil
+        ) -> [String: Any] {
+            errorResponseObject(
+                idValue: id.value,
+                error: ErrorPayload(code: code, message: message, data: data)
+            )
+        }
+
+        package static func errorResponseObject(
+            id: JSONRPC.ID?,
+            error: ErrorPayload
+        ) -> [String: Any] {
+            errorResponseObject(idValue: id?.value, error: error)
+        }
+
+        package static func errorResponseObject(
+            id: JSONRPC.ID,
+            error: ErrorPayload
+        ) -> [String: Any] {
+            errorResponseObject(idValue: id.value, error: error)
+        }
+
+        package static func errorResponseObject(
+            idValue: JSONValue?,
+            error: ErrorPayload
+        ) -> [String: Any] {
+            [
+                "jsonrpc": version,
+                "id": idValue?.foundationObject ?? NSNull(),
+                "error": errorObject(
+                    code: error.code,
+                    message: error.message,
+                    data: error.data
+                ),
+            ]
+        }
+
+        package static func data(from payload: Any) throws -> Data {
+            guard JSONSerialization.isValidJSONObject(payload) else {
+                throw EncodingFailure.invalidJSONObject
+            }
+            return try JSONSerialization.data(withJSONObject: payload, options: [])
+        }
+
+        package static func object(fromData data: Data) throws -> [String: Any] {
+            guard
+                let object = try JSONSerialization.jsonObject(with: data, options: [])
+                    as? [String: Any]
+            else {
+                throw DecodingFailure.messageWasNotObject
+            }
+            return object
+        }
+
+        package static func resultResponseData(
+            id: JSONRPC.ID,
+            result: JSONValue
+        ) throws -> Data {
+            try data(from: resultResponseObject(id: id, result: result))
+        }
+
+        package static func resultResponseData(
+            ids: [JSONRPC.ID],
+            result: JSONValue,
+            forceBatchArray: Bool
+        ) throws -> Data? {
+            let objects = ids.map { resultResponseObject(id: $0, result: result) }
+            return try responsePayloadData(objects: objects, forceBatchArray: forceBatchArray)
+        }
+
+        package static func errorResponseData(
+            id: JSONRPC.ID?,
+            code: Int,
+            message: String,
+            data errorData: JSONValue? = nil,
+            forceBatchArray: Bool = false
+        ) throws -> Data {
+            let object = errorResponseObject(
+                id: id,
+                code: code,
+                message: message,
+                data: errorData
+            )
+            let payload: Any = forceBatchArray ? [object] : object
+            return try data(from: payload)
+        }
+
+        package static func errorResponseData(
+            idValue: JSONValue?,
+            code: Int,
+            message: String,
+            data errorData: JSONValue? = nil,
+            forceBatchArray: Bool = false
+        ) throws -> Data {
+            let object = errorResponseObject(
+                idValue: idValue,
+                error: ErrorPayload(code: code, message: message, data: errorData)
+            )
+            let payload: Any = forceBatchArray ? [object] : object
+            return try data(from: payload)
+        }
+
+        package static func errorResponseData(
+            ids: [JSONRPC.ID],
+            code: Int,
+            message: String,
+            data errorData: JSONValue? = nil,
+            forceBatchArray: Bool,
+            includeNullIDWhenEmpty: Bool = true
+        ) throws -> Data? {
+            guard ids.isEmpty == false else {
+                guard includeNullIDWhenEmpty else {
+                    return nil
+                }
+                return try errorResponseData(
+                    id: nil,
+                    code: code,
+                    message: message,
+                    data: errorData,
+                    forceBatchArray: forceBatchArray
+                )
+            }
+            let objects = ids.map {
+                errorResponseObject(id: $0, code: code, message: message, data: errorData)
+            }
+            return try responsePayloadData(objects: objects, forceBatchArray: forceBatchArray)
+        }
+
+        package static func responsePayloadData(
+            objects: [[String: Any]],
+            forceBatchArray: Bool
+        ) throws -> Data? {
+            guard objects.isEmpty == false else {
+                return nil
+            }
+            let payload: Any = (forceBatchArray || objects.count > 1) ? objects : objects[0]
+            return try data(from: payload)
+        }
+
+        package static func objectByReplacingID(
+            in object: [String: Any],
+            with id: JSONRPC.ID
+        ) -> [String: Any] {
+            var rewritten = object
+            rewritten["id"] = id.value.foundationObject
+            return rewritten
+        }
+
+        package static func dataByReplacingID(
+            in object: [String: Any],
+            with id: JSONRPC.ID
+        ) throws -> Data {
+            try data(from: objectByReplacingID(in: object, with: id))
+        }
+
+        package static func resultValue(inResponseObject object: [String: Any]) -> JSONValue? {
+            guard let resultAny = object["result"] else {
+                return nil
+            }
+            return JSONValue(any: resultAny)
+        }
+
+        package static func resultValue(fromResponseData data: Data) throws -> JSONValue {
+            let object = try object(fromData: data)
+            guard let result = resultValue(inResponseObject: object) else {
+                throw DecodingFailure.missingResult
+            }
+            return result
+        }
+
+        package static func errorPayload(inResponseObject object: [String: Any]) -> ErrorPayload? {
+            guard let errorObject = object["error"] as? [String: Any] else {
+                return nil
+            }
+            let code: Int
+            if let number = errorObject["code"] as? NSNumber {
+                code = number.intValue
+            } else if let int = errorObject["code"] as? Int {
+                code = int
+            } else {
+                code = -32000
+            }
+            let message = errorObject["message"] as? String ?? "upstream error"
+            let data = errorObject["data"].flatMap(JSONValue.init(any:))
+            return ErrorPayload(code: code, message: message, data: data)
+        }
+
+        package static func errorPayload(fromResponseData data: Data) -> ErrorPayload? {
+            guard let object = try? object(fromData: data) else {
+                return nil
+            }
+            return errorPayload(inResponseObject: object)
+        }
+    }
+}

--- a/Sources/ProxySession/DocumentationProvider.swift
+++ b/Sources/ProxySession/DocumentationProvider.swift
@@ -1288,20 +1288,18 @@ package struct LiveDocumentationAssetSearchProvider: DocumentationSearchProvidin
         ]
         let payloadData = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
         let payloadText = String(decoding: payloadData, as: UTF8.self)
-        let response: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": requestID.value.foundationObject,
-            "result": [
-                "content": [
-                    [
-                        "type": "text",
-                        "text": payloadText,
-                    ],
-                ],
-                "isError": false,
-            ],
-        ]
-        return try JSONSerialization.data(withJSONObject: response, options: [])
+        return try JSONRPC.Wire.resultResponseData(
+            id: requestID,
+            result: .object([
+                "content": .array([
+                    .object([
+                        "type": .string("text"),
+                        "text": .string(payloadText),
+                    ])
+                ]),
+                "isError": .bool(false),
+            ])
+        )
     }
 }
 
@@ -1375,10 +1373,9 @@ package actor DocumentationProviderConnection {
     }
 
     package func sendNotification(_ object: [String: Any]) async throws {
-        guard JSONSerialization.isValidJSONObject(object) else {
+        guard let data = try? JSONRPC.Wire.data(from: object) else {
             throw ControlPlane.Error.invalidResponse("invalid notification")
         }
-        let data = try JSONSerialization.data(withJSONObject: object, options: [])
         let result = await session.send(data)
         guard result == .accepted else {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
@@ -1397,11 +1394,13 @@ package actor DocumentationProviderConnection {
         let upstreamID = nextID
         let upstreamIDKey = String(upstreamID)
         nextID += 1
-        object["id"] = upstreamID
-        guard JSONSerialization.isValidJSONObject(object) else {
+        object = JSONRPC.Wire.objectByReplacingID(
+            in: object,
+            with: JSONRPC.ID(any: NSNumber(value: upstreamID))!
+        )
+        guard let upstreamData = try? JSONRPC.Wire.data(from: object) else {
             throw ControlPlane.Error.invalidResponse("invalid DocumentationSearch request")
         }
-        let upstreamData = try JSONSerialization.data(withJSONObject: object, options: [])
 
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
@@ -1465,7 +1464,7 @@ package actor DocumentationProviderConnection {
 
     private func handleMessage(_ data: Data) {
         guard
-            var object = try? JSONSerialization.jsonObject(with: data, options: [])
+            let object = try? JSONSerialization.jsonObject(with: data, options: [])
                 as? [String: Any],
             let responseID = JSONRPC.Message.Inspector.responseID(from: object),
             let pending = pendingResponses.removeValue(forKey: responseID.key)
@@ -1474,10 +1473,10 @@ package actor DocumentationProviderConnection {
         }
 
         pending.timeoutTask?.cancel()
-        object["id"] = pending.originalID.value.foundationObject
-        guard JSONSerialization.isValidJSONObject(object),
-            let rewrittenData = try? JSONSerialization.data(withJSONObject: object, options: [])
-        else {
+        guard let rewrittenData = try? JSONRPC.Wire.dataByReplacingID(
+            in: object,
+            with: pending.originalID
+        ) else {
             pending.continuation.resume(
                 throwing: ControlPlane.Error.invalidResponse("invalid DocumentationSearch response")
             )
@@ -1535,10 +1534,9 @@ package actor SessionBackedDocumentationProviderTransport: DocumentationProvider
             let serverVersion = DocumentationProviderManager.serverVersion(
                 fromInitializeResponse: initialize
             ) ?? ""
-            try await connection.sendNotification([
-                "jsonrpc": "2.0",
-                "method": "notifications/initialized",
-            ])
+            try await connection.sendNotification(
+                JSONRPC.Wire.notificationObject(method: "notifications/initialized")
+            )
             connections[routeID] = connection
             return DocumentationProviderRoute(
                 id: routeID,
@@ -1622,25 +1620,21 @@ package actor SessionBackedDocumentationProviderTransport: DocumentationProvider
     private static func makeInitializeRequestData(
         initializeParams: [String: JSONValue]
     ) throws -> Data {
-        try JSONSerialization.data(
-            withJSONObject: [
-                "jsonrpc": "2.0",
-                "id": "initialize",
-                "method": "initialize",
-                "params": initializeParams.mapValues(\.foundationObject),
-            ],
-            options: []
+        try JSONRPC.Wire.data(
+            from: JSONRPC.Wire.requestObject(
+                id: "initialize",
+                method: "initialize",
+                params: .object(initializeParams)
+            )
         )
     }
 
     private static func makeToolsListRequestData() throws -> Data {
-        try JSONSerialization.data(
-            withJSONObject: [
-                "jsonrpc": "2.0",
-                "id": "tools-list",
-                "method": "tools/list",
-            ],
-            options: []
+        try JSONRPC.Wire.data(
+            from: JSONRPC.Wire.requestObject(
+                id: "tools-list",
+                method: "tools/list"
+            )
         )
     }
 }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -285,11 +285,10 @@ extension RuntimeCoordinator {
                 route: route,
                 purpose: purpose,
                 label: "tools/list",
-                requestObject: [
-                    "jsonrpc": "2.0",
-                    "id": "__control-plane-tools-\(UUID().uuidString)",
-                    "method": "tools/list",
-                ],
+                requestObject: JSONRPC.Wire.requestObject(
+                    id: "__control-plane-tools-\(UUID().uuidString)",
+                    method: "tools/list"
+                ),
                 requestTimeout: requestTimeout,
                 rpcHandle: rpcHandle
             )
@@ -362,15 +361,14 @@ extension RuntimeCoordinator {
                 route: route,
                 purpose: "windows",
                 label: "tools/call:XcodeListWindows",
-                requestObject: [
-                    "jsonrpc": "2.0",
-                    "id": "__control-plane-windows-\(UUID().uuidString)",
-                    "method": "tools/call",
-                    "params": [
-                        "name": "XcodeListWindows",
-                        "arguments": [:],
-                    ],
-                ],
+                requestObject: JSONRPC.Wire.requestObject(
+                    id: "__control-plane-windows-\(UUID().uuidString)",
+                    method: "tools/call",
+                    params: .object([
+                        "name": .string("XcodeListWindows"),
+                        "arguments": .object([:]),
+                    ])
+                ),
                 requestTimeout: effectiveRequestTimeout,
                 rpcHandle: rpcHandle
             )
@@ -525,11 +523,7 @@ extension RuntimeCoordinator {
                 }
                 var upstreamObject = requestTemplate.mapValues(\.foundationObject)
                 upstreamObject["id"] = upstreamID
-                guard JSONSerialization.isValidJSONObject(upstreamObject),
-                    let requestData = try? JSONSerialization.data(
-                        withJSONObject: upstreamObject,
-                        options: []
-                    )
+                guard let requestData = try? JSONRPC.Wire.data(from: upstreamObject)
                 else {
                     self.failRequestLease(
                         leaseID,
@@ -668,50 +662,47 @@ extension RuntimeCoordinator {
 
     func extractJSONRPCResult(from responseData: Data) throws -> JSONValue {
         let object = try extractJSONRPCResponseObject(from: responseData)
-        if let errorObject = object["error"] as? [String: Any] {
+        if let error = JSONRPC.Wire.errorPayload(inResponseObject: object) {
             throw ControlPlane.Error.upstreamRPC(
-                code: (errorObject["code"] as? NSNumber)?.intValue ?? -32000,
-                message: errorObject["message"] as? String ?? "upstream error"
+                code: error.code,
+                message: error.message
             )
         }
-        guard let resultAny = object["result"],
-            let result = JSONValue(any: resultAny)
-        else {
+        guard let result = JSONRPC.Wire.resultValue(inResponseObject: object) else {
             throw ControlPlane.Error.invalidResponse("missing result")
         }
         return result
     }
 
     func extractJSONRPCResponseObject(from responseData: Data) throws -> [String: Any] {
-        guard
-            let responseObject = try JSONSerialization.jsonObject(
-                with: responseData,
-                options: []
-            ) as? [String: Any]
-        else {
+        do {
+            return try JSONRPC.Wire.object(fromData: responseData)
+        } catch JSONRPC.Wire.DecodingFailure.messageWasNotObject {
             throw ControlPlane.Error.invalidResponse("response was not an object")
+        } catch {
+            throw error
         }
-        return responseObject
     }
 
     func responseDataByReplacingJSONRPCID(
         in responseObject: [String: Any],
         with responseID: JSONRPC.ID
     ) throws -> Data {
-        var rewritten = responseObject
-        rewritten["id"] = responseID.value.foundationObject
-        guard JSONSerialization.isValidJSONObject(rewritten) else {
+        do {
+            return try JSONRPC.Wire.dataByReplacingID(in: responseObject, with: responseID)
+        } catch JSONRPC.Wire.EncodingFailure.invalidJSONObject {
             throw ControlPlane.Error.invalidResponse("invalid rewritten response")
+        } catch {
+            throw error
         }
-        return try JSONSerialization.data(withJSONObject: rewritten, options: [])
     }
 
     func extractJSONRPCErrorMessage(from responseObject: [String: Any]) -> String? {
-        (responseObject["error"] as? [String: Any])?["message"] as? String
+        JSONRPC.Wire.errorPayload(inResponseObject: responseObject)?.message
     }
 
     func extractJSONRPCErrorCode(from responseObject: [String: Any]) -> Int? {
-        ((responseObject["error"] as? [String: Any])?["code"] as? NSNumber)?.intValue
+        JSONRPC.Wire.errorPayload(inResponseObject: responseObject)?.code
     }
 
     func responseIsProxyUpstreamFailure(_ responseObject: [String: Any]) -> Bool {

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Health.swift
@@ -51,14 +51,8 @@ extension RuntimeCoordinator {
             upstreamIndex: upstreamIndex
         )
 
-        let request: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": upstreamID,
-            "method": "tools/list",
-        ]
-        guard JSONSerialization.isValidJSONObject(request),
-            let requestData = try? JSONSerialization.data(withJSONObject: request, options: [])
-        else {
+        let request = JSONRPC.Wire.requestObject(id: upstreamID, method: "tools/list")
+        guard let requestData = try? JSONRPC.Wire.data(from: request) else {
             finishHealthProbe(
                 upstreamIndex: upstreamIndex,
                 probeGeneration: probeGeneration,
@@ -197,7 +191,7 @@ extension RuntimeCoordinator {
         scheduleUpstreamInitTimeout(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
 
         let request = makeInternalInitializeRequest(id: upstreamID)
-        if let data = try? JSONSerialization.data(withJSONObject: request, options: []) {
+        if let data = try? JSONRPC.Wire.data(from: request) {
             sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: true)
         } else {
             clearUpstreamState(upstreamIndex: upstreamIndex)

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+Initialization.swift
@@ -72,7 +72,7 @@ extension RuntimeCoordinator {
         markUpstreamInitInFlight(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
 
         let request = makeInternalInitializeRequest(id: upstreamID)
-        if let data = try? JSONSerialization.data(withJSONObject: request, options: []) {
+        if let data = try? JSONRPC.Wire.data(from: request) {
             sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: true)
         } else {
             failInitPending(error: TimeoutError())
@@ -368,14 +368,7 @@ extension RuntimeCoordinator {
     }
 
     func encodeInitializeResponse(originalID: JSONRPC.ID, result: JSONValue) -> ByteBuffer? {
-        let response: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": originalID.value.foundationObject,
-            "result": result.foundationObject,
-        ]
-        guard JSONSerialization.isValidJSONObject(response),
-            let data = try? JSONSerialization.data(withJSONObject: response, options: [])
-        else {
+        guard let data = try? JSONRPC.Wire.resultResponseData(id: originalID, result: result) else {
             return nil
         }
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
@@ -444,13 +437,15 @@ extension RuntimeCoordinator {
     func encodeInitializeErrorResponse(originalID: JSONRPC.ID, errorObject: [String: Any])
         -> ByteBuffer?
     {
-        let response: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": originalID.value.foundationObject,
-            "error": errorObject,
-        ]
-        guard JSONSerialization.isValidJSONObject(response),
-            let data = try? JSONSerialization.data(withJSONObject: response, options: [])
+        guard let error = JSONRPC.Wire.errorPayload(
+            inResponseObject: ["error": errorObject]
+        ),
+            let data = try? JSONRPC.Wire.errorResponseData(
+                id: originalID,
+                code: error.code,
+                message: error.message,
+                data: error.data
+            )
         else {
             return nil
         }
@@ -511,11 +506,8 @@ extension RuntimeCoordinator {
             return
         }
 
-        let notification: [String: Any] = [
-            "jsonrpc": "2.0",
-            "method": "notifications/initialized",
-        ]
-        guard let data = try? JSONSerialization.data(withJSONObject: notification, options: []) else {
+        let notification = JSONRPC.Wire.notificationObject(method: "notifications/initialized")
+        guard let data = try? JSONRPC.Wire.data(from: notification) else {
             guard upstreamHealthManager.initializeAttemptMatches(
                 upstreamIndex: upstreamIndex,
                 expectedUpstreamID: expectedUpstreamID
@@ -748,15 +740,14 @@ extension RuntimeCoordinator {
         }
     }
     func makeInternalInitializeRequest(id: Int64) -> [String: Any] {
-        let mergedParams = InitializeHandshakeJSON.resolved(
-            initializeParamsOverride: initializeParamsOverride
-        ).mapValues(\.foundationObject)
-
-        return [
-            "jsonrpc": "2.0",
-            "id": id,
-            "method": "initialize",
-            "params": mergedParams,
-        ]
+        JSONRPC.Wire.requestObject(
+            id: id,
+            method: "initialize",
+            params: .object(
+                InitializeHandshakeJSON.resolved(
+                    initializeParamsOverride: initializeParamsOverride
+                )
+            )
+        )
     }
 }

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -40,16 +40,11 @@ extension RuntimeCoordinator {
             else {
                 return data
             }
-            var rewritten = object
             let clientID = session.serverRequestTracker.record(
                 upstreamID: upstreamID,
                 upstreamIndex: upstreamIndex
             )
-            rewritten["id"] = clientID.value.foundationObject
-            guard JSONSerialization.isValidJSONObject(rewritten) else {
-                return nil
-            }
-            return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
+            return try? JSONRPC.Wire.dataByReplacingID(in: object, with: clientID)
         }
     }
 
@@ -209,18 +204,13 @@ extension RuntimeCoordinator {
         originalID: JSONRPC.ID
     ) -> [String: Any] {
         if case .malformed = JSONRPC.Message.Inspector.kind(of: object) {
-            return [
-                "jsonrpc": "2.0",
-                "id": originalID.value.foundationObject,
-                "error": [
-                    "code": -32000,
-                    "message": "invalid upstream response",
-                ],
-            ]
+            return JSONRPC.Wire.errorResponseObject(
+                id: originalID,
+                code: -32000,
+                message: "invalid upstream response"
+            )
         }
-        var rewritten = object
-        rewritten["id"] = originalID.value.foundationObject
-        return rewritten
+        return JSONRPC.Wire.objectByReplacingID(in: object, with: originalID)
     }
 
     private func routeClientResponses(
@@ -249,9 +239,7 @@ extension RuntimeCoordinator {
             return false
         }
         let payload: Any = objects.count == 1 ? objects[0] : objects
-        guard JSONSerialization.isValidJSONObject(payload),
-            let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
-        else {
+        guard let data = try? JSONRPC.Wire.data(from: payload) else {
             return false
         }
         recordTraffic(
@@ -540,12 +528,7 @@ extension RuntimeCoordinator {
         _ responseObject: [String: Any],
         id: JSONRPC.ID
     ) -> Data? {
-        var rewritten = responseObject
-        rewritten["id"] = id.value.foundationObject
-        guard JSONSerialization.isValidJSONObject(rewritten) else {
-            return nil
-        }
-        return try? JSONSerialization.data(withJSONObject: rewritten, options: [])
+        try? JSONRPC.Wire.dataByReplacingID(in: responseObject, with: id)
     }
 
     package func debugSnapshot() -> ProxyDebug.Snapshot {
@@ -719,19 +702,12 @@ extension RuntimeCoordinator {
             return
         }
 
-        let overloadError: [String: Any] = [
-            "code": code,
-            "message": message,
-        ]
+        let overloadError = JSONRPC.Wire.ErrorPayload(code: code, message: message)
 
         let responseAny: Any? = {
             if let object = any as? [String: Any] {
                 guard let id = JSONRPC.Message.Inspector.requestID(from: object) else { return nil }
-                return [
-                    "jsonrpc": "2.0",
-                    "id": id.value.foundationObject,
-                    "error": overloadError,
-                ]
+                return JSONRPC.Wire.errorResponseObject(id: id, error: overloadError)
             }
             if let array = any as? [Any] {
                 let objects = array.compactMap { item -> [String: Any]? in
@@ -740,11 +716,7 @@ extension RuntimeCoordinator {
                     else {
                         return nil
                     }
-                    return [
-                        "jsonrpc": "2.0",
-                        "id": id.value.foundationObject,
-                        "error": overloadError,
-                    ]
+                    return JSONRPC.Wire.errorResponseObject(id: id, error: overloadError)
                 }
                 if objects.isEmpty {
                     return nil
@@ -755,8 +727,7 @@ extension RuntimeCoordinator {
         }()
 
         guard let responseAny,
-            JSONSerialization.isValidJSONObject(responseAny),
-            let data = try? JSONSerialization.data(withJSONObject: responseAny, options: [])
+            let data = try? JSONRPC.Wire.data(from: responseAny)
         else {
             return
         }
@@ -842,9 +813,7 @@ extension RuntimeCoordinator {
     }
 
     private func serverInitiatedPayload(from object: [String: Any]) -> ServerInitiatedPayload? {
-        guard JSONSerialization.isValidJSONObject(object),
-            let encoded = try? JSONSerialization.data(withJSONObject: object, options: [])
-        else {
+        guard let encoded = try? JSONRPC.Wire.data(from: object) else {
             return nil
         }
         let kind = JSONRPC.Message.Inspector.kind(of: object)
@@ -894,9 +863,7 @@ extension RuntimeCoordinator {
             return
         }
         let payload: Any = items.count == 1 ? items[0] : items
-        guard JSONSerialization.isValidJSONObject(payload),
-            let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
-        else {
+        guard let data = try? JSONRPC.Wire.data(from: payload) else {
             return
         }
         routeUnmappedUpstreamMessage(data, upstreamIndex: upstreamIndex)

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -1321,15 +1321,7 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         id: JSONRPC.ID,
         result: JSONValue
     ) throws -> ByteBuffer {
-        let response: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": id.value.foundationObject,
-            "result": result.foundationObject,
-        ]
-        guard JSONSerialization.isValidJSONObject(response) else {
-            throw TimeoutError()
-        }
-        let data = try JSONSerialization.data(withJSONObject: response, options: [])
+        let data = try JSONRPC.Wire.resultResponseData(id: id, result: result)
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
         buffer.writeBytes(data)
         return buffer
@@ -1340,18 +1332,11 @@ package final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         error: Error
     ) throws -> ByteBuffer {
         let mapped = ControlPlane.ErrorMapper.jsonRPCError(for: error)
-        let response: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": id.value.foundationObject,
-            "error": [
-                "code": mapped.code,
-                "message": mapped.message,
-            ],
-        ]
-        guard JSONSerialization.isValidJSONObject(response) else {
-            throw TimeoutError()
-        }
-        let data = try JSONSerialization.data(withJSONObject: response, options: [])
+        let data = try JSONRPC.Wire.errorResponseData(
+            id: id,
+            code: mapped.code,
+            message: mapped.message
+        )
         var buffer = ByteBufferAllocator().buffer(capacity: data.count)
         buffer.writeBytes(data)
         return buffer

--- a/Sources/ProxySession/Runtime/RuntimeDocumentationProviderTransport.swift
+++ b/Sources/ProxySession/Runtime/RuntimeDocumentationProviderTransport.swift
@@ -226,16 +226,11 @@ package final class RuntimeDocumentationProviderTransport: DocumentationProvider
     }
 
     private static func responseIsProxyUpstreamFailure(_ data: Data) -> Bool {
-        guard let object = try? JSONSerialization.jsonObject(with: data, options: [])
-            as? [String: Any],
-            let error = object["error"] as? [String: Any],
-            let code = (error["code"] as? NSNumber)?.intValue,
-            let message = error["message"] as? String
-        else {
+        guard let error = JSONRPC.Wire.errorPayload(fromResponseData: data) else {
             return false
         }
-        return (code == -32001 && message == "upstream unavailable")
-            || (code == -32002 && message == "upstream overloaded")
+        return (error.code == -32001 && error.message == "upstream unavailable")
+            || (error.code == -32002 && error.message == "upstream overloaded")
     }
 }
 
@@ -293,11 +288,10 @@ extension RuntimeCoordinator {
                 route: .pinnedUpstream(upstreamIndex),
                 purpose: "documentation-tools",
                 label: "tools/list:DocumentationProvider",
-                requestObject: [
-                    "jsonrpc": "2.0",
-                    "id": "__documentation-tools-\(UUID().uuidString)",
-                    "method": "tools/list",
-                ],
+                requestObject: JSONRPC.Wire.requestObject(
+                    id: "__documentation-tools-\(UUID().uuidString)",
+                    method: "tools/list"
+                ),
                 requestTimeout: requestTimeout,
                 rpcHandle: rpcHandle
             )
@@ -322,7 +316,10 @@ extension RuntimeCoordinator {
         else {
             throw ControlPlane.Error.invalidResponse("missing DocumentationSearch request id")
         }
-        requestObject["id"] = "__documentation-search-\(UUID().uuidString)"
+        requestObject = JSONRPC.Wire.objectByReplacingID(
+            in: requestObject,
+            with: JSONRPC.ID(any: "__documentation-search-\(UUID().uuidString)")!
+        )
         let rpcHandle = ControlPlane.RPCHandle()
         do {
             let response = try await performControlPlaneRPC(

--- a/Sources/XcodeMCPKit/MCPJSONValue.swift
+++ b/Sources/XcodeMCPKit/MCPJSONValue.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProxyMCP
 
 /// A JSON value used by MCP requests, responses, and dynamic metadata.
 ///
@@ -122,61 +123,55 @@ extension MCPJSONValue: ExpressibleByDictionaryLiteral {
 }
 
 extension MCPJSONValue {
-    package init?(foundationObject value: Any) {
+    package init(_ value: JSONValue) {
         switch value {
-        case is NSNull:
+        case .object(let values):
+            self = .object(values.mapValues(MCPJSONValue.init))
+        case .array(let values):
+            self = .array(values.map(MCPJSONValue.init))
+        case .string(let value):
+            self = .string(value)
+        case .number(let value):
+            switch value {
+            case .int(let value):
+                self = .integer(value)
+            case .double(let value):
+                self = .double(value)
+            }
+        case .bool(let value):
+            self = .bool(value)
+        case .null:
             self = .null
-        case let string as String:
-            self = .string(string)
-        case let number as NSNumber:
-            if CFGetTypeID(number) == CFBooleanGetTypeID() {
-                self = .bool(number.boolValue)
-            } else if CFNumberIsFloatType(number) {
-                self = .double(number.doubleValue)
-            } else {
-                self = .integer(number.int64Value)
-            }
-        case let array as [Any]:
-            var values: [MCPJSONValue] = []
-            values.reserveCapacity(array.count)
-            for item in array {
-                guard let value = MCPJSONValue(foundationObject: item) else {
-                    return nil
-                }
-                values.append(value)
-            }
-            self = .array(values)
-        case let object as [String: Any]:
-            var values: [String: MCPJSONValue] = [:]
-            values.reserveCapacity(object.count)
-            for (key, item) in object {
-                guard let value = MCPJSONValue(foundationObject: item) else {
-                    return nil
-                }
-                values[key] = value
-            }
-            self = .object(values)
-        default:
-            return nil
         }
     }
 
+    package init?(foundationObject value: Any) {
+        guard let value = JSONValue(any: value) else {
+            return nil
+        }
+        self.init(value)
+    }
+
     package var foundationObject: Any {
+        jsonValue.foundationObject
+    }
+
+    package var jsonValue: JSONValue {
         switch self {
         case .object(let value):
-            return value.mapValues(\.foundationObject)
+            return .object(value.mapValues(\.jsonValue))
         case .array(let value):
-            return value.map(\.foundationObject)
+            return .array(value.map(\.jsonValue))
         case .string(let value):
-            return value
+            return .string(value)
         case .integer(let value):
-            return NSNumber(value: value)
+            return .number(.int(value))
         case .double(let value):
-            return NSNumber(value: value)
+            return .number(.double(value))
         case .bool(let value):
-            return NSNumber(value: value)
+            return .bool(value)
         case .null:
-            return NSNull()
+            return .null
         }
     }
 

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProxyMCP
 import ProxyMCPContract
 import ProxySessionUpstream
 
@@ -315,9 +316,9 @@ extension XcodeMCP {
 
         let requestID = nextRequestID
         nextRequestID += 1
-        let idValue = MCPJSONValue.integer(requestID)
-        let idKey = String(requestID)
-        let payload = try makeJSONRPCPayload(id: idValue, method: method, params: params)
+        let id = JSONRPC.ID(any: NSNumber(value: requestID))!
+        let idKey = id.key
+        let payload = try makeJSONRPCPayload(id: id, method: method, params: params)
 
         return try await withRequestTimeout(method: method) { [self] in
             try await withTaskCancellationHandler {
@@ -443,53 +444,44 @@ private extension XcodeMCP {
     }
 
     func respondToUnsupportedServerRequest(id: MCPJSONValue, method _: String) async throws {
-        let payload = try makeJSONRPCResponse(
-            id: id,
-            error: .object([
-                "code": .integer(-32601),
-                "message": .string("Unsupported server request"),
-            ])
+        let payload = try JSONRPC.Wire.errorResponseData(
+            idValue: id.jsonValue,
+            code: -32601,
+            message: "Unsupported server request"
         )
         try await transport.send(payload)
     }
 
     func makeJSONRPCPayload(
-        id: MCPJSONValue?,
+        id: JSONRPC.ID?,
         method: String,
         params: MCPJSONValue?
     ) throws -> Data {
-        var object: [String: MCPJSONValue] = [
-            "jsonrpc": .string("2.0"),
-            "method": .string(method),
-        ]
+        let object: [String: Any]
         if let id {
-            object["id"] = id
-        }
-        if let params {
-            object["params"] = params
-        }
-        return try JSONSerialization.data(withJSONObject: MCPJSONValue.object(object).foundationObject)
-    }
-
-    func makeJSONRPCResponse(
-        id: MCPJSONValue,
-        result: MCPJSONValue? = nil,
-        error: MCPJSONValue? = nil
-    ) throws -> Data {
-        var object: [String: MCPJSONValue] = [
-            "jsonrpc": .string("2.0"),
-            "id": id,
-        ]
-        if let error {
-            object["error"] = error
+            object = JSONRPC.Wire.requestObject(
+                id: id,
+                method: method,
+                params: params?.jsonValue
+            )
         } else {
-            object["result"] = result ?? .null
+            object = JSONRPC.Wire.notificationObject(
+                method: method,
+                params: params?.jsonValue
+            )
         }
-        return try JSONSerialization.data(withJSONObject: MCPJSONValue.object(object).foundationObject)
+        return try JSONRPC.Wire.data(from: object)
     }
 
     func parseJSONObject(_ data: Data) throws -> [String: MCPJSONValue] {
-        let raw = try JSONSerialization.jsonObject(with: data)
+        let raw: [String: Any]
+        do {
+            raw = try JSONRPC.Wire.object(fromData: data)
+        } catch JSONRPC.Wire.DecodingFailure.messageWasNotObject {
+            throw XcodeMCPError.invalidResponse("JSON-RPC message is not an object")
+        } catch {
+            throw error
+        }
         guard let value = MCPJSONValue(foundationObject: raw),
               let object = value.objectValue
         else {

--- a/Tests/ProxyContractTests/InternalProxyContractTests.swift
+++ b/Tests/ProxyContractTests/InternalProxyContractTests.swift
@@ -175,4 +175,86 @@ struct InternalProxyContractTests {
         #expect(error["message"] as? String == "upstream unavailable")
         #expect(data["reason"] as? String == "disabled")
     }
+
+    @Test func jsonRPCWireRequestAndResponseBuildersRemainStable() throws {
+        let requestData = try JSONRPC.Wire.data(
+            from: JSONRPC.Wire.requestObject(
+                id: "request-1",
+                method: "tools/call",
+                params: .object([
+                    "name": .string("DocumentationSearch"),
+                    "arguments": .object([
+                        "query": .string("SwiftUI"),
+                        "limit": .number(.int(2)),
+                        "exact": .bool(true),
+                    ]),
+                ])
+            )
+        )
+        let request = try #require(
+            JSONSerialization.jsonObject(with: requestData) as? [String: Any]
+        )
+        let params = try #require(request["params"] as? [String: Any])
+        let arguments = try #require(params["arguments"] as? [String: Any])
+
+        #expect(request["jsonrpc"] as? String == "2.0")
+        #expect(request["id"] as? String == "request-1")
+        #expect(request["method"] as? String == "tools/call")
+        #expect(arguments["query"] as? String == "SwiftUI")
+        #expect((arguments["limit"] as? NSNumber)?.intValue == 2)
+        #expect(arguments["exact"] as? Bool == true)
+
+        let resultData = try JSONRPC.Wire.resultResponseData(
+            id: try #require(JSONRPC.ID(any: NSNumber(value: 42))),
+            result: .object(["ok": .bool(true)])
+        )
+        let resultObject = try #require(
+            JSONSerialization.jsonObject(with: resultData) as? [String: Any]
+        )
+        let result = try #require(resultObject["result"] as? [String: Any])
+
+        #expect(resultObject["jsonrpc"] as? String == "2.0")
+        #expect((resultObject["id"] as? NSNumber)?.intValue == 42)
+        #expect(result["ok"] as? Bool == true)
+    }
+
+    @Test func jsonRPCWireBatchErrorsAndResponseParsingRemainStable() throws {
+        let stringID = try #require(JSONRPC.ID(any: "a"))
+        let numberID = try #require(JSONRPC.ID(any: NSNumber(value: 7)))
+        let batchData = try #require(
+            try JSONRPC.Wire.errorResponseData(
+                ids: [stringID, numberID],
+                code: -32002,
+                message: "upstream overloaded",
+                forceBatchArray: true,
+                includeNullIDWhenEmpty: false
+            )
+        )
+        let batch = try #require(
+            JSONSerialization.jsonObject(with: batchData) as? [[String: Any]]
+        )
+        let firstError = try #require(batch[0]["error"] as? [String: Any])
+        let secondError = try #require(batch[1]["error"] as? [String: Any])
+
+        #expect(batch.count == 2)
+        #expect(batch[0]["jsonrpc"] as? String == "2.0")
+        #expect(batch[0]["id"] as? String == "a")
+        #expect((firstError["code"] as? NSNumber)?.intValue == -32002)
+        #expect(firstError["message"] as? String == "upstream overloaded")
+        #expect((batch[1]["id"] as? NSNumber)?.intValue == 7)
+        #expect((secondError["code"] as? NSNumber)?.intValue == -32002)
+
+        let rewrittenData = try JSONRPC.Wire.dataByReplacingID(
+            in: batch[0],
+            with: numberID
+        )
+        let rewritten = try #require(
+            JSONSerialization.jsonObject(with: rewrittenData) as? [String: Any]
+        )
+        let parsedError = try #require(JSONRPC.Wire.errorPayload(inResponseObject: rewritten))
+
+        #expect((rewritten["id"] as? NSNumber)?.intValue == 7)
+        #expect(parsedError.code == -32002)
+        #expect(parsedError.message == "upstream overloaded")
+    }
 }


### PR DESCRIPTION
## Summary
- Hide `ProxyConfig` and `CLIParser` behind package access so low-level proxy configuration no longer appears as external API surface.
- Add `ProxyMCP.JSONRPC.Wire` as the package-level owner for JSON-RPC request/notification/response/error encoding and common response parsing.
- Route HTTP gateway, runtime/session, documentation provider, and `XcodeMCPKit` envelope construction through the shared wire helper while preserving public `MCPJSONValue`.
- Add contract coverage for JSON-RPC request, response, batch error, parsing, and ID rewrite shapes.

## Validation
- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter 'ProxyContractTests|XcodeMCPKitTests|PublicProductContractTests' -Xswiftc -strict-concurrency=minimal`
- `swift test --filter 'ProxyHTTPGatewayTests|ProxySessionTests' -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `swift test -Xswiftc -strict-concurrency=minimal`
- codex-review against `origin/codex/refactor-layered-runtime-integration`: clean, 0 findings

## Notes
- Supersedes #95 by applying the JSON-RPC wire cleanup on top of the #96 API/target-boundary structure.
- Production sleeps were reviewed. Remaining sleeps are request timeout, shutdown grace, readiness/approval polling, or live clock implementations; normal tests still avoid direct sleep/wait polling.