### PR TITLE
Add Streamable HTTP client transport to XcodeMCPKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [日本語](README.ja.md)
 
 XcodeMCPKit is a Swift library and local proxy for Xcode MCP. Apps can use the
-Swift API to operate a local `mcpbridge` process directly, while MCP clients can
-use the proxy for one stable endpoint and automated approval flow.
+Swift API to operate a local `mcpbridge` process directly or connect to a proxy
+Streamable HTTP endpoint, while MCP clients can use the proxy for one stable
+endpoint and automated approval flow.
 
 ## Requirements
 
@@ -60,9 +61,9 @@ source ~/.zshrc
 
 ## Use From Swift
 
-Add the `XcodeMCPKit` library product to your Swift package or Xcode target, then
-create a top-level client. The async initializer launches local `mcpbridge`,
-performs the MCP initialize handshake, and returns a ready client.
+Add the `XcodeMCPKit` library product to your Swift package or Xcode target,
+then create a top-level client. The default async initializer launches local
+`mcpbridge`, performs the MCP initialize handshake, and returns a ready client.
 
 ```swift
 import XcodeMCPKit
@@ -76,9 +77,37 @@ let result = try await xcode.callTool(
 await xcode.close()
 ```
 
+To connect through a running proxy server instead, select Streamable HTTP
+transport:
+
+```swift
+import XcodeMCPKit
+
+let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
+let xcode = try await XcodeMCP(
+    config: .init(transport: .streamableHTTP(endpoint: endpoint))
+)
+
+let tools = try await xcode.listTools()
+await xcode.close()
+```
+
+If the proxy was started with discovery enabled, you can read its discovery file:
+
+```swift
+let xcode = try await XcodeMCP(
+    config: .init(
+        transport: .streamableHTTP(
+            discoveryFile: URL(fileURLWithPath: "/tmp/xcode-mcp/endpoint.json")
+        )
+    )
+)
+```
+
 The public API exposes MCP domain values such as `MCPJSONValue`, `MCPTool`,
 `MCPToolResult`, `MCPContent`, and `MCPProgress`. Process launch, JSON-RPC
-framing, and session transport are internal implementation details.
+framing, HTTP session headers, SSE parsing, and session transport are internal
+implementation details.
 
 ## Set Up Your MCP Client
 

