### PR TITLE
[codex] Move initialized client session into runtime

### DIFF
--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -1,63 +1,6 @@
 import Foundation
 import XcodeMCPRuntime
 
-private final class XcodeMCPPendingRequests: @unchecked Sendable {
-    private struct PendingRequest {
-        let continuation: CheckedContinuation<MCPJSONValue, Error>
-        var sendTask: Task<Void, Never>?
-    }
-
-    private let lock = NSLock()
-    private var requests: [String: PendingRequest] = [:]
-
-    func add(
-        idKey: String,
-        continuation: CheckedContinuation<MCPJSONValue, Error>
-    ) {
-        lock.withLock {
-            requests[idKey] = PendingRequest(continuation: continuation)
-        }
-    }
-
-    func setSendTask(idKey: String, task: Task<Void, Never>) -> Bool {
-        lock.withLock {
-            guard requests[idKey] != nil else {
-                return false
-            }
-            requests[idKey]?.sendTask = task
-            return true
-        }
-    }
-
-    func complete(idKey: String, result: MCPJSONValue) {
-        let request = lock.withLock {
-            requests.removeValue(forKey: idKey)
-        }
-        request?.sendTask?.cancel()
-        request?.continuation.resume(returning: result)
-    }
-
-    func fail(idKey: String, error: Error) {
-        let request = lock.withLock {
-            requests.removeValue(forKey: idKey)
-        }
-        request?.sendTask?.cancel()
-        request?.continuation.resume(throwing: error)
-    }
-
-    func failAll(error: Error) {
-        let pending = lock.withLock {
-            let current = requests
-            requests.removeAll()
-            return current
-        }
-        for request in pending.values {
-            request.sendTask?.cancel()
-            request.continuation.resume(throwing: error)
-        }
-    }
-}
-
 /// A high-level client for Xcode MCP.
 ///
 /// `XcodeMCP` connects through the configured transport, performs the MCP
@@ -256,13 +199,7 @@ public actor XcodeMCP {
         }
     }
 
-    private let config: Configuration
-    private let transport: any XcodeMCPTransport
-    private let pendingRequests = XcodeMCPPendingRequests()
-    private var nextRequestID: Int64 = 1
-    private var isClosed = false
-    private var eventTask: Task<Void, Never>?
-    private var progressHandlers: [String: @Sendable (MCPProgress) async -> Void] = [:]
+    private let session: InitializedMCPClientSession
 
     /// Connects to the configured MCP transport and returns an initialized
     /// client.
@@ -305,29 +242,25 @@ public actor XcodeMCP {
     }
 
     package init(config: Configuration = Configuration(), transport: any XcodeMCPTransport) async throws {
-        self.config = config
-        self.transport = transport
-        self.eventTask = nil
-        self.eventTask = Task { [weak self, transport] in
-            for await event in transport.events {
-                await self?.handle(event)
-            }
-        }
-
         do {
-            try await initialize()
+            self.session = try await InitializedMCPClientSession(
+                transport: transport,
+                configuration: InitializedMCPClientSession.Configuration(
+                    clientName: config.clientName,
+                    clientVersion: config.clientVersion,
+                    capabilities: config.capabilities.mapValues(\.jsonValue),
+                    requestTimeout: config.requestTimeout
+                )
+            )
         } catch {
-            eventTask?.cancel()
-            await transport.close()
-            throw error
+            throw Self.publicError(from: error)
         }
     }
 
     isolated deinit {
-        eventTask?.cancel()
-        let transport = transport
+        let session = session
         Task {
-            await transport.close()
+            await session.close()
         }
     }
 
@@ -368,29 +301,27 @@ public actor XcodeMCP {
             throw XcodeMCPError.invalidRequest("tool name must not be empty")
         }
 
