### PR TITLE
[codex] Remove ProxyCore runtime shims

### DIFF
--- a/Docs/maintainer-architecture.md
+++ b/Docs/maintainer-architecture.md
@@ -4,6 +4,8 @@
 
 - `ProxyCore`
   - CLI/config parsing, discovery file handling, logging, small shared helpers.
+  - Does not re-export runtime primitives; consumers import `XcodeMCPRuntime`
+    directly for runtime-owned contracts.
 - `XcodeMCPRuntime`
   - JSON-RPC / MCP value types, stdio framing, timeout dispatch, request inspection.
 - `ProxySession`
@@ -23,6 +25,8 @@
 ## Dependency Direction
 
 - `ProxyCore` must not depend on gateway/session/Xcode modules.
+- `ProxyCore` may refer to `XcodeMCPRuntime` for runtime contract validation,
+  but it must not add proxy-facing aliases for runtime-owned primitives.
 - `XcodeMCPRuntime` owns shared protocol/runtime primitives and must not depend on proxy-only modules.
   Avoid introducing gateway/session/Xcode knowledge here.
 - `ProxySession` depends on `ProxyCore` and `XcodeMCPRuntime`.

--- a/Sources/ProxyCore/ClockClient.swift
+++ b/Sources/ProxyCore/ClockClient.swift
@@ -1,3 +1,0 @@
-import XcodeMCPRuntime
-
-package typealias ClockClient = XcodeMCPRuntime.ClockClient

--- a/Sources/ProxyCore/Deadline.swift
+++ b/Sources/ProxyCore/Deadline.swift
@@ -1,3 +1,0 @@
-import XcodeMCPRuntime
-
-package typealias Deadline = XcodeMCPRuntime.Deadline

--- a/Sources/ProxyCore/Discovery.swift
+++ b/Sources/ProxyCore/Discovery.swift
@@ -1,4 +1,0 @@
-import XcodeMCPRuntime
-
-package typealias DiscoveryRecord = XcodeMCPRuntime.DiscoveryRecord
-package typealias Discovery = XcodeMCPRuntime.Discovery

