### PR TITLE
[codex] Use shared MCPJSONValue for proxy capabilities

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -89,6 +89,7 @@ let package = Package(
             name: "XcodeMCPProxyKit",
             dependencies: [
                 "XcodeMCPCore",
+                "XcodeMCPKit",
                 "XcodeMCPProcessRuntime",
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIO", package: "swift-nio"),

--- a/README.md
+++ b/README.md
@@ -201,9 +201,13 @@ if plan.action == .start, let config = plan.configuration {
 ```
 
 Embedded apps can configure proxy-only behavior directly without knowing the
-TOML file schema:
+TOML file schema. The `capabilities` dictionary uses `MCPJSONValue` from
+`XcodeMCPKit`, so Swift JSON literals remain concise:
 
 ```swift
+import XcodeMCPKit
+import XcodeMCPProxyKit
+
 let config = XcodeMCPProxyServer.Configuration(
     toolPolicy: .init(
         disabledToolNames: ["RunAllTests", "RunSomeTests"]

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -90,6 +90,9 @@ set, typed values override the matching file-backed disabled-tools and
 initialize handshake fields.
 
 ```swift
+import XcodeMCPKit
+import XcodeMCPProxyKit
+
 let config = XcodeMCPProxyServer.Configuration(
     configurationFilePath: "/etc/xcode-mcp/proxy.toml",
     toolPolicy: .init(
@@ -105,6 +108,10 @@ let config = XcodeMCPProxyServer.Configuration(
     )
 )
 ```
+
+The `capabilities` dictionary uses `MCPJSONValue` from `XcodeMCPKit`, so Swift
+JSON literals remain concise while proxy internals still translate to the
+runtime config format.
 
 ## Lifecycle
 

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -3,6 +3,7 @@ import Logging
 import NIO
 import NIOHTTP1
 import XcodeMCPCore
+import XcodeMCPKit
 import XcodeMCPProcessRuntime
 
 /// Embeddable Streamable HTTP proxy server for Xcode MCP.
@@ -261,68 +262,6 @@ public final class XcodeMCPProxyServer {
                 }
             }
 
-            /// JSON-compatible value used inside initialize capabilities.
-            public enum CapabilityValue: Equatable, Sendable,
-                ExpressibleByStringLiteral,
-                ExpressibleByBooleanLiteral,
-                ExpressibleByIntegerLiteral,
-                ExpressibleByFloatLiteral,
-                ExpressibleByArrayLiteral,
-                ExpressibleByDictionaryLiteral
-            {
-                /// A JSON object with string keys.
-                case object([String: CapabilityValue])
-
-                /// A JSON array.
-                case array([CapabilityValue])
-
-                /// A JSON string.
-                case string(String)
-
-                /// A JSON integer number.
-                case integer(Int64)
-
-                /// A JSON floating-point number.
-                case double(Double)
-
-                /// A JSON boolean.
-                case bool(Bool)
-
-                /// A JSON null value.
-                case null
-
-                /// Creates a JSON string from a Swift string literal.
-                public init(stringLiteral value: String) {
-                    self = .string(value)
-                }
-
-                /// Creates a JSON boolean from a Swift boolean literal.
-                public init(booleanLiteral value: Bool) {
-                    self = .bool(value)
-                }
-
-                /// Creates a JSON integer from a Swift integer literal.
-                public init(integerLiteral value: Int64) {
-                    self = .integer(value)
-                }
-
-                /// Creates a JSON floating-point number from a Swift float
-                /// literal.
-                public init(floatLiteral value: Double) {
-                    self = .double(value)
-                }
-
-                /// Creates a JSON array from a Swift array literal.
-                public init(arrayLiteral elements: CapabilityValue...) {
-                    self = .array(elements)
-                }
-
-                /// Creates a JSON object from a Swift dictionary literal.
-                public init(dictionaryLiteral elements: (String, CapabilityValue)...) {
-                    self = .object(Dictionary(elements, uniquingKeysWith: { _, last in last }))
-                }
-            }
-
             /// Protocol version to send in initialize params.
             public var protocolVersion: String?
 
@@ -330,13 +269,13 @@ public final class XcodeMCPProxyServer {
             public var clientInfo: ClientInfo?
 
             /// Capability object to send in initialize params.
-            public var capabilities: [String: CapabilityValue]?
+            public var capabilities: [String: MCPJSONValue]?
 
             /// Creates initialize handshake overrides.
             public init(
                 protocolVersion: String? = nil,
                 clientInfo: ClientInfo? = nil,
-                capabilities: [String: CapabilityValue]? = nil
+                capabilities: [String: MCPJSONValue]? = nil
             ) {
                 self.protocolVersion = protocolVersion
                 self.clientInfo = clientInfo
@@ -872,7 +811,7 @@ private extension ProxyConfig.File.InitializeHandshakeOverride {
 }
 
 private extension ProxyConfig.File.Value {
-    init(_ value: XcodeMCPProxyServer.Configuration.InitializeHandshake.CapabilityValue) {
+    init(_ value: MCPJSONValue) {
         switch value {
         case .object(let object):
             self = .object(object.mapValues(ProxyConfig.File.Value.init))

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -102,6 +102,7 @@ struct PublicProductContractTests {
                 .target(
                     name: "XcodeMCPProxyKitClient",
                     dependencies: [
+                        .product(name: "XcodeMCPKit", package: "XcodeMCPKit"),
                         .product(name: "XcodeMCPProxyKit", package: "XcodeMCPKit")
                     ],
                     swiftSettings: [
@@ -417,6 +418,7 @@ func compileOnlyTestingRuntimeSurface() async throws {
 
 private let xcodeMCPProxyKitClientSource = """
 import Foundation
+import XcodeMCPKit
 import XcodeMCPProxyKit
 
 func compileOnlyProxyConfigurationSurface() {
@@ -463,6 +465,8 @@ func compileOnlyProxyConfigurationSurface() {
 
     let typedToolPolicy = config.toolPolicy
     let typedHandshake = config.initializeHandshake
+    let typedCapabilities: [String: MCPJSONValue]? = typedHandshake?.capabilities
+    let metadataIsNull = typedCapabilities?["experimental"]?.objectValue?["metadata"]?.isNull
     let upstreamMode = XcodeMCPProxyServer.Configuration.RefreshCodeIssuesMode.upstream
     let server = XcodeMCPProxyServer(config: config)
     let endpointConfig = XcodeMCPProxyAdapterEndpointResolver.Configuration(
@@ -489,6 +493,8 @@ func compileOnlyProxyConfigurationSurface() {
         customUpstreamConfig,
         typedToolPolicy,
         typedHandshake,
+        typedCapabilities,
+        metadataIsNull,
         upstreamMode,
         server,
         adapterConfig,


### PR DESCRIPTION
## Summary

- Replace the public proxy-specific initialize capability value enum with `XcodeMCPKit.MCPJSONValue`.
- Add the `XcodeMCPKit` target dependency to `XcodeMCPProxyKit` and keep conversion to internal `ProxyConfig.File.Value` at the runtime boundary.
- Update public product contract coverage and README snippets for initialize capabilities.

## Validation

- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- Codex review against `codex/refactor-layered-runtime-integration` with no findings.

## Notes

Raw upstream command and session options are intentionally unchanged in this PR; they still look like candidates for a follow-up advanced API separation.