### PR TITLE
[codex] Add typed proxy configuration facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,31 @@ if plan.action == .start, let config = plan.configuration {
 }
 ```
 
+Embedded apps can configure proxy-only behavior directly without knowing the
+TOML file schema:
+
+```swift
+let config = XcodeMCPProxyServer.Configuration(
+    toolPolicy: .init(
+        disabledToolNames: ["RunAllTests", "RunSomeTests"]
+    ),
+    initializeHandshake: .init(
+        clientInfo: .init(name: "EmbeddingClient", version: "1.0"),
+        capabilities: [
+            "roots": [
+                "listChanged": true,
+            ],
+        ]
+    )
+)
+
+let server = XcodeMCPProxyServer(config: config)
+```
+
+When both typed configuration and `configurationFilePath` are set, the typed
+values override the matching file-backed disabled-tools and initialize
+handshake fields.
+
 `LaunchPlan` also carries help/version text, `--dry-run` output,
 `--force-restart`, and product metadata so launchers do not need to compose the
 lower-level parser or config types directly.

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Configuration/ProxyConfig.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Configuration/ProxyConfig.swift
@@ -69,7 +69,8 @@ struct ProxyConfig: Sendable {
         prewarmToolsList: Bool = true,
         autoApproveXcodeDialog: Bool = false,
         refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode = .proxy,
-        disabledToolNames: Set<String>? = nil
+        disabledToolNames: Set<String>? = nil,
+        initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride? = nil
     ) {
         self.listenHost = listenHost
         self.listenPort = listenPort
@@ -87,9 +88,16 @@ struct ProxyConfig: Sendable {
         self.prewarmToolsList = prewarmToolsList
         self.autoApproveXcodeDialog = autoApproveXcodeDialog
         self.refreshCodeIssuesMode = refreshCodeIssuesMode
-        self.disabledToolNames = disabledToolNames ?? []
+        self.disabledToolNames = []
+        self.initializeParamsOverride = nil
         if configPath != nil {
-            loadFileConfig(preserveDisabledToolNames: disabledToolNames != nil)
+            loadFileConfig()
+        }
+        if let disabledToolNames {
+            self.disabledToolNames = Self.normalizedToolNames(disabledToolNames)
+        }
+        if let initializeParamsOverride {
+            applyInitializeParamsOverride(initializeParamsOverride)
         }
     }
 
@@ -114,6 +122,16 @@ struct ProxyConfig: Sendable {
         )
     }
 
+    mutating func applyInitializeParamsOverride(
+        _ override: ProxyConfig.File.InitializeHandshakeOverride
+    ) {
+        if let current = initializeParamsOverride {
+            initializeParamsOverride = current.merging(overriding: override)
+        } else if override.isEmpty == false {
+            initializeParamsOverride = override
+        }
+    }
+
     func validateModernProtocolConfiguration() throws {
         guard let protocolVersion = initializeParamsOverride?.protocolVersion else {
             return
@@ -121,5 +139,19 @@ struct ProxyConfig: Sendable {
         guard MCPProtocolVersion.isSupported(protocolVersion) else {
             throw ValidationError.unsupportedProtocolVersion(protocolVersion)
         }
+    }
+
+    static func normalizedToolNames<S: Sequence>(_ names: S) -> Set<String>
+        where S.Element == String
+    {
+        var normalized = Set<String>()
+        for rawName in names {
+            let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard name.isEmpty == false else {
+                continue
+            }
+            normalized.insert(name)
+        }
+        return normalized
     }
 }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Configuration/ProxyFileConfig.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Configuration/ProxyFileConfig.swift
@@ -14,9 +14,12 @@ extension ProxyConfig.File {
         case string(String)
         case number(ProxyConfig.File.Number)
         case bool(Bool)
+        case null
 
         init?(any value: Any) {
             switch value {
+            case is NSNull:
+                self = .null
             case let value as Bool:
                 self = .bool(value)
             case let value as Int:
@@ -62,6 +65,18 @@ extension ProxyConfig.File {
                 && capabilities == nil
         }
 
+        init(
+            protocolVersion: String? = nil,
+            clientName: String? = nil,
+            clientVersion: String? = nil,
+            capabilities: [String: ProxyConfig.File.Value]? = nil
+        ) {
+            self.protocolVersion = protocolVersion
+            self.clientName = clientName
+            self.clientVersion = clientVersion
+            self.capabilities = capabilities
+        }
+
         fileprivate init(fileConfig: ProxyInitializeHandshakeFileConfig) throws {
             protocolVersion = fileConfig.protocolVersion
             clientName = fileConfig.clientName
@@ -86,6 +101,17 @@ extension ProxyConfig.File {
                 values[key] = mapped
             }
             return values
+        }
+
+        func merging(
+            overriding override: ProxyConfig.File.InitializeHandshakeOverride
+        ) -> ProxyConfig.File.InitializeHandshakeOverride {
+            ProxyConfig.File.InitializeHandshakeOverride(
+                protocolVersion: override.protocolVersion ?? protocolVersion,
+                clientName: override.clientName ?? clientName,
+                clientVersion: override.clientVersion ?? clientVersion,
+                capabilities: override.capabilities ?? capabilities
+            )
         }
     }
 }
@@ -222,15 +248,7 @@ extension ProxyConfig.File {
                 guard let disabled = tools.disabled else {
                     return []
                 }
-                var disabledToolNames = Set<String>()
-                for rawName in disabled {
-                    let normalizedName = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard normalizedName.isEmpty == false else {
-                        continue
-                    }
-                    disabledToolNames.insert(normalizedName)
-                }
-                return disabledToolNames
+                return ProxyConfig.normalizedToolNames(disabled)
             }
         }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/InitializeHandshakeJSON.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/InitializeHandshakeJSON.swift
@@ -70,6 +70,8 @@ enum InitializeHandshakeJSON {
             return .number(.double(number))
         case .bool(let bool):
             return .bool(bool)
+        case .null:
+            return .null
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -79,9 +79,32 @@ Use `XcodeMCPProxyServer.Configuration` to configure the server:
 - `approval` controls Xcode permission dialog automation.
 - `features.refreshCodeIssuesMode` selects proxy diagnostics or upstream
   forwarding for `XcodeRefreshCodeIssuesInFile`.
+- `toolPolicy.disabledToolNames` hides tools from `tools/list` and rejects
+  matching `tools/call` requests locally.
+- `initializeHandshake` overrides the protocol version, client info, or
+  capabilities sent when the proxy initializes upstream `mcpbridge` processes.
 
 The server can also load TOML-backed initialize overrides and disabled tools
-when `configurationFilePath` is set.
+when `configurationFilePath` is set. If typed configuration and a file are both
+set, typed values override the matching file-backed disabled-tools and
+initialize handshake fields.
+
+```swift
+let config = XcodeMCPProxyServer.Configuration(
+    configurationFilePath: "/etc/xcode-mcp/proxy.toml",
+    toolPolicy: .init(
+        disabledToolNames: ["RunAllTests", "RunSomeTests"]
+    ),
+    initializeHandshake: .init(
+        clientInfo: .init(name: "EmbeddingClient", version: "1.0"),
+        capabilities: [
+            "roots": [
+                "listChanged": true,
+            ],
+        ]
+    )
+)
+```
 
 ## Lifecycle
 

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -222,6 +222,129 @@ public final class XcodeMCPProxyServer {
             public static let `default` = Self()
         }
 
+        /// Tool visibility policy applied by the proxy.
+        public struct ToolPolicy: Equatable, Sendable {
+            /// Tool names hidden from `tools/list` results and rejected for
+            /// `tools/call` requests.
+            ///
+            /// Names are normalized when the server builds its runtime config:
+            /// surrounding whitespace is trimmed and empty names are ignored.
+            public var disabledToolNames: Set<String>
+
+            /// Creates a tool policy.
+            public init(disabledToolNames: Set<String> = []) {
+                self.disabledToolNames = disabledToolNames
+            }
+
+            /// Default tool policy.
+            public static let `default` = Self()
+        }
+
+        /// Initialize handshake overrides sent from the proxy to upstream
+        /// `mcpbridge` processes.
+        ///
+        /// Non-`nil` properties override the matching values loaded from
+        /// ``configurationFilePath``. Properties left as `nil` keep the file
+        /// value when present, otherwise the proxy's built-in default is used.
+        public struct InitializeHandshake: Equatable, Sendable {
+            /// Upstream client information for the initialize handshake.
+            public struct ClientInfo: Equatable, Sendable {
+                /// Client name to advertise to the upstream MCP bridge.
+                public var name: String?
+
+                /// Client version to advertise to the upstream MCP bridge.
+                public var version: String?
+
+                /// Creates upstream client information.
+                public init(name: String? = nil, version: String? = nil) {
+                    self.name = name
+                    self.version = version
+                }
+            }
+
+            /// JSON-compatible value used inside initialize capabilities.
+            public enum CapabilityValue: Equatable, Sendable,
+                ExpressibleByStringLiteral,
+                ExpressibleByBooleanLiteral,
+                ExpressibleByIntegerLiteral,
+                ExpressibleByFloatLiteral,
+                ExpressibleByArrayLiteral,
+                ExpressibleByDictionaryLiteral
+            {
+                /// A JSON object with string keys.
+                case object([String: CapabilityValue])
+
+                /// A JSON array.
+                case array([CapabilityValue])
+
+                /// A JSON string.
+                case string(String)
+
+                /// A JSON integer number.
+                case integer(Int64)
+
+                /// A JSON floating-point number.
+                case double(Double)
+
+                /// A JSON boolean.
+                case bool(Bool)
+
+                /// A JSON null value.
+                case null
+
+                /// Creates a JSON string from a Swift string literal.
+                public init(stringLiteral value: String) {
+                    self = .string(value)
+                }
+
+                /// Creates a JSON boolean from a Swift boolean literal.
+                public init(booleanLiteral value: Bool) {
+                    self = .bool(value)
+                }
+
+                /// Creates a JSON integer from a Swift integer literal.
+                public init(integerLiteral value: Int64) {
+                    self = .integer(value)
+                }
+
+                /// Creates a JSON floating-point number from a Swift float
+                /// literal.
+                public init(floatLiteral value: Double) {
+                    self = .double(value)
+                }
+
+                /// Creates a JSON array from a Swift array literal.
+                public init(arrayLiteral elements: CapabilityValue...) {
+                    self = .array(elements)
+                }
+
+                /// Creates a JSON object from a Swift dictionary literal.
+                public init(dictionaryLiteral elements: (String, CapabilityValue)...) {
+                    self = .object(Dictionary(elements, uniquingKeysWith: { _, last in last }))
+                }
+            }
+
+            /// Protocol version to send in initialize params.
+            public var protocolVersion: String?
+
+            /// Client info to send in initialize params.
+            public var clientInfo: ClientInfo?
+
+            /// Capability object to send in initialize params.
+            public var capabilities: [String: CapabilityValue]?
+
+            /// Creates initialize handshake overrides.
+            public init(
+                protocolVersion: String? = nil,
+                clientInfo: ClientInfo? = nil,
+                capabilities: [String: CapabilityValue]? = nil
+            ) {
+                self.protocolVersion = protocolVersion
+                self.clientInfo = clientInfo
+                self.capabilities = capabilities
+            }
+        }
+
         /// HTTP bind address.
         public var bind: BindAddress
 
@@ -234,6 +357,19 @@ public final class XcodeMCPProxyServer {
         /// Optional TOML configuration path for initialize overrides and
         /// disabled tools.
         public var configurationFilePath: String?
+
+        /// Explicit tool visibility policy.
+        ///
+        /// `nil` keeps disabled tools loaded from ``configurationFilePath``.
+        /// A non-`nil` policy overrides the file's `[tools].disabled` list.
+        public var toolPolicy: ToolPolicy?
+
+        /// Explicit initialize handshake override.
+        ///
+        /// Non-`nil` fields override the matching file-backed
+        /// `[upstream_handshake]` fields. Fields left `nil` keep the file
+        /// value when present, otherwise the built-in default is used.
+        public var initializeHandshake: InitializeHandshake?
 
         /// Endpoint discovery policy.
         public var discovery: Discovery
@@ -254,6 +390,9 @@ public final class XcodeMCPProxyServer {
         ///   - discovery: Endpoint discovery policy.
         ///   - approval: Permission dialog automation policy.
         ///   - features: Optional proxy feature policy.
+        ///   - toolPolicy: Explicit tool visibility policy.
+        ///   - initializeHandshake: Explicit upstream initialize handshake
+        ///     override.
         public init(
             bind: BindAddress = .localhost(),
             upstream: Upstream = .defaultMCPBridge(),
@@ -261,12 +400,16 @@ public final class XcodeMCPProxyServer {
             configurationFilePath: String? = nil,
             discovery: Discovery = .default,
             approval: ApprovalPolicy = .manual,
-            features: FeaturePolicy = .default
+            features: FeaturePolicy = .default,
+            toolPolicy: ToolPolicy? = nil,
+            initializeHandshake: InitializeHandshake? = nil
         ) {
             self.bind = bind
             self.upstream = upstream
             self.limits = limits
             self.configurationFilePath = configurationFilePath
+            self.toolPolicy = toolPolicy
+            self.initializeHandshake = initializeHandshake
             self.discovery = discovery
             self.approval = approval
             self.features = features
@@ -709,8 +852,44 @@ private extension ProxyConfig {
             discoveryFileURL: config.discoveryFileURL,
             prewarmToolsList: config.prewarmToolsList,
             autoApproveXcodeDialog: config.autoApproveXcodeDialog,
-            refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode(config.refreshCodeIssuesMode)
+            refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode(config.refreshCodeIssuesMode),
+            disabledToolNames: config.toolPolicy?.disabledToolNames,
+            initializeParamsOverride: config.initializeHandshake.map {
+                ProxyConfig.File.InitializeHandshakeOverride($0)
+            }
         )
+    }
+}
+
+private extension ProxyConfig.File.InitializeHandshakeOverride {
+    init(_ handshake: XcodeMCPProxyServer.Configuration.InitializeHandshake) {
+        self.init(
+            protocolVersion: handshake.protocolVersion,
+            clientName: handshake.clientInfo?.name,
+            clientVersion: handshake.clientInfo?.version,
+            capabilities: handshake.capabilities?.mapValues(ProxyConfig.File.Value.init)
+        )
+    }
+}
+
+private extension ProxyConfig.File.Value {
+    init(_ value: XcodeMCPProxyServer.Configuration.InitializeHandshake.CapabilityValue) {
+        switch value {
+        case .object(let object):
+            self = .object(object.mapValues(ProxyConfig.File.Value.init))
+        case .array(let array):
+            self = .array(array.map(ProxyConfig.File.Value.init))
+        case .string(let string):
+            self = .string(string)
+        case .integer(let integer):
+            self = .number(.int(integer))
+        case .double(let double):
+            self = .number(.double(double))
+        case .bool(let bool):
+            self = .bool(bool)
+        case .null:
+            self = .null
+        }
     }
 }
 

--- a/Tests/ProxyHTTPGatewayTests/DisabledToolHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/DisabledToolHTTPTests.swift
@@ -11,6 +11,68 @@ import XcodeMCPProxyTestSupport
 
 
 extension HTTPHandlerTests {
+    @Test func httpDisabledToolPolicyFromPublicConfigurationOverridesConfigFile()
+        async throws
+    {
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("xcode-mcp-public-tool-policy-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directoryURL) }
+
+        let configURL = directoryURL.appendingPathComponent("proxy.toml")
+        try """
+        [tools]
+        disabled = ["OtherTool"]
+        """.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let publicServer = XcodeMCPProxyServer(
+            config: .init(
+                configurationFilePath: configURL.path,
+                toolPolicy: .init(disabledToolNames: [" RunAllTests ", ""])
+            )
+        )
+        let config = publicServer.config
+        try await publicServer.shutdown()
+
+        #expect(config.disabledToolNames == ["RunAllTests"])
+
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamPlanResponder: { _, _ in
+                Issue.record("disabled tool call should not reach upstream")
+                return .immediate(Data())
+            }
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setAvailableUpstreamIndex(nil)
+        let server = try TestHTTPHandlerServer.start(
+            config: config,
+            sessionManager: sessionManager
+        )
+
+        do {
+            let (response, body) = try await postHTTPJSON(
+                url: server.url,
+                sessionID: "session-public-disabled-tool",
+                payload: toolsCallPayload(
+                    id: 111,
+                    name: "RunAllTests",
+                    arguments: [:]
+                )
+            )
+
+            #expect(response.statusCode == 200)
+            let result = body["result"] as? [String: Any]
+            #expect((result?["isError"] as? Bool) == true)
+            #expect(sessionManager.sentToolNames().isEmpty)
+        } catch {
+            try? await server.shutdown()
+            throw error
+        }
+        try await server.shutdown()
+    }
+
     @Test func httpDisabledToolCallReturnsLocalToolErrorWhenNoUpstreamIsAvailable() async throws {
         var config = makeConfig(requestTimeout: 2)
         config.disabledToolNames = ["RunAllTests"]

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -5177,6 +5177,60 @@ struct RuntimeCoordinatorTests {
         #expect(capabilities["roots"] as? Bool == true)
     }
 
+    @Test func sessionManagerAppliesPublicInitializeHandshakeOverrideAfterConfigFile()
+        async throws
+    {
+        let configPath = try makeTempProxyConfigFile(
+            """
+            [upstream_handshake]
+            protocolVersion = "2025-06-18"
+            clientName = "file-proxy"
+            clientVersion = "file-version"
+
+            [upstream_handshake.capabilities]
+            roots = true
+            """
+        )
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+
+        let publicServer = XcodeMCPProxyServer(
+            config: .init(
+                configurationFilePath: configPath,
+                features: .init(prewarmToolsList: false),
+                initializeHandshake: .init(
+                    clientInfo: .init(name: "typed-proxy"),
+                    capabilities: [
+                        "sampling": [
+                            "enabled": true,
+                        ],
+                    ]
+                )
+            )
+        )
+        let config = publicServer.config
+        try await publicServer.shutdown()
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        defer { manager.shutdownAndWait() }
+
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let object = try JSONSerialization.jsonObject(with: sent, options: []) as? [String: Any]
+        let params = try #require(object?["params"] as? [String: Any])
+        let clientInfo = try #require(params["clientInfo"] as? [String: Any])
+        let capabilities = try #require(params["capabilities"] as? [String: Any])
+        let sampling = try #require(capabilities["sampling"] as? [String: Any])
+
+        #expect(params["protocolVersion"] as? String == "2025-06-18")
+        #expect(clientInfo["name"] as? String == "typed-proxy")
+        #expect(clientInfo["version"] as? String == "file-version")
+        #expect(capabilities["roots"] == nil)
+        #expect(sampling["enabled"] as? Bool == true)
+    }
+
     @Test func sessionManagerAutoResolvesInitializeVersionFromConfiguredClientName() async throws {
         let configPath = try makeTempProxyConfigFile(
             """

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -423,9 +423,28 @@ func compileOnlyProxyConfigurationSurface() {
         features: .init(
             prewarmToolsList: false,
             refreshCodeIssuesMode: .proxy
+        ),
+        toolPolicy: .init(
+            disabledToolNames: ["RunAllTests", "RunSomeTests"]
+        ),
+        initializeHandshake: .init(
+            protocolVersion: "2025-06-18",
+            clientInfo: .init(name: "EmbeddingClient", version: "1.0"),
+            capabilities: [
+                "roots": [
+                    "listChanged": true,
+                ],
+                "experimental": [
+                    "priority": 1,
+                    "score": 0.5,
+                    "metadata": .null,
+                ],
+            ]
         )
     )
 
+    let typedToolPolicy = config.toolPolicy
+    let typedHandshake = config.initializeHandshake
     let upstreamMode = XcodeMCPProxyServer.Configuration.RefreshCodeIssuesMode.upstream
     let server = XcodeMCPProxyServer(config: config)
     let endpointConfig = XcodeMCPProxyAdapterEndpointResolver.Configuration(
@@ -447,7 +466,17 @@ func compileOnlyProxyConfigurationSurface() {
         XcodeMCPProxyStdioAdapter(endpoint: $0, requestTimeout: 30)
     }
 
-    _ = (config, upstreamMode, server, adapterConfig, endpoint, adapter, plan)
+    _ = (
+        config,
+        typedToolPolicy,
+        typedHandshake,
+        upstreamMode,
+        server,
+        adapterConfig,
+        endpoint,
+        adapter,
+        plan
+    )
     _ = XcodeMCPProxyInstaller.binaryNames
 }
 


### PR DESCRIPTION
## Purpose
Allow external embedders to configure disabled tools and upstream initialize handshake behavior through the public `XcodeMCPProxyKit` API without knowing the TOML schema or internal `ProxyConfig` shape.

## Changes
- Added `XcodeMCPProxyServer.Configuration.ToolPolicy` and `InitializeHandshake` public typed configuration.
- Merged typed public config into internal `ProxyConfig` after file loading, with typed values overriding matching file-backed disabled-tool and initialize fields.
- Added a JSON-compatible public capability value type for initialize capabilities.
- Documented embedder usage and precedence in the root README and `Sources/XcodeMCPProxyKit/README.md`.
- Added public contract, runtime coordinator, and HTTP gateway coverage for the new facade.

## Validation
- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `swift test -Xswiftc -strict-concurrency=minimal`

## Review
- `codex-review` against `codex/refactor-layered-runtime-integration`: clean, 0 findings.