### PR TITLE
Preserve preferred upstream candidate arrays

### DIFF
--- a/Sources/ProxySession/ClientRequestExecution/Post/ClientMCPRequestExecutor.swift
+++ b/Sources/ProxySession/ClientRequestExecution/Post/ClientMCPRequestExecutor.swift
@@ -573,11 +573,15 @@ package final class ClientMCPRequestExecutor: Sendable {
                     if error is CancellationError {
                         return eventLoop.makeFailedFuture(error)
                     }
+                    let releaseReason: LeaseManager.ReleaseReason =
+                        error is UpstreamSlotScheduler.AcquisitionError
+                        ? .upstreamUnavailable
+                        : .upstreamOverloaded
                     cancellationHandle.markCompleted()
                     self.sessionManager.failRequestLease(
                         leaseID,
                         terminalState: .failed,
-                        reason: .upstreamOverloaded
+                        reason: releaseReason
                     )
                     return eventLoop.makeSucceededFuture(
                         Self.makeUpstreamUnavailableResolution(

--- a/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
+++ b/Sources/ProxySession/Runtime/RuntimeCoordinator.swift
@@ -136,13 +136,6 @@ package protocol RuntimeUpstreamForwardingPort: Sendable {
         leaseID: LeaseManager.ID,
         descriptor: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
-        preferredUpstreamIndex: Int?,
-        starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
-    ) -> EventLoopFuture<Output>
-    func enqueueOnUpstreamSlot<Output: Sendable>(
-        leaseID: LeaseManager.ID,
-        descriptor: SessionRequestPipeline.Descriptor,
-        on eventLoop: EventLoop,
         preferredUpstreamIndices: [Int]?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
     ) -> EventLoopFuture<Output>
@@ -298,7 +291,7 @@ extension RuntimeUpstreamForwardingPort {
             leaseID: leaseID,
             descriptor: descriptor,
             on: eventLoop,
-            preferredUpstreamIndex: nil,
+            preferredUpstreamIndices: nil,
             starter: starter
         )
     }
@@ -307,14 +300,14 @@ extension RuntimeUpstreamForwardingPort {
         leaseID: LeaseManager.ID,
         descriptor: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
-        preferredUpstreamIndices: [Int]?,
+        preferredUpstreamIndex: Int?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
     ) -> EventLoopFuture<Output> {
         enqueueOnUpstreamSlot(
             leaseID: leaseID,
             descriptor: descriptor,
             on: eventLoop,
-            preferredUpstreamIndex: preferredUpstreamIndices?.first,
+            preferredUpstreamIndices: preferredUpstreamIndex.map { [$0] },
             starter: starter
         )
     }

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -92,6 +92,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         var sentUpstreamPayloads: [Data] = []
         var availableUpstreamIndices: [Int?] = []
         var preferredUpstreamIndex: Int?
+        var usablePreferredUpstreamIndices: Set<Int>?
         var toolRoutingDecision: ToolRoutingDecision?
         var forceAsyncToolRoutingDecision = false
         var toolRoutingStarted: TestSignal?
@@ -390,13 +391,23 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         leaseID _: LeaseManager.ID,
         descriptor _: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
-        preferredUpstreamIndex: Int?,
+        preferredUpstreamIndices: [Int]?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
     ) -> EventLoopFuture<Output> {
-        let upstreamIndex = preferredUpstreamIndex ?? chooseUpstreamIndex()
+        let upstreamIndex: Int?
+        if let preferredUpstreamIndices, preferredUpstreamIndices.isEmpty == false {
+            upstreamIndex = state.withLockedValue { state in
+                guard let usable = state.usablePreferredUpstreamIndices else {
+                    return preferredUpstreamIndices.first
+                }
+                return preferredUpstreamIndices.first { usable.contains($0) }
+            }
+        } else {
+            upstreamIndex = chooseUpstreamIndex()
+        }
         guard let upstreamIndex else {
             return eventLoop.makeFailedFuture(
-                NSError(domain: "TestRuntimeCoordinator", code: 1)
+                UpstreamSlotScheduler.AcquisitionError.unavailable
             )
         }
         if cancelAfterStartingEnqueueRequest {
@@ -889,6 +900,12 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     func setPreferredUpstreamIndex(_ value: Int?) {
         state.withLockedValue { $0.preferredUpstreamIndex = value }
+    }
+
+    func setUsablePreferredUpstreamIndices(_ values: [Int]?) {
+        state.withLockedValue { state in
+            state.usablePreferredUpstreamIndices = values.map(Set.init)
+        }
     }
 
     func setToolRoutingDecision(_ value: ToolRoutingDecision?) {

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -1389,6 +1389,86 @@ struct HTTPHandlerTests {
         try await server.shutdown()
     }
 
+    @Test func httpToolRoutingForwardAnyUsesNextUsablePreferredCandidate() async throws {
+        let config = makeConfig()
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamResponder: { _, originalID in
+                try makeToolSuccessResponse(id: originalID, text: "{\"ok\":true}")
+            }
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setToolRoutingDecision(.forwardAny(preferredUpstreamIndices: [0, 1]))
+        sessionManager.setUsablePreferredUpstreamIndices([1])
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-routing-forward-any-fallback",
+                payload: toolsCallPayload(
+                    id: 3401,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": "tab-a"]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            #expect(body["result"] != nil)
+            #expect(sessionManager.sentToolRequests() == ["BuildProject@1"])
+            #expect(sessionManager.chooseUpstreamIndexCallCount() == 0)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
+    @Test func httpToolRoutingForwardAnyUnavailableReleasesLeaseWithoutForwarding() async throws {
+        let config = makeConfig()
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        sessionManager.setInitialized(true)
+        sessionManager.setToolRoutingDecision(.forwardAny(preferredUpstreamIndices: [0, 1]))
+        sessionManager.setUsablePreferredUpstreamIndices([])
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-routing-forward-any-unavailable",
+                payload: toolsCallPayload(
+                    id: 3402,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": "tab-a"]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let error = try #require(body["error"] as? [String: Any])
+            #expect((error["code"] as? NSNumber)?.intValue == -32001)
+            #expect((error["message"] as? String) == "upstream unavailable")
+            #expect(sessionManager.sentMethods().isEmpty)
+            #expect(sessionManager.mappedUpstreamRequestCount() == 0)
+            let lease = try #require(
+                sessionManager.leaseDebugSnapshots().first {
+                    $0.label == "tools/call:BuildProject"
+                }
+            )
+            #expect(lease.state == .failed)
+            #expect(lease.releaseReason == "upstreamUnavailable")
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpToolRoutingRejectReturnsErrorsForNonToolBatchItems() async throws {
         let config = makeConfig()
         let sessionManager = TestRuntimeCoordinator(config: config)

--- a/Tests/ProxySessionTests/ToolSurfaceTests.swift
+++ b/Tests/ProxySessionTests/ToolSurfaceTests.swift
@@ -527,7 +527,7 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
         leaseID: LeaseManager.ID,
         descriptor: SessionRequestPipeline.Descriptor,
         on eventLoop: EventLoop,
-        preferredUpstreamIndex: Int?,
+        preferredUpstreamIndices: [Int]?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
     ) -> EventLoopFuture<Output> where Output : Sendable {
         fatalError("unused in ToolSurfaceTests")


### PR DESCRIPTION
## Purpose
Fix the RuntimeUpstreamForwardingPort preferred upstream contract so ordered candidate arrays remain intact and route degradation can fall through from the first unavailable candidate to later usable candidates.

## Changes
- Make the array-based enqueueOnUpstreamSlot overload the required RuntimeUpstreamForwardingPort contract.
- Keep the single-index overload as a convenience that delegates to the array path.
- Update HTTP/test runtime doubles to resolve preferred candidate arrays instead of collapsing to the first candidate.
- Preserve upstreamUnavailable lease release reasons for acquisition failures.
- Add HTTP routing contract coverage for `.forwardAny([0, 1])` fallback and all-candidates-unavailable release behavior.

## Verification
- `swift test --filter ProxySessionTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyContractTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `scripts/check.sh`
- codex-review against `origin/codex/refactor-layered-runtime-integration`: no findings