-        var params: [String: MCPJSONValue] = [
+        let params: [String: MCPJSONValue] = [
             "name": .string(name),
             "arguments": .object(arguments),
         ]
-        let progressToken: String?
+        let progressHandler: InitializedMCPClientSession.ProgressHandler?
         if let onProgress {
-            let token = "xcode-mcp-\(UUID().uuidString)"
-            progressToken = token
-            progressHandlers[token] = onProgress
-            params["_meta"] = .object([
-                "progressToken": .string(token)
-            ])
-        } else {
-            progressToken = nil
-        }
-
-        defer {
-            if let progressToken {
-                progressHandlers.removeValue(forKey: progressToken)
+            progressHandler = { rawProgress in
+                guard let progress = MCPProgress(json: MCPJSONValue(rawProgress)) else {
+                    return
+                }
+                await onProgress(progress)
             }
+        } else {
+            progressHandler = nil
         }
 
-        let result = try await request("tools/call", params: .object(params))
+        let result = try await request(
+            "tools/call",
+            params: .object(params),
+            onProgress: progressHandler
+        )
         return try MCPToolResult(json: result)
     }
 
@@ -400,63 +331,31 @@ public actor XcodeMCP {
     /// registered progress callbacks are discarded, and no further requests may
     /// be sent through this client.
     public func close() async {
-        guard isClosed == false else {
-            return
-        }
-        isClosed = true
-        eventTask?.cancel()
-        eventTask = nil
-        progressHandlers.removeAll()
-        pendingRequests.failAll(error: XcodeMCPError.closed)
-        await transport.close()
+        await session.close()
     }
 }
 
 extension XcodeMCP {
-    package func request(_ method: String, params: MCPJSONValue? = nil) async throws -> MCPJSONValue {
-        guard method.isEmpty == false else {
-            throw XcodeMCPError.invalidRequest("method must not be empty")
-        }
-        try ensureOpen()
-
-        let requestID = nextRequestID
-        nextRequestID += 1
-        let id = JSONRPC.ID(any: NSNumber(value: requestID))!
-        let idKey = id.key
-        let payload = try makeJSONRPCPayload(id: id, method: method, params: params)
-
-        return try await withRequestTimeout(method: method) { [self] in
-            try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation { continuation in
-                    self.pendingRequests.add(idKey: idKey, continuation: continuation)
-                    let sendTask = Task {
-                        do {
-                            try await self.transport.send(payload)
-                        } catch {
-                            self.pendingRequests.fail(
-                                idKey: idKey,
-                                error: Self.publicError(from: error)
-                            )
-                        }
-                    }
-                    if self.pendingRequests.setSendTask(idKey: idKey, task: sendTask) == false {
-                        sendTask.cancel()
-                    }
-                }
-            } onCancel: {
-                self.pendingRequests.fail(idKey: idKey, error: CancellationError())
-            }
+    package func request(
+        _ method: String,
+        params: MCPJSONValue? = nil,
+        onProgress: InitializedMCPClientSession.ProgressHandler? = nil
+    ) async throws -> MCPJSONValue {
+        do {
+            let result = try await session.request(
+                method,
+                params: params?.jsonValue,
+                onProgress: onProgress
+            )
+            return MCPJSONValue(result)
+        } catch {
+            throw Self.publicError(from: error)
         }
     }
 
     package func notify(_ method: String, params: MCPJSONValue? = nil) async throws {
-        guard method.isEmpty == false else {
-            throw XcodeMCPError.invalidRequest("method must not be empty")
-        }
-        try ensureOpen()
-        let payload = try makeJSONRPCPayload(id: nil, method: method, params: params)
         do {
-            try await transport.send(payload)
+            try await session.notify(method, params: params?.jsonValue)
         } catch {
             throw Self.publicError(from: error)
         }
@@ -481,6 +380,14 @@ private extension XcodeMCP {
             return XcodeMCPError.invalidRequest(message)
         case .invalidResponse(let message):
             return XcodeMCPError.invalidResponse(message)
+        case .requestTimedOut(let method):
+            return XcodeMCPError.requestTimedOut(method: method)
+        case .serverError(let code, let message, let data):
+            return XcodeMCPError.serverError(
+                code: code,
+                message: message,
+                data: data.map(MCPJSONValue.init)
+            )
         case .transportUnavailable(let reason):
             return XcodeMCPError.transportUnavailable(reason)
         }
@@ -492,194 +399,5 @@ private extension XcodeMCP {
             return nsError.localizedDescription
         }
         return String(describing: error)
-    }
-
-    func initialize() async throws {
-        let result = try await request(
-            "initialize",
-            params: .object([
-                "protocolVersion": .string(MCP.ProtocolVersion.current),
-                "clientInfo": .object([
-                    "name": .string(config.clientName),
-                    "version": .string(config.clientVersion),
-                ]),
-                "capabilities": .object(initializeCapabilities()),
-            ])
-        )
-        try validateInitializeResult(result)
-        try await notify("notifications/initialized")
-    }
-
-    func validateInitializeResult(_ result: MCPJSONValue) throws {
-        guard let object = result.objectValue else {
-            throw XcodeMCPError.invalidResponse("initialize result is not an object")
-        }
-        guard let protocolVersion = object["protocolVersion"]?.stringValue,
-              protocolVersion.isEmpty == false else {
-            throw XcodeMCPError.invalidResponse("initialize result is missing protocolVersion")
-        }
-        guard MCP.ProtocolVersion.isSupported(protocolVersion) else {
-            throw XcodeMCPError.invalidResponse(
-                "initialize result has unsupported protocolVersion \(protocolVersion)"
-            )
-        }
-    }
-
-    func initializeCapabilities() -> [String: MCPJSONValue] {
-        var capabilities = config.capabilities
-        capabilities.removeValue(forKey: "roots")
-        capabilities.removeValue(forKey: "sampling")
-        capabilities.removeValue(forKey: "elicitation")
-        return capabilities
-    }
-
-    func withRequestTimeout<T: Sendable>(
-        method: String,
-        operation: @escaping @Sendable () async throws -> T
-    ) async throws -> T {
-        guard let requestTimeout = config.requestTimeout else {
-            return try await operation()
-        }
-        return try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask {
-                try await operation()
-            }
-            group.addTask {
-                try await Task.sleep(for: requestTimeout)
-                throw XcodeMCPError.requestTimedOut(method: method)
-            }
-            let result = try await group.next()!
-            group.cancelAll()
-            return result
-        }
-    }
-
-    func ensureOpen() throws {
-        if isClosed {
-            throw XcodeMCPError.closed
-        }
-    }
-
-    func handle(_ event: XcodeMCPTransportEvent) async {
-        switch event {
-        case .message(let data):
-            await handleMessage(data)
-        case .closed(let reason):
-            isClosed = true
-            progressHandlers.removeAll()
-            pendingRequests.failAll(
-                error: XcodeMCPError.transportUnavailable(reason ?? "mcpbridge closed")
-            )
-        }
-    }
-
-    func handleMessage(_ data: Data) async {
-        do {
-            let object = try parseJSONObject(data)
-            if let id = object["id"], let idKey = jsonRPCIDKey(id) {
-                if let method = object["method"]?.stringValue {
-                    try await respondToUnsupportedServerRequest(id: id, method: method)
-                    return
-                }
-                if let errorValue = object["error"] {
-                    pendingRequests.fail(idKey: idKey, error: parseServerError(errorValue))
-                    return
-                }
-                let result = object["result"] ?? .null
-                pendingRequests.complete(idKey: idKey, result: result)
-                return
-            }
-
-            if object["method"]?.stringValue == "notifications/progress",
-               let params = object["params"],
-               let progress = MCPProgress(json: params),
-               let handler = progressHandlers[progress.progressToken]
-            {
-                Task {
-                    await handler(progress)
-                }
-            }
-        } catch {
-            pendingRequests.failAll(error: Self.publicError(from: error))
-        }
-    }
-
-    func respondToUnsupportedServerRequest(id: MCPJSONValue, method _: String) async throws {
-        let payload = try JSONRPC.Wire.errorResponseData(
-            idValue: id.jsonValue,
-            code: -32601,
-            message: "Unsupported server request"
-        )
-        try await transport.send(payload)
-    }
-
-    func makeJSONRPCPayload(
-        id: JSONRPC.ID?,
-        method: String,
-        params: MCPJSONValue?
-    ) throws -> Data {
-        let object: [String: Any]
-        if let id {
-            object = JSONRPC.Wire.requestObject(
-                id: id,
-                method: method,
-                params: params?.jsonValue
-            )
-        } else {
-            object = JSONRPC.Wire.notificationObject(
-                method: method,
-                params: params?.jsonValue
-            )
-        }
-        return try JSONRPC.Wire.data(from: object)
-    }
-
-    func parseJSONObject(_ data: Data) throws -> [String: MCPJSONValue] {
-        let raw: [String: Any]
-        do {
-            raw = try JSONRPC.Wire.object(fromData: data)
-        } catch JSONRPC.Wire.DecodingFailure.messageWasNotObject {
-            throw XcodeMCPError.invalidResponse("JSON-RPC message is not an object")
-        } catch {
-            throw XcodeMCPError.invalidResponse(
-                "invalid JSON-RPC message: \(Self.errorDescription(error))"
-            )
-        }
-        guard let value = MCPJSONValue(foundationObject: raw),
-              let object = value.objectValue
-        else {
-            throw XcodeMCPError.invalidResponse("JSON-RPC message is not an object")
-        }
-        return object
-    }
-
-    func jsonRPCIDKey(_ value: MCPJSONValue) -> String? {
-        switch value {
-        case .string(let value):
-            return value
-        case .integer(let value):
-            return String(value)
-        case .double(let value):
-            return String(value)
-        case .object, .array, .bool, .null:
-            return nil
-        }
-    }
-
-    func parseServerError(_ value: MCPJSONValue) -> XcodeMCPError {
-        guard let object = value.objectValue else {
-            return .invalidResponse("JSON-RPC error is not an object")
-        }
-        let code: Int
-        switch object["code"] {
-        case .integer(let value):
-            code = Int(value)
-        case .double(let value):
-            code = Int(value)
-        default:
-            code = 0
-        }
-        let message = object["message"]?.stringValue ?? "MCP server error"
-        return .serverError(code: code, message: message, data: object["data"])
     }
 }

--- a/Sources/XcodeMCPRuntime/InitializedMCPClientSession.swift
+++ b/Sources/XcodeMCPRuntime/InitializedMCPClientSession.swift
@@ -83,6 +83,7 @@ package actor InitializedMCPClientSession {
     private var isClosed = false
     private var eventTask: Task<Void, Never>?
     private var progressHandlers: [String: ProgressHandler] = [:]
+    private var progressDeliveryTasks: [String: Task<Void, Never>] = [:]
 
     package init(transport: any XcodeMCPTransport, configuration: Configuration) async throws {
         self.configuration = configuration
@@ -141,6 +142,7 @@ package actor InitializedMCPClientSession {
         defer {
             if let progressToken {
                 progressHandlers.removeValue(forKey: progressToken)
+                progressDeliveryTasks.removeValue(forKey: progressToken)
             }
         }
 
@@ -191,6 +193,7 @@ package actor InitializedMCPClientSession {
         eventTask?.cancel()
         eventTask = nil
         progressHandlers.removeAll()
+        cancelProgressDeliveryTasks()
         pendingRequests.failAll(error: MCPBridgeRuntimeError.closed)
         await transport.close()
     }
@@ -288,6 +291,7 @@ private extension InitializedMCPClientSession {
         case .closed(let reason):
             isClosed = true
             progressHandlers.removeAll()
+            cancelProgressDeliveryTasks()
             pendingRequests.failAll(
                 error: MCPBridgeRuntimeError.transportUnavailable(reason ?? "mcpbridge closed")
             )
@@ -316,13 +320,28 @@ private extension InitializedMCPClientSession {
                let progressToken = params.progressToken,
                let handler = progressHandlers[progressToken]
             {
-                Task {
+                let previousDelivery = progressDeliveryTasks[progressToken]
+                let delivery = Task {
+                    if let previousDelivery {
+                        await previousDelivery.value
+                    }
+                    guard Task.isCancelled == false else {
+                        return
+                    }
                     await handler(params)
                 }
+                progressDeliveryTasks[progressToken] = delivery
             }
         } catch {
             pendingRequests.failAll(error: Self.runtimeError(from: error))
         }
+    }
+
+    func cancelProgressDeliveryTasks() {
+        for task in progressDeliveryTasks.values {
+            task.cancel()
+        }
+        progressDeliveryTasks.removeAll()
     }
 
     func respondToUnsupportedServerRequest(id: JSONValue) async throws {

--- a/Sources/XcodeMCPRuntime/InitializedMCPClientSession.swift
+++ b/Sources/XcodeMCPRuntime/InitializedMCPClientSession.swift
@@ -131,8 +131,8 @@ package actor InitializedMCPClientSession {
         if let onProgress {
             let token = "xcode-mcp-\(UUID().uuidString)"
             progressToken = token
-            progressHandlers[token] = onProgress
             requestParams = try paramsByAddingProgressToken(token, to: params)
+            progressHandlers[token] = onProgress
         } else {
             progressToken = nil
             requestParams = params

--- a/Sources/XcodeMCPRuntime/InitializedMCPClientSession.swift
+++ b/Sources/XcodeMCPRuntime/InitializedMCPClientSession.swift
@@ -1,0 +1,432 @@
+import Foundation
+
+private final class MCPClientPendingRequests: @unchecked Sendable {
+    private struct PendingRequest {
+        let continuation: CheckedContinuation<JSONValue, Error>
+        var sendTask: Task<Void, Never>?
+    }
+
+    private let lock = NSLock()
+    private var requests: [String: PendingRequest] = [:]
+
+    func add(idKey: String, continuation: CheckedContinuation<JSONValue, Error>) {
+        lock.withLock {
+            requests[idKey] = PendingRequest(continuation: continuation)
+        }
+    }
+
+    func setSendTask(idKey: String, task: Task<Void, Never>) -> Bool {
+        lock.withLock {
+            guard requests[idKey] != nil else {
+                return false
+            }
+            requests[idKey]?.sendTask = task
+            return true
+        }
+    }
+
+    func complete(idKey: String, result: JSONValue) {
+        let request = lock.withLock {
+            requests.removeValue(forKey: idKey)
+        }
+        request?.sendTask?.cancel()
+        request?.continuation.resume(returning: result)
+    }
+
+    func fail(idKey: String, error: any Error) {
+        let request = lock.withLock {
+            requests.removeValue(forKey: idKey)
+        }
+        request?.sendTask?.cancel()
+        request?.continuation.resume(throwing: error)
+    }
+
+    func failAll(error: any Error) {
+        let pending = lock.withLock {
+            let current = requests
+            requests.removeAll()
+            return current
+        }
+        for request in pending.values {
+            request.sendTask?.cancel()
+            request.continuation.resume(throwing: error)
+        }
+    }
+}
+
+package actor InitializedMCPClientSession {
+    package struct Configuration: Equatable, Sendable {
+        package var clientName: String
+        package var clientVersion: String
+        package var capabilities: [String: JSONValue]
+        package var requestTimeout: Duration?
+
+        package init(
+            clientName: String,
+            clientVersion: String,
+            capabilities: [String: JSONValue],
+            requestTimeout: Duration?
+        ) {
+            self.clientName = clientName
+            self.clientVersion = clientVersion
+            self.capabilities = capabilities
+            self.requestTimeout = requestTimeout
+        }
+    }
+
+    package typealias ProgressHandler = @Sendable (JSONValue) async -> Void
+
+    private let configuration: Configuration
+    private let transport: any XcodeMCPTransport
+    private let pendingRequests = MCPClientPendingRequests()
+    private var nextRequestID: Int64 = 1
+    private var isClosed = false
+    private var eventTask: Task<Void, Never>?
+    private var progressHandlers: [String: ProgressHandler] = [:]
+
+    package init(transport: any XcodeMCPTransport, configuration: Configuration) async throws {
+        self.configuration = configuration
+        self.transport = transport
+        self.eventTask = nil
+        self.eventTask = Task { [weak self, transport] in
+            for await event in transport.events {
+                await self?.handle(event)
+            }
+        }
+
+        do {
+            try await initialize()
+        } catch {
+            eventTask?.cancel()
+            await transport.close()
+            throw error
+        }
+    }
+
+    isolated deinit {
+        eventTask?.cancel()
+        let transport = transport
+        Task {
+            await transport.close()
+        }
+    }
+
+    package func request(
+        _ method: String,
+        params: JSONValue? = nil,
+        onProgress: ProgressHandler? = nil
+    ) async throws -> JSONValue {
+        guard method.isEmpty == false else {
+            throw MCPBridgeRuntimeError.invalidRequest("method must not be empty")
+        }
+        try ensureOpen()
+
+        let requestID = nextRequestID
+        nextRequestID += 1
+        let id = JSONRPC.ID(any: NSNumber(value: requestID))!
+        let idKey = id.key
+
+        let progressToken: String?
+        let requestParams: JSONValue?
+        if let onProgress {
+            let token = "xcode-mcp-\(UUID().uuidString)"
+            progressToken = token
+            progressHandlers[token] = onProgress
+            requestParams = try paramsByAddingProgressToken(token, to: params)
+        } else {
+            progressToken = nil
+            requestParams = params
+        }
+
+        defer {
+            if let progressToken {
+                progressHandlers.removeValue(forKey: progressToken)
+            }
+        }
+
+        let payload = try makeJSONRPCPayload(id: id, method: method, params: requestParams)
+
+        return try await withRequestTimeout(method: method) { [self] in
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    self.pendingRequests.add(idKey: idKey, continuation: continuation)
+                    let sendTask = Task {
+                        do {
+                            try await self.transport.send(payload)
+                        } catch {
+                            self.pendingRequests.fail(
+                                idKey: idKey,
+                                error: Self.runtimeError(from: error)
+                            )
+                        }
+                    }
+                    if self.pendingRequests.setSendTask(idKey: idKey, task: sendTask) == false {
+                        sendTask.cancel()
+                    }
+                }
+            } onCancel: {
+                self.pendingRequests.fail(idKey: idKey, error: CancellationError())
+            }
+        }
+    }
+
+    package func notify(_ method: String, params: JSONValue? = nil) async throws {
+        guard method.isEmpty == false else {
+            throw MCPBridgeRuntimeError.invalidRequest("method must not be empty")
+        }
+        try ensureOpen()
+        let payload = try makeJSONRPCPayload(id: nil, method: method, params: params)
+        do {
+            try await transport.send(payload)
+        } catch {
+            throw Self.runtimeError(from: error)
+        }
+    }
+
+    package func close() async {
+        guard isClosed == false else {
+            return
+        }
+        isClosed = true
+        eventTask?.cancel()
+        eventTask = nil
+        progressHandlers.removeAll()
+        pendingRequests.failAll(error: MCPBridgeRuntimeError.closed)
+        await transport.close()
+    }
+}
+
+private extension InitializedMCPClientSession {
+    static func runtimeError(from error: any Error) -> any Error {
+        if let error = error as? MCPBridgeRuntimeError {
+            return error
+        }
+        if error is CancellationError {
+            return error
+        }
+        return MCPBridgeRuntimeError.transportUnavailable(errorDescription(error))
+    }
+
+    static func errorDescription(_ error: any Error) -> String {
+        let nsError = error as NSError
+        if nsError.localizedDescription.isEmpty == false {
+            return nsError.localizedDescription
+        }
+        return String(describing: error)
+    }
+
+    func initialize() async throws {
+        let result = try await request(
+            "initialize",
+            params: .object([
+                "protocolVersion": .string(MCPProtocolVersion.current),
+                "clientInfo": .object([
+                    "name": .string(configuration.clientName),
+                    "version": .string(configuration.clientVersion),
+                ]),
+                "capabilities": .object(initializeCapabilities()),
+            ])
+        )
+        try validateInitializeResult(result)
+        try await notify("notifications/initialized")
+    }
+
+    func validateInitializeResult(_ result: JSONValue) throws {
+        guard case .object(let object) = result else {
+            throw MCPBridgeRuntimeError.invalidResponse("initialize result is not an object")
+        }
+        guard case .string(let protocolVersion) = object["protocolVersion"],
+              protocolVersion.isEmpty == false else {
+            throw MCPBridgeRuntimeError.invalidResponse("initialize result is missing protocolVersion")
+        }
+        guard MCPProtocolVersion.isSupported(protocolVersion) else {
+            throw MCPBridgeRuntimeError.invalidResponse(
+                "initialize result has unsupported protocolVersion \(protocolVersion)"
+            )
+        }
+    }
+
+    func initializeCapabilities() -> [String: JSONValue] {
+        var capabilities = configuration.capabilities
+        capabilities.removeValue(forKey: "roots")
+        capabilities.removeValue(forKey: "sampling")
+        capabilities.removeValue(forKey: "elicitation")
+        return capabilities
+    }
+
+    func withRequestTimeout<T: Sendable>(
+        method: String,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        guard let requestTimeout = configuration.requestTimeout else {
+            return try await operation()
+        }
+        return try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await operation()
+            }
+            group.addTask {
+                try await Task.sleep(for: requestTimeout)
+                throw MCPBridgeRuntimeError.requestTimedOut(method: method)
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+
+    func ensureOpen() throws {
+        if isClosed {
+            throw MCPBridgeRuntimeError.closed
+        }
+    }
+
+    func handle(_ event: XcodeMCPTransportEvent) async {
+        switch event {
+        case .message(let data):
+            await handleMessage(data)
+        case .closed(let reason):
+            isClosed = true
+            progressHandlers.removeAll()
+            pendingRequests.failAll(
+                error: MCPBridgeRuntimeError.transportUnavailable(reason ?? "mcpbridge closed")
+            )
+        }
+    }
+
+    func handleMessage(_ data: Data) async {
+        do {
+            let object = try parseJSONObject(data)
+            if let id = object["id"], let idKey = jsonRPCIDKey(id) {
+                if object["method"]?.stringValue != nil {
+                    try await respondToUnsupportedServerRequest(id: id)
+                    return
+                }
+                if let errorValue = object["error"] {
+                    pendingRequests.fail(idKey: idKey, error: parseServerError(errorValue))
+                    return
+                }
+                let result = object["result"] ?? .null
+                pendingRequests.complete(idKey: idKey, result: result)
+                return
+            }
+
+            if object["method"]?.stringValue == "notifications/progress",
+               let params = object["params"],
+               let progressToken = params.progressToken,
+               let handler = progressHandlers[progressToken]
+            {
+                Task {
+                    await handler(params)
+                }
+            }
+        } catch {
+            pendingRequests.failAll(error: Self.runtimeError(from: error))
+        }
+    }
+
+    func respondToUnsupportedServerRequest(id: JSONValue) async throws {
+        let payload = try JSONRPC.Wire.errorResponseData(
+            idValue: id,
+            code: -32601,
+            message: "Unsupported server request"
+        )
+        try await transport.send(payload)
+    }
+
+    func makeJSONRPCPayload(id: JSONRPC.ID?, method: String, params: JSONValue?) throws -> Data {
+        let object: [String: Any]
+        if let id {
+            object = JSONRPC.Wire.requestObject(id: id, method: method, params: params)
+        } else {
+            object = JSONRPC.Wire.notificationObject(method: method, params: params)
+        }
+        return try JSONRPC.Wire.data(from: object)
+    }
+
+    func paramsByAddingProgressToken(_ token: String, to params: JSONValue?) throws -> JSONValue {
+        guard let params else {
+            return .object(["_meta": .object(["progressToken": .string(token)])])
+        }
+        guard case .object(var object) = params else {
+            throw MCPBridgeRuntimeError.invalidRequest("progress requests require object params")
+        }
+        var meta: [String: JSONValue]
+        if case .object(let existingMeta) = object["_meta"] {
+            meta = existingMeta
+        } else {
+            meta = [:]
+        }
+        meta["progressToken"] = .string(token)
+        object["_meta"] = .object(meta)
+        return .object(object)
+    }
+
+    func parseJSONObject(_ data: Data) throws -> [String: JSONValue] {
+        let raw: [String: Any]
+        do {
+            raw = try JSONRPC.Wire.object(fromData: data)
+        } catch JSONRPC.Wire.DecodingFailure.messageWasNotObject {
+            throw MCPBridgeRuntimeError.invalidResponse("JSON-RPC message is not an object")
+        } catch {
+            throw MCPBridgeRuntimeError.invalidResponse(
+                "invalid JSON-RPC message: \(Self.errorDescription(error))"
+            )
+        }
+        guard let value = JSONValue(any: raw),
+              case .object(let object) = value
+        else {
+            throw MCPBridgeRuntimeError.invalidResponse("JSON-RPC message is not an object")
+        }
+        return object
+    }
+
+    func jsonRPCIDKey(_ value: JSONValue) -> String? {
+        switch value {
+        case .string(let value):
+            return value
+        case .number(let value):
+            return value.stringValue
+        case .object, .array, .bool, .null:
+            return nil
+        }
+    }
+
+    func parseServerError(_ value: JSONValue) -> MCPBridgeRuntimeError {
+        guard case .object(let object) = value else {
+            return .invalidResponse("JSON-RPC error is not an object")
+        }
+        let code: Int
+        switch object["code"] {
+        case .number(.int(let value)):
+            code = Int(value)
+        case .number(.double(let value)):
+            code = Int(value)
+        default:
+            code = 0
+        }
+        let message: String
+        if case .string(let value) = object["message"] {
+            message = value
+        } else {
+            message = "MCP server error"
+        }
+        return .serverError(code: code, message: message, data: object["data"])
+    }
+}
+
+private extension JSONValue {
+    var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    var progressToken: String? {
+        guard case .object(let object) = self,
+              case .string(let token) = object["progressToken"]
+        else {
+            return nil
+        }
+        return token
+    }
+}

--- a/Sources/XcodeMCPRuntime/JSONValue.swift
+++ b/Sources/XcodeMCPRuntime/JSONValue.swift
@@ -2,8 +2,8 @@ import Foundation
 
 package enum JSONRPC {}
 
-package enum JSONValue: Sendable {
-    package enum Number: Sendable {
+package enum JSONValue: Equatable, Sendable {
+    package enum Number: Equatable, Sendable {
         case int(Int64)
         case double(Double)
 

--- a/Sources/XcodeMCPRuntime/MCPBridgeRuntimeError.swift
+++ b/Sources/XcodeMCPRuntime/MCPBridgeRuntimeError.swift
@@ -2,5 +2,7 @@ package enum MCPBridgeRuntimeError: Error, Equatable, Sendable {
     case closed
     case invalidRequest(String)
     case invalidResponse(String)
+    case requestTimedOut(method: String)
+    case serverError(code: Int, message: String, data: JSONValue?)
     case transportUnavailable(String)
 }

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -223,6 +223,40 @@ struct XcodeMCPTests {
         #expect(response.error?.objectValue?["code"] == .integer(-32601))
     }
 
+    @Test func runtimeSessionDoesNotRetainProgressHandlerForInvalidParams() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let session = try await InitializedMCPClientSession(
+            transport: transport,
+            configuration: .init(
+                clientName: "RuntimeSessionTest",
+                clientVersion: "1.0",
+                capabilities: [:],
+                requestTimeout: .seconds(2)
+            )
+        )
+        defer {
+            Task { await session.close() }
+        }
+
+        weak var weakProbe: DeinitProbe?
+        do {
+            var probe: DeinitProbe? = DeinitProbe()
+            weakProbe = probe
+            let capturedProbe = probe
+
+            await #expect(throws: MCPBridgeRuntimeError.invalidRequest(
+                "progress requests require object params"
+            )) {
+                _ = try await session.request("tools/call", params: .string("invalid")) { _ in
+                    _ = capturedProbe
+                }
+            }
+            probe = nil
+        }
+
+        #expect(weakProbe == nil)
+    }
+
     @Test func closeIsIdempotentAndRejectsFuturePublicCalls() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(transport: transport)
@@ -730,6 +764,8 @@ struct XcodeMCPTests {
         }
     }
 }
+
+private final class DeinitProbe: @unchecked Sendable {}
 
 private actor HangingSendXcodeMCPTransport: XcodeMCPTransport {
     nonisolated let events: AsyncStream<XcodeMCPTransportEvent>

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -174,6 +174,55 @@ struct XcodeMCPTests {
         #expect(progress.message == "halfway")
     }
 
+    @Test func runtimeSessionRoutesProgressAndAnswersUnsupportedServerRequests() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let session = try await InitializedMCPClientSession(
+            transport: transport,
+            configuration: .init(
+                clientName: "RuntimeSessionTest",
+                clientVersion: "1.0",
+                capabilities: [:],
+                requestTimeout: .seconds(2)
+            )
+        )
+        defer {
+            Task { await session.close() }
+        }
+
+        let progressValues = RecordedValues<JSONValue>()
+        let result = try await session.request(
+            "tools/call",
+            params: .object([
+                "name": .string("DocumentationSearch"),
+                "arguments": .object([
+                    "query": .string("Runtime"),
+                ]),
+            ])
+        ) { progress in
+            await progressValues.append(progress)
+        }
+
+        #expect(MCPJSONValue(result).objectValue?["x-result"] == .string("dynamic"))
+
+        let call = try #require(await transport.sentMessages().last { $0.method == "tools/call" })
+        let progressToken = try #require(
+            call.params?.objectValue?["_meta"]?.objectValue?["progressToken"]?.stringValue
+        )
+        let progress = try await waitWithTimeout("runtime progress was not routed") {
+            try await progressValues.nextValue()
+        }
+        #expect(MCPJSONValue(progress).objectValue?["progressToken"] == .string(progressToken))
+
+        await transport.emitServerRequest(method: "sampling/createMessage", id: .integer(99))
+        let response = try await waitWithTimeout("runtime unsupported response was not sent") {
+            try await transport.nextSentMessage { message in
+                message.method == nil && message.error != nil
+            }
+        }
+        #expect(response.id == .integer(99))
+        #expect(response.error?.objectValue?["code"] == .integer(-32601))
+    }
+
     @Test func closeIsIdempotentAndRejectsFuturePublicCalls() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(transport: transport)


### PR DESCRIPTION
## Purpose
Move raw JSON-RPC client session ownership out of the public `XcodeMCPKit.XcodeMCP` facade and into `XcodeMCPRuntime`, while preserving the public `XcodeMCP` API shape.

## Changes
- Added package-internal `InitializedMCPClientSession` in `XcodeMCPRuntime` to own initialize/initialized handshake, request IDs, pending request correlation, timeout/cancellation handling, unsupported server request responses, close semantics, and progress notification routing.
- Kept `XcodeMCP` as the public domain facade that creates configured transports, sends domain requests, maps runtime errors to `XcodeMCPError`, and decodes `MCPTool`, `MCPToolResult`, and `MCPProgress`.
- Extended behavior tests to cover runtime session progress routing, unsupported request responses, invalid progress params cleanup, and ordered progress delivery.

## Validation
- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPKitTestingTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `scripts/check.sh`
- codex-review against `origin/codex/refactor-layered-runtime-integration`: clean

Screenshots not applicable.