### PR TITLE
[codex] Prefer latest DocumentationSearch provider

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -1791,11 +1791,21 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
             {
                 return localProfile
             }
-            let route = try await transport.openRoute(
-                for: target,
-                requestTimeout: startupTimeout,
-                initializeParams: initializeParams
-            )
+            let route: DocumentationProviderRoute
+            do {
+                route = try await transport.openRoute(
+                    for: target,
+                    requestTimeout: startupTimeout,
+                    initializeParams: initializeParams
+                )
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                if let localProfile = await installedDocumentationAssetFallbackProfile(for: target) {
+                    return localProfile
+                }
+                throw error
+            }
             do {
                 try Task.checkCancellation()
                 guard !lifecycle.isShutdown else {
@@ -1829,6 +1839,29 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
             }
             logger.info(
                 "Using installed documentation asset as primary DocumentationSearch provider",
+                metadata: [
+                    "pid": .string("\(target.processID)"),
+                    "app_path": .string(target.appPath),
+                    "xcode_version": .string(target.xcodeVersion),
+                ]
+            )
+            return CandidateProfile(
+                id: UUID(),
+                target: target,
+                backend: .installedDocumentationAsset(descriptor: descriptor),
+                serverVersion: "installed-documentation-asset",
+                descriptorLookupCompleted: true
+            )
+        }
+
+        private func installedDocumentationAssetFallbackProfile(
+            for target: XcodeProcessTarget
+        ) async -> CandidateProfile? {
+            guard let descriptor = await localSearchProvider.descriptor(for: target) else {
+                return nil
+            }
+            logger.warning(
+                "Using installed documentation asset fallback for DocumentationSearch",
                 metadata: [
                     "pid": .string("\(target.processID)"),
                     "app_path": .string(target.appPath),
@@ -2080,6 +2113,9 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
             return .unavailable
         }
         if let activeProvider {
+            guard activeProviderIsCurrentBest(activeProvider, excluding: []) else {
+                return .unchanged
+            }
             guard let descriptor = activeProvider.profile.descriptor else {
                 return .unchanged
             }
@@ -2089,10 +2125,11 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         guard targets.isEmpty == false else {
             return .unavailable
         }
-        for target in targets {
-            if let descriptor = preparedProviders[target.processID]?.descriptor {
-                return .available(descriptor)
-            }
+        guard let firstTarget = targets.first else {
+            return .unavailable
+        }
+        if let descriptor = preparedProviders[firstTarget.processID]?.descriptor {
+            return .available(descriptor)
         }
         return .unchanged
     }
@@ -2879,9 +2916,8 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         let filtered = discovery.runningXcodeTargets().filter {
             excludedProcessIDs.contains($0.processID) == false
         }
-        if discovery is any PriorityOrderedXcodeTargetDiscovering {
-            return filtered
-        }
+        // DocumentationSearch owns provider selection separately from workspace/tab routing.
+        // Discovery order is only target enumeration; version and stable identity choose priority.
         return filtered.sorted { lhs, rhs in
             let versionComparison = Self.compareVersion(lhs.xcodeVersion, rhs.xcodeVersion)
             if versionComparison != .orderedSame {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -177,13 +177,6 @@ extension RuntimeCoordinator {
         documentationCandidateProcessOrder().map(Set.init)
     }
 
-    func xcodeProcessRouteProcessIDs() -> Set<pid_t>? {
-        guard xcodeProcessRoutes.isEmpty == false else {
-            return nil
-        }
-        return Set(xcodeProcessRoutes.map(\.target.processID))
-    }
-
     func catalogEligibleConfiguredProcessIDs() -> Set<pid_t> {
         let unavailable = unavailableXcodeProcessIDs()
         return Set(xcodeProcessRoutes.compactMap { route in

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeXcodeTargetDiscovery.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeXcodeTargetDiscovery.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class RuntimeDocumentationTargetDiscovery:
-    PriorityOrderedXcodeTargetDiscovering,
+    XcodeTargetDiscovering,
     Sendable
 {
     private let base: any XcodeTargetDiscovering
@@ -18,17 +18,19 @@ final class RuntimeDocumentationTargetDiscovery:
     func runningXcodeTargets() -> [XcodeProcessTarget] {
         let targets = base.runningXcodeTargets()
         guard let runtime = runtimeBox.value,
-              let routeProcessIDs = runtime.xcodeProcessRouteProcessIDs(),
               let candidateProcessIDs = runtime.documentationCandidateProcessOrder()
         else {
             return targets
         }
+        let unavailableProcessIDs = runtime.unavailableXcodeProcessIDs()
         let targetsByProcessID = Dictionary(
             uniqueKeysWithValues: targets.map { ($0.processID, $0) }
         )
         let orderedRuntimeTargets = candidateProcessIDs.compactMap { targetsByProcessID[$0] }
+        let orderedRuntimeProcessIDs = Set(candidateProcessIDs)
         let remainingLiveTargets = targets.filter {
-            routeProcessIDs.contains($0.processID) == false
+            orderedRuntimeProcessIDs.contains($0.processID) == false
+                && unavailableProcessIDs.contains($0.processID) == false
         }
         return orderedRuntimeTargets + remainingLiveTargets
     }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeTargetDiscovery.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeTargetDiscovery.swift
@@ -25,5 +25,3 @@ package struct XcodeProcessTarget: Sendable, Equatable {
 package protocol XcodeTargetDiscovering: Sendable {
     func runningXcodeTargets() -> [XcodeProcessTarget]
 }
-
-package protocol PriorityOrderedXcodeTargetDiscovering: XcodeTargetDiscovering {}

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -1257,7 +1257,7 @@ struct DocumentationProviderTests {
         #expect(await factory.documentationQueries(for: older.processID).isEmpty)
     }
 
-    @Test func documentationProviderPreservesRuntimeCandidateOrderForFallback()
+    @Test func documentationProviderIgnoresPriorityDiscoveryOrderWhenNewerXcodeIsAvailable()
         async throws
     {
         let workspaceOwner = xcodeProcessTarget(processID: 752, xcodeVersion: "26.6")
@@ -1268,7 +1268,7 @@ struct DocumentationProviderTests {
                     .init(
                         serverVersion: "26.6",
                         toolCount: 47,
-                        includesDocumentationSearch: false,
+                        includesDocumentationSearch: true,
                         firstDocumentationResponse: .successText("{\"answer\":\"owner\"}")
                     ),
                 ],
@@ -1283,9 +1283,7 @@ struct DocumentationProviderTests {
             ]
         )
         let manager = DocumentationProviderManager(
-            discovery: PriorityOrderedStubXcodeTargetDiscovery(
-                targets: [workspaceOwner, documentationProvider]
-            ),
+            discovery: StubXcodeTargetDiscovery(targets: [workspaceOwner, documentationProvider]),
             sessionFactory: factory
         )
 
@@ -1299,16 +1297,262 @@ struct DocumentationProviderTests {
             return
         }
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"provider\"}")
-        #expect(await factory.startedPIDs() == [
-            workspaceOwner.processID,
-            documentationProvider.processID,
-        ])
+        #expect(await factory.startedPIDs() == [documentationProvider.processID])
         #expect(await factory.documentationQueries(for: workspaceOwner.processID).isEmpty)
         #expect(await factory.documentationQueries(for: documentationProvider.processID) == ["UIView"])
-        try await waitWithTimeout("waiting for skipped documentation provider stop") {
-            try await factory.waitForStopCount(1)
+        #expect(await factory.stoppedPIDs().isEmpty)
+    }
+
+    @Test func documentationProviderUsesStableSameVersionOrderInsteadOfRuntimeOwnerOrder()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let ownerTarget = XcodeProcessTarget(
+            processID: 761,
+            appPath: "/Applications/Xcode-Z.app",
+            developerDir: "/Applications/Xcode-Z.app/Contents/Developer",
+            mcpbridgePath: "/Applications/Xcode-Z.app/Contents/Developer/usr/bin/mcpbridge",
+            xcodeVersion: "27.0"
+        )
+        let stableTarget = XcodeProcessTarget(
+            processID: 762,
+            appPath: "/Applications/Xcode-A.app",
+            developerDir: "/Applications/Xcode-A.app/Contents/Developer",
+            mcpbridgePath: "/Applications/Xcode-A.app/Contents/Developer/usr/bin/mcpbridge",
+            xcodeVersion: "27.0"
+        )
+        let runtime = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [TestUpstreamClient(), TestUpstreamClient()],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: ownerTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: stableTarget, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { runtime.shutdownAndWait() }
+        runtime.markUpstreamInitialized(upstreamIndex: 0)
+        runtime.markUpstreamInitialized(upstreamIndex: 1)
+        #expect(
+            runtime.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: tab-owner, workspacePath: /tmp/Owner.xcworkspace",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        runtimeBox.value = runtime
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                ownerTarget.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"owner\"}")
+                    ),
+                ],
+                stableTarget.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"stable\"}")
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: RuntimeDocumentationTargetDiscovery(
+                base: StubXcodeTargetDiscovery(targets: [ownerTarget, stableTarget]),
+                runtimeBox: runtimeBox
+            ),
+            sessionFactory: factory
+        )
+
+        #expect(runtime.documentationCandidateProcessOrder() == [
+            ownerTarget.processID,
+            stableTarget.processID,
+        ])
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 98, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
         }
