### PR TITLE
[codex] Expose raw MCP request JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ let result = try await xcode.callTool(
     "DocumentationSearch",
     arguments: ["query": .string("SwiftData")]
 )
+let symbols = try await xcode.request(
+    "workspace/symbols",
+    params: try MCPJSONValue(jsonObject: ["query": "NavigationStack"])
+)
 await xcode.close()
 ```
 
@@ -124,9 +128,11 @@ let xcode = try await XcodeMCP(
 ```
 
 The public API exposes MCP domain values such as `MCPJSONValue`, `MCPTool`,
-`MCPToolResult`, `MCPContent`, and `MCPProgress`. Process launch, JSON-RPC
-framing, HTTP session headers, SSE parsing, and session transport are internal
-implementation details.
+`MCPToolResult`, `MCPContent`, and `MCPProgress`. Use `request(_:params:)` and
+`notify(_:params:)` for dynamic MCP methods that are not tool calls; the client
+still owns JSON-RPC framing and transport/session details. Process launch, HTTP
+session headers, SSE parsing, and session transport are internal implementation
+details.
 
 ### Test With XcodeMCPKitTesting
 

--- a/Sources/XcodeMCPKit/MCPJSONValue.swift
+++ b/Sources/XcodeMCPKit/MCPJSONValue.swift
@@ -104,14 +104,17 @@ extension MCPJSONValue {
     /// Creates an MCP JSON value by encoding an `Encodable` value with
     /// `JSONEncoder`.
     ///
-    /// Encoding errors from the value are rethrown. This initializer is useful
-    /// for building dynamic MCP params from local request structs without
-    /// writing a tool-specific wrapper.
+    /// Encoding errors from the value are rethrown. Encoded JSON numbers that
+    /// cannot be represented by ``MCPJSONValue`` throw
+    /// ``XcodeMCPError/invalidRequest(_:)``. This initializer is useful for
+    /// building dynamic MCP params from local request structs without writing a
+    /// tool-specific wrapper.
     ///
     /// - Parameter value: The value to encode into MCP JSON.
     public init<T: Encodable>(encoding value: T) throws {
         let data = try JSONEncoder().encode(value)
-        self = try JSONDecoder().decode(MCPJSONValue.self, from: data)
+        let object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        try self.init(jsonObject: object)
     }
 
     /// A Foundation JSON object suitable for `JSONSerialization`.

--- a/Sources/XcodeMCPKit/MCPJSONValue.swift
+++ b/Sources/XcodeMCPKit/MCPJSONValue.swift
@@ -90,7 +90,8 @@ extension MCPJSONValue {
     ///
     /// - Parameter value: A Foundation object that represents a JSON value.
     public init(jsonObject value: Any) throws {
-        guard let jsonValue = JSONValue(any: value),
+        guard Self.isValidFoundationJSON(value),
+              let jsonValue = JSONValue(any: value),
               Self.isValidJSONValue(jsonValue)
         else {
             throw XcodeMCPError.invalidRequest(
@@ -273,6 +274,36 @@ extension MCPJSONValue {
 }
 
 private extension MCPJSONValue {
+    static func isValidFoundationJSON(_ value: Any) -> Bool {
+        switch value {
+        case is NSNull:
+            return true
+        case is String:
+            return true
+        case is Bool:
+            return true
+        case let number as NSNumber:
+            return isValidJSONNumber(number)
+        case let array as [Any]:
+            return array.allSatisfy(isValidFoundationJSON)
+        case let object as [String: Any]:
+            return object.values.allSatisfy(isValidFoundationJSON)
+        default:
+            return false
+        }
+    }
+
+    static func isValidJSONNumber(_ number: NSNumber) -> Bool {
+        if CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return true
+        }
+        if CFNumberIsFloatType(number) {
+            return number.doubleValue.isFinite
+        }
+        return number.compare(NSNumber(value: Int64.min)) != .orderedAscending
+            && number.compare(NSNumber(value: Int64.max)) != .orderedDescending
+    }
+
     static func isValidJSONValue(_ value: JSONValue) -> Bool {
         switch value {
         case .object(let values):

--- a/Sources/XcodeMCPKit/MCPJSONValue.swift
+++ b/Sources/XcodeMCPKit/MCPJSONValue.swift
@@ -80,6 +80,49 @@ public enum MCPJSONValue: Codable, Equatable, Sendable {
     }
 }
 
+extension MCPJSONValue {
+    /// Creates an MCP JSON value from a Foundation JSON object.
+    ///
+    /// Pass values returned by `JSONSerialization.jsonObject(with:)` or values
+    /// that can be serialized as JSON: `String`, `NSNumber`, `Bool`, `NSNull`,
+    /// arrays, and dictionaries with `String` keys. Non-JSON values throw
+    /// ``XcodeMCPError/invalidRequest(_:)``.
+    ///
+    /// - Parameter value: A Foundation object that represents a JSON value.
+    public init(jsonObject value: Any) throws {
+        guard let jsonValue = JSONValue(any: value),
+              Self.isValidJSONValue(jsonValue)
+        else {
+            throw XcodeMCPError.invalidRequest(
+                "value is not a JSON-compatible Foundation object"
+            )
+        }
+        self.init(jsonValue)
+    }
+
+    /// Creates an MCP JSON value by encoding an `Encodable` value with
+    /// `JSONEncoder`.
+    ///
+    /// Encoding errors from the value are rethrown. This initializer is useful
+    /// for building dynamic MCP params from local request structs without
+    /// writing a tool-specific wrapper.
+    ///
+    /// - Parameter value: The value to encode into MCP JSON.
+    public init<T: Encodable>(encoding value: T) throws {
+        let data = try JSONEncoder().encode(value)
+        self = try JSONDecoder().decode(MCPJSONValue.self, from: data)
+    }
+
+    /// A Foundation JSON object suitable for `JSONSerialization`.
+    ///
+    /// Objects are returned as `[String: Any]`, arrays as `[Any]`, strings as
+    /// `String`, numbers as `NSNumber`, booleans as `Bool`, and null as
+    /// `NSNull`.
+    public var jsonObject: Any {
+        jsonValue.foundationObject
+    }
+}
+
 extension MCPJSONValue: ExpressibleByStringLiteral {
     /// Creates a JSON string from a Swift string literal.
     public init(stringLiteral value: String) {
@@ -201,14 +244,11 @@ extension MCPJSONValue {
     }
 
     package init?(foundationObject value: Any) {
-        guard let value = JSONValue(any: value) else {
-            return nil
-        }
-        self.init(value)
+        try? self.init(jsonObject: value)
     }
 
     package var foundationObject: Any {
-        jsonValue.foundationObject
+        jsonObject
     }
 
     package var jsonValue: JSONValue {
@@ -230,4 +270,19 @@ extension MCPJSONValue {
         }
     }
 
+}
+
+private extension MCPJSONValue {
+    static func isValidJSONValue(_ value: JSONValue) -> Bool {
+        switch value {
+        case .object(let values):
+            return values.values.allSatisfy(isValidJSONValue)
+        case .array(let values):
+            return values.allSatisfy(isValidJSONValue)
+        case .number(.double(let value)):
+            return value.isFinite
+        case .number(.int), .string, .bool, .null:
+            return true
+        }
+    }
 }

--- a/Sources/XcodeMCPKit/README.md
+++ b/Sources/XcodeMCPKit/README.md
@@ -102,6 +102,31 @@ inspect MCP data that this package does not model as a fixed Swift type. Domain
 models keep raw values for unknown fields and future MCP extensions. Use public
 accessors such as `objectValue`, `arrayValue`, `stringValue`, `boolValue`,
 `integerValue`, `doubleValue`, and `isNull` when inspecting dynamic responses.
+Use `MCPJSONValue(jsonObject:)`, `MCPJSONValue(encoding:)`, and `jsonObject` to
+bridge between Foundation or Codable values and raw MCP JSON.
+
+For dynamic MCP methods that are not tool calls, use the raw request and
+notification escape hatches:
+
+```swift
+struct SymbolParams: Encodable {
+    var query: String
+    var limit: Int
+}
+
+let symbols = try await xcode.request(
+    "workspace/symbols",
+    params: try MCPJSONValue(encoding: SymbolParams(
+        query: "NavigationStack",
+        limit: 5
+    ))
+)
+
+try await xcode.notify(
+    "notifications/custom",
+    params: try MCPJSONValue(jsonObject: ["enabled": true])
+)
+```
 
 ## Configuration
 

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -324,6 +324,45 @@ public actor XcodeMCP {
         return try MCPToolResult(json: result)
     }
 
+    /// Sends an arbitrary MCP request and returns the raw result.
+    ///
+    /// Use this escape hatch for dynamic MCP methods that are not `tools/list`
+    /// or `tools/call`. The client still owns JSON-RPC framing, request ids,
+    /// transport session headers, timeouts, and response error mapping.
+    ///
+    /// This method intentionally returns ``MCPJSONValue`` instead of a
+    /// tool-specific model so SDK consumers can call newly discovered MCP
+    /// methods without this package adding typed wrappers.
+    ///
+    /// - Parameters:
+    ///   - method: MCP method name to send.
+    ///   - params: Optional raw MCP params.
+    /// - Returns: The raw MCP result value, or ``MCPJSONValue/null`` when the
+    ///   server response omits `result`.
+    public func request(
+        _ method: String,
+        params: MCPJSONValue? = nil
+    ) async throws -> MCPJSONValue {
+        try await request(method, params: params, onProgress: nil)
+    }
+
+    /// Sends an arbitrary MCP notification.
+    ///
+    /// Use this escape hatch for dynamic MCP notifications. The client still
+    /// owns JSON-RPC framing, transport session headers, and transport error
+    /// mapping, but no response is expected from the server.
+    ///
+    /// - Parameters:
+    ///   - method: MCP notification method name to send.
+    ///   - params: Optional raw MCP params.
+    public func notify(_ method: String, params: MCPJSONValue? = nil) async throws {
+        do {
+            try await session.notify(method, params: params?.jsonValue)
+        } catch {
+            throw Self.publicError(from: error)
+        }
+    }
+
     /// Closes the client and terminates the underlying transport.
     ///
     /// Closing is idempotent. Pending requests fail with ``XcodeMCPError/closed``,
@@ -338,7 +377,7 @@ extension XcodeMCP {
     package func request(
         _ method: String,
         params: MCPJSONValue? = nil,
-        onProgress: InitializedMCPClientSession.ProgressHandler? = nil
+        onProgress: InitializedMCPClientSession.ProgressHandler?
     ) async throws -> MCPJSONValue {
         do {
             let result = try await session.request(
@@ -347,14 +386,6 @@ extension XcodeMCP {
                 onProgress: onProgress
             )
             return MCPJSONValue(result)
-        } catch {
-            throw Self.publicError(from: error)
-        }
-    }
-
-    package func notify(_ method: String, params: MCPJSONValue? = nil) async throws {
-        do {
-            try await session.notify(method, params: params?.jsonValue)
         } catch {
             throw Self.publicError(from: error)
         }

--- a/Sources/XcodeMCPKitTesting/README.md
+++ b/Sources/XcodeMCPKitTesting/README.md
@@ -42,6 +42,17 @@ let result = try await xcode.callTool(
 await xcode.close()
 ```
 
+Raw MCP requests can be handled without creating a tool wrapper:
+
+```swift
+await runtime.setRequestHandler({ method, params in
+    [
+        "method": .string(method),
+        "echo": params ?? .null,
+    ]
+}, forMethod: "workspace/symbols")
+```
+
 The testing runtime owns the fake transport and JSON-RPC response loop. Test
 code should interact with `XcodeMCP`, `MCPTool`, `MCPToolResult`, and
 `MCPJSONValue` instead of building raw JSON-RPC messages.

--- a/Sources/XcodeMCPKitTesting/XcodeMCPTestRuntime.swift
+++ b/Sources/XcodeMCPKitTesting/XcodeMCPTestRuntime.swift
@@ -120,11 +120,20 @@ public actor XcodeMCPTestRuntime {
 
     public typealias ToolHandler = @Sendable (ToolCall) async throws -> MCPToolResult
 
+    /// A handler for raw MCP requests sent through ``XcodeMCP/request(_:params:)``.
+    ///
+    /// Throw ``ServerError`` to return a JSON-RPC error response to the client.
+    public typealias RequestHandler = @Sendable (
+        _ method: String,
+        _ params: MCPJSONValue?
+    ) async throws -> MCPJSONValue
+
     private let initializeResult: MCPJSONValue
     private var tools: [MCPTool]
     private var toolResults: [String: MCPToolResult] = [:]
     private var progressUpdates: [String: [ProgressUpdate]] = [:]
     private var toolHandler: ToolHandler?
+    private var requestHandlers: [String: RequestHandler] = [:]
     private var messages: [RecordedMessage] = []
     private var closeCount = 0
     private var transportContinuations: [UUID: AsyncStream<XcodeMCPTransportEvent>.Continuation] = [:]
@@ -172,6 +181,22 @@ public actor XcodeMCPTestRuntime {
     /// throw ``ServerError`` to produce a JSON-RPC error response.
     public func setToolHandler(_ handler: ToolHandler?) {
         toolHandler = handler
+    }
+
+    /// Installs a dynamic raw request handler for a method name.
+    ///
+    /// Use this when tests exercise ``XcodeMCP/request(_:params:)`` directly
+    /// instead of going through `tools/call`. Passing `nil` removes the
+    /// handler for that method.
+    ///
+    /// - Parameters:
+    ///   - handler: Raw request handler to invoke.
+    ///   - method: MCP method name handled by `handler`.
+    public func setRequestHandler(
+        _ handler: RequestHandler?,
+        forMethod method: String
+    ) {
+        requestHandlers[method] = handler
     }
 
     /// Configures progress updates emitted for a named tool call.
@@ -273,7 +298,7 @@ public actor XcodeMCPTestRuntime {
             return initializeResult
         case "tools/list":
             return .object([
-                "tools": .array(try tools.map(Self.encodedJSONValue))
+                "tools": try MCPJSONValue(encoding: tools)
             ])
         case "tools/call":
             let call = try decodeToolCall(params)
@@ -293,6 +318,9 @@ public actor XcodeMCPTestRuntime {
                 message: "No test result configured for tool \(call.name)"
             )
         default:
+            if let handler = requestHandlers[method] {
+                return try await handler(method, params)
+            }
             throw ServerError(code: -32601, message: "Method not found: \(method)")
         }
     }
@@ -356,7 +384,7 @@ public actor XcodeMCPTestRuntime {
 
     private func emit(_ object: [String: MCPJSONValue], to transportID: UUID) {
         guard let data = try? JSONSerialization.data(
-            withJSONObject: MCPJSONValue.object(object).foundationObject
+            withJSONObject: MCPJSONValue.object(object).jsonObject
         ) else {
             return
         }
@@ -365,21 +393,12 @@ public actor XcodeMCPTestRuntime {
 
     private func parse(_ data: Data) throws -> [String: MCPJSONValue] {
         let raw = try JSONSerialization.jsonObject(with: data)
-        guard let value = MCPJSONValue(foundationObject: raw),
-              let object = value.objectValue
+        let value = try MCPJSONValue(jsonObject: raw)
+        guard let object = value.objectValue
         else {
             throw XcodeMCPError.invalidRequest("message is not an object")
         }
         return object
-    }
-
-    private static func encodedJSONValue<T: Encodable>(_ value: T) throws -> MCPJSONValue {
-        let data = try JSONEncoder().encode(value)
-        let raw = try JSONSerialization.jsonObject(with: data)
-        guard let json = MCPJSONValue(foundationObject: raw) else {
-            throw XcodeMCPError.invalidResponse("encoded value is not JSON")
-        }
-        return json
     }
 }
 

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -171,7 +171,12 @@ private let xcodeMCPKitClientSource = """
 import Foundation
 import XcodeMCPKit
 
-func compileOnlyClientDomainSurface() {
+private struct ContractPayload: Encodable {
+    var query: String
+    var limit: Int
+}
+
+func compileOnlyClientDomainSurface() throws {
     let arguments: [String: MCPJSONValue] = [
         "query": "SwiftData",
         "includeBeta": true,
@@ -219,6 +224,16 @@ func compileOnlyClientDomainSurface() {
     let integerLimit = arguments["limit"]?.integerValue
     let score = arguments["score"]?.doubleValue
     let optionalIsNull = metadata?["optional"]?.isNull
+    let jsonFromObject = try MCPJSONValue(jsonObject: [
+        "query": "NavigationStack",
+        "limit": 3,
+        "optional": NSNull(),
+    ])
+    let jsonFromEncodable = try MCPJSONValue(encoding: ContractPayload(
+        query: "Observation",
+        limit: 2
+    ))
+    let foundationObject = jsonFromObject.jsonObject
 
     let tool = MCPTool(
         name: "DocumentationSearch",
@@ -295,6 +310,9 @@ func compileOnlyClientDomainSurface() {
         integerLimit,
         score,
         optionalIsNull,
+        jsonFromObject,
+        jsonFromEncodable,
+        foundationObject,
         tool,
         result,
         progress,
@@ -313,6 +331,18 @@ func compileOnlyClientLifecycleSurface(config: XcodeMCP.Configuration) async thr
     ) { progress in
         _ = progress.message
     }
+    _ = try await client.request(
+        "workspace/symbols",
+        params: [
+            "query": "NavigationStack",
+        ]
+    )
+    try await client.notify(
+        "notifications/custom",
+        params: [
+            "enabled": true,
+        ]
+    )
     await client.close()
 }
 """

--- a/Tests/XcodeMCPKitTestingTests/XcodeMCPKitTestingTests.swift
+++ b/Tests/XcodeMCPKitTestingTests/XcodeMCPKitTestingTests.swift
@@ -111,6 +111,54 @@ struct XcodeMCPKitTestingTests {
         ])
     }
 
+    @Test func runtimeHandlesRawRequestsAndRecordsNotifications() async throws {
+        let runtime = XcodeMCPTestRuntime()
+        await runtime.setRequestHandler({ method, params in
+            [
+                "method": .string(method),
+                "echo": params ?? .null,
+            ]
+        }, forMethod: "workspace/symbols")
+
+        let client = try await runtime.makeClient()
+        defer {
+            Task { await client.close() }
+        }
+
+        let result = try await client.request(
+            "workspace/symbols",
+            params: [
+                "query": "Observation",
+            ]
+        )
+        try await client.notify(
+            "notifications/custom",
+            params: [
+                "enabled": true,
+            ]
+        )
+
+        #expect(result == [
+            "method": "workspace/symbols",
+            "echo": [
+                "query": "Observation",
+            ],
+        ])
+
+        let messages = await runtime.recordedMessages()
+        let request = try #require(messages.last { $0.method == "workspace/symbols" })
+        #expect(request.id != nil)
+        #expect(request.params == [
+            "query": "Observation",
+        ])
+
+        let notification = try #require(messages.last { $0.method == "notifications/custom" })
+        #expect(notification.id == nil)
+        #expect(notification.params == [
+            "enabled": true,
+        ])
+    }
+
     @Test func runtimeRoutesProgressAndDynamicToolHandler() async throws {
         let runtime = XcodeMCPTestRuntime()
         await runtime.setProgressUpdates(

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -145,6 +145,62 @@ struct XcodeMCPTests {
         ]))
     }
 
+    @Test func rawRequestSendsDynamicMethodAndReturnsRawResult() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let xcode = try await XcodeMCP(transport: transport)
+        defer {
+            Task { await xcode.close() }
+        }
+
+        let result = try await xcode.request(
+            "workspace/symbols",
+            params: [
+                "query": "NavigationStack",
+                "limit": 3,
+            ]
+        )
+
+        #expect(result == [
+            "method": "workspace/symbols",
+            "echo": [
+                "query": "NavigationStack",
+                "limit": 3,
+            ],
+        ])
+
+        let request = try #require(
+            await transport.sentMessages().last { $0.method == "workspace/symbols" }
+        )
+        #expect(request.id != nil)
+        #expect(request.params == [
+            "query": "NavigationStack",
+            "limit": 3,
+        ])
+    }
+
+    @Test func rawNotifySendsDynamicNotificationWithoutRequestID() async throws {
+        let transport = FakeXcodeMCPTransport()
+        let xcode = try await XcodeMCP(transport: transport)
+        defer {
+            Task { await xcode.close() }
+        }
+
+        try await xcode.notify(
+            "notifications/custom",
+            params: [
+                "enabled": true,
+            ]
+        )
+
+        let notification = try #require(
+            await transport.sentMessages().last { $0.method == "notifications/custom" }
+        )
+        #expect(notification.id == nil)
+        #expect(notification.params == [
+            "enabled": true,
+        ])
+    }
+
     @Test func callToolAddsProgressTokenAndRoutesMatchingProgress() async throws {
         let transport = FakeXcodeMCPTransport()
         let progressValues = RecordedValues<MCPProgress>()
@@ -442,6 +498,54 @@ struct XcodeMCPTests {
         let encodedProgress = try jsonObject(encoder.encode(progress))
         #expect(encodedProgress["raw"] == nil)
         #expect(encodedProgress["x-progress"] == .string("kept"))
+    }
+
+    @Test func jsonValueConvertsFoundationObjectsAndEncodableValues() throws {
+        struct Payload: Encodable {
+            var query: String
+            var limit: Int
+            var flags: [String: Bool]
+        }
+
+        let foundationValue = try MCPJSONValue(jsonObject: [
+            "query": "SwiftUI",
+            "limit": NSNumber(value: 5),
+            "tags": ["toolbar", "navigation"],
+            "metadata": [
+                "isBeta": true,
+                "none": NSNull(),
+            ],
+        ])
+
+        #expect(foundationValue == [
+            "query": "SwiftUI",
+            "limit": 5,
+            "tags": ["toolbar", "navigation"],
+            "metadata": [
+                "isBeta": true,
+                "none": .null,
+            ],
+        ])
+
+        let object = try #require(foundationValue.jsonObject as? [String: Any])
+        #expect(object["query"] as? String == "SwiftUI")
+        #expect((object["limit"] as? NSNumber)?.intValue == 5)
+
+        let encoded = try MCPJSONValue(encoding: Payload(
+            query: "Observation",
+            limit: 2,
+            flags: ["exact": true]
+        ))
+
+        #expect(encoded.objectValue?["query"] == .string("Observation"))
+        #expect(encoded.objectValue?["limit"] == .integer(2))
+        #expect(encoded.objectValue?["flags"] == ["exact": true])
+
+        #expect(throws: XcodeMCPError.invalidRequest(
+            "value is not a JSON-compatible Foundation object"
+        )) {
+            _ = try MCPJSONValue(jsonObject: Date())
+        }
     }
 
     @Test func streamableHTTPSendsSessionHeadersAndDeletesOnClose() async throws {
@@ -1185,6 +1289,11 @@ private actor FakeXcodeMCPTransport: XcodeMCPTransport {
                 ]),
                 "isError": .bool(true),
                 "x-result": .string("dynamic"),
+            ])
+        case "workspace/symbols":
+            return .object([
+                "method": .string(method),
+                "echo": params ?? .null,
             ])
         default:
             return .null

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -541,6 +541,15 @@ struct XcodeMCPTests {
         #expect(encoded.objectValue?["limit"] == .integer(2))
         #expect(encoded.objectValue?["flags"] == ["exact": true])
 
+        let maxSigned = try MCPJSONValue(jsonObject: NSNumber(value: UInt64(Int64.max)))
+        #expect(maxSigned == .integer(Int64.max))
+
+        #expect(throws: XcodeMCPError.invalidRequest(
+            "value is not a JSON-compatible Foundation object"
+        )) {
+            _ = try MCPJSONValue(jsonObject: NSNumber(value: UInt64(Int64.max) + 1))
+        }
+
         #expect(throws: XcodeMCPError.invalidRequest(
             "value is not a JSON-compatible Foundation object"
         )) {

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -506,6 +506,9 @@ struct XcodeMCPTests {
             var limit: Int
             var flags: [String: Bool]
         }
+        struct LargeUnsignedPayload: Encodable {
+            var value: UInt64
+        }
 
         let foundationValue = try MCPJSONValue(jsonObject: [
             "query": "SwiftUI",
@@ -548,6 +551,14 @@ struct XcodeMCPTests {
             "value is not a JSON-compatible Foundation object"
         )) {
             _ = try MCPJSONValue(jsonObject: NSNumber(value: UInt64(Int64.max) + 1))
+        }
+
+        #expect(throws: XcodeMCPError.invalidRequest(
+            "value is not a JSON-compatible Foundation object"
+        )) {
+            _ = try MCPJSONValue(encoding: LargeUnsignedPayload(
+                value: UInt64(Int64.max) + 1
+            ))
         }
 
         #expect(throws: XcodeMCPError.invalidRequest(


### PR DESCRIPTION
## Purpose
Make XcodeMCPKit more useful as a Swift SDK for dynamic MCP methods without adding typed tool wrappers.

## Changes
- Add public `XcodeMCP.request(_:params:)` and `XcodeMCP.notify(_:params:)` escape hatches that keep JSON-RPC framing and transport/session ownership internal.
- Add public `MCPJSONValue` Foundation/Codable conversion helpers: `init(jsonObject:)`, `jsonObject`, and `init(encoding:)`.
- Reject Foundation/Codable JSON numbers that cannot be represented safely by `MCPJSONValue` instead of silently corrupting large unsigned values.
- Add raw request handling support to `XcodeMCPKitTesting` and contract tests for raw request/notify and JSON conversion.
- Update SDK READMEs with minimal raw request examples.

## Validation
- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPKitTestingTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter PublicProductContractTests`
- `git diff --check`
- `codex-review` against `codex/refactor-layered-runtime-integration`: clean after fixes
