### PR TITLE
[codex] Determinize timeout and readiness clock owners

### DIFF
--- a/Sources/XcodeMCPCore/StreamableHTTPMCPClient.swift
+++ b/Sources/XcodeMCPCore/StreamableHTTPMCPClient.swift
@@ -35,7 +35,8 @@ package final class StreamableHTTPMCPClient: @unchecked Sendable {
         requestTimeout: Duration? = nil,
         automaticallyStartsEventStream: Bool = true,
         eventStreamReconnectSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
-            try await Task.sleep(for: duration)
+            await ClockClient.liveValue.sleep(duration)
+            try Task.checkCancellation()
         }
     ) {
         let stream = AsyncStream<Data>.makeStream()

--- a/Sources/XcodeMCPKit/Internal/ClientRuntime/InitializedMCPClientSession.swift
+++ b/Sources/XcodeMCPKit/Internal/ClientRuntime/InitializedMCPClientSession.swift
@@ -57,22 +57,25 @@ private final class MCPClientPendingRequests: @unchecked Sendable {
 }
 
 package actor InitializedMCPClientSession {
-    package struct Configuration: Equatable, Sendable {
+    package struct Configuration: Sendable {
         package var clientName: String
         package var clientVersion: String
         package var capabilities: [String: JSONValue]
         package var requestTimeout: Duration?
+        package var clock: ClockClient
 
         package init(
             clientName: String,
             clientVersion: String,
             capabilities: [String: JSONValue],
-            requestTimeout: Duration?
+            requestTimeout: Duration?,
+            clock: ClockClient = .liveValue
         ) {
             self.clientName = clientName
             self.clientVersion = clientVersion
             self.capabilities = capabilities
             self.requestTimeout = requestTimeout
+            self.clock = clock
         }
     }
 
@@ -266,12 +269,14 @@ private extension InitializedMCPClientSession {
         guard let requestTimeout = configuration.requestTimeout else {
             return try await operation()
         }
+        let clock = configuration.clock
         return try await withThrowingTaskGroup(of: T.self) { group in
             group.addTask {
                 try await operation()
             }
             group.addTask {
-                try await Task.sleep(for: requestTimeout)
+                await clock.sleep(requestTimeout)
+                try Task.checkCancellation()
                 throw MCPBridgeRuntimeError.requestTimedOut(method: method)
             }
             let result = try await group.next()!

--- a/Sources/XcodeMCPKit/Internal/ClientRuntime/StreamableHTTPXcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/Internal/ClientRuntime/StreamableHTTPXcodeMCPTransport.swift
@@ -40,7 +40,8 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
         urlSession: URLSession,
         requestTimeout: Duration? = nil,
         eventStreamReconnectSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
-            try await Task.sleep(for: duration)
+            await ClockClient.liveValue.sleep(duration)
+            try Task.checkCancellation()
         }
     ) {
         let stream = AsyncStream<XcodeMCPTransportEvent>.makeStream()

--- a/Sources/XcodeMCPProxyKit/Internal/PermissionDialog/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/PermissionDialog/XcodePermissionDialogAutoApprover.swift
@@ -51,7 +51,7 @@ extension XcodePermissionDialog {
                     assistantNameCandidates: assistantNameCandidates,
                     serverProcessIDCandidates: serverProcessIDCandidates,
                     sleep: { duration in
-                        try? await Task.sleep(for: duration)
+                        await ClockClient.liveValue.sleep(duration)
                     },
                     pollInterval: .milliseconds(250),
                     logger: ProxyLogging.make("xcode.permission")
@@ -68,7 +68,7 @@ extension XcodePermissionDialog {
                 assistantNameCandidates: { [] },
                 serverProcessIDCandidates: { [] },
                 sleep: { _ in
-                    try? await Task.sleep(for: .milliseconds(1))
+                    await ClockClient.liveValue.sleep(.milliseconds(1))
                 },
                 pollInterval: .milliseconds(1),
                 logger: ProxyLogging.make("xcode.permission.test")

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeUpstreamReadiness.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeUpstreamReadiness.swift
@@ -18,7 +18,7 @@ extension UpstreamReadinessGate {
         return .xcodeMCPBridge(
             uptimeNanoseconds: clock.uptimeNanoseconds,
             sleepNanoseconds: { nanoseconds in
-                try? await Task.sleep(nanoseconds: nanoseconds)
+                await clock.sleep(.nanoseconds(Int64(clamping: nanoseconds)))
             },
             runProcess: { request in
                 try await processRunner.run(request)

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -3441,13 +3441,8 @@ struct RuntimeCoordinatorTests {
                 requestTimeoutOverride: .seconds(2)
             )
         }
-        let firstRequest = try await waitWithTimeout(
-            "waiting for first window fanout request on upstream0",
-            timeout: .seconds(2)
-        ) {
-            try await upstream0.nextSent(startingAt: firstUpstream0StartIndex) {
-                methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
-            }
+        let firstRequest = try await upstream0.nextSent(startingAt: firstUpstream0StartIndex) {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
         }
         #expect(await upstream1.sentCount() == firstUpstream1StartIndex)
         await upstream0.yield(
@@ -3458,12 +3453,7 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
-        _ = try await waitWithTimeout(
-            "waiting for first window fanout result",
-            timeout: .seconds(2)
-        ) {
-            try await firstTask.value
-        }
+        _ = try await firstTask.value
         #expect(await upstream1.sentCount() == firstUpstream1StartIndex)
 
         manager.markUpstreamInitialized(upstreamIndex: 1)
@@ -3475,21 +3465,11 @@ struct RuntimeCoordinatorTests {
                 requestTimeoutOverride: .seconds(2)
             )
         }
-        let secondRequest0 = try await waitWithTimeout(
-            "waiting for second window fanout request on upstream0",
-            timeout: .seconds(2)
-        ) {
-            try await upstream0.nextSent(startingAt: secondUpstream0StartIndex) {
-                methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
-            }
+        let secondRequest0 = try await upstream0.nextSent(startingAt: secondUpstream0StartIndex) {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
         }
-        let secondRequest1 = try await waitWithTimeout(
-            "waiting for second window fanout request on upstream1",
-            timeout: .seconds(2)
-        ) {
-            try await upstream1.nextSent(startingAt: secondUpstream1StartIndex) {
-                methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
-            }
+        let secondRequest1 = try await upstream1.nextSent(startingAt: secondUpstream1StartIndex) {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
         }
         await upstream0.yield(
             .message(
@@ -3507,12 +3487,7 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
-        _ = try await waitWithTimeout(
-            "waiting for second window fanout result",
-            timeout: .seconds(2)
-        ) {
-            try await secondTask.value
-        }
+        _ = try await secondTask.value
     }
 
     @Test func mergedXcodeListWindowsPreservesToolErrors() throws {

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -367,6 +367,42 @@ struct XcodeMCPTests {
         await xcode.close()
     }
 
+    @Test func runtimeSessionRequestTimeoutUsesInjectedClock() async throws {
+        let transport = HangingSendXcodeMCPTransport()
+        let timeoutClock = ManualSessionTimeoutClock()
+        let session = try await InitializedMCPClientSession(
+            transport: transport,
+            configuration: .init(
+                clientName: "RuntimeSessionTest",
+                clientVersion: "1.0",
+                capabilities: [:],
+                requestTimeout: .seconds(2),
+                clock: await timeoutClock.client()
+            )
+        )
+        defer {
+            Task { await session.close() }
+        }
+
+        let sleepBaseline = await timeoutClock.requestedSleepCount()
+        let requestTask = Task {
+            try await session.request("tools/list")
+        }
+        defer {
+            requestTask.cancel()
+        }
+
+        _ = try await transport.nextStarted(method: "tools/list")
+        let requestedTimeout = try await timeoutClock.nextRequestedSleep(at: sleepBaseline)
+        #expect(requestedTimeout == .seconds(2))
+
+        await timeoutClock.resumeSleep(at: sleepBaseline)
+        await #expect(throws: MCPBridgeRuntimeError.requestTimedOut(method: "tools/list")) {
+            _ = try await requestTask.value
+        }
+        _ = try await transport.nextCancelled(method: "tools/list")
+    }
+
     @Test func unsupportedServerRequestGetsInternalErrorResponse() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(transport: transport)
@@ -1887,6 +1923,122 @@ private actor RecordedValues<Value: Sendable> {
             return values[index]
         }
         return nil
+    }
+}
+
+private actor ManualSessionTimeoutClock {
+    private struct SleepRequest {
+        let id: UUID
+        let index: Int
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private struct DurationWaiter {
+        let id: UUID
+        let index: Int
+        let continuation: CheckedContinuation<Duration, Error>
+    }
+
+    private var requestedDurations: [Duration] = []
+    private var sleepRequests: [SleepRequest] = []
+    private var cancelledSleepRequestIDs: Set<UUID> = []
+    private var durationWaiters: [DurationWaiter] = []
+
+    func client() -> ClockClient {
+        ClockClient(
+            now: { Date(timeIntervalSince1970: 0) },
+            uptimeNanoseconds: { 0 },
+            sleep: { duration in
+                await self.sleep(for: duration)
+            },
+            sleepForTimeInterval: { _ in }
+        )
+    }
+
+    func requestedSleepCount() -> Int {
+        requestedDurations.count
+    }
+
+    func nextRequestedSleep(at index: Int) async throws -> Duration {
+        if requestedDurations.indices.contains(index) {
+            return requestedDurations[index]
+        }
+
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if requestedDurations.indices.contains(index) {
+                    continuation.resume(returning: requestedDurations[index])
+                    return
+                }
+                durationWaiters.append(
+                    DurationWaiter(id: waiterID, index: index, continuation: continuation)
+                )
+            }
+        } onCancel: {
+            Task { await self.cancelDurationWaiter(id: waiterID) }
+        }
+    }
+
+    func resumeSleep(at index: Int) {
+        guard let requestIndex = sleepRequests.firstIndex(where: { $0.index == index }) else {
+            return
+        }
+        let request = sleepRequests.remove(at: requestIndex)
+        request.continuation.resume()
+    }
+
+    private func sleep(for duration: Duration) async {
+        let requestID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if cancelledSleepRequestIDs.remove(requestID) != nil {
+                    continuation.resume()
+                    return
+                }
+                let index = requestedDurations.count
+                requestedDurations.append(duration)
+                sleepRequests.append(
+                    SleepRequest(
+                        id: requestID,
+                        index: index,
+                        continuation: continuation
+                    )
+                )
+                resumeReadyDurationWaiters()
+            }
+        } onCancel: {
+            Task { await self.cancelSleepRequest(id: requestID) }
+        }
+    }
+
+    private func cancelSleepRequest(id: UUID) {
+        guard let index = sleepRequests.firstIndex(where: { $0.id == id }) else {
+            cancelledSleepRequestIDs.insert(id)
+            return
+        }
+        let request = sleepRequests.remove(at: index)
+        request.continuation.resume()
+    }
+
+    private func cancelDurationWaiter(id: UUID) {
+        guard let index = durationWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = durationWaiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func resumeReadyDurationWaiters() {
+        var remaining: [DurationWaiter] = []
+        for waiter in durationWaiters {
+            if requestedDurations.indices.contains(waiter.index) {
+                waiter.continuation.resume(returning: requestedDurations[waiter.index])
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        durationWaiters = remaining
     }
 }
 


### PR DESCRIPTION
## Purpose

Make time-dependent runtime owner paths fakeable and reduce wall-clock dependence in high-risk tests.

## Changes

- Added package-level `ClockClient` injection to `InitializedMCPClientSession.Configuration` and routed request timeout sleeps through that owner.
- Routed readiness polling, Streamable HTTP reconnect defaults, and permission auto-approver default sleeps through `ClockClient.liveValue`.
- Added a deterministic request-timeout contract test using a manual clock.
- Removed wall-clock `waitWithTimeout` wrappers from `sessionManagerSkipsUninitializedProcessRoutesDuringWindowFanout` where upstream send/result owner signals are available.

## Validation

- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `codex-review` branch-wide against `codex/refactor-layered-runtime-integration`: clean

## Notes

No screenshots needed. Remaining wall-clock dependencies still exist in broader async tests such as other `waitWithTimeout` uses and the real-HTTP queue/order tests; this PR keeps scope to the owner boundaries touched here.