-        #expect(await factory.stoppedPIDs() == [workspaceOwner.processID])
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"stable\"}")
+        #expect(await factory.startedPIDs() == [stableTarget.processID])
+        #expect(await factory.documentationQueries(for: ownerTarget.processID).isEmpty)
+        #expect(await factory.documentationQueries(for: stableTarget.processID) == ["SwiftUI"])
+    }
+
+    @Test func documentationProviderUsesNewestAssetFallbackBeforeOlderCandidateWhenRouteUnavailable()
+        async throws
+    {
+        let older = xcodeProcessTarget(processID: 754, xcodeVersion: "26.6")
+        let newest = xcodeProcessTarget(processID: 755, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                older.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"older\"}")
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-newest"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 95,
+                text: "{\"answer\":\"asset-newest\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [older, newest]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 95, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset-newest\"}")
+        #expect(await factory.startAttempts() == [newest.processID])
+        #expect(await factory.startedPIDs().isEmpty)
+        #expect(await factory.documentationQueries(for: older.processID).isEmpty)
+        #expect(await localProvider.requestedDescriptorPIDs() == [newest.processID])
+        #expect(await localProvider.requestedCallPIDs() == [newest.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI"])
+    }
+
+    @Test func documentationProviderUsesNewestAssetFallbackBeforeOlderCandidateWhenCallFails()
+        async throws
+    {
+        let older = xcodeProcessTarget(processID: 756, xcodeVersion: "26.6")
+        let newest = xcodeProcessTarget(processID: 757, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                older.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"older\"}")
+                    ),
+                ],
+                newest.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .notEnabled
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-newest"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 96,
+                text: "{\"answer\":\"asset-newest\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [older, newest]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 96, query: "SwiftData"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset-newest\"}")
+        #expect(await factory.startedPIDs() == [newest.processID])
+        #expect(await factory.documentationQueries(for: newest.processID) == ["SwiftData"])
+        #expect(await factory.documentationQueries(for: older.processID).isEmpty)
+        #expect(await localProvider.requestedCallPIDs() == [newest.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftData"])
+    }
+
+    @Test func documentationProviderUsesNewestAssetFallbackBeforeOlderCandidateWhenDescriptorMissing()
+        async throws
+    {
+        let older = xcodeProcessTarget(processID: 758, xcodeVersion: "26.6")
+        let newest = xcodeProcessTarget(processID: 759, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                older.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"older\"}")
+                    ),
+                ],
+                newest.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .successText("{\"answer\":\"unused\"}")
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-newest"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 97,
+                text: "{\"answer\":\"asset-newest\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [older, newest]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 97, query: "Observation"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset-newest\"}")
+        #expect(await factory.startedPIDs() == [newest.processID])
+        #expect(await factory.documentationQueries(for: newest.processID).isEmpty)
+        #expect(await factory.documentationQueries(for: older.processID).isEmpty)
+        #expect(await localProvider.requestedDescriptorPIDs() == [newest.processID])
+        #expect(await localProvider.requestedCallPIDs() == [newest.processID])
+        #expect(await localProvider.requestedQueries() == ["Observation"])
     }
 
     @Test func sharedToolsListAdvertisesProxyOwnedDocumentationSearchDescriptor() async throws {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2954,7 +2954,7 @@ struct RuntimeCoordinatorTests {
         #expect(manager.documentationCandidateProcessOrder() == [badTarget.processID])
     }
 
-    @Test func documentationCandidatesSkipUninitializedProcessRoutesButKeepInitializedWindowlessFallbacks()
+    @Test func runtimeDocumentationDiscoveryKeepsLiveTargetsOutsideUsableRouteCandidates()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -2990,7 +2990,10 @@ struct RuntimeCoordinatorTests {
         )
 
         #expect(manager.documentationCandidateProcessOrder() == [ownerTarget.processID])
-        #expect(discovery.runningXcodeTargets().map(\.processID) == [ownerTarget.processID])
+        #expect(discovery.runningXcodeTargets().map(\.processID) == [
+            ownerTarget.processID,
+            fallbackTarget.processID,
+        ])
 
         manager.markUpstreamInitialized(upstreamIndex: 1)
 

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -357,14 +357,6 @@ struct StubXcodeTargetDiscovery: XcodeTargetDiscovering {
     }
 }
 
