### PR TITLE
Move proxy process control into ProcessRuntime

### DIFF
--- a/Sources/XcodeMCPProcessRuntime/Process/ProcessControlClient.swift
+++ b/Sources/XcodeMCPProcessRuntime/Process/ProcessControlClient.swift
@@ -1,0 +1,250 @@
+import Darwin
+import Foundation
+import XcodeMCPCore
+
+package struct ProcessSignalResult: Sendable {
+    package let result: Int32
+    package let errnoValue: Int32
+
+    package init(result: Int32, errnoValue: Int32) {
+        self.result = result
+        self.errnoValue = errnoValue
+    }
+}
+
+package struct ProcessControlClient: Sendable {
+    package var runCommand: @Sendable (_ launchPath: String, _ arguments: [String]) -> String?
+    package var sendSignal: @Sendable (_ processID: Int, _ signal: Int32) -> ProcessSignalResult
+
+    package init(
+        runCommand: @escaping @Sendable (_ launchPath: String, _ arguments: [String]) -> String?,
+        sendSignal: @escaping @Sendable (_ processID: Int, _ signal: Int32) -> ProcessSignalResult
+    ) {
+        self.runCommand = runCommand
+        self.sendSignal = sendSignal
+    }
+
+    package static let liveValue = Self(
+        runCommand: defaultRunCommand,
+        sendSignal: defaultSendSignal
+    )
+
+    package func commandLine(processID: Int) -> String? {
+        guard processID > 0 else { return nil }
+        return Self.firstLine(
+            runCommand("/bin/ps", ["-ww", "-p", "\(processID)", "-o", "command="])
+        )?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    package func executablePath(processID: Int) -> String? {
+        guard
+            let commandLine = commandLine(processID: processID),
+            !commandLine.isEmpty,
+            let executable = commandLine.split(whereSeparator: \.isWhitespace).first.map(String.init),
+            !executable.isEmpty
+        else {
+            return nil
+        }
+        return executable
+    }
+
+    package func executableName(processID: Int) -> String? {
+        guard let executablePath = executablePath(processID: processID) else {
+            return nil
+        }
+        return URL(fileURLWithPath: executablePath).lastPathComponent
+    }
+
+    package func listeningProcessIDs(onTCPPort port: Int, matchingHost host: String) -> [Int] {
+        guard let output = runCommand(
+            "/usr/sbin/lsof",
+            ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-Fpn"]
+        ) else {
+            return []
+        }
+
+        return Self.listeningProcessIDs(fromLsofOutput: output, matchingHost: host)
+    }
+
+    @discardableResult
+    package func waitForNoListeningProcesses(
+        onTCPPort port: Int,
+        matchingHost host: String,
+        timeout: TimeInterval,
+        clock: ClockClient
+    ) -> Bool {
+        let deadline = clock.now().addingTimeInterval(timeout)
+        while clock.now() < deadline {
+            if listeningProcessIDs(onTCPPort: port, matchingHost: host).isEmpty {
+                return true
+            }
+            clock.sleepForTimeInterval(0.05)
+        }
+        return listeningProcessIDs(onTCPPort: port, matchingHost: host).isEmpty
+    }
+
+    package func terminate(processID: Int, clock: ClockClient) -> Bool {
+        guard processID > 0 else { return false }
+        if !isProcessAlive(processID) {
+            return true
+        }
+
+        let termResult = sendSignal(processID, SIGTERM)
+        if termResult.result != 0, termResult.errnoValue != ESRCH {
+            return false
+        }
+        if waitForProcessExit(processID: processID, timeout: 1.0, clock: clock) {
+            return true
+        }
+
+        let killResult = sendSignal(processID, SIGKILL)
+        if killResult.result != 0, killResult.errnoValue != ESRCH {
+            return false
+        }
+        return waitForProcessExit(processID: processID, timeout: 1.0, clock: clock)
+    }
+
+    package func isProcessAlive(_ processID: Int) -> Bool {
+        guard processID > 0 else { return false }
+        let result = sendSignal(processID, 0)
+        if result.result == 0 {
+            return true
+        }
+        return result.errnoValue == EPERM
+    }
+
+    package func waitForProcessExit(
+        processID: Int,
+        timeout: TimeInterval,
+        clock: ClockClient
+    ) -> Bool {
+        let deadline = clock.now().addingTimeInterval(timeout)
+        while clock.now() < deadline {
+            if !isProcessAlive(processID) {
+                return true
+            }
+            clock.sleepForTimeInterval(0.05)
+        }
+        return !isProcessAlive(processID)
+    }
+
+    package static func hostMatches(requestedHost: String, actualHost: String) -> Bool {
+        let requested = normalizeHost(requestedHost)
+        let actual = normalizeHost(actualHost)
+
+        if isWildcardHost(requested) { return true }
+        if isWildcardHost(actual) { return true }
+
+        if requested == "localhost" {
+            return actual == "localhost" || actual == "127.0.0.1" || actual == "::1"
+        }
+        if actual == "localhost" {
+            return requested == "localhost" || requested == "127.0.0.1" || requested == "::1"
+        }
+
+        return requested == actual
+    }
+
+    package static func listeningProcessIDs(fromLsofOutput output: String, matchingHost host: String) -> [Int] {
+        let matchAllHosts = isWildcardHost(host)
+
+        var processIDs: [Int] = []
+        processIDs.reserveCapacity(4)
+
+        var currentProcessID: Int?
+        var currentMatched = matchAllHosts
+
+        func flush() {
+            if let currentProcessID, currentMatched {
+                processIDs.append(currentProcessID)
+            }
+        }
+
+        for rawLine in output.split(whereSeparator: \.isNewline) {
+            guard let first = rawLine.first else { continue }
+            if first == "p" {
+                flush()
+                currentProcessID = Int(rawLine.dropFirst())
+                currentMatched = matchAllHosts
+                continue
+            }
+            if first == "n", !matchAllHosts {
+                let name = String(rawLine.dropFirst())
+                if let listenerHost = extractListenerHost(fromLsofName: name),
+                   hostMatches(requestedHost: host, actualHost: listenerHost) {
+                    currentMatched = true
+                }
+            }
+        }
+        flush()
+
+        var seen = Set<Int>()
+        return processIDs.filter { seen.insert($0).inserted }
+    }
+
+    private static func firstLine(_ output: String?) -> String? {
+        guard let output else { return nil }
+        return output.split(whereSeparator: \.isNewline).first.map(String.init)
+    }
+
+    private static func normalizeHost(_ host: String) -> String {
+        var value = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("["), value.hasSuffix("]") {
+            value = String(value.dropFirst().dropLast())
+        }
+        return value.lowercased()
+    }
+
+    private static func isWildcardHost(_ host: String) -> Bool {
+        let value = normalizeHost(host)
+        return value.isEmpty || value == "*" || value == "0.0.0.0" || value == "::"
+    }
+
+    private static func extractListenerHost(fromLsofName name: String) -> String? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let endpointSource: Substring
+        if trimmed.hasPrefix("TCP ") {
+            endpointSource = trimmed.dropFirst(4)
+        } else {
+            endpointSource = trimmed[...]
+        }
+
+        guard let endpoint = endpointSource.split(whereSeparator: \.isWhitespace).first else { return nil }
+        let endpointString = String(endpoint)
+        if endpointString.hasPrefix("["),
+           let close = endpointString.firstIndex(of: "]") {
+            let start = endpointString.index(after: endpointString.startIndex)
+            return String(endpointString[start..<close])
+        }
+        guard let colon = endpointString.lastIndex(of: ":") else { return nil }
+        return String(endpointString[..<colon])
+    }
+
+    private static func defaultRunCommand(_ launchPath: String, _ arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: launchPath)
+        process.arguments = arguments
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func defaultSendSignal(processID: Int, signal: Int32) -> ProcessSignalResult {
+        errno = 0
+        let result = kill(pid_t(processID), signal)
+        return ProcessSignalResult(result: result, errnoValue: errno)
+    }
+}

