### PR TITLE
Remove polling HTTP test helpers

### DIFF
--- a/Sources/XcodeMCPCore/Support/AsyncTaskSupervisor.swift
+++ b/Sources/XcodeMCPCore/Support/AsyncTaskSupervisor.swift
@@ -72,6 +72,13 @@ package final class AsyncTaskSupervisor: @unchecked Sendable {
         return Drain(tasks: tasks)
     }
 
+    package func drainCurrentTasks() -> Drain {
+        let tasks = state.withLockedValue { state -> [Task<Void, Never>] in
+            state.records.values.compactMap(\.task)
+        }
+        return Drain(tasks: tasks)
+    }
+
     private func finish(_ id: UUID) {
         _ = state.withLockedValue { state in
             state.records.removeValue(forKey: id)

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -217,7 +217,7 @@ struct HTTPConcurrencyTests {
             executeSnippetPayload(id: 300, tabIdentifier: "windowtab-queued-timeout-1")
         )
         eventLoop.run()
-        let firstRequestLabels = upstream.recordedRequestLabels(count: 1)
+        let firstRequestLabels = try upstream.recordedRequestLabels(count: 1)
         #expect(firstRequestLabels == ["tools/call:ExecuteSnippet"])
 
         let secondOperation = try handlePost(
@@ -240,7 +240,7 @@ struct HTTPConcurrencyTests {
         #expect(firstObject["error"] == nil)
 
         eventLoop.run()
-        let secondRequestLabels = upstream.recordedRequestLabels(count: 2)
+        let secondRequestLabels = try upstream.recordedRequestLabels(count: 2)
         #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
             "tools/call:ExecuteSnippet",
@@ -310,7 +310,7 @@ struct HTTPConcurrencyTests {
             to: firstChannel
         )
         firstChannel.embeddedEventLoop.run()
-        let firstRequestLabels = upstream.recordedRequestLabels(count: 1)
+        let firstRequestLabels = try upstream.recordedRequestLabels(count: 1)
         #expect(firstRequestLabels == ["tools/call:ExecuteSnippet"])
 
         try postEmbeddedJSON(
@@ -329,7 +329,7 @@ struct HTTPConcurrencyTests {
         #expect((firstObject["error"] as? [String: Any])?["message"] as? String == "upstream timeout")
 
         secondChannel.embeddedEventLoop.run()
-        let secondRequestLabels = upstream.recordedRequestLabels(count: 2)
+        let secondRequestLabels = try upstream.recordedRequestLabels(count: 2)
         #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
             "tools/call:ExecuteSnippet",
@@ -946,13 +946,18 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
         }
     }
 
-    func recordedRequestLabels(count: Int) -> [String] {
+    func recordedRequestLabels(count: Int) throws -> [String] {
         guard count > 0 else { return [] }
 
+        let timeoutAt = Date(timeIntervalSinceNow: 2)
         condition.lock()
         defer { condition.unlock() }
         while state.requestHistory.count < count {
-            condition.wait()
+            guard condition.wait(until: timeoutAt) else {
+                throw AsyncTestTimeoutError(
+                    description: "waiting for \(count) embedded upstream request(s)"
+                )
+            }
         }
         return Array(state.requestHistory.prefix(count))
     }

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Dispatch
 import NIO
 import NIOEmbedded
 import NIOHTTP1
@@ -218,7 +217,8 @@ struct HTTPConcurrencyTests {
             executeSnippetPayload(id: 300, tabIdentifier: "windowtab-queued-timeout-1")
         )
         eventLoop.run()
-        #expect(try upstream.waitForRequestCount(1) == ["tools/call:ExecuteSnippet"])
+        let firstRequestLabels = upstream.recordedRequestLabels(count: 1)
+        #expect(firstRequestLabels == ["tools/call:ExecuteSnippet"])
 
         let secondOperation = try handlePost(
             executeSnippetPayload(id: 301, tabIdentifier: "windowtab-queued-timeout-2")
@@ -240,7 +240,8 @@ struct HTTPConcurrencyTests {
         #expect(firstObject["error"] == nil)
 
         eventLoop.run()
-        #expect(try upstream.waitForRequestCount(2) == [
+        let secondRequestLabels = upstream.recordedRequestLabels(count: 2)
+        #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
             "tools/call:ExecuteSnippet",
         ])
@@ -309,7 +310,8 @@ struct HTTPConcurrencyTests {
             to: firstChannel
         )
         firstChannel.embeddedEventLoop.run()
-        #expect(try upstream.waitForRequestCount(1) == ["tools/call:ExecuteSnippet"])
+        let firstRequestLabels = upstream.recordedRequestLabels(count: 1)
+        #expect(firstRequestLabels == ["tools/call:ExecuteSnippet"])
 
         try postEmbeddedJSON(
             executeSnippetPayload(id: 701, tabIdentifier: "windowtab-timeout-2"),
@@ -327,7 +329,8 @@ struct HTTPConcurrencyTests {
         #expect((firstObject["error"] as? [String: Any])?["message"] as? String == "upstream timeout")
 
         secondChannel.embeddedEventLoop.run()
-        #expect(try upstream.waitForRequestCount(2) == [
+        let secondRequestLabels = upstream.recordedRequestLabels(count: 2)
+        #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
             "tools/call:ExecuteSnippet",
         ])
@@ -872,15 +875,6 @@ private actor EchoUpstreamClient: UpstreamSlotControlling {
     }
 }
 
-private func waitForSemaphore(
-    _ semaphore: DispatchSemaphore,
-    description: String
-) throws {
-    guard semaphore.wait(timeout: .now() + .seconds(2)) == .success else {
-        throw AsyncTestTimeoutError(description: description)
-    }
-}
-
 private func waitForUpstreamRequest(
     _ upstream: ControlledUpstreamClient,
     label: String
@@ -912,8 +906,7 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
 
     nonisolated let events: AsyncStream<Upstream.Event>
     private let continuation: AsyncStream<Upstream.Event>.Continuation
-    private let lock = NSLock()
-    private let requestSemaphore = DispatchSemaphore(value: 0)
+    private let condition = NSCondition()
     private var state = State()
 
     init() {
@@ -953,18 +946,15 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
         }
     }
 
-    func waitForRequestCount(_ count: Int) throws -> [String] {
+    func recordedRequestLabels(count: Int) -> [String] {
         guard count > 0 else { return [] }
-        while true {
-            let labels = withLock { $0.requestHistory }
-            if labels.count >= count {
-                return Array(labels.prefix(count))
-            }
-            try waitForSemaphore(
-                requestSemaphore,
-                description: "waiting for \(count) embedded upstream request(s)"
-            )
+
+        condition.lock()
+        defer { condition.unlock() }
+        while state.requestHistory.count < count {
+            condition.wait()
         }
+        return Array(state.requestHistory.prefix(count))
     }
 
     @discardableResult
@@ -1007,16 +997,16 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
 
         let label = requestLabel(from: object)
         let responseData = makeDefaultResponse(id: object["id"], method: method)
-        withLock {
-            $0.sentRequests.append(SentRequest(label: label, responseData: responseData))
-            $0.requestHistory.append(label)
-        }
-        requestSemaphore.signal()
+        condition.lock()
+        state.sentRequests.append(SentRequest(label: label, responseData: responseData))
+        state.requestHistory.append(label)
+        condition.broadcast()
+        condition.unlock()
     }
 
     private func withLock<T>(_ body: (inout State) -> T) -> T {
-        lock.lock()
-        defer { lock.unlock() }
+        condition.lock()
+        defer { condition.unlock() }
         return body(&state)
     }
 

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -217,7 +217,8 @@ struct HTTPConcurrencyTests {
             executeSnippetPayload(id: 300, tabIdentifier: "windowtab-queued-timeout-1")
         )
         eventLoop.run()
-        let firstRequestLabels = try upstream.recordedRequestLabels(count: 1)
+        sessionManager.drainRuntimeTasksAndWaitForTesting()
+        let firstRequestLabels = upstream.recordedRequestLabels(count: 1)
         #expect(firstRequestLabels == ["tools/call:ExecuteSnippet"])
 
         let secondOperation = try handlePost(
@@ -240,7 +241,8 @@ struct HTTPConcurrencyTests {
         #expect(firstObject["error"] == nil)
 
         eventLoop.run()
-        let secondRequestLabels = try upstream.recordedRequestLabels(count: 2)
+        sessionManager.drainRuntimeTasksAndWaitForTesting()
+        let secondRequestLabels = upstream.recordedRequestLabels(count: 2)
         #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
             "tools/call:ExecuteSnippet",
@@ -310,7 +312,8 @@ struct HTTPConcurrencyTests {
             to: firstChannel
         )
         firstChannel.embeddedEventLoop.run()
-        let firstRequestLabels = try upstream.recordedRequestLabels(count: 1)
+        sessionManager.drainRuntimeTasksAndWaitForTesting()
+        let firstRequestLabels = upstream.recordedRequestLabels(count: 1)
         #expect(firstRequestLabels == ["tools/call:ExecuteSnippet"])
 
         try postEmbeddedJSON(
@@ -329,7 +332,8 @@ struct HTTPConcurrencyTests {
         #expect((firstObject["error"] as? [String: Any])?["message"] as? String == "upstream timeout")
 
         secondChannel.embeddedEventLoop.run()
-        let secondRequestLabels = try upstream.recordedRequestLabels(count: 2)
+        sessionManager.drainRuntimeTasksAndWaitForTesting()
+        let secondRequestLabels = upstream.recordedRequestLabels(count: 2)
         #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
             "tools/call:ExecuteSnippet",
@@ -906,7 +910,7 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
 
     nonisolated let events: AsyncStream<Upstream.Event>
     private let continuation: AsyncStream<Upstream.Event>.Continuation
-    private let condition = NSCondition()
+    private let lock = NSLock()
     private var state = State()
 
     init() {
@@ -946,20 +950,10 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
         }
     }
 
-    func recordedRequestLabels(count: Int) throws -> [String] {
+    func recordedRequestLabels(count: Int) -> [String] {
         guard count > 0 else { return [] }
 
-        let timeoutAt = Date(timeIntervalSinceNow: 2)
-        condition.lock()
-        defer { condition.unlock() }
-        while state.requestHistory.count < count {
-            guard condition.wait(until: timeoutAt) else {
-                throw AsyncTestTimeoutError(
-                    description: "waiting for \(count) embedded upstream request(s)"
-                )
-            }
-        }
-        return Array(state.requestHistory.prefix(count))
+        return withLock { Array($0.requestHistory.prefix(count)) }
     }
 
     @discardableResult
@@ -1002,16 +996,15 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
 
         let label = requestLabel(from: object)
         let responseData = makeDefaultResponse(id: object["id"], method: method)
-        condition.lock()
-        state.sentRequests.append(SentRequest(label: label, responseData: responseData))
-        state.requestHistory.append(label)
-        condition.broadcast()
-        condition.unlock()
+        withLock {
+            $0.sentRequests.append(SentRequest(label: label, responseData: responseData))
+            $0.requestHistory.append(label)
+        }
     }
 
     private func withLock<T>(_ body: (inout State) -> T) -> T {
-        condition.lock()
-        defer { condition.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         return body(&state)
     }
 

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -1045,22 +1045,6 @@ final class ManualDateClock: @unchecked Sendable {
     }
 }
 
-func waitForHTTPTestSemaphore(
-    _ semaphore: DispatchSemaphore,
-    timeoutSeconds: TimeInterval
-) async -> DispatchTimeoutResult {
-    await withCheckedContinuation { continuation in
-        DispatchQueue.global().async {
-            let timeoutMilliseconds = Int((timeoutSeconds * 1000).rounded(.up))
-            continuation.resume(
-                returning: semaphore.wait(
-                    timeout: .now() + .milliseconds(timeoutMilliseconds)
-                )
-            )
-        }
-    }
-}
-
 func addHTTPHandler(
     to channel: EmbeddedChannel,
     config: ProxyConfig,

--- a/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
@@ -435,6 +435,16 @@ extension RuntimeCoordinator {
         }
         semaphore.wait()
     }
+
+    package func drainRuntimeTasksAndWaitForTesting() {
+        let drain = runtimeTasks.drainCurrentTasks()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task.detached(priority: .userInitiated) {
+            await drain.wait()
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
 }
 
 package func shutdownAndWait(_ group: EventLoopGroup) {

--- a/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
@@ -416,30 +416,6 @@ package func waitWithTimeout<T: Sendable>(
     }
 }
 
-package func waitUntil(
-    timeout: Duration = .seconds(5),
-    pollInterval: Duration = .milliseconds(10),
-    _ condition: @escaping @Sendable () async -> Bool
-) async -> Bool {
-    // Use this only as a guard around external I/O or OS-driven eventual state.
-    // Intra-process concurrency tests should prefer RecordedValues, OperationGate,
-    // or TestClock so the awaited synchronization point is explicit.
-    let clock = ContinuousClock()
-    let deadline = clock.now.advanced(by: timeout)
-
-    while clock.now < deadline {
-        if Task.isCancelled {
-            return false
-        }
-        if await condition() {
-            return true
-        }
-        try? await clock.sleep(until: clock.now.advanced(by: pollInterval))
-    }
-
-    return await condition()
-}
-
 package func shutdown(_ group: EventLoopGroup) async {
     await withCheckedContinuation { continuation in
         group.shutdownGracefully { _ in


### PR DESCRIPTION
## Summary
- Remove unused HTTP test polling/semaphore helpers.
- Replace the embedded upstream request-count semaphore with deterministic runtime-task draining plus immediate upstream request-label snapshots.
- Add a package-internal `AsyncTaskSupervisor.drainCurrentTasks()` hook so embedded HTTP tests can observe accepted runtime send tasks without wall-clock timeout, sleep, retry, or polling.

## Validation
- swift test --filter HTTPConcurrencyTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal
- git diff --check
- codex-review baseBranch codex/refactor-layered-runtime-integration: no findings

## Impact
This is test determinism cleanup for HTTP gateway contract tests. Production behavior is unchanged; the core addition only exposes a package-internal drain handle used by test support.