### PR TITLE
[codex] Centralize MCP bridge invocation

### DIFF
--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XcodeMCPCore
+import XcodeMCPProcessRuntime
 
 /// A high-level client for Xcode MCP.
 ///
@@ -78,22 +79,21 @@ public actor XcodeMCP {
                 environment: [String: String]
             )
 
-            package var command: String {
+            package var invocation: MCPBridgeInvocation {
                 switch self {
                 case .defaultMCPBridge:
-                    return "/usr/bin/xcrun"
-                case .custom(let command, _, _):
-                    return command
+                    return .defaultMCPBridge
+                case .custom(let command, let arguments, _):
+                    return MCPBridgeInvocation(command: command, arguments: arguments)
                 }
             }
 
+            package var command: String {
+                invocation.command
+            }
+
             package var arguments: [String] {
-                switch self {
-                case .defaultMCPBridge:
-                    return ["mcpbridge"]
-                case .custom(_, let arguments, _):
-                    return arguments
-                }
+                invocation.arguments
             }
 
             package var environment: [String: String] {

--- a/Sources/XcodeMCPProcessRuntime/Process/ExecutableLookupClient.swift
+++ b/Sources/XcodeMCPProcessRuntime/Process/ExecutableLookupClient.swift
@@ -102,7 +102,7 @@ package struct ExecutableLookupClient: DependencyClient {
         ) {
             executablePath = resolvedCommandPath
         } else {
-            executablePath = "/usr/bin/xcrun"
+            executablePath = MCPBridgeInvocation.xcrunCommand
         }
 
         guard let output = runCommand(executablePath, preToolArguments + ["--find", toolName])?

--- a/Sources/XcodeMCPProcessRuntime/Process/MCPBridgeInvocation.swift
+++ b/Sources/XcodeMCPProcessRuntime/Process/MCPBridgeInvocation.swift
@@ -1,0 +1,26 @@
+/// Canonical raw process invocation for Xcode's MCP bridge.
+package struct MCPBridgeInvocation: Equatable, Sendable {
+    /// Raw process command used to launch the bridge.
+    package let command: String
+
+    /// Raw process arguments passed to the bridge command.
+    package let arguments: [String]
+
+    /// Creates a raw bridge process invocation.
+    package init(command: String, arguments: [String]) {
+        self.command = command
+        self.arguments = arguments
+    }
+
+    /// The canonical tool name resolved through `xcrun` for Xcode MCP.
+    package static let mcpBridgeToolName = "mcpbridge"
+
+    /// The canonical system `xcrun` path used for the default bridge launch.
+    package static let xcrunCommand = "/usr/bin/xcrun"
+
+    /// Xcode's default MCP bridge invocation.
+    package static let defaultMCPBridge = Self(
+        command: xcrunCommand,
+        arguments: [mcpBridgeToolName]
+    )
+}

--- a/Sources/XcodeMCPProxyKit/Internal/CLI/Common/CLIParser.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/CLI/Common/CLIParser.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XcodeMCPProcessRuntime
 
 enum CLIError: Error, CustomStringConvertible {
     case message(String)
@@ -38,8 +39,9 @@ struct CLIParser {
     ) throws -> ProxyConfig {
         var listenHost = "localhost"
         var listenPort = 0
-        var upstreamCommand = "xcrun"
-        var upstreamArgs = ["mcpbridge"]
+        let defaultBridgeInvocation = MCPBridgeInvocation.defaultMCPBridge
+        var upstreamCommand = defaultBridgeInvocation.command
+        var upstreamArgs = defaultBridgeInvocation.arguments
         var upstreamProcessCount = 1
         var upstreamSessionID: String?
         var maxBodyBytes = 1_048_576

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcrunArguments+ProxyConfig.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcrunArguments+ProxyConfig.swift
@@ -12,6 +12,6 @@ extension XcrunArguments {
         else {
             return false
         }
-        return URL(fileURLWithPath: toolName).lastPathComponent == "mcpbridge"
+        return URL(fileURLWithPath: toolName).lastPathComponent == MCPBridgeInvocation.mcpBridgeToolName
     }
 }

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -113,22 +113,21 @@ public final class XcodeMCPProxyServer {
                 sessionID: String? = nil
             )
 
-            var command: String {
+            var invocation: MCPBridgeInvocation {
                 switch self {
                 case .defaultMCPBridge:
-                    return "xcrun"
-                case .custom(let command, _, _, _):
-                    return command
+                    return .defaultMCPBridge
+                case .custom(let command, let arguments, _, _):
+                    return MCPBridgeInvocation(command: command, arguments: arguments)
                 }
             }
 
+            var command: String {
+                invocation.command
+            }
+
             var arguments: [String] {
-                switch self {
-                case .defaultMCPBridge:
-                    return ["mcpbridge"]
-                case .custom(_, let arguments, _, _):
-                    return arguments
-                }
+                invocation.arguments
             }
 
             var processesPerXcode: Int {

--- a/Tests/ProxyCLITests/CLIParserTests.swift
+++ b/Tests/ProxyCLITests/CLIParserTests.swift
@@ -13,6 +13,16 @@ private func makeTempDiscoveryURL() -> URL {
 
 @Suite
 struct CLIParserTests {
+    @Test func cliUsesCanonicalDefaultMCPBridgeInvocation() async throws {
+        let config = try CLIParser.parse(
+            args: ["xcode-mcp-proxy"],
+            environment: [:]
+        )
+
+        #expect(config.upstreamCommand == MCPBridgeInvocation.defaultMCPBridge.command)
+        #expect(config.upstreamArgs == MCPBridgeInvocation.defaultMCPBridge.arguments)
+    }
+
     @Test func cliParsesListenAddress() async throws {
         let config = try CLIParser.parse(
             args: ["xcode-mcp-proxy", "--listen", "0.0.0.0:9999"],
@@ -171,8 +181,8 @@ struct CLIParserTests {
         let config = ProxyConfig(
             listenHost: "localhost",
             listenPort: 0,
-            upstreamCommand: "xcrun",
-            upstreamArgs: ["mcpbridge"],
+            upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+            upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
             maxBodyBytes: 1_048_576,
             requestTimeout: 300,
             configPath: configPath,
@@ -195,8 +205,8 @@ struct CLIParserTests {
         let config = ProxyConfig(
             listenHost: "localhost",
             listenPort: 0,
-            upstreamCommand: "xcrun",
-            upstreamArgs: ["mcpbridge"],
+            upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+            upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
             maxBodyBytes: 1_048_576,
             requestTimeout: 300,
             configPath: configPath

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -752,8 +752,8 @@ private struct TestHTTPServer {
             var config = ProxyConfig(
                 listenHost: "127.0.0.1",
                 listenPort: 0,
-                upstreamCommand: "xcrun",
-                upstreamArgs: ["mcpbridge"],
+                upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+                upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
                 upstreamSessionID: nil,
                 maxBodyBytes: 1_048_576,
                 requestTimeout: requestTimeout
@@ -1777,8 +1777,8 @@ private func makeEmbeddedConfig(requestTimeout: TimeInterval) -> ProxyConfig {
     var config = ProxyConfig(
         listenHost: "127.0.0.1",
         listenPort: 0,
-        upstreamCommand: "xcrun",
-        upstreamArgs: ["mcpbridge"],
+        upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+        upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
         upstreamSessionID: nil,
         maxBodyBytes: 1_048_576,
         requestTimeout: requestTimeout

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -1006,8 +1006,8 @@ func makeConfig(
     ProxyConfig(
         listenHost: "127.0.0.1",
         listenPort: 0,
-        upstreamCommand: "xcrun",
-        upstreamArgs: ["mcpbridge"],
+        upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+        upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
         upstreamSessionID: nil,
         maxBodyBytes: maxBodyBytes,
         requestTimeout: requestTimeout

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import XcodeMCPCore
+import XcodeMCPProcessRuntime
 @testable import XcodeMCPProxyKit
 
 
@@ -9,8 +10,8 @@ struct XcodeMCPProxyServerBuildInfoTests {
         let config = ProxyConfig(
             listenHost: "localhost",
             listenPort: 8765,
-            upstreamCommand: "xcrun",
-            upstreamArgs: ["mcpbridge"],
+            upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+            upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
             upstreamProcessCount: 2,
             maxBodyBytes: 1_048_576,
             requestTimeout: 300,

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -268,8 +268,8 @@ struct XcodeMCPProxyServerTests {
         let config = ProxyConfig(
             listenHost: "127.0.0.1",
             listenPort: blockedPort,
-            upstreamCommand: "xcrun",
-            upstreamArgs: ["mcpbridge"],
+            upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+            upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
             maxBodyBytes: 1_048_576,
             requestTimeout: 300,
             autoApproveXcodeDialog: true
@@ -308,8 +308,8 @@ struct XcodeMCPProxyServerTests {
         let config = ProxyConfig(
             listenHost: "127.0.0.1",
             listenPort: 0,
-            upstreamCommand: "xcrun",
-            upstreamArgs: ["mcpbridge"],
+            upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+            upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
             maxBodyBytes: 1_048_576,
             requestTimeout: 300,
             autoApproveXcodeDialog: true

--- a/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
+++ b/Tests/ProxyLiveMCPBridgeTests/LiveMCPBridgeTests.swift
@@ -11,7 +11,10 @@ import XcodeMCPProcessRuntime
 struct LiveMCPBridgeTests {
     @Test(.enabled(if: DirectMCPBridgeTestEnvironment.isEnabled))
     func directMCPBridgeToolsListCanAutoApprovePermissionDialog() async throws {
-        let xcrunResult = try runProcess("/usr/bin/xcrun", ["--find", "mcpbridge"])
+        let xcrunResult = try runProcess(
+            MCPBridgeInvocation.xcrunCommand,
+            ["--find", MCPBridgeInvocation.mcpBridgeToolName]
+        )
         guard xcrunResult.terminationStatus == 0 else {
             Issue.record("mcpbridge is not available in the selected Xcode toolchain")
             throw LiveMCPBridgeTestError.mcpbridgeNotFound
@@ -82,7 +85,10 @@ struct LiveMCPBridgeTests {
     }
 
     @Test func proxyServerTalksToLiveMCPBridge() async throws {
-        let xcrunResult = try runProcess("/usr/bin/xcrun", ["--find", "mcpbridge"])
+        let xcrunResult = try runProcess(
+            MCPBridgeInvocation.xcrunCommand,
+            ["--find", MCPBridgeInvocation.mcpBridgeToolName]
+        )
         guard xcrunResult.terminationStatus == 0,
               xcrunResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         else {
@@ -118,8 +124,8 @@ struct LiveMCPBridgeTests {
         let config = ProxyConfig(
             listenHost: "127.0.0.1",
             listenPort: 0,
-            upstreamCommand: "/usr/bin/xcrun",
-            upstreamArgs: ["mcpbridge"],
+            upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+            upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
             maxBodyBytes: 1_048_576,
             requestTimeout: 20,
             discoveryFileURL: discoveryFile,

--- a/Tests/ProxyStressTests/DocumentationSearchStressTests.swift
+++ b/Tests/ProxyStressTests/DocumentationSearchStressTests.swift
@@ -150,8 +150,8 @@ private struct StressHTTPServer {
             var config = ProxyConfig(
                 listenHost: "127.0.0.1",
                 listenPort: 0,
-                upstreamCommand: "xcrun",
-                upstreamArgs: ["mcpbridge"],
+                upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+                upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
                 upstreamSessionID: nil,
                 maxBodyBytes: 1_048_576,
                 requestTimeout: 60

--- a/Tests/ProxyToolSurfaceTests/ToolSurfaceTests.swift
+++ b/Tests/ProxyToolSurfaceTests/ToolSurfaceTests.swift
@@ -463,8 +463,8 @@ private func makeToolSurfaceConfig() -> ProxyConfig {
     ProxyConfig(
         listenHost: "localhost",
         listenPort: 8765,
-        upstreamCommand: "xcrun",
-        upstreamArgs: ["mcpbridge"],
+        upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+        upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
         maxBodyBytes: 1_048_576,
         requestTimeout: 300
     )

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -190,11 +190,7 @@ func compileOnlyClientDomainSurface() throws {
     ]
 
     let config = XcodeMCP.Configuration(
-        bridge: .custom(
-            command: "/usr/bin/xcrun",
-            arguments: ["mcpbridge"],
-            environment: ["PUBLIC_CONTRACT": "1"]
-        ),
+        bridge: .defaultMCPBridge,
         clientName: "PublicContractClient",
         clientVersion: "1.0",
         capabilities: [
@@ -203,6 +199,13 @@ func compileOnlyClientDomainSurface() throws {
             ]
         ],
         requestTimeout: .seconds(1)
+    )
+    let customBridgeConfig = XcodeMCP.Configuration(
+        bridge: .custom(
+            command: "/usr/bin/env",
+            arguments: ["printf"],
+            environment: ["PUBLIC_CONTRACT": "1"]
+        )
     )
 
     let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
@@ -301,6 +304,7 @@ func compileOnlyClientDomainSurface() throws {
     _ = (
         arguments,
         config,
+        customBridgeConfig,
         httpConfig,
         discoveryConfig,
         tags,
@@ -410,9 +414,7 @@ import XcodeMCPProxyKit
 func compileOnlyProxyConfigurationSurface() {
     let config = XcodeMCPProxyServer.Configuration(
         bind: .init(host: "127.0.0.1", port: 0),
-        upstream: .custom(
-            command: "/usr/bin/xcrun",
-            arguments: ["mcpbridge"],
+        upstream: .defaultMCPBridge(
             processesPerXcode: 1,
             sessionID: "session-1"
         ),
@@ -423,6 +425,14 @@ func compileOnlyProxyConfigurationSurface() {
         features: .init(
             prewarmToolsList: false,
             refreshCodeIssuesMode: .proxy
+        )
+    )
+    let customUpstreamConfig = XcodeMCPProxyServer.Configuration(
+        upstream: .custom(
+            command: "/usr/bin/env",
+            arguments: ["printf"],
+            processesPerXcode: 1,
+            sessionID: "session-1"
         )
     )
 
@@ -447,7 +457,7 @@ func compileOnlyProxyConfigurationSurface() {
         XcodeMCPProxyStdioAdapter(endpoint: $0, requestTimeout: 30)
     }
 
-    _ = (config, upstreamMode, server, adapterConfig, endpoint, adapter, plan)
+    _ = (config, customUpstreamConfig, upstreamMode, server, adapterConfig, endpoint, adapter, plan)
     _ = XcodeMCPProxyInstaller.binaryNames
 }
 

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -48,8 +48,8 @@ func makeConfig(requestTimeout: TimeInterval) -> ProxyConfig {
     ProxyConfig(
         listenHost: "127.0.0.1",
         listenPort: 0,
-        upstreamCommand: "xcrun",
-        upstreamArgs: ["mcpbridge"],
+        upstreamCommand: MCPBridgeInvocation.defaultMCPBridge.command,
+        upstreamArgs: MCPBridgeInvocation.defaultMCPBridge.arguments,
         upstreamSessionID: nil,
         maxBodyBytes: 1024,
         requestTimeout: requestTimeout,


### PR DESCRIPTION
## Purpose

Centralize the default `mcpbridge` process invocation so XcodeMCPKit, XcodeMCPProxyKit, CLI parsing, and tests no longer each own `/usr/bin/xcrun` / `mcpbridge` defaults.

## Changes

- Added package-level `MCPBridgeInvocation` in `XcodeMCPProcessRuntime` as the canonical default bridge invocation.
- Rewired `XcodeMCP.Configuration.Bridge.defaultMCPBridge`, `XcodeMCPProxyServer.Configuration.Upstream.defaultMCPBridge`, CLI parser defaults, xcrun fallback, and default bridge readiness checks to use the canonical value.
- Updated contract and proxy tests to use public default configuration or canonical test values while preserving raw custom command coverage as an escape hatch.

## Validation

- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `swift test -Xswiftc -strict-concurrency=minimal`
- `codex-review` against `codex/refactor-layered-runtime-integration`: clean, 0 findings
