### PR TITLE
Neutralize runtime naming leaks

### DIFF
--- a/Sources/XcodeMCPCore/XcodeMCPRuntimeLogging.swift
+++ b/Sources/XcodeMCPCore/XcodeMCPRuntimeLogging.swift
@@ -1,7 +1,7 @@
 import Logging
 
 package enum XcodeMCPRuntimeLogging {
-    private static let labelPrefix = "XcodeMCPProxy"
+    private static let labelPrefix = "XcodeMCPRuntime"
 
     package static func make(_ name: String) -> Logger {
         Logger(label: "\(labelPrefix).\(name)")

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Launch.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Launch.swift
@@ -10,7 +10,7 @@ extension XcodeMCPProxyServer {
         public let version: String
 
         /// Creates product metadata.
-        public init(name: String = "XcodeMCPKit", version: String) {
+        public init(name: String = "XcodeMCPProxyKit", version: String) {
             self.name = name
             self.version = version
         }

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
@@ -34,7 +34,7 @@ struct XcodeMCPProxyServerBuildInfoTests {
         )
 
         #expect(summary == """
-        XcodeMCPKit \(XcodeMCPProxyServer.productMetadata.version)
+        XcodeMCPProxyKit \(XcodeMCPProxyServer.productMetadata.version)
 
         Server
           URL: http://localhost:8765/mcp


### PR DESCRIPTION
## Summary
- Rename the shared Core runtime logger label prefix from `XcodeMCPProxy` to `XcodeMCPRuntime`.
- Change the proxy server `ProductMetadata` default display name to `XcodeMCPProxyKit`.
- Update the startup summary expectation for the new proxy-facing product name.

## Impact
This keeps shared runtime logs neutral after the target split while leaving package and release version semantics unchanged. The `ProductMetadata` initializer signature is unchanged, but embedders that relied on the previous default display string will now see `XcodeMCPProxyKit` in startup summaries unless they pass an explicit name.

## Validation
- `swift test --filter XcodeMCPRuntimeTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyStartupLoggingTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter PublicProductContractTests`
- `git diff --check`
- `codex-review` against `codex/refactor-layered-runtime-integration`: no findings