### PR TITLE
[codex] Expose proxy discovery and runner facades

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ let xcode = try await XcodeMCP(
 )
 ```
 
+To use the standard proxy discovery location, including
+`XCODE_MCP_PROXY_DISCOVERY_FILE` and `XCODE_MCP_PROXY_CACHE_ROOT` overrides:
+
+```swift
+let xcode = try await XcodeMCP(
+    config: .init(transport: .streamableHTTPProxyDiscovery())
+)
+```
+
 The public API exposes MCP domain values such as `MCPJSONValue`, `MCPTool`,
 `MCPToolResult`, `MCPContent`, and `MCPProgress`. Use `request(_:params:)` and
 `notify(_:params:)` for dynamic MCP methods that are not tool calls; the client
@@ -219,6 +228,17 @@ handshake fields.
 `LaunchPlan` also carries help/version text, `--dry-run` output,
 `--force-restart`, and product metadata so launchers do not need to compose the
 lower-level parser or config types directly.
+
+Executable-style hosts can run the same facades directly:
+
+```swift
+let exitCode = await XcodeMCPProxyServer.run(
+    arguments: CommandLine.arguments,
+    environment: ProcessInfo.processInfo.environment,
+    stdout: { print($0) },
+    stderr: { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+)
+```
 
 `XcodeMCPProxyKit` also exposes `XcodeMCPProxyStdioAdapter`,
 `XcodeMCPProxyAdapterEndpointResolver`, and `XcodeMCPProxyInstaller`. The STDIO

--- a/Sources/XcodeMCPCore/Discovery.swift
+++ b/Sources/XcodeMCPCore/Discovery.swift
@@ -25,11 +25,35 @@ package struct DiscoveryRecord: Codable, Sendable {
 }
 
 package enum Discovery {
+    package static let cacheRootEnvironmentVariable = "XCODE_MCP_PROXY_CACHE_ROOT"
+    package static let discoveryFileEnvironmentVariable = "XCODE_MCP_PROXY_DISCOVERY_FILE"
+
     package static var defaultFileURL: URL {
-        let defaultRoot =
-            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-            ?? FileManager.default.temporaryDirectory
-        return defaultRoot
+        defaultFileURL(environment: ProcessInfo.processInfo.environment)
+    }
+
+    package static func defaultFileURL(
+        environment: [String: String],
+        fileManager: FileManager = .default
+    ) -> URL {
+        if let overridePath = nonEmpty(environment[discoveryFileEnvironmentVariable]) {
+            return URL(fileURLWithPath: NSString(string: overridePath).expandingTildeInPath)
+        }
+
+        let cacheRootURL: URL
+        if let overrideRoot = nonEmpty(environment[cacheRootEnvironmentVariable]) {
+            cacheRootURL = URL(
+                fileURLWithPath: NSString(string: overrideRoot).expandingTildeInPath,
+                isDirectory: true
+            )
+        } else {
+            let defaultRoot =
+                fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+                ?? fileManager.temporaryDirectory
+            cacheRootURL = defaultRoot
+        }
+
+        return cacheRootURL
             .appendingPathComponent("XcodeMCPProxy", isDirectory: true)
             .appendingPathComponent("endpoint.json")
     }
@@ -136,6 +160,14 @@ package enum Discovery {
         let value = host.lowercased()
         if value.hasPrefix("["), value.hasSuffix("]") {
             return String(value.dropFirst().dropLast())
+        }
+        return value
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
         }
         return value
     }

--- a/Sources/XcodeMCPKit/README.md
+++ b/Sources/XcodeMCPKit/README.md
@@ -92,6 +92,15 @@ let config = XcodeMCP.Configuration(
 )
 ```
 
+For the standard proxy discovery location, including
+`XCODE_MCP_PROXY_DISCOVERY_FILE` and `XCODE_MCP_PROXY_CACHE_ROOT` overrides, use:
+
+```swift
+let config = XcodeMCP.Configuration(
+    transport: .streamableHTTPProxyDiscovery()
+)
+```
+
 ## Dynamic Tools And Raw Values
 
 The Xcode MCP server decides which tools are available at runtime. Call
@@ -133,8 +142,8 @@ try await xcode.notify(
 
 `XcodeMCP.Configuration` controls transport selection and MCP initialization:
 
-- `transport` chooses `.localBridge(...)`, `.streamableHTTP(endpoint:)`, or
-  `.streamableHTTP(discoveryFile:)`.
+- `transport` chooses `.localBridge(...)`, `.streamableHTTP(endpoint:)`,
+  `.streamableHTTP(discoveryFile:)`, or `.streamableHTTPProxyDiscovery()`.
 - The compatibility `bridge` property still chooses the upstream bridge for
   local process transport. The default is Xcode's `/usr/bin/xcrun mcpbridge`.
 - Use bridge `.custom(command:arguments:environment:)` only when embedding a

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -65,6 +65,21 @@ public actor XcodeMCP {
             public static func streamableHTTP(discoveryFile: URL) -> Self {
                 .streamableHTTPDiscoveryFile(discoveryFile)
             }
+
+            /// Connect to the Streamable HTTP proxy endpoint discovered from
+            /// the standard proxy discovery file location.
+            ///
+            /// The file path honors `XCODE_MCP_PROXY_DISCOVERY_FILE` first,
+            /// then `XCODE_MCP_PROXY_CACHE_ROOT`, and otherwise uses the
+            /// default user caches location used by `xcode-mcp-proxy-server`.
+            ///
+            /// - Parameter environment: Environment used to resolve proxy
+            ///   discovery overrides.
+            public static func streamableHTTPProxyDiscovery(
+                environment: [String: String] = ProcessInfo.processInfo.environment
+            ) -> Self {
+                .streamableHTTP(discoveryFile: Discovery.defaultFileURL(environment: environment))
+            }
         }
 
         /// Upstream bridge process policy.

--- a/Sources/XcodeMCPProxyCLI/XcodeMCPProxyCLI.swift
+++ b/Sources/XcodeMCPProxyCLI/XcodeMCPProxyCLI.swift
@@ -4,14 +4,20 @@ import XcodeMCPProxyKit
 @main
 struct XcodeMCPProxyCLI {
     static func main() async {
-        let command = XcodeMCPProxyCLICommand()
-        let exitCode = await command.run(
-            args: CommandLine.arguments,
-            environment: ProcessInfo.processInfo.environment
+        XcodeMCPProxyLogging.bootstrap(environment: ProcessInfo.processInfo.environment)
+        let exitCode = await XcodeMCPProxyStdioAdapter.run(
+            arguments: CommandLine.arguments,
+            environment: ProcessInfo.processInfo.environment,
+            stdout: { print($0) },
+            stderr: { writeStandardErrorLine($0) }
         )
         guard exitCode != 0 else {
             return
         }
         exit(exitCode)
     }
+}
+
+private func writeStandardErrorLine(_ text: String) {
+    FileHandle.standardError.write(Data((text + "\n").utf8))
 }

--- a/Sources/XcodeMCPProxyInstall/main.swift
+++ b/Sources/XcodeMCPProxyInstall/main.swift
@@ -1,11 +1,16 @@
 import Foundation
 import XcodeMCPProxyKit
 
-let command = XcodeMCPProxyInstallCommand()
-let exitCode = command.run(
-    args: CommandLine.arguments,
-    environment: ProcessInfo.processInfo.environment
+let exitCode = XcodeMCPProxyInstaller.run(
+    arguments: CommandLine.arguments,
+    environment: ProcessInfo.processInfo.environment,
+    stdout: { print($0) },
+    stderr: { writeStandardErrorLine($0) }
 )
 if exitCode != 0 {
     exit(exitCode)
+}
+
+private func writeStandardErrorLine(_ text: String) {
+    FileHandle.standardError.write(Data((text + "\n").utf8))
 }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Support/ProxyFilesystemLocations.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Support/ProxyFilesystemLocations.swift
@@ -1,40 +1,14 @@
 import Foundation
+import XcodeMCPCore
 
 enum ProxyFilesystemLocations {
-    static let cacheRootEnv = "XCODE_MCP_PROXY_CACHE_ROOT"
-    static let discoveryFileEnv = "XCODE_MCP_PROXY_DISCOVERY_FILE"
+    static let cacheRootEnv = Discovery.cacheRootEnvironmentVariable
+    static let discoveryFileEnv = Discovery.discoveryFileEnvironmentVariable
 
     static func discoveryFileURL(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> URL {
-        if let overridePath = nonEmpty(environment[discoveryFileEnv]) {
-            return URL(fileURLWithPath: NSString(string: overridePath).expandingTildeInPath)
-        }
-
-        let cacheRootURL: URL
-        if let overrideRoot = nonEmpty(environment[cacheRootEnv]) {
-            cacheRootURL = URL(
-                fileURLWithPath: NSString(string: overrideRoot).expandingTildeInPath,
-                isDirectory: true
-            )
-        } else {
-            let defaultRoot =
-                fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
-                ?? fileManager.temporaryDirectory
-            cacheRootURL = defaultRoot
-        }
-
-        return cacheRootURL
-            .appendingPathComponent("XcodeMCPProxy", isDirectory: true)
-            .appendingPathComponent("endpoint.json")
-    }
-
-    private static func nonEmpty(_ value: String?) -> String? {
-        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else {
-            return nil
-        }
-        return value
+        Discovery.defaultFileURL(environment: environment, fileManager: fileManager)
     }
 }

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -154,6 +154,17 @@ The package executable uses a package-level launcher facade to execute the same
 plan, keeping force-restart, start/wait, and port-in-use diagnostics inside this
 target.
 
+Executable-style hosts can delegate directly to the public runner facade:
+
+```swift
+let exitCode = await XcodeMCPProxyServer.run(
+    arguments: CommandLine.arguments,
+    environment: ProcessInfo.processInfo.environment,
+    stdout: { print($0) },
+    stderr: { FileHandle.standardError.write(Data(($0 + "\n").utf8)) }
+)
+```
+
 ## STDIO Adapter
 
 `XcodeMCPProxyStdioAdapter` forwards MCP STDIO messages to a running
@@ -191,6 +202,9 @@ without a session header, subsequent POST/GET/DELETE requests include the
 server-issued `MCP-Session-Id`, and the negotiated
 `MCP-Protocol-Version` is forwarded after initialize.
 
+Command-line hosts can run the same adapter facade with
+`XcodeMCPProxyStdioAdapter.run(arguments:environment:stdout:stderr:)`.
+
 ## Installer
 
 `XcodeMCPProxyInstaller` owns the source install composition used by
@@ -214,3 +228,6 @@ print(plan.dryRunLines.joined(separator: "\n"))
 `~/.local/bin`. A non-dry-run install builds release products when the installer
 is running from a SwiftPM `.build` directory and then copies
 `XcodeMCPProxyInstaller.binaryNames` into the resolved bin directory.
+
+Command-line hosts can run the installer facade with
+`XcodeMCPProxyInstaller.run(arguments:environment:stdout:stderr:)`.

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyRunners.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyRunners.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+extension XcodeMCPProxyServer {
+    /// Runs the `xcode-mcp-proxy-server` command-line facade.
+    ///
+    /// This helper parses the same arguments and environment accepted by the
+    /// executable, executes the normalized launch plan, and returns a
+    /// process-style exit code. Output that belongs on standard output or
+    /// standard error is delivered through the supplied callbacks. Hosts that
+    /// want swift-log output should configure logging before calling this
+    /// method.
+    ///
+    /// - Parameters:
+    ///   - arguments: Command-line arguments, including the executable name.
+    ///   - environment: Environment variables used for launch resolution.
+    ///   - stdout: Callback for standard output lines.
+    ///   - stderr: Callback for standard error lines.
+    /// - Returns: `0` for success, or a nonzero exit code for launch or
+    ///   validation failures.
+    public static func run(
+        arguments: [String],
+        environment: [String: String],
+        stdout: @escaping @Sendable (String) -> Void,
+        stderr: @escaping @Sendable (String) -> Void
+    ) async -> Int32 {
+        return await Launcher().run(
+            arguments: arguments,
+            environment: environment,
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+}
+
+extension XcodeMCPProxyStdioAdapter {
+    /// Runs the `xcode-mcp-proxy` STDIO adapter command-line facade.
+    ///
+    /// This helper parses the same arguments and environment accepted by the
+    /// executable, resolves the Streamable HTTP endpoint, starts the adapter
+    /// when requested, and returns a process-style exit code. Display output is
+    /// sent to `stdout`; validation and launch errors are sent to `stderr`.
+    /// Hosts that want swift-log output should configure logging before calling
+    /// this method.
+    ///
+    /// - Parameters:
+    ///   - arguments: Command-line arguments, including the executable name.
+    ///   - environment: Environment variables used for endpoint resolution.
+    ///   - stdout: Callback for standard output lines.
+    ///   - stderr: Callback for standard error lines.
+    /// - Returns: `0` for success, or a nonzero exit code for launch or
+    ///   validation failures.
+    public static func run(
+        arguments: [String],
+        environment: [String: String],
+        stdout: @escaping @Sendable (String) -> Void,
+        stderr: @escaping @Sendable (String) -> Void
+    ) async -> Int32 {
+        return await Launcher().run(
+            arguments: arguments,
+            environment: environment,
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+}
+
+extension XcodeMCPProxyInstaller {
+    /// Runs the `xcode-mcp-proxy-install` command-line facade.
+    ///
+    /// This helper parses the same arguments and environment accepted by the
+    /// executable, executes the normalized install plan, and returns a
+    /// process-style exit code. Output that belongs on standard output or
+    /// standard error is delivered through the supplied callbacks.
+    ///
+    /// - Parameters:
+    ///   - arguments: Command-line arguments, including the executable name.
+    ///   - environment: Environment variables used for install resolution.
+    ///   - stdout: Callback for standard output lines.
+    ///   - stderr: Callback for standard error lines.
+    /// - Returns: `0` for success, or a nonzero exit code for launch or
+    ///   validation failures.
+    public static func run(
+        arguments: [String],
+        environment: [String: String],
+        stdout: @escaping @Sendable (String) -> Void,
+        stderr: @escaping @Sendable (String) -> Void
+    ) -> Int32 {
+        Launcher().run(
+            arguments: arguments,
+            environment: environment,
+            stdout: stdout,
+            stderr: stderr
+        )
+    }
+}

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyStdioAdapter.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyStdioAdapter.swift
@@ -729,7 +729,8 @@ extension XcodeMCPProxyStdioAdapter {
         package func run(
             arguments: [String],
             environment: [String: String],
-            stdout: (String) -> Void
+            stdout: (String) -> Void,
+            stderr: ((String) -> Void)? = nil
         ) async -> Int32 {
             do {
                 let plan = try XcodeMCPProxyStdioAdapter.resolveLaunchPlan(
@@ -745,10 +746,10 @@ extension XcodeMCPProxyStdioAdapter {
                     stdout(plan.versionLine)
                     return 0
                 case .start:
-                    return await startAdapter(from: plan, environment: environment)
+                    return await startAdapter(from: plan, environment: environment, stderr: stderr)
                 }
             } catch let error as XcodeMCPProxyStdioAdapter.LaunchResolutionError {
-                let logSink = dependencies.makeLogSink()
+                let logSink = makeLogSink(stderr: stderr)
                 switch error.presentation {
                 case .plain:
                     logSink.error(error.description)
@@ -761,21 +762,22 @@ extension XcodeMCPProxyStdioAdapter {
                 }
                 return 1
             } catch {
-                dependencies.makeLogSink().error("error: \(error)")
+                makeLogSink(stderr: stderr).error("error: \(error)")
                 return 1
             }
         }
 
         private func startAdapter(
             from plan: XcodeMCPProxyStdioAdapter.LaunchPlan,
-            environment: [String: String]
+            environment: [String: String],
+            stderr: ((String) -> Void)?
         ) async -> Int32 {
             guard let endpoint = plan.endpoint else {
-                dependencies.makeLogSink().error("adapter launch plan is missing endpoint")
+                makeLogSink(stderr: stderr).error("adapter launch plan is missing endpoint")
                 return 1
             }
 
-            let logSink = dependencies.makeLogSink()
+            let logSink = makeLogSink(stderr: stderr)
             logResolvedUpstream(endpoint: endpoint, environment: environment, logSink: logSink)
 
             let adapter = dependencies.makeAdapter(
@@ -823,6 +825,17 @@ extension XcodeMCPProxyStdioAdapter {
                     ["url": "\(url)"]
                 )
             }
+        }
+
+        private func makeLogSink(stderr: ((String) -> Void)?) -> XcodeMCPProxyStdioAdapter.LogSink {
+            let logSink = dependencies.makeLogSink()
+            guard let stderr else {
+                return logSink
+            }
+            return XcodeMCPProxyStdioAdapter.LogSink(
+                error: stderr,
+                info: logSink.info
+            )
         }
     }
 }

--- a/Sources/XcodeMCPProxyServer/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyServer/XcodeMCPProxyServer.swift
@@ -4,14 +4,22 @@ import XcodeMCPProxyKit
 @main
 struct XcodeMCPProxyServer {
     static func main() async {
-        let command = XcodeMCPProxyServerCommand()
-        let exitCode = await command.run(
-            args: CommandLine.arguments,
+        XcodeMCPProxyKit.XcodeMCPProxyServer.bootstrapLogging(
             environment: ProcessInfo.processInfo.environment
+        )
+        let exitCode = await XcodeMCPProxyKit.XcodeMCPProxyServer.run(
+            arguments: CommandLine.arguments,
+            environment: ProcessInfo.processInfo.environment,
+            stdout: { print($0) },
+            stderr: { writeStandardErrorLine($0) }
         )
         guard exitCode != 0 else {
             return
         }
         exit(exitCode)
     }
+}
+
+private func writeStandardErrorLine(_ text: String) {
+    FileHandle.standardError.write(Data((text + "\n").utf8))
 }

--- a/Tests/ProxyCLITests/PublicRunnerTests.swift
+++ b/Tests/ProxyCLITests/PublicRunnerTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+import XcodeMCPProxyKit
+
+@Suite
+struct PublicRunnerTests {
+    @Test func adapterDiscoveryFileURLHonorsProxyDiscoveryEnvironment() throws {
+        let explicitURL = XcodeMCPProxyAdapterEndpointResolver.discoveryFileURL(
+            environment: [
+                "XCODE_MCP_PROXY_DISCOVERY_FILE": "/tmp/runner-contract/endpoint.json",
+                "XCODE_MCP_PROXY_CACHE_ROOT": "/tmp/ignored-runner-cache",
+            ]
+        )
+        #expect(explicitURL == URL(fileURLWithPath: "/tmp/runner-contract/endpoint.json"))
+
+        let cacheRootURL = XcodeMCPProxyAdapterEndpointResolver.discoveryFileURL(
+            environment: [
+                "XCODE_MCP_PROXY_CACHE_ROOT": "/tmp/runner-cache",
+            ]
+        )
+        #expect(
+            cacheRootURL == URL(fileURLWithPath: "/tmp/runner-cache")
+                .appendingPathComponent("XcodeMCPProxy", isDirectory: true)
+                .appendingPathComponent("endpoint.json")
+        )
+    }
+
+    @Test func serverRunnerPrintsVersionThroughPublicAPI() async throws {
+        let output = CapturedLines()
+        let errors = CapturedLines()
+
+        let exitCode = await XcodeMCPProxyServer.run(
+            arguments: ["xcode-mcp-proxy-server", "--version"],
+            environment: [:],
+            stdout: { output.append($0) },
+            stderr: { errors.append($0) }
+        )
+
+        #expect(exitCode == 0)
+        #expect(output.snapshot() == ["xcode-mcp-proxy-server \(XcodeMCPProxyServer.productMetadata.version)"])
+        #expect(errors.snapshot().isEmpty)
+    }
+
+    @Test func stdioAdapterRunnerRoutesValidationErrorsToStderr() async throws {
+        let output = CapturedLines()
+        let errors = CapturedLines()
+
+        let exitCode = await XcodeMCPProxyStdioAdapter.run(
+            arguments: [
+                "xcode-mcp-proxy",
+                "--url", "http://localhost:8765/mcp",
+                "--stdio",
+            ],
+            environment: [:],
+            stdout: { output.append($0) },
+            stderr: { errors.append($0) }
+        )
+
+        #expect(exitCode == 1)
+        #expect(output.snapshot().isEmpty)
+        let errorLines = errors.snapshot()
+        #expect(errorLines.contains("Use either --url or --stdio (not both)."))
+        #expect(errorLines.contains { $0.contains("Usage:") })
+    }
+
+    @Test func installerRunnerPrintsVersionThroughPublicAPI() throws {
+        let output = CapturedLines()
+        let errors = CapturedLines()
+
+        let exitCode = XcodeMCPProxyInstaller.run(
+            arguments: ["xcode-mcp-proxy-install", "--version"],
+            environment: [:],
+            stdout: { output.append($0) },
+            stderr: { errors.append($0) }
+        )
+
+        #expect(exitCode == 0)
+        #expect(output.snapshot() == ["xcode-mcp-proxy-install \(XcodeMCPProxyServer.productMetadata.version)"])
+        #expect(errors.snapshot().isEmpty)
+    }
+}

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -218,6 +218,13 @@ func compileOnlyClientDomainSurface() throws {
     let discoveryConfig = XcodeMCP.Configuration(
         transport: .streamableHTTP(discoveryFile: URL(fileURLWithPath: "/tmp/xcode-mcp/endpoint.json"))
     )
+    let proxyDiscoveryConfig = XcodeMCP.Configuration(
+        transport: .streamableHTTPProxyDiscovery(
+            environment: [
+                "XCODE_MCP_PROXY_DISCOVERY_FILE": "/tmp/xcode-mcp/proxy-endpoint.json",
+            ]
+        )
+    )
 
     let metadata = arguments["metadata"]?.objectValue
     let tags = arguments["tags"]?.arrayValue?.compactMap { $0.stringValue }
@@ -307,6 +314,7 @@ func compileOnlyClientDomainSurface() throws {
         customBridgeConfig,
         httpConfig,
         discoveryConfig,
+        proxyDiscoveryConfig,
         tags,
         query,
         includeBeta,
@@ -491,7 +499,7 @@ func compileOnlyProxyConfigurationSurface() {
     _ = XcodeMCPProxyInstaller.binaryNames
 }
 
-func compileOnlyProxyLaunchSurface() throws {
+func compileOnlyProxyLaunchSurface() async throws {
     let plan = try XcodeMCPProxyServer.resolveLaunchPlan(
         arguments: [
             "xcode-mcp-proxy-server",
@@ -532,6 +540,35 @@ func compileOnlyProxyLaunchSurface() throws {
         ],
         environment: [:]
     )
+    let runnerStdout: @Sendable (String) -> Void = { _ in }
+    let runnerStderr: @Sendable (String) -> Void = { _ in }
+    let serverExitCode = await XcodeMCPProxyServer.run(
+        arguments: [
+            "xcode-mcp-proxy-server",
+            "--version",
+        ],
+        environment: [:],
+        stdout: runnerStdout,
+        stderr: runnerStderr
+    )
+    let adapterExitCode = await XcodeMCPProxyStdioAdapter.run(
+        arguments: [
+            "xcode-mcp-proxy",
+            "--version",
+        ],
+        environment: [:],
+        stdout: runnerStdout,
+        stderr: runnerStderr
+    )
+    let installerExitCode = XcodeMCPProxyInstaller.run(
+        arguments: [
+            "xcode-mcp-proxy-install",
+            "--version",
+        ],
+        environment: [:],
+        stdout: runnerStdout,
+        stderr: runnerStderr
+    )
 
     _ = (
         plan.action,
@@ -556,7 +593,10 @@ func compileOnlyProxyLaunchSurface() throws {
         installPlan.configuration,
         installPlan.options.executableName,
         installPlan.usage,
-        installPlan.versionLine
+        installPlan.versionLine,
+        serverExitCode,
+        adapterExitCode,
+        installerExitCode
     )
 }
 

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -567,6 +567,33 @@ struct XcodeMCPTests {
         }
     }
 
+    @Test func streamableHTTPProxyDiscoveryUsesStandardProxyDiscoveryEnvironment() throws {
+        let explicitDiscovery = XcodeMCP.Configuration.Transport.streamableHTTPProxyDiscovery(
+            environment: [
+                "XCODE_MCP_PROXY_DISCOVERY_FILE": "/tmp/public-contract/endpoint.json",
+                "XCODE_MCP_PROXY_CACHE_ROOT": "/tmp/ignored-cache-root",
+            ]
+        )
+        #expect(
+            explicitDiscovery == .streamableHTTP(
+                discoveryFile: URL(fileURLWithPath: "/tmp/public-contract/endpoint.json")
+            )
+        )
+
+        let cacheRootDiscovery = XcodeMCP.Configuration.Transport.streamableHTTPProxyDiscovery(
+            environment: [
+                "XCODE_MCP_PROXY_CACHE_ROOT": "/tmp/public-contract-cache",
+            ]
+        )
+        #expect(
+            cacheRootDiscovery == .streamableHTTP(
+                discoveryFile: URL(fileURLWithPath: "/tmp/public-contract-cache")
+                    .appendingPathComponent("XcodeMCPProxy", isDirectory: true)
+                    .appendingPathComponent("endpoint.json")
+            )
+        )
+    }
+
     @Test func streamableHTTPSendsSessionHeadersAndDeletesOnClose() async throws {
         let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
         let server = FakeStreamableHTTPServer(progressDelivery: .none)


### PR DESCRIPTION
## Summary

- Add `XcodeMCP.Configuration.Transport.streamableHTTPProxyDiscovery(environment:)` and move proxy discovery env resolution into `XcodeMCPCore.Discovery`.
- Add public runner facades for `XcodeMCPProxyServer`, `XcodeMCPProxyStdioAdapter`, and `XcodeMCPProxyInstaller`.
- Switch proxy executables to the public runner APIs while keeping logging bootstrap in executable targets.
- Extend public product and CLI contract tests for the new API surface.

## Verification

- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `codex-review` branch-wide against `codex/refactor-layered-runtime-integration`: clean

## Notes

Public runner APIs intentionally do not bootstrap swift-log; embedding hosts can configure logging before calling them. Package executables keep the previous bootstrap behavior before delegating to the public runners.