### PR TITLE
Move Xcode discovery into ProxyKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -250,7 +250,6 @@ let package = Package(
             name: "ProxyStartupLoggingTests",
             dependencies: [
                 "XcodeMCPCore",
-                "XcodeMCPProcessRuntime",
                 "XcodeMCPProxyKit",
             ],
             path: "Tests/ProxyStartupLoggingTests",

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ endpoint and automated approval flow.
 The public products above are backed by internal production targets split by
 owner boundary. `XcodeMCPKit` owns the SDK's high-level API, initialized
 single-client session, and client transports. `XcodeMCPCore` owns JSON/MCP wire
-contracts and low-level support. `XcodeMCPProcessRuntime` owns local process IO
-and process discovery helpers. `XcodeMCPProxyKit` owns the embeddable proxy
-facades plus its internal HTTP, session routing, multi-upstream broker, health,
-readiness, and route scheduling primitives.
+contracts and low-level support. `XcodeMCPProcessRuntime` owns local process IO,
+stdio upstream processes, process enumeration, process runner support, and
+`xcrun` argument handling. `XcodeMCPProxyKit` owns the embeddable proxy facades
+plus its internal HTTP, session routing, Xcode process target discovery,
+multi-upstream broker, health, readiness, and route scheduling primitives.
 
 ## Install
 

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/UpstreamTopologySnapshot.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/UpstreamTopologySnapshot.swift
@@ -1,5 +1,4 @@
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 import Foundation
 
 struct UpstreamSlotID: Sendable, Hashable, Comparable {

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/XcodeProcessRoute.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/XcodeProcessRoute.swift
@@ -1,5 +1,4 @@
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 import Foundation
 
 struct XcodeProcessRoute: Sendable, Equatable {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/LiveXcodeTargetDiscovery.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/LiveXcodeTargetDiscovery.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Foundation
-import XcodeMCPCore
 import XcodeMCPProcessRuntime
 
 struct LiveXcodeTargetDiscovery: XcodeTargetDiscovering, Sendable {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ProcessToolCatalogRegistry.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ProcessToolCatalogRegistry.swift
@@ -1,7 +1,6 @@
 import Foundation
 import NIOConcurrencyHelpers
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 
 final class ProcessToolCatalogRegistry: Sendable {
     struct Catalog: Sendable {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -3,7 +3,6 @@ import Logging
 import NIO
 import NIOConcurrencyHelpers
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 
 extension ControlPlane {
     enum Error: Swift.Error, Sendable {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -2,7 +2,6 @@ import Foundation
 import Logging
 import NIOCore
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 
 extension RuntimeCoordinator {
     private static let xcodeProcessRouteUnavailableCooldownNanoseconds: UInt64 =

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeDocumentationProviderTransport.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeDocumentationProviderTransport.swift
@@ -2,7 +2,6 @@ import Foundation
 import NIO
 import NIOConcurrencyHelpers
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 
 final class RuntimeDocumentationProviderTransport: DocumentationProviderRouting {
     private struct State: Sendable {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeXcodeTargetDiscovery.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeXcodeTargetDiscovery.swift
@@ -1,6 +1,4 @@
 import Foundation
-import XcodeMCPCore
-import XcodeMCPProcessRuntime
 
 final class RuntimeDocumentationTargetDiscovery:
     PriorityOrderedXcodeTargetDiscovering,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ToolCatalogStartupLogFormatter.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ToolCatalogStartupLogFormatter.swift
@@ -1,6 +1,5 @@
 import Foundation
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 
 enum ToolCatalogStartupLogFormatter {
     struct Process: Sendable, Equatable {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ToolRoutingDecision.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ToolRoutingDecision.swift
@@ -1,6 +1,5 @@
 import Foundation
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 
 enum ToolRoutingDecision: Sendable {
     case forward(preferredUpstreamIndex: Int?)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeTargetDiscovery.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeTargetDiscovery.swift
@@ -1,4 +1,3 @@
-import XcodeMCPCore
 import Foundation
 
 package struct XcodeProcessTarget: Sendable, Equatable {

--- a/Tests/ProxyIntegrationTests/DiscoveryTests.swift
+++ b/Tests/ProxyIntegrationTests/DiscoveryTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Testing
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 @testable import XcodeMCPProxyKit
 
 

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
@@ -1,6 +1,5 @@
 import Testing
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 @testable import XcodeMCPProxyKit
 
 

--- a/Tests/ProxyStartupLoggingTests/ToolCatalogStartupLogFormatterTests.swift
+++ b/Tests/ProxyStartupLoggingTests/ToolCatalogStartupLogFormatterTests.swift
@@ -1,5 +1,4 @@
 import XcodeMCPCore
-import XcodeMCPProcessRuntime
 @testable import XcodeMCPProxyKit
 import Testing
 


### PR DESCRIPTION
## Purpose

Restrict `XcodeMCPProcessRuntime` to local process IO and stdio upstream process runtime ownership, and move proxy-only Xcode process routing/discovery concepts into the `XcodeMCPProxyKit` internal runtime boundary.

## Changes

- Moved `XcodeProcessTarget`, `XcodeTargetDiscovering`, and `PriorityOrderedXcodeTargetDiscovering` from `XcodeMCPProcessRuntime` into `XcodeMCPProxyKit` internal session runtime code.
- Removed now-misleading ProcessRuntime imports from proxy route, topology, catalog, and runtime files that only use proxy-owned Xcode process topology types.
- Dropped the unnecessary `XcodeMCPProcessRuntime` dependency from `ProxyStartupLoggingTests`.
- Updated README internal target ownership docs to describe ProcessRuntime as local process IO / stdio upstream runtime and ProxyKit as owner of Xcode process target discovery.

## Validation

- `swift test --filter XcodeMCPRuntimeProcessTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyDocumentationProviderTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `swift test -Xswiftc -strict-concurrency=minimal`

## Review

- `codex-review` against `codex/refactor-layered-runtime-integration`: clean, 0 findings. Job: `52EE8D79-5D36-4162-A3A8-6DECDE77DDC9`.