--- a/Sources/XcodeMCPProxyKit/Internal/Process/ExistingProxyServerProcessController.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Process/ExistingProxyServerProcessController.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import XcodeMCPCore
 import XcodeMCPProcessRuntime
@@ -33,9 +32,7 @@ struct ExistingProxyServerProcessController: DependencyClient {
         currentProcessID: @escaping @Sendable () -> Int = {
             Int(ProcessInfo.processInfo.processIdentifier)
         },
-        runCommand: @escaping @Sendable (_ launchPath: String, _ arguments: [String]) -> String? =
-            defaultRunCommand,
-        sendSignal: @escaping @Sendable (_ pid: Int, _ signal: Int32) -> SignalResult = defaultSendSignal
+        processControl: ProcessControlClient = .liveValue
     ) -> Self {
         Self(
             terminateExistingServer: { host, port, emitWarning in
@@ -46,8 +43,7 @@ struct ExistingProxyServerProcessController: DependencyClient {
                     discoveryClient: discoveryClient,
                     clock: clock,
                     currentProcessID: currentProcessID,
-                    runCommand: runCommand,
-                    sendSignal: sendSignal
+                    processControl: processControl
                 )
             },
             detectExistingServerProcessIDs: { host, port in
@@ -55,74 +51,10 @@ struct ExistingProxyServerProcessController: DependencyClient {
                     host: host,
                     port: port,
                     discoveryClient: discoveryClient,
-                    runCommand: runCommand
+                    processControl: processControl
                 )
             }
         )
-    }
-
-    struct SignalResult: Sendable {
-        let result: Int32
-        let errnoValue: Int32
-
-        init(result: Int32, errnoValue: Int32) {
-            self.result = result
-            self.errnoValue = errnoValue
-        }
-    }
-
-    static func hostMatches(requestedHost: String, actualHost: String) -> Bool {
-        let requested = normalizeHost(requestedHost)
-        let actual = normalizeHost(actualHost)
-
-        if isWildcardHost(requested) { return true }
-        if isWildcardHost(actual) { return true }
-
-        if requested == "localhost" {
-            return actual == "localhost" || actual == "127.0.0.1" || actual == "::1"
-        }
-        if actual == "localhost" {
-            return requested == "localhost" || requested == "127.0.0.1" || requested == "::1"
-        }
-
-        return requested == actual
-    }
-
-    static func listeningProcessIDs(fromLsofOutput output: String, matchingHost host: String) -> [Int] {
-        let matchAllHosts = isWildcardHost(host)
-
-        var processIDs: [Int] = []
-        processIDs.reserveCapacity(4)
-
-        var currentProcessID: Int?
-        var currentMatched = matchAllHosts
-
-        func flush() {
-            if let currentProcessID, currentMatched {
-                processIDs.append(currentProcessID)
-            }
-        }
-
-        for rawLine in output.split(whereSeparator: \.isNewline) {
-            guard let first = rawLine.first else { continue }
-            if first == "p" {
-                flush()
-                currentProcessID = Int(rawLine.dropFirst())
-                currentMatched = matchAllHosts
-                continue
-            }
-            if first == "n", !matchAllHosts {
-                let name = String(rawLine.dropFirst())
-                if let listenerHost = extractListenerHost(fromLsofName: name),
-                   hostMatches(requestedHost: host, actualHost: listenerHost) {
-                    currentMatched = true
-                }
-            }
-        }
-        flush()
-
-        var seen = Set<Int>()
-        return processIDs.filter { seen.insert($0).inserted }
     }
 
     private static func terminateExistingProxyServerIfNeeded(
@@ -132,48 +64,45 @@ struct ExistingProxyServerProcessController: DependencyClient {
         discoveryClient: DiscoveryClient,
         clock: ClockClient,
         currentProcessID: @Sendable () -> Int,
-        runCommand: @escaping @Sendable (_ launchPath: String, _ arguments: [String]) -> String?,
-        sendSignal: @escaping @Sendable (_ pid: Int, _ signal: Int32) -> SignalResult
+        processControl: ProcessControlClient
     ) -> Bool {
         if let record = discoveryClient.read(nil),
            record.port == port,
-           hostMatches(requestedHost: host, actualHost: record.host) {
+           ProcessControlClient.hostMatches(requestedHost: host, actualHost: record.host) {
             let currentPID = currentProcessID()
             if record.pid != currentPID,
-               isProxyServerProcess(pid: record.pid, runCommand: runCommand) {
+               isProxyServerProcess(pid: record.pid, processControl: processControl) {
                 emitWarning(terminationWarning(port: port, pid: record.pid))
-                if terminate(pid: record.pid, clock: clock, sendSignal: sendSignal) {
-                    waitForPortToBeFree(
-                        host: host,
-                        port: port,
+                if processControl.terminate(processID: record.pid, clock: clock) {
+                    processControl.waitForNoListeningProcesses(
+                        onTCPPort: port,
+                        matchingHost: host,
                         timeout: 2.0,
-                        clock: clock,
-                        runCommand: runCommand
+                        clock: clock
                     )
                     return true
                 }
             }
         }
 
-        let processIDs = listeningProcessIDs(onTCPPort: port, matchingHost: host, runCommand: runCommand)
+        let processIDs = processControl.listeningProcessIDs(onTCPPort: port, matchingHost: host)
         guard !processIDs.isEmpty else { return false }
 
         let currentPID = currentProcessID()
         var didTerminate = false
         for processID in processIDs where processID != currentPID {
-            guard isProxyServerProcess(pid: processID, runCommand: runCommand) else { continue }
+            guard isProxyServerProcess(pid: processID, processControl: processControl) else { continue }
             emitWarning(terminationWarning(port: port, pid: processID))
-            if terminate(pid: processID, clock: clock, sendSignal: sendSignal) {
+            if processControl.terminate(processID: processID, clock: clock) {
                 didTerminate = true
             }
         }
         if didTerminate {
-            waitForPortToBeFree(
-                host: host,
-                port: port,
+            processControl.waitForNoListeningProcesses(
+                onTCPPort: port,
+                matchingHost: host,
                 timeout: 2.0,
-                clock: clock,
-                runCommand: runCommand
+                clock: clock
             )
         }
         return didTerminate
@@ -183,20 +112,20 @@ struct ExistingProxyServerProcessController: DependencyClient {
         host: String,
         port: Int,
         discoveryClient: DiscoveryClient,
-        runCommand: @escaping @Sendable (_ launchPath: String, _ arguments: [String]) -> String?
+        processControl: ProcessControlClient
     ) -> [Int] {
         var processIDs: [Int] = []
         processIDs.reserveCapacity(4)
 
         if let record = discoveryClient.read(nil),
            record.port == port,
-           hostMatches(requestedHost: host, actualHost: record.host),
-           isProxyServerProcess(pid: record.pid, runCommand: runCommand) {
+           ProcessControlClient.hostMatches(requestedHost: host, actualHost: record.host),
+           isProxyServerProcess(pid: record.pid, processControl: processControl) {
             processIDs.append(record.pid)
         }
 
-        for processID in listeningProcessIDs(onTCPPort: port, matchingHost: host, runCommand: runCommand)
-        where isProxyServerProcess(pid: processID, runCommand: runCommand) {
+        for processID in processControl.listeningProcessIDs(onTCPPort: port, matchingHost: host)
+        where isProxyServerProcess(pid: processID, processControl: processControl) {
             processIDs.append(processID)
         }
 
@@ -208,170 +137,10 @@ struct ExistingProxyServerProcessController: DependencyClient {
         "warning: port \(port) is already in use by xcode-mcp-proxy-server (pid: \(pid)); terminating it."
     }
 
-    private static func firstLine(_ output: String?) -> String? {
-        guard let output else { return nil }
-        return output.split(whereSeparator: \.isNewline).first.map(String.init)
-    }
-
-    private static func normalizeHost(_ host: String) -> String {
-        var value = host.trimmingCharacters(in: .whitespacesAndNewlines)
-        if value.hasPrefix("["), value.hasSuffix("]") {
-            value = String(value.dropFirst().dropLast())
-        }
-        return value.lowercased()
-    }
-
-    private static func isWildcardHost(_ host: String) -> Bool {
-        let value = normalizeHost(host)
-        return value.isEmpty || value == "*" || value == "0.0.0.0" || value == "::"
-    }
-
-    private static func extractListenerHost(fromLsofName name: String) -> String? {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        let endpointSource: Substring
-        if trimmed.hasPrefix("TCP ") {
-            endpointSource = trimmed.dropFirst(4)
-        } else {
-            endpointSource = trimmed[...]
-        }
-
-        guard let endpoint = endpointSource.split(whereSeparator: \.isWhitespace).first else { return nil }
-        let endpointString = String(endpoint)
-        if endpointString.hasPrefix("["),
-           let close = endpointString.firstIndex(of: "]") {
-            let start = endpointString.index(after: endpointString.startIndex)
-            return String(endpointString[start..<close])
-        }
-        guard let colon = endpointString.lastIndex(of: ":") else { return nil }
-        return String(endpointString[..<colon])
-    }
-
-    private static func listeningProcessIDs(
-        onTCPPort port: Int,
-        matchingHost host: String,
-        runCommand: @escaping @Sendable (_ launchPath: String, _ arguments: [String]) -> String?
-    ) -> [Int] {
-        guard let output = runCommand(
-            "/usr/sbin/lsof",
-            ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-Fpn"]
-        ) else {
-            return []
-        }
-
-        return listeningProcessIDs(fromLsofOutput: output, matchingHost: host)
-    }
-
     private static func isProxyServerProcess(
         pid: Int,
-        runCommand: @escaping @Sendable (_ launchPath: String, _ arguments: [String]) -> String?
+        processControl: ProcessControlClient
     ) -> Bool {
-        guard pid > 0 else { return false }
-        guard
-            let commandLine = firstLine(
-                runCommand("/bin/ps", ["-ww", "-p", "\(pid)", "-o", "command="])
-            )?.trimmingCharacters(in: .whitespacesAndNewlines),
-            !commandLine.isEmpty,
-            let executable = commandLine.split(whereSeparator: \.isWhitespace).first.map(String.init),
-            !executable.isEmpty
-        else {
-            return false
-        }
-        return URL(fileURLWithPath: executable).lastPathComponent == "xcode-mcp-proxy-server"
-    }
-
-    private static func terminate(
-        pid: Int,
-        clock: ClockClient,
-        sendSignal: @escaping @Sendable (_ pid: Int, _ signal: Int32) -> SignalResult
-    ) -> Bool {
-        guard pid > 0 else { return false }
-        if !isProcessAlive(pid, sendSignal: sendSignal) {
-            return true
-        }
-
-        let termResult = sendSignal(pid, SIGTERM)
-        if termResult.result != 0, termResult.errnoValue != ESRCH {
-            return false
-        }
-        if waitForProcessExit(pid: pid, timeout: 1.0, clock: clock, sendSignal: sendSignal) {
-            return true
-        }
-
-        let killResult = sendSignal(pid, SIGKILL)
-        if killResult.result != 0, killResult.errnoValue != ESRCH {
-            return false
-        }
-        return waitForProcessExit(pid: pid, timeout: 1.0, clock: clock, sendSignal: sendSignal)
-    }
-
-    private static func isProcessAlive(
-        _ pid: Int,
-        sendSignal: @escaping @Sendable (_ pid: Int, _ signal: Int32) -> SignalResult
-    ) -> Bool {
-        guard pid > 0 else { return false }
-        let result = sendSignal(pid, 0)
-        if result.result == 0 {
-            return true
-        }
-        return result.errnoValue == EPERM
-    }
-
-    private static func waitForProcessExit(
-        pid: Int,
-        timeout: TimeInterval,
-        clock: ClockClient,
-        sendSignal: @escaping @Sendable (_ pid: Int, _ signal: Int32) -> SignalResult
-    ) -> Bool {
-        let deadline = clock.now().addingTimeInterval(timeout)
-        while clock.now() < deadline {
-            if !isProcessAlive(pid, sendSignal: sendSignal) {
-                return true
-            }
-            clock.sleepForTimeInterval(0.05)
-        }
-        return !isProcessAlive(pid, sendSignal: sendSignal)
-    }
-
-    private static func waitForPortToBeFree(
-        host: String,
-        port: Int,
-        timeout: TimeInterval,
-        clock: ClockClient,
-        runCommand: @escaping @Sendable (_ launchPath: String, _ arguments: [String]) -> String?
-    ) {
-        let deadline = clock.now().addingTimeInterval(timeout)
-        while clock.now() < deadline {
-            if listeningProcessIDs(onTCPPort: port, matchingHost: host, runCommand: runCommand).isEmpty {
-                return
-            }
-            clock.sleepForTimeInterval(0.05)
-        }
-    }
-
-    private static func defaultRunCommand(_ launchPath: String, _ arguments: [String]) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: launchPath)
-        process.arguments = arguments
-        let output = Pipe()
-        process.standardOutput = output
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else { return nil }
-        let data = output.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)
-    }
-
-    private static func defaultSendSignal(pid: Int, signal: Int32) -> SignalResult {
-        errno = 0
-        let result = kill(pid_t(pid), signal)
-        return SignalResult(result: result, errnoValue: errno)
+        processControl.executableName(processID: pid) == "xcode-mcp-proxy-server"
     }
 }

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+ExistingServerController.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+ExistingServerController.swift
@@ -5,8 +5,8 @@ import XcodeMCPProcessRuntime
 extension XcodeMCPProxyServer {
     /// High-level launcher dependency adapter.
     ///
-    /// Low-level `lsof`/`ps`/signal mechanics stay inside `XcodeMCPProxyKit`
-    /// without becoming part of the public server launcher facade.
+    /// Proxy restart policy stays inside `XcodeMCPProxyKit`; low-level process
+    /// command and signal mechanics are owned by `XcodeMCPProcessRuntime`.
     struct ExistingServerController: DependencyClient {
         var terminateExistingServer:
             @Sendable (_ host: String, _ port: Int, _ emitWarning: (String) -> Void) -> Bool

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -161,85 +161,64 @@ struct XcodeMCPProxyServerTests {
         #expect(config.refreshCodeIssuesMode == .upstream)
     }
 
-    @Test func existingServerControllerHostMatchingHandlesLoopbackAndWildcard() throws {
-        #expect(
-            ExistingProxyServerProcessController.hostMatches(
-                requestedHost: "localhost",
-                actualHost: "127.0.0.1"
-            )
+    @Test func existingServerControllerDetectsOnlyProxyServerProcesses() throws {
+        let record = DiscoveryRecord(
+            url: "http://localhost:8765/mcp",
+            host: "localhost",
+            port: 8765,
+            pid: 123,
+            updatedAt: Date(timeIntervalSince1970: 1)
         )
-        #expect(
-            ExistingProxyServerProcessController.hostMatches(
-                requestedHost: "::",
-                actualHost: "127.0.0.1"
-            )
+        let discoveryClient = DiscoveryClient.live(
+            defaultFileURL: { URL(fileURLWithPath: "/unused/endpoint.json") },
+            loadRecord: { _ in record },
+            persistRecord: { _, _ in
+                Issue.record("detect should not persist discovery records")
+            },
+            createDirectory: { _ in
+                Issue.record("detect should not create directories")
+            },
+            isProcessAlive: { pid in
+                #expect(pid == record.pid)
+                return true
+            },
+            now: { Date(timeIntervalSince1970: 2) }
         )
-        #expect(
-            ExistingProxyServerProcessController.hostMatches(
-                requestedHost: "127.0.0.1",
-                actualHost: "::1"
-            ) == false
+        let processControl = ProcessControlClient(
+            runCommand: { launchPath, arguments in
+                switch (launchPath, arguments) {
+                case ("/usr/sbin/lsof", ["-nP", "-iTCP:8765", "-sTCP:LISTEN", "-Fpn"]):
+                    return """
+                    p456
+                    f9
+                    n127.0.0.1:8765
+                    p789
+                    f9
+                    n127.0.0.1:8765
+                    """
+                case ("/bin/ps", ["-ww", "-p", "123", "-o", "command="]):
+                    return "/tmp/xcode-mcp-proxy-server --listen localhost:8765\n"
+                case ("/bin/ps", ["-ww", "-p", "456", "-o", "command="]):
+                    return "/usr/local/bin/xcode-mcp-proxy-server --listen localhost:8765\n"
+                case ("/bin/ps", ["-ww", "-p", "789", "-o", "command="]):
+                    return "/usr/bin/python3 other-server.py\n"
+                default:
+                    Issue.record("unexpected process command: \(launchPath) \(arguments)")
+                    return nil
+                }
+            },
+            sendSignal: { _, _ in
+                Issue.record("detect should not send signals")
+                return ProcessSignalResult(result: -1, errnoValue: ESRCH)
+            }
         )
-    }
-
-    @Test func existingServerControllerExtractsListeningPIDsFromLsofFieldOutputForLocalhost() throws {
-        let output = """
-        p51731
-        f9
-        n127.0.0.1:8765
-        f13
-        n[::1]:8765
-        p60000
-        f8
-        n10.0.0.5:8765
-        """
-
-        #expect(
-            ExistingProxyServerProcessController.listeningProcessIDs(
-                fromLsofOutput: output,
-                matchingHost: "localhost"
-            ) == [51731]
+        let controller = ExistingProxyServerProcessController.live(
+            discoveryClient: discoveryClient,
+            currentProcessID: { 999 },
+            processControl: processControl
         )
-    }
 
-    @Test func existingServerControllerExtractsListeningPIDsFromLsofFieldOutputSkipsNonMatchingHosts() throws {
-        let output = """
-        p51731
-        f9
-        n[::1]:8765
-        p60000
-        f8
-        n10.0.0.5:8765
-        """
-
-        #expect(
-            ExistingProxyServerProcessController.listeningProcessIDs(
-                fromLsofOutput: output,
-                matchingHost: "127.0.0.1"
-            )
-            .isEmpty
-        )
-    }
-
-    @Test func existingServerControllerExtractsListeningPIDsFromLegacyTCPNames() throws {
-        let output = """
-        p111
-        f9
-        nTCP 127.0.0.1:8765 (LISTEN)
-        p222
-        f13
-        nTCP [::1]:8765 (LISTEN)
-        p333
-        f8
-        nTCP 10.0.0.5:8765 (LISTEN)
-        """
-
-        #expect(
-            ExistingProxyServerProcessController.listeningProcessIDs(
-                fromLsofOutput: output,
-                matchingHost: "localhost"
-            ) == [111, 222]
-        )
+        #expect(controller.detectExistingServerProcessIDs("localhost", 8765) == [123, 456])
     }
 
     @Test func portInUseDiagnosticFormatsMessage() throws {

--- a/Tests/XcodeMCPProcessRuntimeTests/ProcessControlClientTests.swift
+++ b/Tests/XcodeMCPProcessRuntimeTests/ProcessControlClientTests.swift
@@ -1,0 +1,257 @@
+import Darwin
+import Foundation
+import Testing
+import XcodeMCPCore
+
+@testable import XcodeMCPProcessRuntime
+
+@Suite
+struct ProcessControlClientTests {
+    @Test func hostMatchingHandlesLoopbackAndWildcard() throws {
+        #expect(
+            ProcessControlClient.hostMatches(
+                requestedHost: "localhost",
+                actualHost: "127.0.0.1"
+            )
+        )
+        #expect(
+            ProcessControlClient.hostMatches(
+                requestedHost: "::",
+                actualHost: "127.0.0.1"
+            )
+        )
+        #expect(
+            ProcessControlClient.hostMatches(
+                requestedHost: "127.0.0.1",
+                actualHost: "::1"
+            ) == false
+        )
+    }
+
+    @Test func extractsListeningPIDsFromLsofFieldOutputForLocalhost() throws {
+        let output = """
+        p51731
+        f9
+        n127.0.0.1:8765
+        f13
+        n[::1]:8765
+        p60000
+        f8
+        n10.0.0.5:8765
+        """
+
+        #expect(
+            ProcessControlClient.listeningProcessIDs(
+                fromLsofOutput: output,
+                matchingHost: "localhost"
+            ) == [51731]
+        )
+    }
+
+    @Test func extractsListeningPIDsFromLsofFieldOutputSkipsNonMatchingHosts() throws {
+        let output = """
+        p51731
+        f9
+        n[::1]:8765
+        p60000
+        f8
+        n10.0.0.5:8765
+        """
+
+        #expect(
+            ProcessControlClient.listeningProcessIDs(
+                fromLsofOutput: output,
+                matchingHost: "127.0.0.1"
+            )
+            .isEmpty
+        )
+    }
+
+    @Test func extractsListeningPIDsFromLegacyTCPNames() throws {
+        let output = """
+        p111
+        f9
+        nTCP 127.0.0.1:8765 (LISTEN)
+        p222
+        f13
+        nTCP [::1]:8765 (LISTEN)
+        p333
+        f8
+        nTCP 10.0.0.5:8765 (LISTEN)
+        """
+
+        #expect(
+            ProcessControlClient.listeningProcessIDs(
+                fromLsofOutput: output,
+                matchingHost: "localhost"
+            ) == [111, 222]
+        )
+    }
+
+    @Test func executableNameUsesFirstCommandTokenFromPSOutput() throws {
+        let commandRecorder = CommandRecorder(
+            outputs: [
+                "/bin/ps|-ww -p 123 -o command=": "/tmp/xcode-mcp-proxy-server --flag\nignored\n",
+            ]
+        )
+        let client = ProcessControlClient(
+            runCommand: commandRecorder.runCommand,
+            sendSignal: { _, _ in
+                Issue.record("executable lookup should not send signals")
+                return ProcessSignalResult(result: -1, errnoValue: ESRCH)
+            }
+        )
+
+        #expect(client.executableName(processID: 123) == "xcode-mcp-proxy-server")
+        #expect(
+            commandRecorder.snapshot() == [
+                CommandInvocation(launchPath: "/bin/ps", arguments: ["-ww", "-p", "123", "-o", "command="]),
+            ]
+        )
+    }
+
+    @Test func terminateSendsTermThenKillWhenProcessDoesNotExitAfterTerm() throws {
+        let clock = ManualClock()
+        let signals = SignalRecorder()
+        let client = ProcessControlClient(
+            runCommand: { _, _ in nil },
+            sendSignal: signals.sendSignal
+        )
+
+        #expect(client.terminate(processID: 42, clock: clock.client))
+        let sentSignals = signals.snapshot().map(\.signal)
+        #expect(sentSignals.first == 0)
+        #expect(sentSignals.contains(SIGTERM))
+        #expect(sentSignals.contains(SIGKILL))
+        #expect(clock.sleepIntervals().contains(0.05))
+    }
+
+    @Test func waitForNoListeningProcessesPollsUntilLsofReturnsNoMatches() throws {
+        let outputWithListener = """
+        p51731
+        f9
+        n127.0.0.1:8765
+        """
+        let commandRecorder = CommandRecorder(
+            outputs: [
+                "/usr/sbin/lsof|-nP -iTCP:8765 -sTCP:LISTEN -Fpn": outputWithListener,
+            ],
+            defaultOutput: ""
+        )
+        let clock = ManualClock()
+        let client = ProcessControlClient(
+            runCommand: commandRecorder.runCommand,
+            sendSignal: { _, _ in ProcessSignalResult(result: -1, errnoValue: ESRCH) }
+        )
+
+        #expect(
+            client.waitForNoListeningProcesses(
+                onTCPPort: 8765,
+                matchingHost: "localhost",
+                timeout: 2.0,
+                clock: clock.client
+            )
+        )
+        #expect(commandRecorder.snapshot().count == 2)
+        #expect(clock.sleepIntervals() == [0.05])
+    }
+}
+
+private struct CommandInvocation: Equatable, Sendable {
+    let launchPath: String
+    let arguments: [String]
+}
+
+private final class CommandRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var outputs: [String: [String]]
+    private let defaultOutput: String?
+    private var invocations: [CommandInvocation] = []
+
+    init(outputs: [String: String], defaultOutput: String? = nil) {
+        self.outputs = outputs.mapValues { [$0] }
+        self.defaultOutput = defaultOutput
+    }
+
+    func runCommand(_ launchPath: String, _ arguments: [String]) -> String? {
+        lock.withLock {
+            invocations.append(CommandInvocation(launchPath: launchPath, arguments: arguments))
+            let key = Self.key(launchPath: launchPath, arguments: arguments)
+            guard var values = outputs[key], values.isEmpty == false else {
+                return defaultOutput
+            }
+            let output = values.removeFirst()
+            outputs[key] = values
+            return output
+        }
+    }
+
+    func snapshot() -> [CommandInvocation] {
+        lock.withLock { invocations }
+    }
+
+    private static func key(launchPath: String, arguments: [String]) -> String {
+        "\(launchPath)|\(arguments.joined(separator: " "))"
+    }
+}
+
+private struct SignalInvocation: Sendable {
+    let processID: Int
+    let signal: Int32
+}
+
+private final class SignalRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var invocations: [SignalInvocation] = []
+    private var isAlive = true
+
+    func sendSignal(processID: Int, signal: Int32) -> ProcessSignalResult {
+        lock.withLock {
+            invocations.append(SignalInvocation(processID: processID, signal: signal))
+            if signal == SIGKILL {
+                isAlive = false
+                return ProcessSignalResult(result: 0, errnoValue: 0)
+            }
+            if signal == 0, !isAlive {
+                return ProcessSignalResult(result: -1, errnoValue: ESRCH)
+            }
+            return ProcessSignalResult(result: 0, errnoValue: 0)
+        }
+    }
+
+    func snapshot() -> [SignalInvocation] {
+        lock.withLock { invocations }
+    }
+}
+
+private final class ManualClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentTime = Date(timeIntervalSince1970: 0)
+    private var sleeps: [TimeInterval] = []
+
+    var client: ClockClient {
+        ClockClient(
+            now: { self.now() },
+            uptimeNanoseconds: { 0 },
+            sleep: { _ in },
+            sleepForTimeInterval: { interval in
+                self.sleep(interval)
+            }
+        )
+    }
+
+    func sleepIntervals() -> [TimeInterval] {
+        lock.withLock { sleeps }
+    }
+
+    private func now() -> Date {
+        lock.withLock { currentTime }
+    }
+
+    private func sleep(_ interval: TimeInterval) {
+        lock.withLock {
+            sleeps.append(interval)
+            currentTime = currentTime.addingTimeInterval(interval)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Move reusable process command, TCP listener discovery, executable lookup, and signal termination primitives into `XcodeMCPProcessRuntime`.
- Keep `ExistingProxyServerProcessController` focused on proxy restart policy and proxy-server executable filtering.
- Move low-level lsof/host/signal contract coverage into `XcodeMCPProcessRuntimeTests` and keep ProxyIntegration coverage for proxy-specific filtering.

## Testing
- `swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPProcessRuntimeTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check origin/codex/refactor-layered-runtime-integration...HEAD`
- `codex-review` against `codex/refactor-layered-runtime-integration` (no findings)
