### PR TITLE
[codex] Move upstream forwarding lifecycle into proxy runtime

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/MCP/MCPForwardingService.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/MCP/MCPForwardingService.swift
@@ -5,37 +5,8 @@ import XcodeMCPProcessRuntime
 import XcodeMCPProxyRuntime
 
 package struct MCPForwardingService: Sendable {
-    package struct PreparedRequest: Sendable {
-        package let transform: RequestTransform
-        package let upstreamIndex: Int
-
-        package init(transform: RequestTransform, upstreamIndex: Int) {
-            self.transform = transform
-            self.upstreamIndex = upstreamIndex
-        }
-    }
-
-    package struct StartedRequest: Sendable {
-        package let transform: RequestTransform
-        package let upstreamIndex: Int
-        package let requestTimeout: TimeAmount?
-        package let routerPendingToken: UUID
-        package let future: EventLoopFuture<ByteBuffer>
-
-        package init(
-            transform: RequestTransform,
-            upstreamIndex: Int,
-            requestTimeout: TimeAmount?,
-            routerPendingToken: UUID,
-            future: EventLoopFuture<ByteBuffer>
-        ) {
-            self.transform = transform
-            self.upstreamIndex = upstreamIndex
-            self.requestTimeout = requestTimeout
-            self.routerPendingToken = routerPendingToken
-            self.future = future
-        }
-    }
+    package typealias PreparedRequest = ProxyUpstreamRequestRuntime.PreparedRequest
+    package typealias StartedRequest = ProxyUpstreamRequestRuntime.StartedRequest
 
     package enum ResponseResolution: Sendable {
         case success(Data)
@@ -45,11 +16,13 @@ package struct MCPForwardingService: Sendable {
 
     private let config: ProxyConfig
     private let sessionManager: any RuntimeMCPForwardingPort
+    private let upstreamRuntime: ProxyUpstreamRequestRuntime
     private let toolSurface: ToolSurface
 
     package init(config: ProxyConfig, sessionManager: any RuntimeMCPForwardingPort) {
         self.config = config
         self.sessionManager = sessionManager
+        self.upstreamRuntime = ProxyUpstreamRequestRuntime(port: sessionManager)
         self.toolSurface = ToolSurface(config: config, sessionManager: sessionManager)
     }
 
@@ -59,29 +32,12 @@ package struct MCPForwardingService: Sendable {
         sessionID: String,
         upstreamIndexOverride: Int? = nil
     ) throws -> PreparedRequest? {
-        let upstreamIndex: Int
-        if let upstreamIndexOverride {
-            upstreamIndex = upstreamIndexOverride
-        } else {
-            guard let chosen = sessionManager.chooseUpstreamIndex() else {
-                return nil
-            }
-            upstreamIndex = chosen
-        }
-
-        let transform = try RequestInspector.transform(
-            bodyData,
-            parsedJSON: parsedRequestJSON,
+        try upstreamRuntime.prepareRequest(
+            bodyData: bodyData,
+            parsedRequestJSON: parsedRequestJSON,
             sessionID: sessionID,
-            mapID: { sessionID, originalID in
-                sessionManager.assignUpstreamID(
-                    sessionID: sessionID,
-                    originalID: originalID,
-                    upstreamIndex: upstreamIndex
-                )
-            }
+            upstreamIndexOverride: upstreamIndexOverride
         )
-        return PreparedRequest(transform: transform, upstreamIndex: upstreamIndex)
     }
 
     package func startRequest(
@@ -99,52 +55,17 @@ package struct MCPForwardingService: Sendable {
                 prepared.transform.method,
                 defaultSeconds: config.requestTimeout
             )
-        struct MissingRequestIDError: Error {}
-        let registration: JSONRPCResponseRouter.PendingRegistration
-        if prepared.transform.isBatch {
-            let responseIDKeys = prepared.transform.responseIDs.map(\.key)
-            guard responseIDKeys.isEmpty == false else {
-                throw MissingRequestIDError()
-            }
-            registration = session.router.registerBatchPending(
-                on: eventLoop,
-                timeout: requestTimeout,
-                responseIDKeys: responseIDKeys,
-                onTimeout: onTimeout
-            )
-        } else if let idKey = prepared.transform.idKey {
-            registration = session.router.registerRequestPending(
-                idKey: idKey,
-                on: eventLoop,
-                timeout: requestTimeout,
-                onTimeout: onTimeout
-            )
-        } else {
-            throw MissingRequestIDError()
-        }
-
-        if let leaseID {
-            sessionManager.activateRequestLease(
-                leaseID,
-                requestIDKey: prepared.transform.responseIDs.first?.key,
-                upstreamIndex: prepared.upstreamIndex,
-                timeout: requestTimeout
-            )
-        }
-        cancellationHandle?.activate(upstreamIndex: prepared.upstreamIndex)
-        cancellationHandle?.bindRouterPendingToken(registration.token)
-
-        sessionManager.sendUpstream(
-            prepared.transform.upstreamData,
-            upstreamIndex: prepared.upstreamIndex,
-            ensureRunning: false
-        )
-        return StartedRequest(
-            transform: prepared.transform,
-            upstreamIndex: prepared.upstreamIndex,
+        return try upstreamRuntime.startRequest(
+            prepared,
+            router: session.router,
+            on: eventLoop,
             requestTimeout: requestTimeout,
-            routerPendingToken: registration.token,
-            future: registration.future
+            leaseID: leaseID,
+            onRegistered: { registration in
+                cancellationHandle?.activate(upstreamIndex: registration.upstreamIndex)
+                cancellationHandle?.bindRouterPendingToken(registration.routerPendingToken)
+            },
+            onTimeout: onTimeout
         )
     }
 
@@ -181,39 +102,19 @@ package struct MCPForwardingService: Sendable {
                 )
             }
             if accountSuccess, toolSurface.shouldNotifyUpstreamSuccess(for: responseData) {
-                for responseID in started.transform.responseIDs {
-                    sessionManager.onRequestSucceeded(
-                        sessionID: sessionID,
-                        requestIDKey: responseID.key,
-                        upstreamIndex: started.upstreamIndex
-                    )
-                }
+                upstreamRuntime.recordRequestSucceeded(
+                    sessionID: sessionID,
+                    started: started
+                )
             }
             return .success(responseData)
 
         case .failure:
-            if let firstResponseID = started.transform.responseIDs.first {
-                if accountTimeout {
-                    sessionManager.onRequestTimeout(
-                        sessionID: sessionID,
-                        requestIDKey: firstResponseID.key,
-                        upstreamIndex: started.upstreamIndex
-                    )
-                } else {
-                    sessionManager.removeUpstreamIDMapping(
-                        sessionID: sessionID,
-                        requestIDKey: firstResponseID.key,
-                        upstreamIndex: started.upstreamIndex
-                    )
-                }
-                for responseID in started.transform.responseIDs.dropFirst() {
-                    sessionManager.removeUpstreamIDMapping(
-                        sessionID: sessionID,
-                        requestIDKey: responseID.key,
-                        upstreamIndex: started.upstreamIndex
-                    )
-                }
-            }
+            upstreamRuntime.recordRequestTimedOut(
+                sessionID: sessionID,
+                started: started,
+                accountTimeout: accountTimeout
+            )
             return .timeout
         }
     }
@@ -314,12 +215,6 @@ package struct MCPForwardingService: Sendable {
                 preferredUpstreamIndices: preferredUpstreamIndices
             ) { selectedUpstreamIndex in
                 internalCancellationHandle.activate(upstreamIndex: selectedUpstreamIndex)
-                self.sessionManager.activateRequestLease(
-                    leaseID,
-                    requestIDKey: nil,
-                    upstreamIndex: selectedUpstreamIndex,
-                    timeout: nil
-                )
                 let parsedRequestJSON = parsedRequestJSONValue.foundationObject
                 let prepared: PreparedRequest
                 do {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+ForwardExecutor.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+ForwardExecutor.swift
@@ -341,7 +341,6 @@ extension ClientMCPRequestExecutor {
                         )
                     }
                 )
-                cancellationHandle?.bindRouterPendingToken(started.routerPendingToken)
             } catch {
                 return makeImmediateLeaseResolution(
                     .mcpError(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+RefreshSupport.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+RefreshSupport.swift
@@ -142,7 +142,6 @@ extension ClientMCPRequestExecutor {
                             )
                         }
                     )
-                    cancellationHandle?.bindRouterPendingToken(started.routerPendingToken)
                 } catch {
                     return eventLoop.makeSucceededFuture(
                         MCPForwardingService.ResponseResolution.invalidUpstreamResponse

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -148,7 +148,6 @@ package protocol RuntimeToolRoutingPort: Sendable {
 
 package protocol RuntimeUpstreamForwardingPort: Sendable {
     func session(id: String) -> SessionContext
-    func chooseUpstreamIndex() -> Int?
     func enqueueOnUpstreamSlot<Output: Sendable>(
         leaseID: LeaseManager.ID,
         descriptor: SessionRequestPipeline.Descriptor,
@@ -156,11 +155,6 @@ package protocol RuntimeUpstreamForwardingPort: Sendable {
         preferredUpstreamIndices: [Int]?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
     ) -> EventLoopFuture<Output>
-    func assignUpstreamID(sessionID: String, originalID: JSONRPC.ID, upstreamIndex: Int) -> Int64
-    func removeUpstreamIDMapping(sessionID: String, requestIDKey: String, upstreamIndex: Int)
-    func onRequestTimeout(sessionID: String, requestIDKey: String, upstreamIndex: Int)
-    func onRequestSucceeded(sessionID: String, requestIDKey: String, upstreamIndex: Int)
-    func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool)
     func forwardServerRequestResponse(
         responseData: Data,
         sessionID: String,
@@ -218,7 +212,8 @@ package protocol RuntimeMCPForwardingPort:
     RuntimeInitializeToolsPort,
     RuntimeToolRoutingPort,
     RuntimeUpstreamForwardingPort,
-    RuntimeRequestLeasePort {}
+    RuntimeRequestLeasePort,
+    ProxyUpstreamRequestRuntimePort {}
 
 package protocol RuntimeClientMCPRequestPort:
     RuntimeSessionRegistryPort,
@@ -285,10 +280,6 @@ extension RuntimeToolRoutingPort {
 }
 
 extension RuntimeUpstreamForwardingPort {
-    func sendUpstream(_ data: Data, upstreamIndex: Int) {
-        sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: false)
-    }
-
     package func forwardServerRequestResponse(
         responseData _: Data,
         sessionID _: String,

--- a/Sources/XcodeMCPProxyRuntime/Broker/ProxyUpstreamRequestRuntime.swift
+++ b/Sources/XcodeMCPProxyRuntime/Broker/ProxyUpstreamRequestRuntime.swift
@@ -1,0 +1,212 @@
+import Foundation
+import NIO
+import XcodeMCPCore
+
+package protocol ProxyUpstreamRequestRuntimePort: Sendable {
+    func chooseUpstreamIndex() -> Int?
+    func assignUpstreamID(sessionID: String, originalID: JSONRPC.ID, upstreamIndex: Int) -> Int64
+    func removeUpstreamIDMapping(sessionID: String, requestIDKey: String, upstreamIndex: Int)
+    func onRequestTimeout(sessionID: String, requestIDKey: String, upstreamIndex: Int)
+    func onRequestSucceeded(sessionID: String, requestIDKey: String, upstreamIndex: Int)
+    func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool)
+    func activateRequestLease(
+        _ leaseID: LeaseManager.ID,
+        requestIDKey: String?,
+        upstreamIndex: Int?,
+        timeout: TimeAmount?
+    )
+}
+
+extension ProxyUpstreamRequestRuntimePort {
+    package func sendUpstream(_ data: Data, upstreamIndex: Int) {
+        sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: false)
+    }
+}
+
+package struct ProxyUpstreamRequestRuntime: Sendable {
+    package struct PreparedRequest: Sendable {
+        package let transform: RequestTransform
+        package let upstreamIndex: Int
+
+        package init(transform: RequestTransform, upstreamIndex: Int) {
+            self.transform = transform
+            self.upstreamIndex = upstreamIndex
+        }
+    }
+
+    package struct StartedRegistration: Sendable {
+        package let upstreamIndex: Int
+        package let routerPendingToken: UUID
+
+        package init(upstreamIndex: Int, routerPendingToken: UUID) {
+            self.upstreamIndex = upstreamIndex
+            self.routerPendingToken = routerPendingToken
+        }
+    }
+
+    package struct StartedRequest: Sendable {
+        package let transform: RequestTransform
+        package let upstreamIndex: Int
+        package let requestTimeout: TimeAmount?
+        package let routerPendingToken: UUID
+        package let future: EventLoopFuture<ByteBuffer>
+
+        package init(
+            transform: RequestTransform,
+            upstreamIndex: Int,
+            requestTimeout: TimeAmount?,
+            routerPendingToken: UUID,
+            future: EventLoopFuture<ByteBuffer>
+        ) {
+            self.transform = transform
+            self.upstreamIndex = upstreamIndex
+            self.requestTimeout = requestTimeout
+            self.routerPendingToken = routerPendingToken
+            self.future = future
+        }
+    }
+
+    package enum Error: Swift.Error, Sendable {
+        case missingRequestID
+    }
+
+    private let port: any ProxyUpstreamRequestRuntimePort
+
+    package init(port: any ProxyUpstreamRequestRuntimePort) {
+        self.port = port
+    }
+
+    package func prepareRequest(
+        bodyData: Data,
+        parsedRequestJSON: Any,
+        sessionID: String,
+        upstreamIndexOverride: Int? = nil
+    ) throws -> PreparedRequest? {
+        let upstreamIndex: Int
+        if let upstreamIndexOverride {
+            upstreamIndex = upstreamIndexOverride
+        } else {
+            guard let chosen = port.chooseUpstreamIndex() else {
+                return nil
+            }
+            upstreamIndex = chosen
+        }
+
+        let transform = try RequestInspector.transform(
+            bodyData,
+            parsedJSON: parsedRequestJSON,
+            sessionID: sessionID,
+            mapID: { sessionID, originalID in
+                port.assignUpstreamID(
+                    sessionID: sessionID,
+                    originalID: originalID,
+                    upstreamIndex: upstreamIndex
+                )
+            }
+        )
+        return PreparedRequest(transform: transform, upstreamIndex: upstreamIndex)
+    }
+
+    package func startRequest(
+        _ prepared: PreparedRequest,
+        router: JSONRPCResponseRouter,
+        on eventLoop: EventLoop,
+        requestTimeout: TimeAmount?,
+        leaseID: LeaseManager.ID? = nil,
+        onRegistered: (@Sendable (StartedRegistration) -> Void)? = nil,
+        onTimeout: (@Sendable () -> Void)? = nil
+    ) throws -> StartedRequest {
+        let registration: JSONRPCResponseRouter.PendingRegistration
+        if prepared.transform.isBatch {
+            let responseIDKeys = prepared.transform.responseIDs.map(\.key)
+            guard responseIDKeys.isEmpty == false else {
+                throw Error.missingRequestID
+            }
+            registration = router.registerBatchPending(
+                on: eventLoop,
+                timeout: requestTimeout,
+                responseIDKeys: responseIDKeys,
+                onTimeout: onTimeout
+            )
+        } else if let idKey = prepared.transform.idKey {
+            registration = router.registerRequestPending(
+                idKey: idKey,
+                on: eventLoop,
+                timeout: requestTimeout,
+                onTimeout: onTimeout
+            )
+        } else {
+            throw Error.missingRequestID
+        }
+
+        if let leaseID {
+            port.activateRequestLease(
+                leaseID,
+                requestIDKey: prepared.transform.responseIDs.first?.key,
+                upstreamIndex: prepared.upstreamIndex,
+                timeout: requestTimeout
+            )
+        }
+        onRegistered?(
+            StartedRegistration(
+                upstreamIndex: prepared.upstreamIndex,
+                routerPendingToken: registration.token
+            )
+        )
+        port.sendUpstream(
+            prepared.transform.upstreamData,
+            upstreamIndex: prepared.upstreamIndex,
+            ensureRunning: false
+        )
+        return StartedRequest(
+            transform: prepared.transform,
+            upstreamIndex: prepared.upstreamIndex,
+            requestTimeout: requestTimeout,
+            routerPendingToken: registration.token,
+            future: registration.future
+        )
+    }
+
+    package func recordRequestSucceeded(
+        sessionID: String,
+        started: StartedRequest
+    ) {
+        for responseID in started.transform.responseIDs {
+            port.onRequestSucceeded(
+                sessionID: sessionID,
+                requestIDKey: responseID.key,
+                upstreamIndex: started.upstreamIndex
+            )
+        }
+    }
+
+    package func recordRequestTimedOut(
+        sessionID: String,
+        started: StartedRequest,
+        accountTimeout: Bool
+    ) {
+        guard let firstResponseID = started.transform.responseIDs.first else {
+            return
+        }
+        if accountTimeout {
+            port.onRequestTimeout(
+                sessionID: sessionID,
+                requestIDKey: firstResponseID.key,
+                upstreamIndex: started.upstreamIndex
+            )
+        } else {
+            port.removeUpstreamIDMapping(
+                sessionID: sessionID,
+                requestIDKey: firstResponseID.key,
+                upstreamIndex: started.upstreamIndex
+            )
+        }
+        for responseID in started.transform.responseIDs.dropFirst() {
+            port.removeUpstreamIDMapping(
+                sessionID: sessionID,
+                requestIDKey: responseID.key,
+                upstreamIndex: started.upstreamIndex
+            )
+        }
+    }
+}

--- a/Tests/XcodeMCPRuntimeTests/ProxyUpstreamRequestRuntimeTests.swift
+++ b/Tests/XcodeMCPRuntimeTests/ProxyUpstreamRequestRuntimeTests.swift
@@ -1,0 +1,340 @@
+import Foundation
+import NIO
+import NIOConcurrencyHelpers
+import NIOEmbedded
+import Testing
+import XcodeMCPCore
+import XcodeMCPProxyRuntime
+
+@Suite
+struct ProxyUpstreamRequestRuntimeTests {
+    @Test func prepareRequestSelectsUpstreamAndAssignsRuntimeIDs() throws {
+        let port = RecordingUpstreamRuntimePort(chosenUpstreamIndex: 2)
+        let runtime = ProxyUpstreamRequestRuntime(port: port)
+        let requestData = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": "client-1",
+                "method": "tools/list",
+            ],
+            options: []
+        )
+        let parsed = try JSONSerialization.jsonObject(with: requestData, options: [])
+
+        let prepared = try #require(
+            try runtime.prepareRequest(
+                bodyData: requestData,
+                parsedRequestJSON: parsed,
+                sessionID: "session-1"
+            )
+        )
+
+        #expect(prepared.upstreamIndex == 2)
+        #expect(port.assignments() == [
+            RecordingUpstreamRuntimePort.Assignment(
+                sessionID: "session-1",
+                requestIDKey: "client-1",
+                upstreamIndex: 2
+            )
+        ])
+        let upstreamObject = try #require(
+            try JSONSerialization.jsonObject(
+                with: prepared.transform.upstreamData,
+                options: []
+            ) as? [String: Any]
+        )
+        let upstreamID = try #require(upstreamObject["id"] as? NSNumber)
+        #expect(upstreamID.int64Value == 100)
+    }
+
+    @Test func startRequestRegistersPendingActivatesLeaseAndSends() throws {
+        let port = RecordingUpstreamRuntimePort(chosenUpstreamIndex: 1)
+        let runtime = ProxyUpstreamRequestRuntime(port: port)
+        let requestData = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": "client-2",
+                "method": "tools/list",
+            ],
+            options: []
+        )
+        let parsed = try JSONSerialization.jsonObject(with: requestData, options: [])
+        let prepared = try #require(
+            try runtime.prepareRequest(
+                bodyData: requestData,
+                parsedRequestJSON: parsed,
+                sessionID: "session-2"
+            )
+        )
+        let eventLoop = EmbeddedEventLoop()
+        let router = JSONRPCResponseRouter(
+            requestTimeout: nil,
+            hasActiveClients: { false },
+            sendNotification: { _ in }
+        )
+        let leaseID = LeaseManager.ID()
+        let registered = NIOLockedValueBox<ProxyUpstreamRequestRuntime.StartedRegistration?>(nil)
+
+        let started = try runtime.startRequest(
+            prepared,
+            router: router,
+            on: eventLoop,
+            requestTimeout: .seconds(3),
+            leaseID: leaseID,
+            onRegistered: { registration in
+                registered.withLockedValue { $0 = registration }
+            }
+        )
+
+        #expect(registered.withLockedValue { $0?.routerPendingToken } == started.routerPendingToken)
+        #expect(registered.withLockedValue { $0?.upstreamIndex } == 1)
+        #expect(port.activations() == [
+            RecordingUpstreamRuntimePort.Activation(
+                leaseID: leaseID,
+                requestIDKey: "client-2",
+                upstreamIndex: 1,
+                timeout: .seconds(3)
+            )
+        ])
+        #expect(port.sentRequests().map(\.upstreamIndex) == [1])
+
+        let responseData = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": "client-2",
+                "result": ["ok": true],
+            ],
+            options: []
+        )
+        router.handleIncoming(responseData)
+        eventLoop.run()
+        var buffer = try started.future.wait()
+        let readBytes = buffer.readBytes(length: buffer.readableBytes)
+        let responseBytes = try #require(readBytes)
+        #expect(Data(responseBytes) == responseData)
+    }
+
+    @Test func completionAccountingCoversAllResponseIDs() throws {
+        let port = RecordingUpstreamRuntimePort(chosenUpstreamIndex: 0)
+        let runtime = ProxyUpstreamRequestRuntime(port: port)
+        let requestData = try JSONSerialization.data(
+            withJSONObject: [
+                [
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list",
+                ],
+                [
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list",
+                ],
+            ],
+            options: []
+        )
+        let parsed = try JSONSerialization.jsonObject(with: requestData, options: [])
+        let prepared = try #require(
+            try runtime.prepareRequest(
+                bodyData: requestData,
+                parsedRequestJSON: parsed,
+                sessionID: "session-3"
+            )
+        )
+        let eventLoop = EmbeddedEventLoop()
+        let started = ProxyUpstreamRequestRuntime.StartedRequest(
+            transform: prepared.transform,
+            upstreamIndex: prepared.upstreamIndex,
+            requestTimeout: nil,
+            routerPendingToken: UUID(),
+            future: eventLoop.makeSucceededFuture(ByteBuffer())
+        )
+
+        runtime.recordRequestSucceeded(sessionID: "session-3", started: started)
+        #expect(port.successes().map(\.requestIDKey) == ["1", "2"])
+
+        runtime.recordRequestTimedOut(
+            sessionID: "session-3",
+            started: started,
+            accountTimeout: true
+        )
+        #expect(port.timeouts().map(\.requestIDKey) == ["1"])
+        #expect(port.removals().map(\.requestIDKey) == ["2"])
+
+        let alreadyAccountedPort = RecordingUpstreamRuntimePort(chosenUpstreamIndex: 0)
+        let alreadyAccountedRuntime = ProxyUpstreamRequestRuntime(port: alreadyAccountedPort)
+        let alreadyAccountedPrepared = try #require(
+            try alreadyAccountedRuntime.prepareRequest(
+                bodyData: requestData,
+                parsedRequestJSON: parsed,
+                sessionID: "session-4"
+            )
+        )
+        let alreadyAccountedStarted = ProxyUpstreamRequestRuntime.StartedRequest(
+            transform: alreadyAccountedPrepared.transform,
+            upstreamIndex: alreadyAccountedPrepared.upstreamIndex,
+            requestTimeout: nil,
+            routerPendingToken: UUID(),
+            future: eventLoop.makeSucceededFuture(ByteBuffer())
+        )
+        alreadyAccountedRuntime.recordRequestTimedOut(
+            sessionID: "session-4",
+            started: alreadyAccountedStarted,
+            accountTimeout: false
+        )
+        #expect(alreadyAccountedPort.timeouts().isEmpty)
+        #expect(alreadyAccountedPort.removals().map(\.requestIDKey) == ["1", "2"])
+    }
+}
+
+private final class RecordingUpstreamRuntimePort: ProxyUpstreamRequestRuntimePort {
+    struct Assignment: Equatable, Sendable {
+        let sessionID: String
+        let requestIDKey: String
+        let upstreamIndex: Int
+    }
+
+    struct Activation: Equatable, Sendable {
+        let leaseID: LeaseManager.ID
+        let requestIDKey: String?
+        let upstreamIndex: Int?
+        let timeout: TimeAmount?
+    }
+
+    struct SentRequest: Equatable, Sendable {
+        let data: Data
+        let upstreamIndex: Int
+        let ensureRunning: Bool
+    }
+
+    struct RequestEvent: Equatable, Sendable {
+        let sessionID: String
+        let requestIDKey: String
+        let upstreamIndex: Int
+    }
+
+    private struct State: Sendable {
+        var chosenUpstreamIndex: Int?
+        var nextID: Int64 = 100
+        var assignments: [Assignment] = []
+        var activations: [Activation] = []
+        var sentRequests: [SentRequest] = []
+        var removals: [RequestEvent] = []
+        var timeouts: [RequestEvent] = []
+        var successes: [RequestEvent] = []
+    }
+
+    private let state: NIOLockedValueBox<State>
+
+    init(chosenUpstreamIndex: Int?) {
+        self.state = NIOLockedValueBox(State(chosenUpstreamIndex: chosenUpstreamIndex))
+    }
+
+    func chooseUpstreamIndex() -> Int? {
+        state.withLockedValue { $0.chosenUpstreamIndex }
+    }
+
+    func assignUpstreamID(sessionID: String, originalID: JSONRPC.ID, upstreamIndex: Int) -> Int64 {
+        state.withLockedValue { state in
+            let id = state.nextID
+            state.nextID += 1
+            state.assignments.append(
+                Assignment(
+                    sessionID: sessionID,
+                    requestIDKey: originalID.key,
+                    upstreamIndex: upstreamIndex
+                )
+            )
+            return id
+        }
+    }
+
+    func removeUpstreamIDMapping(sessionID: String, requestIDKey: String, upstreamIndex: Int) {
+        state.withLockedValue { state in
+            state.removals.append(
+                RequestEvent(
+                    sessionID: sessionID,
+                    requestIDKey: requestIDKey,
+                    upstreamIndex: upstreamIndex
+                )
+            )
+        }
+    }
+
+    func onRequestTimeout(sessionID: String, requestIDKey: String, upstreamIndex: Int) {
+        state.withLockedValue { state in
+            state.timeouts.append(
+                RequestEvent(
+                    sessionID: sessionID,
+                    requestIDKey: requestIDKey,
+                    upstreamIndex: upstreamIndex
+                )
+            )
+        }
+    }
+
+    func onRequestSucceeded(sessionID: String, requestIDKey: String, upstreamIndex: Int) {
+        state.withLockedValue { state in
+            state.successes.append(
+                RequestEvent(
+                    sessionID: sessionID,
+                    requestIDKey: requestIDKey,
+                    upstreamIndex: upstreamIndex
+                )
+            )
+        }
+    }
+
+    func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool) {
+        state.withLockedValue { state in
+            state.sentRequests.append(
+                SentRequest(
+                    data: data,
+                    upstreamIndex: upstreamIndex,
+                    ensureRunning: ensureRunning
+                )
+            )
+        }
+    }
+
+    func activateRequestLease(
+        _ leaseID: LeaseManager.ID,
+        requestIDKey: String?,
+        upstreamIndex: Int?,
+        timeout: TimeAmount?
+    ) {
+        state.withLockedValue { state in
+            state.activations.append(
+                Activation(
+                    leaseID: leaseID,
+                    requestIDKey: requestIDKey,
+                    upstreamIndex: upstreamIndex,
+                    timeout: timeout
+                )
+            )
+        }
+    }
+
+    func assignments() -> [Assignment] {
+        state.withLockedValue { $0.assignments }
+    }
+
+    func activations() -> [Activation] {
+        state.withLockedValue { $0.activations }
+    }
+
+    func sentRequests() -> [SentRequest] {
+        state.withLockedValue { $0.sentRequests }
+    }
+
+    func removals() -> [RequestEvent] {
+        state.withLockedValue { $0.removals }
+    }
+
+    func timeouts() -> [RequestEvent] {
+        state.withLockedValue { $0.timeouts }
+    }
+
+    func successes() -> [RequestEvent] {
+        state.withLockedValue { $0.successes }
+    }
+}


### PR DESCRIPTION
## Purpose
Move the first proxy MCP forwarding lifecycle slice out of `XcodeMCPProxyKit` and into `XcodeMCPProxyRuntime`, without moving HTTP, DocumentationSearch, ToolSurface, or response construction ownership.

## Changes
- Added `ProxyUpstreamRequestRuntime` and `ProxyUpstreamRequestRuntimePort` in `XcodeMCPProxyRuntime`.
- Runtime now owns upstream selection, JSON-RPC ID assignment, response router pending registration, lease activation, upstream send, and success/timeout ID accounting for forwarded response-bearing requests.
- Refactored `MCPForwardingService` to delegate upstream lifecycle primitives to the runtime facade while keeping ToolSurface response rewriting and cache updates in ProxyKit.
- Connected existing Kit runtime ports to the new runtime-owned protocol without changing public products or the target graph.
- Added focused runtime tests for prepare/start/accounting behavior.

## Validation
- `swift test --filter XcodeMCPRuntimeTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyToolSurfaceTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter PublicProductContractTests`
- `git diff --check`
- `codex-review` against `codex/refactor-layered-runtime-integration`: no findings