--- a/Sources/ProxyCore/DiscoveryClient.swift
+++ b/Sources/ProxyCore/DiscoveryClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XcodeMCPRuntime
 
 package struct DiscoveryClient: DependencyClient {
     package var defaultFileURL: @Sendable () -> URL

--- a/Sources/ProxyCore/InitializeHandshakeParams.swift
+++ b/Sources/ProxyCore/InitializeHandshakeParams.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// Core-owned defaults and Xcode chat client version lookup for the
 /// initialize params the proxy presents to mcpbridge. JSON shaping is kept
-/// in ProxySession so ProxyCore stays independent of XcodeMCPRuntime.
+/// in ProxySession; ProxyCore only owns config/default lookup and refers to
+/// runtime protocol-version validation through XcodeMCPRuntime.
 package enum InitializeHandshakeParams {
     package static func hasExplicitClientVersionOverride(
         initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride?

--- a/Sources/ProxyCore/MCPProtocolVersion.swift
+++ b/Sources/ProxyCore/MCPProtocolVersion.swift
@@ -1,3 +1,0 @@
-import XcodeMCPRuntime
-
-package typealias MCPProtocolVersion = XcodeMCPRuntime.MCPProtocolVersion

--- a/Sources/ProxyCore/OrderedPipeReader.swift
+++ b/Sources/ProxyCore/OrderedPipeReader.swift
@@ -1,3 +1,0 @@
-import XcodeMCPRuntime
-
-package typealias OrderedPipeReader = XcodeMCPRuntime.OrderedPipeReader

--- a/Sources/ProxyCore/ProcessRunner.swift
+++ b/Sources/ProxyCore/ProcessRunner.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Darwin
 import NIOConcurrencyHelpers
+import XcodeMCPRuntime
 
 final class DispatchGroupLeaveGuard: @unchecked Sendable {
     private let group: DispatchGroup

--- a/Sources/ProxyCore/ProxyConfig.swift
+++ b/Sources/ProxyCore/ProxyConfig.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XcodeMCPRuntime
 
 package struct ProxyConfig: Sendable {
     package enum Transport: String, CaseIterable, Sendable {

--- a/Sources/ProxyCore/RuntimeScheduledTimeout.swift
+++ b/Sources/ProxyCore/RuntimeScheduledTimeout.swift
@@ -1,3 +1,0 @@
-import XcodeMCPRuntime
-
-package typealias RuntimeScheduledTimeout = XcodeMCPRuntime.RuntimeScheduledTimeout

--- a/Sources/ProxyCore/UpstreamReadinessGate.swift
+++ b/Sources/ProxyCore/UpstreamReadinessGate.swift
@@ -1,3 +1,0 @@
-import XcodeMCPRuntime
-
-package typealias UpstreamReadinessGate = XcodeMCPRuntime.UpstreamReadinessGate

--- a/Sources/ProxyCore/XcodeTargetDiscovery.swift
+++ b/Sources/ProxyCore/XcodeTargetDiscovery.swift
@@ -1,6 +1,0 @@
-import XcodeMCPRuntime
-
-package typealias XcodeProcessTarget = XcodeMCPRuntime.XcodeProcessTarget
-package typealias XcodeTargetDiscovering = XcodeMCPRuntime.XcodeTargetDiscovering
-package typealias PriorityOrderedXcodeTargetDiscovering =
-    XcodeMCPRuntime.PriorityOrderedXcodeTargetDiscovering

--- a/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator+LoadPromotion.swift
+++ b/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator+LoadPromotion.swift
@@ -1,6 +1,7 @@
 import Foundation
 import NIO
 import ProxyCore
+import XcodeMCPRuntime
 
 extension ControlPlaneCoordinator {
     func replaceToolsCatalogRequestLoad(

--- a/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator+Utilities.swift
+++ b/Sources/ProxySession/ControlPlane/ControlPlaneCoordinator+Utilities.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NIO
+import XcodeMCPRuntime
 
 extension ControlPlaneCoordinator {
     private var sharedLoadPromotionGraceNanoseconds: UInt64 { 100_000_000 }

--- a/Sources/ProxySession/Runtime/LiveXcodeTargetDiscovery.swift
+++ b/Sources/ProxySession/Runtime/LiveXcodeTargetDiscovery.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import ProxyCore
+import XcodeMCPRuntime
 
 package struct LiveXcodeTargetDiscovery: XcodeTargetDiscovering, Sendable {
     package init() {}

--- a/Sources/ProxySession/Runtime/RuntimeXcodeTargetDiscovery.swift
+++ b/Sources/ProxySession/Runtime/RuntimeXcodeTargetDiscovery.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ProxyCore
+import XcodeMCPRuntime
 
 package final class RuntimeDocumentationTargetDiscovery:
     PriorityOrderedXcodeTargetDiscovering,

--- a/Sources/ProxySession/Runtime/XcodeUpstreamReadiness.swift
+++ b/Sources/ProxySession/Runtime/XcodeUpstreamReadiness.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ProxyCore
+import XcodeMCPRuntime
 
 extension UpstreamReadinessGate {
     /// The live gate for the stock xcrun mcpbridge upstream: hold

--- a/Sources/ProxySession/XcodeFeatures/RefreshCodeIssuesDebugState.swift
+++ b/Sources/ProxySession/XcodeFeatures/RefreshCodeIssuesDebugState.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ProxyCore
+import XcodeMCPRuntime
 
 extension RefreshCodeIssues {
     package struct QueueSnapshot: Codable, Sendable {

--- a/Sources/XcodeMCPProxyKit/Internal/Process/ExistingProxyServerProcessController.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Process/ExistingProxyServerProcessController.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import ProxyCore
+import XcodeMCPRuntime
 
 struct ExistingProxyServerProcessController: DependencyClient {
     var terminateExistingServer:

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -4,6 +4,7 @@ import NIO
 import NIOHTTP1
 import ProxyCore
 import ProxySession
+import XcodeMCPRuntime
 
 /// Embeddable Streamable HTTP proxy server for Xcode MCP.
 ///

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import XcodeMCPProxyKit
+import XcodeMCPRuntime
 
 @testable import ProxyCore
 

--- a/Tests/ProxyIntegrationTests/DiscoveryTests.swift
+++ b/Tests/ProxyIntegrationTests/DiscoveryTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import XcodeMCPRuntime
 
 @testable import ProxyCore
 

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
@@ -1,5 +1,6 @@
 import ProxyCore
 import Testing
+import XcodeMCPRuntime
 
 @testable import XcodeMCPProxyKit
 


### PR DESCRIPTION
## Purpose

Remove the ProxyCore runtime re-export/typealias shims so callers use XcodeMCPRuntime as the owner of runtime types directly.

## Changes

- Deleted ProxyCore package typealiases for runtime-owned types such as ClockClient, Deadline, Discovery, MCPProtocolVersion, OrderedPipeReader, RuntimeScheduledTimeout, UpstreamReadinessGate, and Xcode target discovery protocols.
- Added direct XcodeMCPRuntime imports in ProxyCore implementation files and proxy/test consumers that use those runtime-owned contracts.
- Kept ProxyCore focused on proxy-specific core pieces such as config, logging, process running, and discovery client behavior.

## Validation

- `swift test --filter ProxySessionTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyContractTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `scripts/check.sh`
- Codex review against `origin/codex/refactor-layered-runtime-integration`: no findings