### PR TITLE
Harden release asset verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    outputs:
+      archive_sha256: ${{ steps.release_digests.outputs.archive_sha256 }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -112,6 +114,13 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --release-dir release
 
+      - name: Record trusted release digest
+        id: release_digests
+        run: |
+          set -euo pipefail
+          archive_sha256="$(shasum -a 256 release/xcode-mcp-proxy-darwin-arm64.tar.gz | awk '{ print $1 }')"
+          echo "archive_sha256=${archive_sha256}" >> "$GITHUB_OUTPUT"
+
       - name: Upload release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -195,7 +204,8 @@ jobs:
           scripts/verify-release-assets.sh \
             --version "${RELEASE_VERSION}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --release-dir release
+            --release-dir release \
+            --archive-sha256 "${{ needs.build-release.outputs.archive_sha256 }}"
 
       - name: Create draft release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,49 +107,10 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.version }}
         run: |
-          set -euo pipefail
-
-          expected_assets=(
-            "xcode-mcp-proxy-darwin-arm64.tar.gz"
-            "SHA256SUMS.txt"
-            "install.sh"
-          )
-
-          for asset in "${expected_assets[@]}"; do
-            if [[ ! -f "release/${asset}" ]]; then
-              echo "Expected release asset was not created: ${asset}" >&2
-              exit 1
-            fi
-          done
-
-          (
-            cd release
-            shasum -a 256 -c SHA256SUMS.txt
-          )
-
-          sh -n release/install.sh
-          scripts/render-install-script.sh \
+          scripts/verify-release-assets.sh \
             --version "${RELEASE_VERSION}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --output release/install.expected.sh
-          if ! cmp -s release/install.expected.sh release/install.sh; then
-            echo "install.sh does not match the generated installer for ${RELEASE_VERSION}." >&2
-            diff -u release/install.expected.sh release/install.sh || true
-            exit 1
-          fi
-          rm release/install.expected.sh
-
-          expected_entries="$(printf '%s\n' \
-            "bin/" \
-            "bin/xcode-mcp-proxy" \
-            "bin/xcode-mcp-proxy-server")"
-          actual_entries="$(tar -tzf release/xcode-mcp-proxy-darwin-arm64.tar.gz | sort)"
-          if [[ "${actual_entries}" != "${expected_entries}" ]]; then
-            echo "Release archive contents are not expected." >&2
-            printf 'Expected:\n%s\n' "${expected_entries}" >&2
-            printf 'Actual:\n%s\n' "${actual_entries}" >&2
-            exit 1
-          fi
+            --release-dir release
 
       - name: Upload release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -226,6 +187,15 @@ jobs:
             fi
             echo "Existing draft release will be repaired: ${RELEASE_VERSION}"
           fi