--- a/Sources/XcodeMCPKit/MCPJSONValue.swift
+++ b/Sources/XcodeMCPKit/MCPJSONValue.swift
@@ -123,6 +123,61 @@ extension MCPJSONValue: ExpressibleByDictionaryLiteral {
 }
 
 extension MCPJSONValue {
+    /// Returns the object dictionary when this value is a JSON object.
+    public var objectValue: [String: MCPJSONValue]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+
+    /// Returns the array elements when this value is a JSON array.
+    public var arrayValue: [MCPJSONValue]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+
+    /// Returns the Swift string when this value is a JSON string.
+    public var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    /// Returns the Swift boolean when this value is a JSON boolean.
+    public var boolValue: Bool? {
+        guard case .bool(let value) = self else { return nil }
+        return value
+    }
+
+    /// Returns the integer when this value is an integer JSON number.
+    public var integerValue: Int64? {
+        guard case .integer(let value) = self else { return nil }
+        return value
+    }
+
+    /// Returns the integer when this value is an integer JSON number.
+    public var intValue: Int64? {
+        integerValue
+    }
+
+    /// Returns the numeric value as a `Double` when this value is any JSON
+    /// number.
+    public var doubleValue: Double? {
+        switch self {
+        case .integer(let value):
+            return Double(value)
+        case .double(let value):
+            return value
+        case .object, .array, .string, .bool, .null:
+            return nil
+        }
+    }
+
+    /// Whether this value is JSON null.
+    public var isNull: Bool {
+        self == .null
+    }
+}
+
+extension MCPJSONValue {
     package init(_ value: JSONValue) {
         switch value {
         case .object(let values):
@@ -175,29 +230,4 @@ extension MCPJSONValue {
         }
     }
 
-    package var objectValue: [String: MCPJSONValue]? {
-        guard case .object(let value) = self else { return nil }
-        return value
-    }
-
-    package var arrayValue: [MCPJSONValue]? {
-        guard case .array(let value) = self else { return nil }
-        return value
-    }
-
-    package var stringValue: String? {
-        guard case .string(let value) = self else { return nil }
-        return value
-    }
-
-    package var doubleValue: Double? {
-        switch self {
-        case .integer(let value):
-            return Double(value)
-        case .double(let value):
-            return value
-        case .object, .array, .string, .bool, .null:
-            return nil
-        }
-    }
 }

--- a/Sources/XcodeMCPKit/README.md
+++ b/Sources/XcodeMCPKit/README.md
@@ -4,9 +4,11 @@ Swift client API for talking to Xcode's local MCP bridge from an app or tool.
 
 ## Status
 
-`XcodeMCPKit` is the public client-side library target. It launches the
-configured `mcpbridge` process, performs the MCP initialize handshake, and
-exposes the dynamic Xcode MCP tool catalog through a small Swift API.
+`XcodeMCPKit` is the public client-side library target. It connects to the
+configured MCP transport, performs the MCP initialize handshake, and exposes the
+dynamic Xcode MCP tool catalog through a small Swift API. The default transport
+launches `xcrun mcpbridge`; clients can also connect to a proxy Streamable HTTP
+endpoint.
 
 This target owns:
 
@@ -27,7 +29,7 @@ Add the `XcodeMCPKit` product to your target, then construct a client:
 import XcodeMCPKit
 
 let config = XcodeMCP.Configuration(
-    bridge: .defaultMCPBridge,
+    transport: .localBridge(.defaultMCPBridge),
     clientName: "MyApp",
     clientVersion: "1.0"
 )
@@ -55,6 +57,30 @@ if tools.contains(where: { $0.name == "DocumentationSearch" }) {
 await xcode.close()
 ```
 
+To use a running `xcode-mcp-proxy-server`, configure Streamable HTTP:
+
+```swift
+let config = XcodeMCP.Configuration(
+    transport: .streamableHTTP(
+        endpoint: URL(string: "http://127.0.0.1:8765/mcp")!
+    ),
+    clientName: "MyApp",
+    clientVersion: "1.0"
+)
+
+let xcode = try await XcodeMCP(config: config)
+```
+
+Discovery files written by the proxy are supported as well:
+
+```swift
+let config = XcodeMCP.Configuration(
+    transport: .streamableHTTP(
+        discoveryFile: URL(fileURLWithPath: "/tmp/xcode-mcp/endpoint.json")
+    )
+)
+```
+
 ## Dynamic Tools And Raw Values
 
 The Xcode MCP server decides which tools are available at runtime. Call
@@ -63,26 +89,32 @@ selected tool name to `callTool(_:arguments:onProgress:)`.
 
 Arguments and dynamic response fields use `MCPJSONValue` so clients can send and
 inspect MCP data that this package does not model as a fixed Swift type. Domain
-models keep raw values for unknown fields and future MCP extensions.
+models keep raw values for unknown fields and future MCP extensions. Use public
+accessors such as `objectValue`, `arrayValue`, `stringValue`, `boolValue`,
+`integerValue`, `doubleValue`, and `isNull` when inspecting dynamic responses.
 
 ## Configuration
 
-`XcodeMCP.Configuration` controls bridge selection and MCP initialization:
+`XcodeMCP.Configuration` controls transport selection and MCP initialization:
 
-- `bridge` chooses the upstream bridge. The default is Xcode's
-  `/usr/bin/xcrun mcpbridge`.
-- Use `.custom(command:arguments:environment:)` only when embedding a non-default
-  bridge command.
+- `transport` chooses `.localBridge(...)`, `.streamableHTTP(endpoint:)`, or
+  `.streamableHTTP(discoveryFile:)`.
+- The compatibility `bridge` property still chooses the upstream bridge for
+  local process transport. The default is Xcode's `/usr/bin/xcrun mcpbridge`.
+- Use bridge `.custom(command:arguments:environment:)` only when embedding a
+  non-default bridge command.
 - `clientName`, `clientVersion`, and `capabilities` are sent in `initialize`.
 - `requestTimeout` bounds requests when non-`nil`.
 
 Capabilities that require server-to-client handlers are filtered because this
-v1 API does not expose those handlers.
+v1 API does not expose those handlers. For Streamable HTTP, the transport owns
+`MCP-Session-Id`, `MCP-Protocol-Version`, POST response parsing, long-lived SSE
+GET parsing, and best-effort session DELETE during `close()`.
 
 ## Lifecycle
 
-Create one `XcodeMCP` per bridge session. The async initializer starts the
-process and completes initialization before returning. `callTool` returns the
+Create one `XcodeMCP` per MCP session. The async initializer connects the
+transport and completes initialization before returning. `callTool` returns the
 final MCP result; progress is callback-only and the underlying event stream is
 not public API. Call `close()` when finished. Closing is idempotent and rejects
 future requests.

--- a/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
@@ -12,15 +12,26 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
 
     private let endpoint: URL
     private let urlSession: URLSession
+    private let requestTimeout: Duration?
     private let streamContinuation: AsyncStream<XcodeMCPTransportEvent>.Continuation
     private let state = StreamableHTTPTransportState()
 
-    package static func start(endpoint: URL) async throws -> StreamableHTTPXcodeMCPTransport {
+    package static func start(
+        endpoint: URL,
+        requestTimeout: Duration?
+    ) async throws -> StreamableHTTPXcodeMCPTransport {
         try validateEndpoint(endpoint)
-        return StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: .shared)
+        return StreamableHTTPXcodeMCPTransport(
+            endpoint: endpoint,
+            urlSession: .shared,
+            requestTimeout: requestTimeout
+        )
     }
 
-    package static func start(discoveryFile: URL) async throws -> StreamableHTTPXcodeMCPTransport {
+    package static func start(
+        discoveryFile: URL,
+        requestTimeout: Duration?
+    ) async throws -> StreamableHTTPXcodeMCPTransport {
         guard let record = Discovery.read(overrideURL: discoveryFile),
               let endpoint = URL(string: record.url)
         else {
@@ -28,13 +39,18 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
                 "Streamable HTTP discovery file is missing, stale, or invalid: \(discoveryFile.path)"
             )
         }
-        return try await start(endpoint: endpoint)
+        return try await start(endpoint: endpoint, requestTimeout: requestTimeout)
     }
 
-    package init(endpoint: URL, urlSession: URLSession) {
+    package init(
+        endpoint: URL,
+        urlSession: URLSession,
+        requestTimeout: Duration? = nil
+    ) {
         let stream = AsyncStream<XcodeMCPTransportEvent>.makeStream()
         self.endpoint = endpoint
         self.urlSession = urlSession
+        self.requestTimeout = requestTimeout
         self.events = stream.stream
         self.streamContinuation = stream.continuation
     }
@@ -99,6 +115,7 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
     private func makePostRequest(body: Data) async -> URLRequest {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
+        request.timeoutInterval = Self.urlTimeoutInterval(for: requestTimeout)
         request.httpBody = body
         request.setValue(Self.postAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -325,6 +342,16 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
         default:
             return false
         }
+    }
+
+    private static func urlTimeoutInterval(for duration: Duration?) -> TimeInterval {
+        guard let duration else {
+            return .infinity
+        }
+        let components = duration.components
+        let seconds = Double(max(0, components.seconds))
+        let fractional = Double(max(0, components.attoseconds)) / 1_000_000_000_000_000_000
+        return seconds + fractional
     }
 
     private static func jsonObject(from data: Data) -> [String: MCPJSONValue]? {

--- a/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
@@ -190,6 +190,9 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
                         throw XcodeMCPError.transportUnavailable("Streamable HTTP event stream response was not HTTP")
                     }
                     guard (200..<300).contains(httpResponse.statusCode) else {
+                        if Self.isTerminalEventStreamStatus(httpResponse.statusCode) {
+                            return
+                        }
                         let bodyData = (try? await Self.collect(bytes)) ?? Data()
                         let body = String(data: bodyData, encoding: .utf8) ?? ""
                         let suffix = body.isEmpty ? "" : ": \(body)"
@@ -198,9 +201,7 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
                         )
                     }
                     guard Self.isEventStream(httpResponse) else {
-                        throw XcodeMCPError.transportUnavailable(
-                            "Streamable HTTP event stream response was not text/event-stream"
-                        )
+                        return
                     }
                     try await Self.consumeEventStream(
                         bytes,
@@ -314,6 +315,15 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
             return .seconds(1)
         default:
             return .seconds(5)
+        }
+    }
+
+    private static func isTerminalEventStreamStatus(_ statusCode: Int) -> Bool {
+        switch statusCode {
+        case 404, 405, 406, 410, 501:
+            return true
+        default:
+            return false
         }
     }
 

--- a/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
@@ -103,9 +103,12 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
         request.setValue(Self.postAcceptHeader, forHTTPHeaderField: "Accept")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        if let session = await state.sessionHeaders() {
-            request.setValue(session.sessionID, forHTTPHeaderField: Self.sessionHeader)
-            request.setValue(session.protocolVersion, forHTTPHeaderField: Self.protocolVersionHeader)
+        let session = await state.sessionHeaders()
+        if let protocolVersion = session.protocolVersion {
+            request.setValue(protocolVersion, forHTTPHeaderField: Self.protocolVersionHeader)
+        }
+        if let sessionID = session.sessionID {
+            request.setValue(sessionID, forHTTPHeaderField: Self.sessionHeader)
         }
         return request
     }
@@ -149,49 +152,56 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
                 "initialize response is missing protocolVersion"
             )
         }
-        let sessionID = try await state.completeInitialize(protocolVersion: protocolVersion)
-        await startEventStream(sessionID: sessionID, protocolVersion: protocolVersion)
+        let sessionID = await state.completeInitialize(protocolVersion: protocolVersion)
+        if let sessionID {
+            await startEventStream(sessionID: sessionID, protocolVersion: protocolVersion)
+        }
     }
 
     private func startEventStream(sessionID: String, protocolVersion: String) async {
         let task = Task { [endpoint, urlSession, streamContinuation, state] in
-            let request = Self.makeEventStreamRequest(
-                endpoint: endpoint,
-                sessionID: sessionID,
-                protocolVersion: protocolVersion
-            )
-            do {
-                let (bytes, response) = try await urlSession.bytes(for: request)
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    throw XcodeMCPError.transportUnavailable("Streamable HTTP event stream response was not HTTP")
+            var attempt = 0
+            while await state.isOpen {
+                if attempt > 0 {
+                    do {
+                        try await Task.sleep(for: Self.eventStreamReconnectDelay(attempt: attempt))
+                    } catch {
+                        return
+                    }
                 }
-                guard (200..<300).contains(httpResponse.statusCode) else {
-                    let bodyData = (try? await Self.collect(bytes)) ?? Data()
-                    let body = String(data: bodyData, encoding: .utf8) ?? ""
-                    let suffix = body.isEmpty ? "" : ": \(body)"
-                    throw XcodeMCPError.transportUnavailable(
-                        "Streamable HTTP event stream failed with status \(httpResponse.statusCode)\(suffix)"
+
+                do {
+                    let request = Self.makeEventStreamRequest(
+                        endpoint: endpoint,
+                        sessionID: sessionID,
+                        protocolVersion: protocolVersion
                     )
-                }
-                guard Self.isEventStream(httpResponse) else {
-                    throw XcodeMCPError.transportUnavailable(
-                        "Streamable HTTP event stream response was not text/event-stream"
+                    let (bytes, response) = try await urlSession.bytes(for: request)
+                    guard let httpResponse = response as? HTTPURLResponse else {
+                        throw XcodeMCPError.transportUnavailable("Streamable HTTP event stream response was not HTTP")
+                    }
+                    guard (200..<300).contains(httpResponse.statusCode) else {
+                        let bodyData = (try? await Self.collect(bytes)) ?? Data()
+                        let body = String(data: bodyData, encoding: .utf8) ?? ""
+                        let suffix = body.isEmpty ? "" : ": \(body)"
+                        throw XcodeMCPError.transportUnavailable(
+                            "Streamable HTTP event stream failed with status \(httpResponse.statusCode)\(suffix)"
+                        )
+                    }
+                    guard Self.isEventStream(httpResponse) else {
+                        throw XcodeMCPError.transportUnavailable(
+                            "Streamable HTTP event stream response was not text/event-stream"
+                        )
+                    }
+                    try await Self.consumeEventStream(
+                        bytes,
+                        streamContinuation: streamContinuation
                     )
-                }
-                try await Self.consumeEventStream(
-                    bytes,
-                    streamContinuation: streamContinuation
-                )
-                if await state.isOpen {
-                    streamContinuation.yield(.closed("Streamable HTTP event stream closed"))
-                    streamContinuation.finish()
-                }
-            } catch is CancellationError {
-                return
-            } catch {
-                if await state.isOpen {
-                    streamContinuation.yield(.closed(String(describing: error)))
-                    streamContinuation.finish()
+                    attempt += 1
+                } catch is CancellationError {
+                    return
+                } catch {
+                    attempt += 1
                 }
             }
         }
@@ -287,6 +297,17 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
             .contains(eventStreamContentType) == true
     }
 
+    private static func eventStreamReconnectDelay(attempt: Int) -> Duration {
+        switch attempt {
+        case ..<2:
+            return .milliseconds(100)
+        case 2..<5:
+            return .seconds(1)
+        default:
+            return .seconds(5)
+        }
+    }
+
     private static func initializeProtocolVersion(from data: Data) -> String? {
         guard let raw = try? JSONSerialization.jsonObject(with: data),
               let value = MCPJSONValue(foundationObject: raw),
@@ -317,23 +338,15 @@ private actor StreamableHTTPTransportState {
         }
     }
 
-    func sessionHeaders() -> (sessionID: String, protocolVersion: String)? {
-        guard let sessionID, let protocolVersion else {
-            return nil
-        }
-        return (sessionID, protocolVersion)
+    func sessionHeaders() -> (sessionID: String?, protocolVersion: String?) {
+        (sessionID, protocolVersion)
     }
 
     func setSessionID(_ sessionID: String) {
         self.sessionID = sessionID
     }
 
-    func completeInitialize(protocolVersion: String) throws -> String {
-        guard let sessionID, sessionID.isEmpty == false else {
-            throw XcodeMCPError.invalidResponse(
-                "initialize response is missing MCP-Session-Id"
-            )
-        }
+    func completeInitialize(protocolVersion: String) -> String? {
         self.protocolVersion = protocolVersion
         return sessionID
     }

--- a/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
@@ -1,0 +1,391 @@
+import Foundation
+import ProxyCore
+import ProxyMCP
+
+package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @unchecked Sendable {
+    package nonisolated let events: AsyncStream<XcodeMCPTransportEvent>
+
+    private static let sessionHeader = "MCP-Session-Id"
+    private static let protocolVersionHeader = "MCP-Protocol-Version"
+    private static let postAcceptHeader = "application/json, text/event-stream"
+    private static let eventStreamContentType = "text/event-stream"
+
+    private let endpoint: URL
+    private let urlSession: URLSession
+    private let streamContinuation: AsyncStream<XcodeMCPTransportEvent>.Continuation
+    private let state = StreamableHTTPTransportState()
+
+    package static func start(endpoint: URL) async throws -> StreamableHTTPXcodeMCPTransport {
+        try validateEndpoint(endpoint)
+        return StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: .shared)
+    }
+
+    package static func start(discoveryFile: URL) async throws -> StreamableHTTPXcodeMCPTransport {
+        guard let record = Discovery.read(overrideURL: discoveryFile),
+              let endpoint = URL(string: record.url)
+        else {
+            throw XcodeMCPError.invalidRequest(
+                "Streamable HTTP discovery file is missing, stale, or invalid: \(discoveryFile.path)"
+            )
+        }
+        return try await start(endpoint: endpoint)
+    }
+
+    package init(endpoint: URL, urlSession: URLSession) {
+        let stream = AsyncStream<XcodeMCPTransportEvent>.makeStream()
+        self.endpoint = endpoint
+        self.urlSession = urlSession
+        self.events = stream.stream
+        self.streamContinuation = stream.continuation
+    }
+
+    package func send(_ data: Data) async throws {
+        try await state.ensureOpen()
+        let requestInfo = try OutgoingHTTPRequestInfo(data: data)
+        let request = await makePostRequest(body: data)
+        let (responseBytes, response) = try await urlSession.bytes(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw XcodeMCPError.transportUnavailable("Streamable HTTP response was not HTTP")
+        }
+
+        try await validateSuccess(httpResponse, body: responseBytes)
+        await recordSessionHeader(from: httpResponse, requestInfo: requestInfo)
+
+        if Self.isEventStream(httpResponse) {
+            try await consumeEventStream(responseBytes, requestInfo: requestInfo)
+        } else {
+            let responseData = try await Self.collect(responseBytes)
+            guard responseData.isEmpty == false else {
+                return
+            }
+            try await recordInitializeResponseIfNeeded(responseData, requestInfo: requestInfo)
+            streamContinuation.yield(.message(responseData))
+        }
+    }
+
+    package func close() async {
+        let closeState = await state.close()
+        closeState.eventStreamTask?.cancel()
+
+        guard let sessionID = closeState.sessionID else {
+            streamContinuation.yield(.closed(nil))
+            streamContinuation.finish()
+            return
+        }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "DELETE"
+        request.timeoutInterval = 5
+        request.setValue(sessionID, forHTTPHeaderField: Self.sessionHeader)
+        if let protocolVersion = closeState.protocolVersion {
+            request.setValue(protocolVersion, forHTTPHeaderField: Self.protocolVersionHeader)
+        }
+        _ = try? await urlSession.data(for: request)
+
+        streamContinuation.yield(.closed(nil))
+        streamContinuation.finish()
+    }
+
+    private static func validateEndpoint(_ endpoint: URL) throws {
+        guard let scheme = endpoint.scheme?.lowercased(),
+              scheme == "http" || scheme == "https"
+        else {
+            throw XcodeMCPError.invalidRequest(
+                "Streamable HTTP endpoint must use http or https: \(endpoint.absoluteString)"
+            )
+        }
+    }
+
+    private func makePostRequest(body: Data) async -> URLRequest {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.setValue(Self.postAcceptHeader, forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let session = await state.sessionHeaders() {
+            request.setValue(session.sessionID, forHTTPHeaderField: Self.sessionHeader)
+            request.setValue(session.protocolVersion, forHTTPHeaderField: Self.protocolVersionHeader)
+        }
+        return request
+    }
+
+    private func validateSuccess(
+        _ response: HTTPURLResponse,
+        body responseBytes: URLSession.AsyncBytes
+    ) async throws {
+        guard (200..<300).contains(response.statusCode) else {
+            let responseData = (try? await Self.collect(responseBytes)) ?? Data()
+            let body = String(data: responseData, encoding: .utf8) ?? ""
+            let suffix = body.isEmpty ? "" : ": \(body)"
+            throw XcodeMCPError.transportUnavailable(
+                "Streamable HTTP request failed with status \(response.statusCode)\(suffix)"
+            )
+        }
+    }
+
+    private func recordSessionHeader(
+        from response: HTTPURLResponse,
+        requestInfo: OutgoingHTTPRequestInfo
+    ) async {
+        guard requestInfo.method == "initialize",
+              let sessionID = response.value(forHTTPHeaderField: Self.sessionHeader),
+              sessionID.isEmpty == false
+        else {
+            return
+        }
+        await state.setSessionID(sessionID)
+    }
+
+    private func recordInitializeResponseIfNeeded(
+        _ data: Data,
+        requestInfo: OutgoingHTTPRequestInfo
+    ) async throws {
+        guard requestInfo.method == "initialize" else {
+            return
+        }
+        guard let protocolVersion = Self.initializeProtocolVersion(from: data) else {
+            throw XcodeMCPError.invalidResponse(
+                "initialize response is missing protocolVersion"
+            )
+        }
+        let sessionID = try await state.completeInitialize(protocolVersion: protocolVersion)
+        await startEventStream(sessionID: sessionID, protocolVersion: protocolVersion)
+    }
+
+    private func startEventStream(sessionID: String, protocolVersion: String) async {
+        let task = Task { [endpoint, urlSession, streamContinuation, state] in
+            let request = Self.makeEventStreamRequest(
+                endpoint: endpoint,
+                sessionID: sessionID,
+                protocolVersion: protocolVersion
+            )
+            do {
+                let (bytes, response) = try await urlSession.bytes(for: request)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw XcodeMCPError.transportUnavailable("Streamable HTTP event stream response was not HTTP")
+                }
+                guard (200..<300).contains(httpResponse.statusCode) else {
+                    let bodyData = (try? await Self.collect(bytes)) ?? Data()
+                    let body = String(data: bodyData, encoding: .utf8) ?? ""
+                    let suffix = body.isEmpty ? "" : ": \(body)"
+                    throw XcodeMCPError.transportUnavailable(
+                        "Streamable HTTP event stream failed with status \(httpResponse.statusCode)\(suffix)"
+                    )
+                }
+                guard Self.isEventStream(httpResponse) else {
+                    throw XcodeMCPError.transportUnavailable(
+                        "Streamable HTTP event stream response was not text/event-stream"
+                    )
+                }
+                try await Self.consumeEventStream(
+                    bytes,
+                    streamContinuation: streamContinuation
+                )
+                if await state.isOpen {
+                    streamContinuation.yield(.closed("Streamable HTTP event stream closed"))
+                    streamContinuation.finish()
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                if await state.isOpen {
+                    streamContinuation.yield(.closed(String(describing: error)))
+                    streamContinuation.finish()
+                }
+            }
+        }
+        await state.setEventStreamTask(task)
+    }
+
+    private func consumeEventStream(
+        _ bytes: URLSession.AsyncBytes,
+        requestInfo: OutgoingHTTPRequestInfo
+    ) async throws {
+        var decoder = SSEDecoder()
+        var lineBuffer = Data()
+        for try await byte in bytes {
+            guard byte == 0x0A else {
+                lineBuffer.append(byte)
+                continue
+            }
+            let line = String(data: lineBuffer, encoding: .utf8) ?? ""
+            lineBuffer.removeAll(keepingCapacity: true)
+            guard let data = decoder.feed(line: line) else {
+                continue
+            }
+            try await recordInitializeResponseIfNeeded(data, requestInfo: requestInfo)
+            streamContinuation.yield(.message(data))
+        }
+        if lineBuffer.isEmpty == false {
+            let line = String(data: lineBuffer, encoding: .utf8) ?? ""
+            if let data = decoder.feed(line: line) {
+                try await recordInitializeResponseIfNeeded(data, requestInfo: requestInfo)
+                streamContinuation.yield(.message(data))
+            }
+        }
+        if let data = decoder.flushIfNeeded() {
+            try await recordInitializeResponseIfNeeded(data, requestInfo: requestInfo)
+            streamContinuation.yield(.message(data))
+        }
+    }
+
+    private static func makeEventStreamRequest(
+        endpoint: URL,
+        sessionID: String,
+        protocolVersion: String
+    ) -> URLRequest {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.setValue(eventStreamContentType, forHTTPHeaderField: "Accept")
+        request.setValue(sessionID, forHTTPHeaderField: sessionHeader)
+        request.setValue(protocolVersion, forHTTPHeaderField: protocolVersionHeader)
+        return request
+    }
+
+    private static func consumeEventStream(
+        _ bytes: URLSession.AsyncBytes,
+        streamContinuation: AsyncStream<XcodeMCPTransportEvent>.Continuation
+    ) async throws {
+        var decoder = SSEDecoder()
+        var lineBuffer = Data()
+        for try await byte in bytes {
+            guard byte == 0x0A else {
+                lineBuffer.append(byte)
+                continue
+            }
+            let line = String(data: lineBuffer, encoding: .utf8) ?? ""
+            lineBuffer.removeAll(keepingCapacity: true)
+            if let data = decoder.feed(line: line) {
+                streamContinuation.yield(.message(data))
+            }
+        }
+        if lineBuffer.isEmpty == false {
+            let line = String(data: lineBuffer, encoding: .utf8) ?? ""
+            if let data = decoder.feed(line: line) {
+                streamContinuation.yield(.message(data))
+            }
+        }
+        if let data = decoder.flushIfNeeded() {
+            streamContinuation.yield(.message(data))
+        }
+    }
+
+    private static func collect(_ bytes: URLSession.AsyncBytes) async throws -> Data {
+        var data = Data()
+        for try await byte in bytes {
+            data.append(byte)
+        }
+        return data
+    }
+
+    private static func isEventStream(_ response: HTTPURLResponse) -> Bool {
+        response
+            .value(forHTTPHeaderField: "Content-Type")?
+            .lowercased()
+            .contains(eventStreamContentType) == true
+    }
+
+    private static func initializeProtocolVersion(from data: Data) -> String? {
+        guard let raw = try? JSONSerialization.jsonObject(with: data),
+              let value = MCPJSONValue(foundationObject: raw),
+              let object = value.objectValue,
+              let result = object["result"]?.objectValue,
+              let protocolVersion = result["protocolVersion"]?.stringValue,
+              protocolVersion.isEmpty == false
+        else {
+            return nil
+        }
+        return protocolVersion
+    }
+}
+
+private actor StreamableHTTPTransportState {
+    private var closed = false
+    private var sessionID: String?
+    private var protocolVersion: String?
+    private var eventStreamTask: Task<Void, Never>?
+
+    var isOpen: Bool {
+        closed == false
+    }
+
+    func ensureOpen() throws {
+        if closed {
+            throw XcodeMCPError.closed
+        }
+    }
+
+    func sessionHeaders() -> (sessionID: String, protocolVersion: String)? {
+        guard let sessionID, let protocolVersion else {
+            return nil
+        }
+        return (sessionID, protocolVersion)
+    }
+
+    func setSessionID(_ sessionID: String) {
+        self.sessionID = sessionID
+    }
+
+    func completeInitialize(protocolVersion: String) throws -> String {
+        guard let sessionID, sessionID.isEmpty == false else {
+            throw XcodeMCPError.invalidResponse(
+                "initialize response is missing MCP-Session-Id"
+            )
+        }
+        self.protocolVersion = protocolVersion
+        return sessionID
+    }
+
+    func setEventStreamTask(_ task: Task<Void, Never>) {
+        if closed {
+            task.cancel()
+            return
+        }
+        if eventStreamTask == nil {
+            eventStreamTask = task
+        } else {
+            task.cancel()
+        }
+    }
+
+    func close() -> CloseState {
+        guard closed == false else {
+            return CloseState(
+                sessionID: nil,
+                protocolVersion: nil,
+                eventStreamTask: nil
+            )
+        }
+        closed = true
+        let closeState = CloseState(
+            sessionID: sessionID,
+            protocolVersion: protocolVersion,
+            eventStreamTask: eventStreamTask
+        )
+        eventStreamTask = nil
+        return closeState
+    }
+
+    struct CloseState: Sendable {
+        var sessionID: String?
+        var protocolVersion: String?
+        var eventStreamTask: Task<Void, Never>?
+    }
+}
+
+private struct OutgoingHTTPRequestInfo: Sendable {
+    var id: MCPJSONValue?
+    var method: String?
+
+    init(data: Data) throws {
+        let raw = try JSONSerialization.jsonObject(with: data)
+        guard let value = MCPJSONValue(foundationObject: raw),
+              let object = value.objectValue
+        else {
+            throw XcodeMCPError.invalidRequest("JSON-RPC message is not an object")
+        }
+        self.id = object["id"]
+        self.method = object["method"]?.stringValue
+    }
+}

--- a/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
@@ -147,7 +147,16 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
         guard requestInfo.method == "initialize" else {
             return
         }
-        guard let protocolVersion = Self.initializeProtocolVersion(from: data) else {
+        guard let requestIDKey = Self.jsonRPCIDKey(requestInfo.id),
+              let object = Self.jsonObject(from: data),
+              Self.jsonRPCIDKey(object["id"]) == requestIDKey
+        else {
+            return
+        }
+        if object["error"] != nil {
+            return
+        }
+        guard let protocolVersion = Self.initializeProtocolVersion(from: object) else {
             throw XcodeMCPError.invalidResponse(
                 "initialize response is missing protocolVersion"
             )
@@ -308,17 +317,37 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
         }
     }
 
-    private static func initializeProtocolVersion(from data: Data) -> String? {
+    private static func jsonObject(from data: Data) -> [String: MCPJSONValue]? {
         guard let raw = try? JSONSerialization.jsonObject(with: data),
               let value = MCPJSONValue(foundationObject: raw),
-              let object = value.objectValue,
-              let result = object["result"]?.objectValue,
+              let object = value.objectValue
+        else {
+            return nil
+        }
+        return object
+    }
+
+    private static func initializeProtocolVersion(from object: [String: MCPJSONValue]) -> String? {
+        guard let result = object["result"]?.objectValue,
               let protocolVersion = result["protocolVersion"]?.stringValue,
               protocolVersion.isEmpty == false
         else {
             return nil
         }
         return protocolVersion
+    }
+
+    private static func jsonRPCIDKey(_ value: MCPJSONValue?) -> String? {
+        switch value {
+        case .string(let value):
+            return value
+        case .integer(let value):
+            return String(value)
+        case .double(let value):
+            return String(value)
+        case .object, .array, .bool, .null, .none:
+            return nil
+        }
     }
 }
 

--- a/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/StreamableHTTPXcodeMCPTransport.swift
@@ -237,6 +237,7 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
     ) -> URLRequest {
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
+        request.timeoutInterval = .infinity
         request.setValue(eventStreamContentType, forHTTPHeaderField: "Accept")
         request.setValue(sessionID, forHTTPHeaderField: sessionHeader)
         request.setValue(protocolVersion, forHTTPHeaderField: protocolVersionHeader)

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -288,9 +288,15 @@ public actor XcodeMCP {
                 )
             )
         case .streamableHTTP(let endpoint):
-            transport = try await StreamableHTTPXcodeMCPTransport.start(endpoint: endpoint)
+            transport = try await StreamableHTTPXcodeMCPTransport.start(
+                endpoint: endpoint,
+                requestTimeout: config.requestTimeout
+            )
         case .streamableHTTPDiscoveryFile(let discoveryFile):
-            transport = try await StreamableHTTPXcodeMCPTransport.start(discoveryFile: discoveryFile)
+            transport = try await StreamableHTTPXcodeMCPTransport.start(
+                discoveryFile: discoveryFile,
+                requestTimeout: config.requestTimeout
+            )
         }
         try await self.init(config: config, transport: transport)
     }

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -45,11 +45,13 @@ private final class XcodeMCPPendingRequests: @unchecked Sendable {
     }
 }
 
-/// A high-level client for the local Xcode MCP bridge.
+/// A high-level client for Xcode MCP.
 ///
-/// `XcodeMCP` starts an `mcpbridge` process, performs the MCP initialize
-/// handshake, and exposes the dynamic Xcode tool catalog through
-/// ``listTools()`` and ``callTool(_:arguments:onProgress:)``.
+/// `XcodeMCP` connects through the configured transport, performs the MCP
+/// initialize handshake, and exposes the dynamic Xcode tool catalog through
+/// ``listTools()`` and ``callTool(_:arguments:onProgress:)``. The default
+/// transport starts a local `mcpbridge` process. Streamable HTTP transport can
+/// connect to a running proxy endpoint.
 ///
 /// The tool catalog is discovered at runtime. This package intentionally does
 /// not promise tool-specific Swift methods or typed request/response models for
@@ -79,11 +81,35 @@ private final class XcodeMCPPendingRequests: @unchecked Sendable {
 /// await xcode.close()
 /// ```
 public actor XcodeMCP {
-    /// Settings used to launch and initialize the local MCP bridge.
+    /// Settings used to connect to and initialize an MCP endpoint.
     ///
     /// The default configuration starts `xcrun mcpbridge` with the current
-    /// process environment and a conservative per-request timeout.
+    /// process environment and a conservative per-request timeout. Use
+    /// ``Transport/streamableHTTP(endpoint:)`` to connect to a proxy
+    /// Streamable HTTP endpoint instead.
     public struct Configuration: Equatable, Sendable {
+        /// Transport used to reach the Xcode MCP server.
+        public enum Transport: Equatable, Sendable {
+            /// Launch and talk to a local bridge process over stdio.
+            case localBridge(Bridge)
+
+            /// Connect to a concrete Streamable HTTP MCP endpoint.
+            case streamableHTTP(endpoint: URL)
+
+            /// Connect to the Streamable HTTP endpoint recorded in a proxy
+            /// discovery file.
+            case streamableHTTPDiscoveryFile(URL)
+
+            /// Connect to the Streamable HTTP endpoint recorded in a proxy
+            /// discovery file.
+            ///
+            /// The discovery file uses the same shape written by
+            /// `xcode-mcp-proxy-server startAndWriteDiscovery()`.
+            public static func streamableHTTP(discoveryFile: URL) -> Self {
+                .streamableHTTPDiscoveryFile(discoveryFile)
+            }
+        }
+
         /// Upstream bridge process policy.
         public enum Bridge: Equatable, Sendable {
             /// Use Xcode's default `xcrun mcpbridge` invocation.
@@ -128,8 +154,25 @@ public actor XcodeMCP {
             }
         }
 
+        /// Transport used to reach the Xcode MCP server.
+        public var transport: Transport
+
         /// Bridge process policy.
-        public var bridge: Bridge
+        ///
+        /// This compatibility property reads and writes the local bridge used
+        /// by ``Transport/localBridge(_:)``. Setting it switches the
+        /// configuration back to local process transport.
+        public var bridge: Bridge {
+            get {
+                guard case .localBridge(let bridge) = transport else {
+                    return .defaultMCPBridge
+                }
+                return bridge
+            }
+            set {
+                transport = .localBridge(newValue)
+            }
+        }
 
         /// Client name sent in the MCP `initialize` request.
         public var clientName: String
@@ -149,7 +192,7 @@ public actor XcodeMCP {
         /// Set this to `nil` to disable client-side request timeouts.
         public var requestTimeout: Duration?
 
-        /// Creates a bridge configuration.
+        /// Creates a local bridge configuration.
         ///
         /// - Parameters:
         ///   - bridge: Upstream bridge process policy.
@@ -167,7 +210,32 @@ public actor XcodeMCP {
             capabilities: [String: MCPJSONValue] = [:],
             requestTimeout: Duration? = .seconds(60)
         ) {
-            self.bridge = bridge
+            self.transport = .localBridge(bridge)
+            self.clientName = clientName
+            self.clientVersion = clientVersion
+            self.capabilities = capabilities
+            self.requestTimeout = requestTimeout
+        }
+
+        /// Creates a configuration for the selected transport.
+        ///
+        /// - Parameters:
+        ///   - transport: Transport used to reach the Xcode MCP server.
+        ///   - clientName: Client name sent in the MCP `initialize` request.
+        ///   - clientVersion: Client version sent in the MCP `initialize`
+        ///     request.
+        ///   - capabilities: Additional MCP client capabilities encoded as raw
+        ///     MCP JSON.
+        ///   - requestTimeout: Maximum duration to wait for each request, or
+        ///     `nil` to disable client-side request timeouts.
+        public init(
+            transport: Transport,
+            clientName: String = "XcodeMCPKit",
+            clientVersion: String = "dev",
+            capabilities: [String: MCPJSONValue] = [:],
+            requestTimeout: Duration? = .seconds(60)
+        ) {
+            self.transport = transport
             self.clientName = clientName
             self.clientVersion = clientVersion
             self.capabilities = capabilities
@@ -183,22 +251,33 @@ public actor XcodeMCP {
     private var eventTask: Task<Void, Never>?
     private var progressHandlers: [String: @Sendable (MCPProgress) async -> Void] = [:]
 
-    /// Starts the local MCP bridge and returns an initialized client.
+    /// Connects to the configured MCP transport and returns an initialized
+    /// client.
     ///
-    /// The initializer launches the configured process, sends MCP
-    /// `initialize`, then sends `notifications/initialized`. If initialization
-    /// fails, the process is closed before the error is rethrown.
+    /// For local bridge transport the initializer launches the configured
+    /// process. For Streamable HTTP transport it connects to the configured
+    /// endpoint. In both cases it sends MCP `initialize`, then sends
+    /// `notifications/initialized`. If initialization fails, the transport is
+    /// closed before the error is rethrown.
     ///
-    /// - Parameter config: Launch and initialization settings for the bridge.
+    /// - Parameter config: Connection and initialization settings.
     public init(config: Configuration = Configuration()) async throws {
-        let transport = try await UpstreamProcessXcodeMCPTransport.start(
-            config: UpstreamProcess.Config(
-                command: config.bridge.command,
-                args: config.bridge.arguments,
-                environment: config.bridge.environment,
-                maxQueuedWriteBytes: config.bridge.maxQueuedWriteBytes
+        let transport: any XcodeMCPTransport
+        switch config.transport {
+        case .localBridge(let bridge):
+            transport = try await UpstreamProcessXcodeMCPTransport.start(
+                config: UpstreamProcess.Config(
+                    command: bridge.command,
+                    args: bridge.arguments,
+                    environment: bridge.environment,
+                    maxQueuedWriteBytes: bridge.maxQueuedWriteBytes
+                )
             )
-        )
+        case .streamableHTTP(let endpoint):
+            transport = try await StreamableHTTPXcodeMCPTransport.start(endpoint: endpoint)
+        case .streamableHTTPDiscoveryFile(let discoveryFile):
+            transport = try await StreamableHTTPXcodeMCPTransport.start(discoveryFile: discoveryFile)
+        }
         try await self.init(config: config, transport: transport)
     }
 

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -5,6 +5,7 @@ import ProxyMCPContract
 private final class XcodeMCPPendingRequests: @unchecked Sendable {
     private struct PendingRequest {
         let continuation: CheckedContinuation<MCPJSONValue, Error>
+        var sendTask: Task<Void, Never>?
     }
 
     private let lock = NSLock()
@@ -19,10 +20,17 @@ private final class XcodeMCPPendingRequests: @unchecked Sendable {
         }
     }
 
+    func setSendTask(idKey: String, task: Task<Void, Never>) {
+        lock.withLock {
+            requests[idKey]?.sendTask = task
+        }
+    }
+
     func complete(idKey: String, result: MCPJSONValue) {
         let request = lock.withLock {
             requests.removeValue(forKey: idKey)
         }
+        request?.sendTask?.cancel()
         request?.continuation.resume(returning: result)
     }
 
@@ -30,6 +38,7 @@ private final class XcodeMCPPendingRequests: @unchecked Sendable {
         let request = lock.withLock {
             requests.removeValue(forKey: idKey)
         }
+        request?.sendTask?.cancel()
         request?.continuation.resume(throwing: error)
     }
 
@@ -40,6 +49,7 @@ private final class XcodeMCPPendingRequests: @unchecked Sendable {
             return current
         }
         for request in pending.values {
+            request.sendTask?.cancel()
             request.continuation.resume(throwing: error)
         }
     }
@@ -402,13 +412,14 @@ extension XcodeMCP {
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { continuation in
                     self.pendingRequests.add(idKey: idKey, continuation: continuation)
-                    Task {
+                    let sendTask = Task {
                         do {
                             try await self.transport.send(payload)
                         } catch {
                             self.pendingRequests.fail(idKey: idKey, error: error)
                         }
                     }
+                    self.pendingRequests.setSendTask(idKey: idKey, task: sendTask)
                 }
             } onCancel: {
                 self.pendingRequests.fail(idKey: idKey, error: CancellationError())

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -20,9 +20,13 @@ private final class XcodeMCPPendingRequests: @unchecked Sendable {
         }
     }
 
-    func setSendTask(idKey: String, task: Task<Void, Never>) {
+    func setSendTask(idKey: String, task: Task<Void, Never>) -> Bool {
         lock.withLock {
+            guard requests[idKey] != nil else {
+                return false
+            }
             requests[idKey]?.sendTask = task
+            return true
         }
     }
 
@@ -419,7 +423,9 @@ extension XcodeMCP {
                             self.pendingRequests.fail(idKey: idKey, error: error)
                         }
                     }
-                    self.pendingRequests.setSendTask(idKey: idKey, task: sendTask)
+                    if self.pendingRequests.setSendTask(idKey: idKey, task: sendTask) == false {
+                        sendTask.cancel()
+                    }
                 }
             } onCancel: {
                 self.pendingRequests.fail(idKey: idKey, error: CancellationError())

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -177,6 +177,26 @@ func compileOnlyClientDomainSurface() {
         requestTimeout: .seconds(1)
     )
 
+    let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
+    let httpConfig = XcodeMCP.Configuration(
+        transport: .streamableHTTP(endpoint: endpoint),
+        clientName: "PublicHTTPContractClient",
+        clientVersion: "1.0",
+        requestTimeout: .seconds(1)
+    )
+    let discoveryConfig = XcodeMCP.Configuration(
+        transport: .streamableHTTP(discoveryFile: URL(fileURLWithPath: "/tmp/xcode-mcp/endpoint.json"))
+    )
+
+    let metadata = arguments["metadata"]?.objectValue
+    let tags = arguments["tags"]?.arrayValue?.compactMap(\\.stringValue)
+    let query = arguments["query"]?.stringValue
+    let includeBeta = arguments["includeBeta"]?.boolValue
+    let limit = arguments["limit"]?.intValue
+    let integerLimit = arguments["limit"]?.integerValue
+    let score = arguments["score"]?.doubleValue
+    let optionalIsNull = metadata?["optional"]?.isNull
+
     let tool = MCPTool(
         name: "DocumentationSearch",
         description: "Search Apple documentation",
@@ -240,7 +260,23 @@ func compileOnlyClientDomainSurface() {
         .transportUnavailable("mcpbridge closed"),
     ]
 
-    _ = (arguments, config, tool, result, progress, errors)
+    _ = (
+        arguments,
+        config,
+        httpConfig,
+        discoveryConfig,
+        tags,
+        query,
+        includeBeta,
+        limit,
+        integerLimit,
+        score,
+        optionalIsNull,
+        tool,
+        result,
+        progress,
+        errors
+    )
 }
 
 func compileOnlyClientLifecycleSurface(config: XcodeMCP.Configuration) async throws {

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -189,7 +189,7 @@ func compileOnlyClientDomainSurface() {
     )
 
     let metadata = arguments["metadata"]?.objectValue
-    let tags = arguments["tags"]?.arrayValue?.compactMap(\\.stringValue)
+    let tags = arguments["tags"]?.arrayValue?.compactMap { $0.stringValue }
     let query = arguments["query"]?.stringValue
     let includeBeta = arguments["includeBeta"]?.boolValue
     let limit = arguments["limit"]?.intValue

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -129,6 +129,33 @@ struct XcodeMCPTests {
         }
     }
 
+    @Test func cancelledRequestCancelsInFlightTransportSend() async throws {
+        let transport = HangingSendXcodeMCPTransport()
+        let xcode = try await XcodeMCP(
+            config: .init(requestTimeout: nil),
+            transport: transport
+        )
+
+        let listTask = Task {
+            try await xcode.listTools()
+        }
+        _ = try await waitWithTimeout("tools/list send did not start") {
+            try await transport.nextStarted(method: "tools/list")
+        }
+
+        listTask.cancel()
+        do {
+            _ = try await listTask.value
+            Issue.record("expected cancellation")
+        } catch is CancellationError {
+        }
+
+        _ = try await waitWithTimeout("tools/list send was not cancelled") {
+            try await transport.nextCancelled(method: "tools/list")
+        }
+        await xcode.close()
+    }
+
     @Test func unsupportedServerRequestGetsInternalErrorResponse() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(transport: transport)
@@ -423,6 +450,81 @@ struct XcodeMCPTests {
                 transport: transport
             )
         }
+    }
+}
+
+private actor HangingSendXcodeMCPTransport: XcodeMCPTransport {
+    nonisolated let events: AsyncStream<XcodeMCPTransportEvent>
+
+    private let continuation: AsyncStream<XcodeMCPTransportEvent>.Continuation
+    private let startedValues = RecordedValues<String>()
+    private let cancelledValues = RecordedValues<String>()
+
+    init() {
+        let stream = AsyncStream<XcodeMCPTransportEvent>.makeStream()
+        self.events = stream.stream
+        self.continuation = stream.continuation
+    }
+
+    func send(_ data: Data) async throws {
+        let object = try parse(data)
+        let method = object["method"]?.stringValue ?? ""
+        if method == "initialize" {
+            try yieldMessage([
+                "jsonrpc": .string("2.0"),
+                "id": object["id"] ?? .integer(1),
+                "result": .object([
+                    "protocolVersion": .string("2025-06-18"),
+                    "serverInfo": .object([
+                        "name": .string("hanging-transport"),
+                        "version": .string("test"),
+                    ]),
+                    "capabilities": .object([:]),
+                ]),
+            ])
+            return
+        }
+        if method == "notifications/initialized" {
+            return
+        }
+
+        await startedValues.append(method)
+        do {
+            try await Task.sleep(for: .seconds(3_600))
+        } catch {
+            await cancelledValues.append(method)
+            throw error
+        }
+    }
+
+    func close() async {
+        continuation.yield(.closed(nil))
+        continuation.finish()
+    }
+
+    func nextStarted(method: String) async throws -> String {
+        try await startedValues.nextValue { $0 == method }
+    }
+
+    func nextCancelled(method: String) async throws -> String {
+        try await cancelledValues.nextValue { $0 == method }
+    }
+
+    private func yieldMessage(_ object: [String: MCPJSONValue]) throws {
+        let data = try JSONSerialization.data(
+            withJSONObject: MCPJSONValue.object(object).foundationObject
+        )
+        continuation.yield(.message(data))
+    }
+
+    private func parse(_ data: Data) throws -> [String: MCPJSONValue] {
+        let raw = try JSONSerialization.jsonObject(with: data)
+        guard let value = MCPJSONValue(foundationObject: raw),
+              let object = value.objectValue
+        else {
+            throw XcodeMCPError.invalidRequest("message is not an object")
+        }
+        return object
     }
 }
 

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -249,6 +249,7 @@ struct XcodeMCPTests {
         #expect(list.header("MCP-Protocol-Version") == "2025-06-18")
 
         let get = try #require(requests.first(where: { $0.httpMethod == "GET" }))
+        #expect(get.timeoutInterval.isInfinite)
         #expect(get.header("Accept") == "text/event-stream")
         #expect(get.header("MCP-Session-Id") == "session-http-1")
         #expect(get.header("MCP-Protocol-Version") == "2025-06-18")
@@ -518,12 +519,14 @@ private struct RecordedHTTPRequest: Sendable, Equatable {
     var httpMethod: String
     var url: URL
     var headers: [String: String]
+    var timeoutInterval: TimeInterval
     var body: MCPJSONValue?
 
     init(request: URLRequest) {
         self.httpMethod = request.httpMethod ?? "GET"
         self.url = request.url ?? URL(string: "http://invalid.local/")!
         self.headers = request.allHTTPHeaderFields ?? [:]
+        self.timeoutInterval = request.timeoutInterval
         if let bodyData = Self.bodyData(from: request),
            let raw = try? JSONSerialization.jsonObject(with: bodyData),
            let value = MCPJSONValue(foundationObject: raw)

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -246,7 +246,11 @@ struct XcodeMCPTests {
             FakeStreamableHTTPURLProtocolRegistry.shared.reset()
         }
 
-        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let transport = StreamableHTTPXcodeMCPTransport(
+            endpoint: endpoint,
+            urlSession: session,
+            requestTimeout: .seconds(2)
+        )
         let xcode = try await XcodeMCP(
             config: .init(
                 transport: .streamableHTTP(endpoint: endpoint),
@@ -262,6 +266,7 @@ struct XcodeMCPTests {
         let requests = await server.recordedRequests()
         let initialize = try #require(requests.firstJSONRPC(method: "initialize"))
         #expect(initialize.httpMethod == "POST")
+        #expect(initialize.timeoutInterval == 2)
         #expect(initialize.header("Accept") == "application/json, text/event-stream")
         #expect(initialize.header("Content-Type") == "application/json")
         #expect(initialize.header("MCP-Session-Id") == nil)
@@ -272,6 +277,7 @@ struct XcodeMCPTests {
         #expect(initialized.header("MCP-Protocol-Version") == "2025-06-18")
 
         let list = try #require(requests.firstJSONRPC(method: "tools/list"))
+        #expect(list.timeoutInterval == 2)
         #expect(list.header("MCP-Session-Id") == "session-http-1")
         #expect(list.header("MCP-Protocol-Version") == "2025-06-18")
 
@@ -295,7 +301,11 @@ struct XcodeMCPTests {
             FakeStreamableHTTPURLProtocolRegistry.shared.reset()
         }
 
-        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let transport = StreamableHTTPXcodeMCPTransport(
+            endpoint: endpoint,
+            urlSession: session,
+            requestTimeout: .seconds(2)
+        )
         let xcode = try await XcodeMCP(
             config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
@@ -336,7 +346,11 @@ struct XcodeMCPTests {
             FakeStreamableHTTPURLProtocolRegistry.shared.reset()
         }
 
-        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let transport = StreamableHTTPXcodeMCPTransport(
+            endpoint: endpoint,
+            urlSession: session,
+            requestTimeout: .seconds(2)
+        )
         let xcode = try await XcodeMCP(
             config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
@@ -376,7 +390,11 @@ struct XcodeMCPTests {
             FakeStreamableHTTPURLProtocolRegistry.shared.reset()
         }
 
-        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let transport = StreamableHTTPXcodeMCPTransport(
+            endpoint: endpoint,
+            urlSession: session,
+            requestTimeout: .seconds(2)
+        )
         let xcode = try await XcodeMCP(
             config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
@@ -409,7 +427,11 @@ struct XcodeMCPTests {
             FakeStreamableHTTPURLProtocolRegistry.shared.reset()
         }
 
-        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let transport = StreamableHTTPXcodeMCPTransport(
+            endpoint: endpoint,
+            urlSession: session,
+            requestTimeout: .seconds(2)
+        )
         let xcode = try await XcodeMCP(
             config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
@@ -439,7 +461,11 @@ struct XcodeMCPTests {
             FakeStreamableHTTPURLProtocolRegistry.shared.reset()
         }
 
-        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let transport = StreamableHTTPXcodeMCPTransport(
+            endpoint: endpoint,
+            urlSession: session,
+            requestTimeout: .seconds(2)
+        )
         await #expect(throws: XcodeMCPError.serverError(
             code: -32000,
             message: "initialize rejected",

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -399,6 +399,31 @@ struct XcodeMCPTests {
         #expect(tools.first?.name == "DocumentationSearch")
         await xcode.close()
     }
+
+    @Test func streamableHTTPPreservesInitializeServerError() async throws {
+        let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
+        let server = FakeStreamableHTTPServer(
+            progressDelivery: .none,
+            initializeError: true
+        )
+        let session = makeFakeHTTPURLSession(server: server)
+        defer {
+            session.invalidateAndCancel()
+            FakeStreamableHTTPURLProtocolRegistry.shared.reset()
+        }
+
+        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        await #expect(throws: XcodeMCPError.serverError(
+            code: -32000,
+            message: "initialize rejected",
+            data: nil
+        )) {
+            _ = try await XcodeMCP(
+                config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                transport: transport
+            )
+        }
+    }
 }
 
 private struct SentMessage: Sendable, Equatable {
@@ -653,6 +678,7 @@ private actor FakeStreamableHTTPServer {
     private let progressDelivery: ProgressDelivery
     private let sessionID: String?
     private let eventStreamFinishesImmediately: Bool
+    private let initializeError: Bool
     private let requestValues = RecordedValues<RecordedHTTPRequest>()
     private var requests: [RecordedHTTPRequest] = []
     private var eventConnection: ActiveHTTPConnection?
@@ -660,11 +686,13 @@ private actor FakeStreamableHTTPServer {
     init(
         progressDelivery: ProgressDelivery,
         sessionID: String? = "session-http-1",
-        eventStreamFinishesImmediately: Bool = false
+        eventStreamFinishesImmediately: Bool = false,
+        initializeError: Bool = false
     ) {
         self.progressDelivery = progressDelivery
         self.sessionID = sessionID
         self.eventStreamFinishesImmediately = eventStreamFinishesImmediately
+        self.initializeError = initializeError
     }
 
     func response(
@@ -723,6 +751,19 @@ private actor FakeStreamableHTTPServer {
 
         switch method {
         case "initialize":
+            if initializeError {
+                return FakeURLProtocolResponse(
+                    headers: ["Content-Type": "application/json"],
+                    chunks: [jsonData([
+                        "jsonrpc": "2.0",
+                        "id": request.body?.objectValue?["id"] ?? .null,
+                        "error": [
+                            "code": -32000,
+                            "message": "initialize rejected",
+                        ],
+                    ])]
+                )
+            }
             let headers = sessionID.map { ["Mcp-Session-Id": $0] } ?? [:]
             return jsonResponse(
                 id: request.body?.objectValue?["id"],

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -209,6 +209,139 @@ struct XcodeMCPTests {
         #expect(encodedProgress["raw"] == nil)
         #expect(encodedProgress["x-progress"] == .string("kept"))
     }
+
+    @Test func streamableHTTPSendsSessionHeadersAndDeletesOnClose() async throws {
+        let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
+        let server = FakeStreamableHTTPServer(progressDelivery: .none)
+        let session = makeFakeHTTPURLSession(server: server)
+        defer {
+            session.invalidateAndCancel()
+            FakeStreamableHTTPURLProtocolRegistry.shared.reset()
+        }
+
+        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let xcode = try await XcodeMCP(
+            config: .init(
+                transport: .streamableHTTP(endpoint: endpoint),
+                clientName: "HTTPContractClient",
+                requestTimeout: .seconds(2)
+            ),
+            transport: transport
+        )
+
+        _ = try await xcode.listTools()
+        await xcode.close()
+
+        let requests = await server.recordedRequests()
+        let initialize = try #require(requests.firstJSONRPC(method: "initialize"))
+        #expect(initialize.httpMethod == "POST")
+        #expect(initialize.header("Accept") == "application/json, text/event-stream")
+        #expect(initialize.header("Content-Type") == "application/json")
+        #expect(initialize.header("MCP-Session-Id") == nil)
+        #expect(initialize.header("MCP-Protocol-Version") == nil)
+
+        let initialized = try #require(requests.firstJSONRPC(method: "notifications/initialized"))
+        #expect(initialized.header("MCP-Session-Id") == "session-http-1")
+        #expect(initialized.header("MCP-Protocol-Version") == "2025-06-18")
+
+        let list = try #require(requests.firstJSONRPC(method: "tools/list"))
+        #expect(list.header("MCP-Session-Id") == "session-http-1")
+        #expect(list.header("MCP-Protocol-Version") == "2025-06-18")
+
+        let get = try #require(requests.first(where: { $0.httpMethod == "GET" }))
+        #expect(get.header("Accept") == "text/event-stream")
+        #expect(get.header("MCP-Session-Id") == "session-http-1")
+        #expect(get.header("MCP-Protocol-Version") == "2025-06-18")
+
+        let delete = try #require(requests.first(where: { $0.httpMethod == "DELETE" }))
+        #expect(delete.header("MCP-Session-Id") == "session-http-1")
+        #expect(delete.header("MCP-Protocol-Version") == "2025-06-18")
+    }
+
+    @Test func streamableHTTPPostSSERoutesProgressAndFinalResult() async throws {
+        let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
+        let server = FakeStreamableHTTPServer(progressDelivery: .postSSE)
+        let session = makeFakeHTTPURLSession(server: server)
+        defer {
+            session.invalidateAndCancel()
+            FakeStreamableHTTPURLProtocolRegistry.shared.reset()
+        }
+
+        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let xcode = try await XcodeMCP(
+            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+            transport: transport
+        )
+        defer {
+            Task { await xcode.close() }
+        }
+
+        let progressValues = RecordedValues<MCPProgress>()
+        let result = try await xcode.callTool(
+            "DocumentationSearch",
+            arguments: ["query": .string("POST SSE")]
+        ) { progress in
+            await progressValues.append(progress)
+        }
+
+        let progress = try await waitWithTimeout("POST SSE progress was not delivered") {
+            try await progressValues.nextValue()
+        }
+        #expect(progress.message == "from POST SSE")
+        #expect(result.structuredContent?.objectValue?["source"] == .string("post-sse"))
+        guard case .text(let text, _) = try #require(result.content.first) else {
+            Issue.record("expected text content")
+            return
+        }
+        #expect(text == "Result for POST SSE")
+
+        let call = try #require(await server.recordedRequests().firstJSONRPC(method: "tools/call"))
+        #expect(call.header("Accept") == "application/json, text/event-stream")
+        #expect(call.header("MCP-Session-Id") == "session-http-1")
+        #expect(call.header("MCP-Protocol-Version") == "2025-06-18")
+    }
+
+    @Test func streamableHTTPGetSSERoutesProgressWhilePOSTReturnsJSONResult() async throws {
+        let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
+        let server = FakeStreamableHTTPServer(progressDelivery: .getSSE)
+        let session = makeFakeHTTPURLSession(server: server)
+        defer {
+            session.invalidateAndCancel()
+            FakeStreamableHTTPURLProtocolRegistry.shared.reset()
+        }
+
+        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let xcode = try await XcodeMCP(
+            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+            transport: transport
+        )
+        defer {
+            Task { await xcode.close() }
+        }
+
+        _ = try await waitWithTimeout("event stream GET was not opened") {
+            try await server.nextRequest { $0.httpMethod == "GET" }
+        }
+
+        let progressValues = RecordedValues<MCPProgress>()
+        let result = try await xcode.callTool(
+            "DocumentationSearch",
+            arguments: ["query": .string("GET SSE")]
+        ) { progress in
+            await progressValues.append(progress)
+        }
+
+        let progress = try await waitWithTimeout("GET SSE progress was not delivered") {
+            try await progressValues.nextValue()
+        }
+        #expect(progress.message == "from GET SSE")
+        #expect(result.structuredContent?.objectValue?["source"] == .string("get-sse"))
+        guard case .text(let text, _) = try #require(result.content.first) else {
+            Issue.record("expected text content")
+            return
+        }
+        #expect(text == "Result for GET SSE")
+    }
 }
 
 private struct SentMessage: Sendable, Equatable {
@@ -379,6 +512,441 @@ private actor FakeXcodeMCPTransport: XcodeMCPTransport {
             return .null
         }
     }
+}
+
+private struct RecordedHTTPRequest: Sendable, Equatable {
+    var httpMethod: String
+    var url: URL
+    var headers: [String: String]
+    var body: MCPJSONValue?
+
+    init(request: URLRequest) {
+        self.httpMethod = request.httpMethod ?? "GET"
+        self.url = request.url ?? URL(string: "http://invalid.local/")!
+        self.headers = request.allHTTPHeaderFields ?? [:]
+        if let bodyData = Self.bodyData(from: request),
+           let raw = try? JSONSerialization.jsonObject(with: bodyData),
+           let value = MCPJSONValue(foundationObject: raw)
+        {
+            self.body = value
+        } else {
+            self.body = nil
+        }
+    }
+
+    var jsonRPCMethod: String? {
+        body?.objectValue?["method"]?.stringValue
+    }
+
+    func header(_ name: String) -> String? {
+        headers.first { key, _ in
+            key.compare(name, options: .caseInsensitive) == .orderedSame
+        }?.value
+    }
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer {
+            stream.close()
+        }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while stream.hasBytesAvailable {
+            let count = unsafe buffer.withUnsafeMutableBufferPointer { buffer in
+                guard let baseAddress = buffer.baseAddress else {
+                    return 0
+                }
+                return unsafe stream.read(baseAddress, maxLength: buffer.count)
+            }
+            if count > 0 {
+                data.append(contentsOf: buffer.prefix(count))
+            } else {
+                break
+            }
+        }
+        return data
+    }
+}
+
+private extension Array where Element == RecordedHTTPRequest {
+    func firstJSONRPC(method: String) -> RecordedHTTPRequest? {
+        first { $0.jsonRPCMethod == method }
+    }
+}
+
+private actor FakeStreamableHTTPServer {
+    enum ProgressDelivery: Sendable {
+        case none
+        case postSSE
+        case getSSE
+    }
+
+    private let progressDelivery: ProgressDelivery
+    private let requestValues = RecordedValues<RecordedHTTPRequest>()
+    private var requests: [RecordedHTTPRequest] = []
+    private var eventConnection: ActiveHTTPConnection?
+
+    init(progressDelivery: ProgressDelivery) {
+        self.progressDelivery = progressDelivery
+    }
+
+    func response(
+        for request: URLRequest,
+        connection: ActiveHTTPConnection
+    ) async -> FakeURLProtocolResponse {
+        let recorded = RecordedHTTPRequest(request: request)
+        requests.append(recorded)
+        await requestValues.append(recorded)
+
+        switch recorded.httpMethod {
+        case "GET":
+            eventConnection = connection
+            return FakeURLProtocolResponse(
+                headers: [
+                    "Content-Type": "text/event-stream",
+                    "Cache-Control": "no-cache",
+                    "Mcp-Session-Id": "session-http-1",
+                ],
+                chunks: [Data(": ok\n\n".utf8)],
+                finishesLoading: false
+            )
+        case "DELETE":
+            eventConnection?.finish()
+            eventConnection = nil
+            return FakeURLProtocolResponse(
+                headers: ["Mcp-Session-Id": "session-http-1"],
+                chunks: []
+            )
+        case "POST":
+            return postResponse(for: recorded)
+        default:
+            return FakeURLProtocolResponse(statusCode: 405, chunks: [Data("method not allowed".utf8)])
+        }
+    }
+
+    func recordedRequests() -> [RecordedHTTPRequest] {
+        requests
+    }
+
+    func nextRequest(
+        matching predicate: @escaping @Sendable (RecordedHTTPRequest) -> Bool
+    ) async throws -> RecordedHTTPRequest {
+        try await requestValues.nextValue(matching: predicate)
+    }
+
+    private func postResponse(for request: RecordedHTTPRequest) -> FakeURLProtocolResponse {
+        guard let method = request.jsonRPCMethod else {
+            return FakeURLProtocolResponse(statusCode: 400, chunks: [Data("missing method".utf8)])
+        }
+
+        switch method {
+        case "initialize":
+            return jsonResponse(
+                id: request.body?.objectValue?["id"],
+                result: [
+                    "protocolVersion": "2025-06-18",
+                    "serverInfo": [
+                        "name": "fake-http-proxy",
+                        "version": "test",
+                    ],
+                    "capabilities": [:],
+                ],
+                headers: ["Mcp-Session-Id": "session-http-1"]
+            )
+        case "notifications/initialized":
+            return FakeURLProtocolResponse(statusCode: 202, chunks: [])
+        case "tools/list":
+            return jsonResponse(
+                id: request.body?.objectValue?["id"],
+                result: [
+                    "tools": [
+                        [
+                            "name": "DocumentationSearch",
+                            "description": "Search Apple developer documentation",
+                            "inputSchema": [
+                                "type": "object",
+                            ],
+                        ],
+                    ],
+                ]
+            )
+        case "tools/call":
+            return toolCallResponse(for: request)
+        default:
+            return jsonResponse(id: request.body?.objectValue?["id"], result: .null)
+        }
+    }
+
+    private func toolCallResponse(for request: RecordedHTTPRequest) -> FakeURLProtocolResponse {
+        let params = request.body?.objectValue?["params"]?.objectValue
+        let progressToken = params?["_meta"]?.objectValue?["progressToken"]?.stringValue
+        let query = params?["arguments"]?.objectValue?["query"]?.stringValue ?? ""
+
+        switch progressDelivery {
+        case .postSSE:
+            return FakeURLProtocolResponse(
+                headers: ["Content-Type": "text/event-stream"],
+                chunks: [
+                    sseEventData(progressNotificationData(
+                        progressToken: progressToken,
+                        message: "from POST SSE"
+                    )),
+                    sseEventData(toolResultResponseData(
+                        id: request.body?.objectValue?["id"],
+                        query: query,
+                        source: "post-sse"
+                    )),
+                ]
+            )
+        case .getSSE:
+            if let eventConnection {
+                eventConnection.send(sseEventData(progressNotificationData(
+                    progressToken: progressToken,
+                    message: "from GET SSE"
+                )))
+            }
+            return FakeURLProtocolResponse(
+                headers: ["Content-Type": "application/json"],
+                chunks: [
+                    toolResultResponseData(
+                        id: request.body?.objectValue?["id"],
+                        query: query,
+                        source: "get-sse"
+                    )
+                ]
+            )
+        case .none:
+            return FakeURLProtocolResponse(
+                headers: ["Content-Type": "application/json"],
+                chunks: [
+                    toolResultResponseData(
+                        id: request.body?.objectValue?["id"],
+                        query: query,
+                        source: "json"
+                    )
+                ]
+            )
+        }
+    }
+
+    private func jsonResponse(
+        id: MCPJSONValue?,
+        result: MCPJSONValue,
+        headers: [String: String] = [:]
+    ) -> FakeURLProtocolResponse {
+        FakeURLProtocolResponse(
+            headers: ["Content-Type": "application/json"].merging(headers) { _, new in new },
+            chunks: [jsonResponseData(id: id, result: result)]
+        )
+    }
+
+    private func progressNotificationData(progressToken: String?, message: String) -> Data {
+        jsonData([
+            "jsonrpc": "2.0",
+            "method": "notifications/progress",
+            "params": [
+                "progressToken": .string(progressToken ?? ""),
+                "progress": 0.5,
+                "total": 1,
+                "message": .string(message),
+            ],
+        ])
+    }
+
+    private func toolResultResponseData(id: MCPJSONValue?, query: String, source: String) -> Data {
+        jsonResponseData(
+            id: id,
+            result: [
+                "content": [
+                    [
+                        "type": "text",
+                        "text": .string("Result for \(query)"),
+                    ],
+                ],
+                "structuredContent": [
+                    "source": .string(source),
+                ],
+                "isError": false,
+            ]
+        )
+    }
+
+    private func jsonResponseData(id: MCPJSONValue?, result: MCPJSONValue) -> Data {
+        jsonData([
+            "jsonrpc": "2.0",
+            "id": id ?? .null,
+            "result": result,
+        ])
+    }
+
+    private func jsonData(_ value: MCPJSONValue) -> Data {
+        (try? JSONSerialization.data(withJSONObject: value.foundationObject)) ?? Data()
+    }
+
+    private func sseEventData(_ data: Data) -> Data {
+        guard let text = String(data: data, encoding: .utf8) else {
+            return Data()
+        }
+        return Data("data: \(text)\n\n".utf8)
+    }
+}
+
+private struct FakeURLProtocolResponse: Sendable {
+    var statusCode: Int = 200
+    var headers: [String: String] = [:]
+    var chunks: [Data]
+    var finishesLoading: Bool = true
+}
+
+private final class ActiveHTTPConnection: @unchecked Sendable {
+    private let lock = NSLock()
+    private var urlProtocol: URLProtocol?
+    private var client: URLProtocolClient?
+
+    init(urlProtocol: URLProtocol, client: URLProtocolClient?) {
+        self.urlProtocol = urlProtocol
+        self.client = client
+    }
+
+    func send(_ data: Data) {
+        let snapshot = lock.withLock {
+            (urlProtocol, client)
+        }
+        guard let urlProtocol = snapshot.0,
+              let client = snapshot.1
+        else {
+            return
+        }
+        client.urlProtocol(urlProtocol, didLoad: data)
+    }
+
+    func receive(_ response: URLResponse) {
+        let snapshot = lock.withLock {
+            (urlProtocol, client)
+        }
+        guard let urlProtocol = snapshot.0,
+              let client = snapshot.1
+        else {
+            return
+        }
+        client.urlProtocol(urlProtocol, didReceive: response, cacheStoragePolicy: .notAllowed)
+    }
+
+    func fail(_ error: Error) {
+        let snapshot = lock.withLock { () -> (URLProtocol?, URLProtocolClient?) in
+            let snapshot = (urlProtocol, client)
+            urlProtocol = nil
+            client = nil
+            return snapshot
+        }
+        guard let urlProtocol = snapshot.0,
+              let client = snapshot.1
+        else {
+            return
+        }
+        client.urlProtocol(urlProtocol, didFailWithError: error)
+    }
+
+    func finish() {
+        let snapshot = lock.withLock { () -> (URLProtocol?, URLProtocolClient?) in
+            let snapshot = (urlProtocol, client)
+            urlProtocol = nil
+            client = nil
+            return snapshot
+        }
+        guard let urlProtocol = snapshot.0,
+              let client = snapshot.1
+        else {
+            return
+        }
+        client.urlProtocolDidFinishLoading(urlProtocol)
+    }
+}
+
+private final class FakeStreamableHTTPURLProtocolRegistry: @unchecked Sendable {
+    static let shared = FakeStreamableHTTPURLProtocolRegistry()
+
+    private let lock = NSLock()
+    private var server: FakeStreamableHTTPServer?
+
+    func set(_ server: FakeStreamableHTTPServer) {
+        lock.withLock {
+            self.server = server
+        }
+    }
+
+    func currentServer() -> FakeStreamableHTTPServer? {
+        lock.withLock {
+            server
+        }
+    }
+
+    func reset() {
+        lock.withLock {
+            server = nil
+        }
+    }
+}
+
+private final class FakeStreamableHTTPURLProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "127.0.0.1"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let server = FakeStreamableHTTPURLProtocolRegistry.shared.currentServer() else {
+            client?.urlProtocol(self, didFailWithError: XcodeMCPError.transportUnavailable("missing fake server"))
+            return
+        }
+
+        let connection = ActiveHTTPConnection(urlProtocol: self, client: client)
+        Task { [request, connection] in
+            let response = await server.response(
+                for: request,
+                connection: connection
+            )
+            guard let url = request.url,
+                  let httpResponse = HTTPURLResponse(
+                    url: url,
+                    statusCode: response.statusCode,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: response.headers
+                  )
+            else {
+                connection.fail(XcodeMCPError.invalidResponse("invalid fake response"))
+                return
+            }
+
+            connection.receive(httpResponse)
+            for chunk in response.chunks {
+                connection.send(chunk)
+            }
+            if response.finishesLoading {
+                connection.finish()
+            }
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func makeFakeHTTPURLSession(server: FakeStreamableHTTPServer) -> URLSession {
+    FakeStreamableHTTPURLProtocolRegistry.shared.set(server)
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [FakeStreamableHTTPURLProtocol.self]
+    return URLSession(configuration: config)
 }
 
 private actor RecordedValues<Value: Sendable> {

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -273,9 +273,6 @@ struct XcodeMCPTests {
             config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
         )
-        defer {
-            Task { await xcode.close() }
-        }
 
         let progressValues = RecordedValues<MCPProgress>()
         let result = try await xcode.callTool(
@@ -300,6 +297,7 @@ struct XcodeMCPTests {
         #expect(call.header("Accept") == "application/json, text/event-stream")
         #expect(call.header("MCP-Session-Id") == "session-http-1")
         #expect(call.header("MCP-Protocol-Version") == "2025-06-18")
+        await xcode.close()
     }
 
     @Test func streamableHTTPGetSSERoutesProgressWhilePOSTReturnsJSONResult() async throws {
@@ -316,9 +314,6 @@ struct XcodeMCPTests {
             config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
         )
-        defer {
-            Task { await xcode.close() }
-        }
 
         _ = try await waitWithTimeout("event stream GET was not opened") {
             try await server.nextRequest { $0.httpMethod == "GET" }
@@ -342,6 +337,67 @@ struct XcodeMCPTests {
             return
         }
         #expect(text == "Result for GET SSE")
+        await xcode.close()
+    }
+
+    @Test func streamableHTTPAllowsStatelessEndpointWithoutSessionHeader() async throws {
+        let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
+        let server = FakeStreamableHTTPServer(progressDelivery: .none, sessionID: nil)
+        let session = makeFakeHTTPURLSession(server: server)
+        defer {
+            session.invalidateAndCancel()
+            FakeStreamableHTTPURLProtocolRegistry.shared.reset()
+        }
+
+        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let xcode = try await XcodeMCP(
+            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+            transport: transport
+        )
+
+        let tools = try await xcode.listTools()
+        await xcode.close()
+
+        #expect(tools.first?.name == "DocumentationSearch")
+        let requests = await server.recordedRequests()
+        let initialized = try #require(requests.firstJSONRPC(method: "notifications/initialized"))
+        #expect(initialized.header("MCP-Session-Id") == nil)
+        #expect(initialized.header("MCP-Protocol-Version") == "2025-06-18")
+        let list = try #require(requests.firstJSONRPC(method: "tools/list"))
+        #expect(list.header("MCP-Session-Id") == nil)
+        #expect(list.header("MCP-Protocol-Version") == "2025-06-18")
+        #expect(requests.contains(where: { $0.httpMethod == "GET" }) == false)
+        #expect(requests.contains(where: { $0.httpMethod == "DELETE" }) == false)
+    }
+
+    @Test func streamableHTTPReconnectsGETSSEWithoutClosingPOSTs() async throws {
+        let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
+        let server = FakeStreamableHTTPServer(
+            progressDelivery: .none,
+            eventStreamFinishesImmediately: true
+        )
+        let session = makeFakeHTTPURLSession(server: server)
+        defer {
+            session.invalidateAndCancel()
+            FakeStreamableHTTPURLProtocolRegistry.shared.reset()
+        }
+
+        let transport = StreamableHTTPXcodeMCPTransport(endpoint: endpoint, urlSession: session)
+        let xcode = try await XcodeMCP(
+            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+            transport: transport
+        )
+
+        let firstGET = try await waitWithTimeout("first event stream GET was not opened") {
+            try await server.nextRequest { $0.httpMethod == "GET" }
+        }
+        _ = try await waitWithTimeout("event stream GET was not reconnected") {
+            try await server.nextRequest(startingAt: firstGET.sequence + 1) { $0.httpMethod == "GET" }
+        }
+
+        let tools = try await xcode.listTools()
+        #expect(tools.first?.name == "DocumentationSearch")
+        await xcode.close()
     }
 }
 
@@ -516,6 +572,7 @@ private actor FakeXcodeMCPTransport: XcodeMCPTransport {
 }
 
 private struct RecordedHTTPRequest: Sendable, Equatable {
+    var sequence: Int
     var httpMethod: String
     var url: URL
     var headers: [String: String]
@@ -523,6 +580,7 @@ private struct RecordedHTTPRequest: Sendable, Equatable {
     var body: MCPJSONValue?
 
     init(request: URLRequest) {
+        self.sequence = 0
         self.httpMethod = request.httpMethod ?? "GET"
         self.url = request.url ?? URL(string: "http://invalid.local/")!
         self.headers = request.allHTTPHeaderFields ?? [:]
@@ -593,39 +651,51 @@ private actor FakeStreamableHTTPServer {
     }
 
     private let progressDelivery: ProgressDelivery
+    private let sessionID: String?
+    private let eventStreamFinishesImmediately: Bool
     private let requestValues = RecordedValues<RecordedHTTPRequest>()
     private var requests: [RecordedHTTPRequest] = []
     private var eventConnection: ActiveHTTPConnection?
 
-    init(progressDelivery: ProgressDelivery) {
+    init(
+        progressDelivery: ProgressDelivery,
+        sessionID: String? = "session-http-1",
+        eventStreamFinishesImmediately: Bool = false
+    ) {
         self.progressDelivery = progressDelivery
+        self.sessionID = sessionID
+        self.eventStreamFinishesImmediately = eventStreamFinishesImmediately
     }
 
     func response(
         for request: URLRequest,
         connection: ActiveHTTPConnection
     ) async -> FakeURLProtocolResponse {
-        let recorded = RecordedHTTPRequest(request: request)
+        var recorded = RecordedHTTPRequest(request: request)
+        recorded.sequence = requests.count
         requests.append(recorded)
         await requestValues.append(recorded)
 
         switch recorded.httpMethod {
         case "GET":
             eventConnection = connection
+            var headers = [
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+            ]
+            if let sessionID {
+                headers["Mcp-Session-Id"] = sessionID
+            }
             return FakeURLProtocolResponse(
-                headers: [
-                    "Content-Type": "text/event-stream",
-                    "Cache-Control": "no-cache",
-                    "Mcp-Session-Id": "session-http-1",
-                ],
+                headers: headers,
                 chunks: [Data(": ok\n\n".utf8)],
-                finishesLoading: false
+                finishesLoading: eventStreamFinishesImmediately
             )
         case "DELETE":
             eventConnection?.finish()
             eventConnection = nil
             return FakeURLProtocolResponse(
-                headers: ["Mcp-Session-Id": "session-http-1"],
+                headers: sessionID.map { ["Mcp-Session-Id": $0] } ?? [:],
                 chunks: []
             )
         case "POST":
@@ -640,9 +710,10 @@ private actor FakeStreamableHTTPServer {
     }
 
     func nextRequest(
+        startingAt startIndex: Int = 0,
         matching predicate: @escaping @Sendable (RecordedHTTPRequest) -> Bool
     ) async throws -> RecordedHTTPRequest {
-        try await requestValues.nextValue(matching: predicate)
+        try await requestValues.nextValue(startingAt: startIndex, matching: predicate)
     }
 
     private func postResponse(for request: RecordedHTTPRequest) -> FakeURLProtocolResponse {
@@ -652,6 +723,7 @@ private actor FakeStreamableHTTPServer {
 
         switch method {
         case "initialize":
+            let headers = sessionID.map { ["Mcp-Session-Id": $0] } ?? [:]
             return jsonResponse(
                 id: request.body?.objectValue?["id"],
                 result: [
@@ -662,7 +734,7 @@ private actor FakeStreamableHTTPServer {
                     ],
                     "capabilities": [:],
                 ],
-                headers: ["Mcp-Session-Id": "session-http-1"]
+                headers: headers
             )
         case "notifications/initialized":
             return FakeURLProtocolResponse(statusCode: 202, chunks: [])


### PR DESCRIPTION
## Purpose
Make XcodeMCPKit usable as a public client SDK for both local mcpbridge and proxy Streamable HTTP endpoints.

## Main Changes
- Added `XcodeMCP.Configuration.Transport` with local bridge, Streamable HTTP endpoint, and discovery-file options while keeping the existing bridge initializer/property compatible.
- Added an internal Streamable HTTP transport that handles POST `/mcp`, negotiated `MCP-Session-Id` / `MCP-Protocol-Version`, POST SSE responses, long-lived GET SSE notifications, best-effort DELETE, stateless endpoints, SSE reconnects, and request cancellation/timeout behavior.
- Added public `MCPJSONValue` accessors for object, array, string, bool, integer/int, double, and null inspection.
- Added deterministic HTTP transport contract tests and external public product compile contracts.
- Updated root and target README guidance for XcodeMCPKit client usage.

## Verification
- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`

## Codex Review
- Clean against base `codex/refactor-layered-runtime-integration` with no actionable findings.

## Residual Risks
- Streamable HTTP has deterministic fake URLProtocol coverage, but no live proxy integration test was run in this worktree.
- Public API adds transport selection and JSON accessors; downstream source compatibility is covered by contract tests, but broader package adopters may still need doc-driven migration examples.