-struct PriorityOrderedStubXcodeTargetDiscovery: PriorityOrderedXcodeTargetDiscovering {
-    let targets: [XcodeProcessTarget]
-
-    func runningXcodeTargets() -> [XcodeProcessTarget] {
-        targets
-    }
-}
-
 final class CountingXcodeTargetDiscovery: XcodeTargetDiscovering, @unchecked Sendable {
     private let lock = NSLock()
     private let targets: [XcodeProcessTarget]


### PR DESCRIPTION
## Summary

- Make DocumentationSearch provider selection always sort candidates by newest Xcode version first, independent of workspace/tab owner routing.
- Keep same-target installed documentation asset fallback before trying an older Xcode when the newest provider route, descriptor, or call is unavailable.
- Keep runtime discovery responsible for enumerating live targets, including live Xcode processes outside usable route candidates, while excluding unavailable route targets.
- Remove the obsolete priority-ordered discovery marker and add contract tests for latest-first routing, asset fallback, same-version stable ordering, and runtime discovery enumeration.

## Root Cause

DocumentationSearch provider selection could treat runtime-provided candidate order as authoritative. That allowed workspace/tab owner routing and normal route capability state to override the DocumentationSearch-specific contract, so an older or route-preferred Xcode could be tried before the newest Xcode and its installed asset fallback.

## Validation

- `swift test --filter ProxyDocumentationProviderTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- Codex review against `codex/refactor-layered-runtime-integration`: clean