+
+      - name: Verify downloaded release assets
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          scripts/verify-release-assets.sh \
+            --version "${RELEASE_VERSION}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --release-dir release
 
       - name: Create draft release
         env:

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verify-release-assets.sh --version <tag> --repo <owner/repo> [--release-dir <dir>]
+EOF
+}
+
+version=""
+release_repo=""
+release_dir="release"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      release_repo="${2:-}"
+      shift 2
+      ;;
+    --release-dir)
+      release_dir="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$version" || -z "$release_repo" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ ! "$version" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must look like v1.2.3." >&2
+  exit 1
+fi
+
+if [[ ! "$release_repo" =~ ^[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+$ ]]; then
+  echo "Release repo must look like owner/repo." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "$release_dir" = /* ]]; then
+  release_base="$release_dir"
+else
+  release_base="$repo_root/$release_dir"
+fi
+
+if [[ ! -d "$release_base" ]]; then
+  echo "Missing release directory: $release_base" >&2
+  exit 1
+fi
+
+expected_assets=(
+  "xcode-mcp-proxy-darwin-arm64.tar.gz"
+  "SHA256SUMS.txt"
+  "install.sh"
+)
+
+for asset in "${expected_assets[@]}"; do
+  if [[ ! -f "$release_base/$asset" ]]; then
+    echo "Expected release asset was not created: $asset" >&2
+    exit 1
+  fi
+done
+
+expected_asset_list="$(printf '%s\n' "${expected_assets[@]}" | sort)"
+actual_asset_list="$(
+  cd "$release_base"
+  for path in *; do
+    [[ -f "$path" ]] && printf '%s\n' "$path"
+  done | sort
+)"
+if [[ "$actual_asset_list" != "$expected_asset_list" ]]; then
+  echo "Release asset set is not expected." >&2
+  printf 'Expected:\n%s\n' "$expected_asset_list" >&2
+  printf 'Actual:\n%s\n' "$actual_asset_list" >&2
+  exit 1
+fi
+
+(
+  cd "$release_base"
+  shasum -a 256 -c SHA256SUMS.txt
+)
+
+sh -n "$release_base/install.sh"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+"$repo_root/scripts/render-install-script.sh" \
+  --version "$version" \
+  --repo "$release_repo" \
+  --output "$tmp_dir/install.expected.sh"
+if ! cmp -s "$tmp_dir/install.expected.sh" "$release_base/install.sh"; then
+  echo "install.sh does not match the generated installer for $version." >&2
+  diff -u "$tmp_dir/install.expected.sh" "$release_base/install.sh" || true
+  exit 1
+fi
+
+expected_entries="$(printf '%s\n' \
+  "bin/" \
+  "bin/xcode-mcp-proxy" \
+  "bin/xcode-mcp-proxy-server")"
+actual_entries="$(tar -tzf "$release_base/xcode-mcp-proxy-darwin-arm64.tar.gz" | sort)"
+if [[ "$actual_entries" != "$expected_entries" ]]; then
+  echo "Release archive contents are not expected." >&2
+  printf 'Expected:\n%s\n' "$expected_entries" >&2
+  printf 'Actual:\n%s\n' "$actual_entries" >&2
+  exit 1
+fi

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -3,13 +3,14 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/verify-release-assets.sh --version <tag> --repo <owner/repo> [--release-dir <dir>]
+Usage: scripts/verify-release-assets.sh --version <tag> --repo <owner/repo> [--release-dir <dir>] [--archive-sha256 <sha256>]
 EOF
 }
 
 version=""
 release_repo=""
 release_dir="release"
+archive_sha256=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -23,6 +24,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --release-dir)
       release_dir="${2:-}"
+      shift 2
+      ;;
+    --archive-sha256)
+      archive_sha256="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -52,6 +57,11 @@ if [[ ! "$release_repo" =~ ^[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+$ ]]; then
   exit 1
 fi
 
+if [[ -n "$archive_sha256" && ! "$archive_sha256" =~ ^[0-9A-Fa-f]{64}$ ]]; then
+  echo "Archive SHA256 must be a 64-character hex digest." >&2
+  exit 1
+fi
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if [[ "$release_dir" = /* ]]; then
   release_base="$release_dir"
@@ -64,10 +74,13 @@ if [[ ! -d "$release_base" ]]; then
   exit 1
 fi
 
+archive_asset="xcode-mcp-proxy-darwin-arm64.tar.gz"
+checksum_asset="SHA256SUMS.txt"
+installer_asset="install.sh"
 expected_assets=(
-  "xcode-mcp-proxy-darwin-arm64.tar.gz"
-  "SHA256SUMS.txt"
-  "install.sh"
+  "$archive_asset"
+  "$checksum_asset"
+  "$installer_asset"
 )
 
 for asset in "${expected_assets[@]}"; do
@@ -91,22 +104,45 @@ if [[ "$actual_asset_list" != "$expected_asset_list" ]]; then
   exit 1
 fi
 
-(
-  cd "$release_base"
-  shasum -a 256 -c SHA256SUMS.txt
-)
-
-sh -n "$release_base/install.sh"
-
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
+
+expected_checksums="$tmp_dir/SHA256SUMS.expected"
+(
+  cd "$release_base"
+  shasum -a 256 "$archive_asset" "$installer_asset" > "$expected_checksums"
+)
+if ! cmp -s "$expected_checksums" "$release_base/$checksum_asset"; then
+  echo "SHA256SUMS.txt does not match the expected release assets." >&2
+  diff -u "$expected_checksums" "$release_base/$checksum_asset" || true
+  exit 1
+fi
+
+(
+  cd "$release_base"
+  shasum -a 256 -c "$checksum_asset"
+)
+
+if [[ -n "$archive_sha256" ]]; then
+  actual_archive_sha256="$(shasum -a 256 "$release_base/$archive_asset" | awk '{ print $1 }')"
+  expected_archive_sha256="$(printf '%s' "$archive_sha256" | tr 'A-F' 'a-f')"
+  if [[ "$actual_archive_sha256" != "$expected_archive_sha256" ]]; then
+    echo "Archive SHA256 does not match the trusted build output." >&2
+    echo "Expected: $expected_archive_sha256" >&2
+    echo "Actual:   $actual_archive_sha256" >&2
+    exit 1
+  fi
+fi
+
+sh -n "$release_base/$installer_asset"
+
 "$repo_root/scripts/render-install-script.sh" \
   --version "$version" \
   --repo "$release_repo" \
   --output "$tmp_dir/install.expected.sh"
-if ! cmp -s "$tmp_dir/install.expected.sh" "$release_base/install.sh"; then
+if ! cmp -s "$tmp_dir/install.expected.sh" "$release_base/$installer_asset"; then
   echo "install.sh does not match the generated installer for $version." >&2
-  diff -u "$tmp_dir/install.expected.sh" "$release_base/install.sh" || true
+  diff -u "$tmp_dir/install.expected.sh" "$release_base/$installer_asset" || true
   exit 1
 fi
 
@@ -114,7 +150,7 @@ expected_entries="$(printf '%s\n' \
   "bin/" \
   "bin/xcode-mcp-proxy" \
   "bin/xcode-mcp-proxy-server")"
-actual_entries="$(tar -tzf "$release_base/xcode-mcp-proxy-darwin-arm64.tar.gz" | sort)"
+actual_entries="$(tar -tzf "$release_base/$archive_asset" | sort)"
 if [[ "$actual_entries" != "$expected_entries" ]]; then
   echo "Release archive contents are not expected." >&2
   printf 'Expected:\n%s\n' "$expected_entries" >&2


### PR DESCRIPTION
## Purpose

Harden the release workflow against artifact-boundary tampering before publishing draft release assets.

## Changes

- Move release asset validation into `scripts/verify-release-assets.sh` so the checks are reusable.
- Re-run release asset validation after `actions/download-artifact` in the write-permission release job, immediately before draft release creation or repair.
- Require `SHA256SUMS.txt` to exactly match regenerated checksums for `xcode-mcp-proxy-darwin-arm64.tar.gz` and `install.sh`.
- Carry the build-produced archive SHA256 as a job output and verify the downloaded archive against that trusted digest before release publication.
- Keep validation for expected asset names, installer contents, shell syntax, and tar archive entries.

## Testing

- `bash -n scripts/verify-release-assets.sh scripts/render-install-script.sh scripts/package-release.sh scripts/build-release.sh scripts/check.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`
- Created temporary release assets and ran `scripts/verify-release-assets.sh --version v0.0.0 --repo lynnswap/XcodeMCPKit --release-dir <tmp>/release --archive-sha256 <sha>`
- Verified the release verifier rejects a truncated `SHA256SUMS.txt` missing `install.sh`
- Verified the release verifier rejects a tarball replaced with same-path contents when checked against the build-produced trusted digest
- Branch-wide `codex-review` found no issues against `main`

Note: the existing PR CI run was cancelled during package tests and was intentionally ignored for this PR-fix pass per maintainer direction.
