### PR TITLE
Fix route catalog ownership and fallback

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -3174,7 +3174,7 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
                 "Xcode documentation service repair could not reopen provider route",
                 metadata: candidateLogMetadata(target: profile.target, error: error)
             )
-            return profile
+            return await profileByAddingInstalledDocumentationAssetFallback(profile)
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -102,14 +102,11 @@ extension RuntimeCoordinator {
         deadlineUptimeNs: UInt64?,
         startedAt: UInt64
     ) async throws -> CanonicalToolsCatalogLoadResult {
-        let candidateProcessOrder = documentationCandidateProcessOrder()
-        let processRoutes =
-            candidateProcessOrder.map { order in
-                order.compactMap { processID in
-                    xcodeProcessRoutes.first { $0.target.processID == processID }
-                }
-            } ?? xcodeProcessRoutes
-        let routes = processRoutes.compactMap { route -> AvailableToolsCatalogRoute? in
+        let unavailable = unavailableXcodeProcessIDs()
+        let routes = xcodeProcessRoutes.compactMap { route -> AvailableToolsCatalogRoute? in
+            guard unavailable.contains(route.target.processID) == false else {
+                return nil
+            }
             let upstreamIndices = usableInitializedUpstreamIndices(in: route)
             guard upstreamIndices.isEmpty == false else {
                 return nil
@@ -120,14 +117,12 @@ extension RuntimeCoordinator {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
 
-        let routeBatches = availableToolsCatalogRouteBatches(routes)
-        let highestPriorityProcessIDs = Set(routeBatches.first?.map { $0.target.processID } ?? [])
+        let exposedProcessIDs = Set(routes.map { $0.target.processID })
         if let surface = processToolCatalogRegistry.availableToolCatalogSurface(
-            processIDs: highestPriorityProcessIDs
+            processIDs: exposedProcessIDs
         ),
            let sourceUpstream = surface.sourceUpstream,
-           let highestPriorityProcessID = routeBatches.first?.first?.target.processID,
-           surface.processIDs.contains(highestPriorityProcessID) {
+           surface.processIDs == exposedProcessIDs {
             return CanonicalToolsCatalogLoadResult(
                 rawResult: surface.rawResult,
                 sourceUpstream: sourceUpstream,
@@ -135,42 +130,13 @@ extension RuntimeCoordinator {
             )
         }
 
-        var lastFailure: (any Error)?
-        for routeBatch in routeBatches {
-            do {
-                return try await loadFirstAvailableToolsCatalogInBatch(
-                    routeBatch,
-                    requestTimeout: requestTimeout,
-                    deadlineUptimeNs: deadlineUptimeNs,
-                    startedAt: startedAt,
-                    exposedProcessIDs: Set(routeBatch.map { $0.target.processID })
-                )
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                lastFailure = error
-            }
-        }
-        if let lastFailure {
-            throw lastFailure
-        }
-        throw UpstreamSlotScheduler.AcquisitionError.unavailable
-    }
-
-    private func availableToolsCatalogRouteBatches(
-        _ routes: [AvailableToolsCatalogRoute]
-    ) -> [[AvailableToolsCatalogRoute]] {
-        let ownerProcessIDs = Set(workspaceOwnerProcessIDs.withLockedValue(\.values))
-            .union(Set(tabOwnerProcessIDs.withLockedValue(\.values)))
-        guard ownerProcessIDs.isEmpty == false else {
-            return [routes]
-        }
-        let ownerRoutes = routes.filter { ownerProcessIDs.contains($0.target.processID) }
-        guard ownerRoutes.isEmpty == false else {
-            return [routes]
-        }
-        let fallbackRoutes = routes.filter { ownerProcessIDs.contains($0.target.processID) == false }
-        return fallbackRoutes.isEmpty ? [ownerRoutes] : [ownerRoutes, fallbackRoutes]
+        return try await loadFirstAvailableToolsCatalogInBatch(
+            routes,
+            requestTimeout: requestTimeout,
+            deadlineUptimeNs: deadlineUptimeNs,
+            startedAt: startedAt,
+            exposedProcessIDs: exposedProcessIDs
+        )
     }
 
     private func loadFirstAvailableToolsCatalogInBatch(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Logging
 import NIO
-import NIOConcurrencyHelpers
 import XcodeMCPCore
 
 extension ControlPlane {
@@ -118,9 +117,10 @@ extension RuntimeCoordinator {
         }
 
         let exposedProcessIDs = Set(routes.map { $0.target.processID })
-        if let surface = processToolCatalogRegistry.availableToolCatalogSurface(
+        let currentSurface = processToolCatalogRegistry.availableToolCatalogSurface(
             processIDs: exposedProcessIDs
-        ),
+        )
+        if let surface = currentSurface,
            let sourceUpstream = surface.sourceUpstream,
            surface.processIDs == exposedProcessIDs {
             return CanonicalToolsCatalogLoadResult(
@@ -130,8 +130,14 @@ extension RuntimeCoordinator {
             )
         }
 
-        return try await loadFirstAvailableToolsCatalogInBatch(
-            routes,
+        let cachedProcessIDs = currentSurface?.processIDs ?? []
+        let uncachedRoutes = routes.filter { cachedProcessIDs.contains($0.target.processID) == false }
+        guard uncachedRoutes.isEmpty == false else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+
+        return try await loadAvailableToolsCatalogsInBatch(
+            uncachedRoutes,
             requestTimeout: requestTimeout,
             deadlineUptimeNs: deadlineUptimeNs,
             startedAt: startedAt,
@@ -139,7 +145,7 @@ extension RuntimeCoordinator {
         )
     }
 
-    private func loadFirstAvailableToolsCatalogInBatch(
+    private func loadAvailableToolsCatalogsInBatch(
         _ routes: [AvailableToolsCatalogRoute],
         requestTimeout: TimeAmount?,
         deadlineUptimeNs: UInt64?,
@@ -150,14 +156,8 @@ extension RuntimeCoordinator {
             of: AvailableToolsCatalogOutcome.self,
             returning: CanonicalToolsCatalogLoadResult.self
         ) { group in
-            let completedRouteCount = NIOLockedValueBox(0)
             for route in routes {
                 group.addTask {
-                    defer {
-                        completedRouteCount.withLockedValue { count in
-                            count += 1
-                        }
-                    }
                     do {
                         try Task.checkCancellation()
                         let result = try await self.loadToolsCatalogFromAvailableProcessRoute(
@@ -190,9 +190,7 @@ extension RuntimeCoordinator {
 
             var failures: [(target: XcodeProcessTarget, upstreamIndex: Int, error: any Error)] = []
             var firstSuccess: CanonicalToolsCatalogLoadResult?
-            var processedOutcomes = 0
             while let outcome = try await group.next() {
-                processedOutcomes += 1
                 switch outcome {
                 case .success(_, let result):
                     if firstSuccess == nil {
@@ -200,23 +198,6 @@ extension RuntimeCoordinator {
                     }
                 case .failure(let route, let upstreamIndex, let error):
                     failures.append((target: route.target, upstreamIndex: upstreamIndex, error: error))
-                }
-
-                if let firstSuccess {
-                    let completed = completedRouteCount.withLockedValue { $0 }
-                    if completed <= processedOutcomes {
-                        await drainControlPlaneCompletions()
-                        let completedAfterDrain = completedRouteCount.withLockedValue { $0 }
-                        if completedAfterDrain > processedOutcomes {
-                            continue
-                        }
-                        group.cancelAll()
-                        return availableToolsCatalogSurfaceResult(
-                            startedAt: startedAt,
-                            exposedProcessIDs: exposedProcessIDs,
-                            fallback: firstSuccess
-                        )
-                    }
                 }
             }
             if let firstSuccess {
@@ -235,10 +216,6 @@ extension RuntimeCoordinator {
             }
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
-    }
-
-    private func drainControlPlaneCompletions() async {
-        _ = try? await eventLoop.submit {}.get()
     }
 
     private func availableToolsCatalogSurfaceResult(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -144,6 +144,8 @@ extension RuntimeCoordinator {
                 startedAt: startedAt,
                 exposedProcessIDs: exposedProcessIDs
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             guard let surface = currentSurface,
                   let sourceUpstream = surface.sourceUpstream else {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -136,13 +136,25 @@ extension RuntimeCoordinator {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
 
-        return try await loadAvailableToolsCatalogsInBatch(
-            uncachedRoutes,
-            requestTimeout: requestTimeout,
-            deadlineUptimeNs: deadlineUptimeNs,
-            startedAt: startedAt,
-            exposedProcessIDs: exposedProcessIDs
-        )
+        do {
+            return try await loadAvailableToolsCatalogsInBatch(
+                uncachedRoutes,
+                requestTimeout: requestTimeout,
+                deadlineUptimeNs: deadlineUptimeNs,
+                startedAt: startedAt,
+                exposedProcessIDs: exposedProcessIDs
+            )
+        } catch {
+            guard let surface = currentSurface,
+                  let sourceUpstream = surface.sourceUpstream else {
+                throw error
+            }
+            return CanonicalToolsCatalogLoadResult(
+                rawResult: surface.rawResult,
+                sourceUpstream: sourceUpstream,
+                durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt)
+            )
+        }
     }
 
     private func loadAvailableToolsCatalogsInBatch(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -174,7 +174,16 @@ extension RuntimeCoordinator {
     }
 
     func documentationCandidateProcessIDs() -> Set<pid_t>? {
-        documentationCandidateProcessOrder().map(Set.init)
+        guard xcodeProcessRoutes.isEmpty == false else {
+            return nil
+        }
+        let unavailable = unavailableXcodeProcessIDs()
+        return Set(xcodeProcessRoutes.compactMap { route in
+            unavailable.contains(route.target.processID) == false
+                && firstUsableInitializedUpstreamIndex(in: route) != nil
+                ? route.target.processID
+                : nil
+        })
     }
 
     func catalogEligibleConfiguredProcessIDs() -> Set<pid_t> {
@@ -182,50 +191,6 @@ extension RuntimeCoordinator {
         return Set(xcodeProcessRoutes.compactMap { route in
             unavailable.contains(route.target.processID) ? nil : route.target.processID
         })
-    }
-
-    func documentationCandidateProcessOrder() -> [pid_t]? {
-        guard xcodeProcessRoutes.isEmpty == false else {
-            return nil
-        }
-        let unavailable = unavailableXcodeProcessIDs()
-        let candidateRoutes = xcodeProcessRoutes.filter { route in
-            unavailable.contains(route.target.processID) == false
-                && firstUsableInitializedUpstreamIndex(in: route) != nil
-        }
-        let candidateProcessIDsInRouteOrder = candidateRoutes.map(\.target.processID)
-        let workspaceOwnerProcesses = Set(workspaceOwnerProcessIDs.withLockedValue(\.values))
-        let tabOwnerProcesses = Set(tabOwnerProcessIDs.withLockedValue(\.values))
-        let ownerProcesses = workspaceOwnerProcesses.union(tabOwnerProcesses)
-        let ownerProcessIDs = orderedProcessIDs(
-            candidateProcessIDsInRouteOrder.filter { ownerProcesses.contains($0) },
-            unavailable: unavailable
-        )
-        let ownerProcessIDSet = Set(ownerProcessIDs)
-
-        let nonOwnerProcessIDs = orderedProcessIDs(
-            candidateProcessIDsInRouteOrder.filter { ownerProcessIDSet.contains($0) == false },
-            unavailable: unavailable
-        )
-        let candidateProcessIDs = ownerProcessIDs + nonOwnerProcessIDs
-        if candidateProcessIDs.isEmpty == false {
-            return candidateProcessIDs
-        }
-        return []
-    }
-
-    private func orderedProcessIDs(
-        _ processIDs: [pid_t],
-        unavailable: Set<pid_t>
-    ) -> [pid_t] {
-        var seen = Set<pid_t>()
-        return processIDs.compactMap { processID -> pid_t? in
-            guard unavailable.contains(processID) == false,
-                  seen.insert(processID).inserted else {
-                return nil
-            }
-            return processID
-        }
     }
 
     func unavailableXcodeProcessIDs() -> Set<pid_t> {
@@ -761,7 +726,12 @@ extension RuntimeCoordinator {
     private func preferredUpstreamIndex(in object: [String: Any]) -> Int? {
         guard JSONRPC.Message.Inspector.method(from: object) == "tools/call",
               let params = object["params"] as? [String: Any],
+              let toolName = params["name"] as? String,
               let arguments = params["arguments"] as? [String: Any] else {
+            return nil
+        }
+        guard processToolCatalogRegistry.isOwnerBoundTool(toolName)
+            || cachedOwnerBoundToolNames().contains(toolName) else {
             return nil
         }
         if let tabIdentifier = arguments["tabIdentifier"] as? String,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeXcodeTargetDiscovery.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeXcodeTargetDiscovery.swift
@@ -17,21 +17,12 @@ final class RuntimeDocumentationTargetDiscovery:
 
     func runningXcodeTargets() -> [XcodeProcessTarget] {
         let targets = base.runningXcodeTargets()
-        guard let runtime = runtimeBox.value,
-              let candidateProcessIDs = runtime.documentationCandidateProcessOrder()
-        else {
+        guard let runtime = runtimeBox.value else {
             return targets
         }
         let unavailableProcessIDs = runtime.unavailableXcodeProcessIDs()
-        let targetsByProcessID = Dictionary(
-            uniqueKeysWithValues: targets.map { ($0.processID, $0) }
-        )
-        let orderedRuntimeTargets = candidateProcessIDs.compactMap { targetsByProcessID[$0] }
-        let orderedRuntimeProcessIDs = Set(candidateProcessIDs)
-        let remainingLiveTargets = targets.filter {
-            orderedRuntimeProcessIDs.contains($0.processID) == false
-                && unavailableProcessIDs.contains($0.processID) == false
+        return targets.filter {
+            unavailableProcessIDs.contains($0.processID) == false
         }
-        return orderedRuntimeTargets + remainingLiveTargets
     }
 }

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -1368,18 +1368,18 @@ struct DocumentationProviderTests {
                 ],
             ]
         )
-        let manager = DocumentationProviderManager(
-            discovery: RuntimeDocumentationTargetDiscovery(
-                base: StubXcodeTargetDiscovery(targets: [ownerTarget, stableTarget]),
-                runtimeBox: runtimeBox
-            ),
-            sessionFactory: factory
+        let discovery = RuntimeDocumentationTargetDiscovery(
+            base: StubXcodeTargetDiscovery(targets: [ownerTarget, stableTarget]),
+            runtimeBox: runtimeBox
         )
-
-        #expect(runtime.documentationCandidateProcessOrder() == [
+        #expect(discovery.runningXcodeTargets().map(\.processID) == [
             ownerTarget.processID,
             stableTarget.processID,
         ])
+        let manager = DocumentationProviderManager(
+            discovery: discovery,
+            sessionFactory: factory
+        )
 
         let outcome = try await manager.callDocumentationSearch(
             requestData: makeDocumentationSearchRequest(id: 98, query: "SwiftUI"),
@@ -2399,6 +2399,75 @@ struct DocumentationProviderTests {
         #expect(await localProvider.requestedCallPIDs() == [target.processID])
         #expect(await localProvider.requestedQueries() == ["UIView"])
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
+    }
+
+    @Test func documentationProviderUsesSameTargetAssetFallbackWhenRepairReopenIsUnavailable()
+        async throws
+    {
+        let older = xcodeProcessTarget(processID: 120, xcodeVersion: "26.6")
+        let newest = xcodeProcessTarget(processID: 121, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                older.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 20,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"older\"}")
+                    ),
+                ],
+                newest.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 20,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let repairer = StubDocumentationSearchServiceRepairer(
+            result: .repaired(
+                DocumentationSearchServiceRepairReport(
+                    configURL: "/docs/config.json",
+                    xcodeVersion: "27.0",
+                    osVersion: "26.2",
+                    documentationRelease: 900340,
+                    changedDefault: true
+                )
+            )
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-fallback"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 121,
+                text: "{\"answer\":\"asset-newest\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [older, newest]),
+            sessionFactory: factory,
+            serviceRepairer: repairer,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 121, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset-newest\"}")
+        #expect(await repairer.repairedPIDs() == [newest.processID])
+        #expect(await factory.startAttempts() == [newest.processID, newest.processID])
+        #expect(await factory.startedPIDs() == [newest.processID])
+        #expect(await factory.documentationQueries(for: older.processID).isEmpty)
+        #expect(await localProvider.requestedDescriptorPIDs() == [newest.processID])
+        #expect(await localProvider.requestedCallPIDs() == [newest.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI"])
     }
 
     @Test func documentationProviderRejectsRepairedRouteWhenDescriptorIsStillMissing()

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2441,6 +2441,60 @@ struct RuntimeCoordinatorTests {
         ])
     }
 
+    @Test func sessionManagerToolsListDoesNotReturnCachedProcessCatalogWhenFreshRouteIsCancelled()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let olderUpstream = TestUpstreamClient()
+        let latestUpstream = TestUpstreamClient()
+        let olderTarget = xcodeProcessTarget(processID: 66341, xcodeVersion: "26.6")
+        let latestTarget = xcodeProcessTarget(processID: 80428, xcodeVersion: "27.0")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [olderUpstream, latestUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: latestTarget, upstreamIndices: [1]),
+                XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (olderTarget, 0, [toolDescriptor(name: "OlderRouteOnly")]),
+            ]
+        )
+        manager.canonicalBrokerState.clearToolsCatalog()
+
+        let task = Task {
+            try await manager.sharedToolsList(
+                sessionID: "session-process-catalog-cached-fresh-cancelled",
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+
+        _ = try await latestUpstream.nextSent {
+            methodName(from: $0) == "tools/list"
+        }
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+        #expect(await olderUpstream.sentCount() == 0)
+        #expect(await latestUpstream.sentCount() == 1)
+        #expect(manager.cachedToolsListResult() == nil)
+        #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [
+            olderTarget.processID,
+        ])
+    }
+
     @Test func sessionManagerToolsListSkipsUnavailableProcessRouteCatalog() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2371,6 +2371,76 @@ struct RuntimeCoordinatorTests {
         #expect(try #require(catalogs.first { $0.processID == latestTarget.processID }).toolCount == 1)
     }
 
+    @Test func sessionManagerToolsListKeepsCachedProcessCatalogWhenFreshRouteFails()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let olderUpstream = TestUpstreamClient()
+        let latestUpstream = TestUpstreamClient()
+        let olderTarget = xcodeProcessTarget(processID: 66340, xcodeVersion: "26.6")
+        let latestTarget = xcodeProcessTarget(processID: 80427, xcodeVersion: "27.0")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [olderUpstream, latestUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: latestTarget, upstreamIndices: [1]),
+                XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (olderTarget, 0, [toolDescriptor(name: "OlderRouteOnly")]),
+            ]
+        )
+        manager.canonicalBrokerState.clearToolsCatalog()
+
+        let task = Task {
+            try await manager.sharedToolsList(
+                sessionID: "session-process-catalog-cached-fresh-fails",
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+
+        let latestRequest = try await latestUpstream.nextSent {
+            methodName(from: $0) == "tools/list"
+        }
+        await latestUpstream.yield(
+            .message(
+                try JSONSerialization.data(
+                    withJSONObject: [
+                        "jsonrpc": "2.0",
+                        "id": try extractUpstreamID(from: latestRequest),
+                        "result": [
+                            "tools": "invalid",
+                        ],
+                    ],
+                    options: []
+                )
+            )
+        )
+
+        let result = try await waitWithTimeout("waiting for cached process catalog fallback") {
+            try await task.value
+        }
+
+        #expect(toolNames(in: result) == ["OlderRouteOnly"])
+        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["OlderRouteOnly"])
+        #expect(await olderUpstream.sentCount() == 0)
+        #expect(await latestUpstream.sentCount() == 1)
+        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 0)
+        #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [
+            olderTarget.processID,
+        ])
+    }
+
     @Test func sessionManagerToolsListSkipsUnavailableProcessRouteCatalog() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -206,10 +206,10 @@ struct RuntimeCoordinatorTests {
         let recoveryUpstreamID = try extractUpstreamID(from: recoveryInitialize)
         await upstream0.yield(.message(try makeInitializeResponse(id: recoveryUpstreamID)))
         _ = try await sentValue(from: upstream0, at: 2, timeout: .seconds(2))
-        let expectedCandidateProcessOrder = [
+        let expectedCandidateProcessIDs = Set([
             newerTarget.processID,
             olderTarget.processID,
-        ]
+        ])
         let recoveredUpstreamIndex = try await waitWithTimeout(
             "waiting for recovered primary upstream initialization"
         ) {
@@ -218,7 +218,7 @@ struct RuntimeCoordinatorTests {
         #expect(recoveredUpstreamIndex == 0)
         #expect(manager.testStateSnapshot().upstreams[0].isInitialized == true)
         #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 1)
-        #expect(manager.documentationCandidateProcessOrder() == expectedCandidateProcessOrder)
+        #expect(manager.documentationCandidateProcessIDs() == expectedCandidateProcessIDs)
     }
 
     @Test func sessionManagerRoutesInitializeHandshakeNotificationsFromRetriedPrimaryProcess()
@@ -306,7 +306,7 @@ struct RuntimeCoordinatorTests {
         #expect(response["result"] != nil)
         #expect(manager.testStateSnapshot().upstreams[0].isInitialized == false)
         #expect(manager.testStateSnapshot().upstreams[1].isInitialized == true)
-        #expect(manager.documentationCandidateProcessOrder() == [target.processID])
+        #expect(manager.documentationCandidateProcessIDs() == Set([target.processID]))
     }
 
     @Test func sessionManagerRetriesProcessPrimaryInitializeOnNextXcodeProcessAfterExit()
@@ -2089,7 +2089,9 @@ struct RuntimeCoordinatorTests {
             methodName(from: $0) == "tools/list"
         }
         #expect(methodName(from: latestRequest) == "tools/list")
-        #expect(await olderUpstream.sentCount() == 0)
+        let olderRequest = try await olderUpstream.nextSent {
+            methodName(from: $0) == "tools/list"
+        }
         await latestUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -2101,29 +2103,44 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
+        await olderUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: olderRequest),
+                    tools: [
+                        toolDescriptor(name: "SharedTool", description: "from-26"),
+                        toolDescriptor(name: "Only26", description: "old-only"),
+                    ],
+                )
+            )
+        )
 
         let result = try await waitWithTimeout("waiting for process-routed tools/list") {
             try await task.value
         }
-        #expect(toolNames(in: result) == ["Only27", "SharedTool"])
+        #expect(toolNames(in: result) == ["Only26", "Only27", "SharedTool"])
         #expect(toolDescription(in: result, name: "SharedTool") == "from-27")
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
-        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["Only27", "SharedTool"])
-        #expect(await olderUpstream.sentCount() == 0)
+        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == [
+            "Only26",
+            "Only27",
+            "SharedTool",
+        ])
+        #expect(await olderUpstream.sentCount() == 1)
 
         let catalogs = manager.debugSnapshot().processToolCatalogs
-        #expect(catalogs.count == 1)
+        #expect(catalogs.count == 2)
         let latestCatalog = try #require(catalogs.first { $0.processID == latestTarget.processID })
         #expect(latestCatalog.toolCount == 2)
         #expect(latestCatalog.tabOwnerCount == 1)
         #expect(latestCatalog.workspaceOwnerCount == 1)
         #expect(latestCatalog.isCanonicalSource)
         #expect(latestCatalog.exposurePolicy == "available_route_catalog_surface")
-        #expect(latestCatalog.extraBeyondExposedCatalog == [])
-        #expect(latestCatalog.schemaConflicts == [])
+        #expect(latestCatalog.extraBeyondExposedCatalog == ["Only26"])
+        #expect(latestCatalog.schemaConflicts == ["SharedTool"])
     }
 
-    @Test func sessionManagerToolsListRefreshesFallbackCatalogAfterOwnerIsLearned()
+    @Test func sessionManagerToolsListUnionsFallbackCatalogAfterOwnerIsLearned()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -2194,7 +2211,8 @@ struct RuntimeCoordinatorTests {
         let ownerRequest = try await ownerUpstream.nextSent {
             methodName(from: $0) == "tools/list"
         }
-        #expect(await fallbackUpstream.sentCount() == 1)
+        try await waitForSentCount(fallbackUpstream, count: 2, timeoutSeconds: 2)
+        #expect(await fallbackUpstream.sentCount() == 2)
         await ownerUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -2208,9 +2226,12 @@ struct RuntimeCoordinatorTests {
         let ownerResult = try await waitWithTimeout("waiting for owner tools/list") {
             try await ownerTask.value
         }
-        #expect(toolNames(in: ownerResult) == ["OwnerOnly"])
-        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["OwnerOnly"])
-        #expect(await fallbackUpstream.sentCount() == 1)
+        #expect(toolNames(in: ownerResult) == ["FallbackOnly", "OwnerOnly"])
+        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == [
+            "FallbackOnly",
+            "OwnerOnly",
+        ])
+        #expect(await fallbackUpstream.sentCount() == 2)
         #expect(await ownerUpstream.sentCount() == 1)
     }
 
@@ -2456,7 +2477,7 @@ struct RuntimeCoordinatorTests {
             target.processID,
         ])
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
-        #expect(manager.documentationCandidateProcessOrder() == [target.processID])
+        #expect(manager.documentationCandidateProcessIDs() == Set([target.processID]))
     }
 
     @Test func sessionManagerToolsListSiblingRetryUsesSharedDeadline()
@@ -2793,7 +2814,7 @@ struct RuntimeCoordinatorTests {
         #expect(await olderUpstream.sentCount() == 0)
     }
 
-    @Test func documentationCandidatesPreferWorkspaceOwnersButKeepFallbackProcesses()
+    @Test func documentationCandidatesIgnoreWorkspaceOwnersAndKeepUsableProcesses()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -2823,12 +2844,6 @@ struct RuntimeCoordinatorTests {
         #expect(manager.recordXcodeWindowOwners(from: result, upstreamIndex: 1))
 
         #expect(
-            manager.documentationCandidateProcessOrder() == [
-                goodTarget.processID,
-                badTarget.processID,
-            ]
-        )
-        #expect(
             manager.documentationCandidateProcessIDs() == Set([
                 badTarget.processID,
                 goodTarget.processID,
@@ -2836,88 +2851,56 @@ struct RuntimeCoordinatorTests {
         )
     }
 
-    @Test func documentationCandidatesPreserveRouteOrderWithinOwnersBeforeFallbacks()
+    @Test func runtimeDocumentationDiscoveryPreservesDiscoveryOrderExceptUnavailableProcessIDs()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
-        let fallbackTarget0 = xcodeProcessTarget(processID: 80430, xcodeVersion: "27.0")
-        let ownerTarget0 = xcodeProcessTarget(processID: 80431, xcodeVersion: "27.0")
-        let fallbackTarget1 = xcodeProcessTarget(processID: 80432, xcodeVersion: "26.6")
-        let ownerTarget1 = xcodeProcessTarget(processID: 80433, xcodeVersion: "26.6")
-
-        func candidateOrder(routeTargets: [XcodeProcessTarget]) throws -> [pid_t]? {
-            let manager = RuntimeCoordinator(
-                config: makeConfig(requestTimeout: 5),
-                eventLoop: eventLoop,
-                upstreams: routeTargets.map { _ in TestUpstreamClient() },
-                xcodeProcessRoutes: routeTargets.enumerated().map { index, target in
-                    XcodeProcessRoute(target: target, upstreamIndices: [index])
-                },
-                startImmediately: false
-            )
-            defer { manager.shutdownAndWait() }
-            for index in routeTargets.indices {
-                manager.markUpstreamInitialized(upstreamIndex: index)
-            }
-
-            func upstreamIndex(for target: XcodeProcessTarget) throws -> Int {
-                try #require(routeTargets.firstIndex {
-                    $0.processID == target.processID
-                })
-            }
-
-            #expect(
-                manager.recordXcodeWindowOwners(
-                    from: try jsonValue([
-                        "structuredContent": [
-                            "message": "* tabIdentifier: tab-owner-1, workspacePath: /tmp/Owner1.xcworkspace",
-                        ],
-                    ]),
-                    upstreamIndex: try upstreamIndex(for: ownerTarget1)
-                )
-            )
-            #expect(
-                manager.recordXcodeWindowOwners(
-                    from: try jsonValue([
-                        "structuredContent": [
-                            "message": "* tabIdentifier: tab-owner-0, workspacePath: /tmp/Owner0.xcworkspace",
-                        ],
-                    ]),
-                    upstreamIndex: try upstreamIndex(for: ownerTarget0)
-                )
-            )
-
-            return manager.documentationCandidateProcessOrder()
-        }
-
-        #expect(
-            try candidateOrder(routeTargets: [
-                fallbackTarget0,
-                ownerTarget0,
-                fallbackTarget1,
-                ownerTarget1,
-            ]) == [
-                ownerTarget0.processID,
-                ownerTarget1.processID,
-                fallbackTarget0.processID,
-                fallbackTarget1.processID,
-            ]
+        let routeFirst = xcodeProcessTarget(processID: 80430, xcodeVersion: "26.6")
+        let unavailable = xcodeProcessTarget(processID: 80431, xcodeVersion: "27.0")
+        let routeLast = xcodeProcessTarget(processID: 80432, xcodeVersion: "25.4")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [TestUpstreamClient(), TestUpstreamClient(), TestUpstreamClient()],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: routeFirst, upstreamIndices: [0]),
+                XcodeProcessRoute(target: unavailable, upstreamIndices: [1]),
+                XcodeProcessRoute(target: routeLast, upstreamIndices: [2]),
+            ],
+            startImmediately: false
         )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        manager.markUpstreamInitialized(upstreamIndex: 2)
         #expect(
-            try candidateOrder(routeTargets: [
-                fallbackTarget0,
-                ownerTarget1,
-                fallbackTarget1,
-                ownerTarget0,
-            ]) == [
-                ownerTarget1.processID,
-                ownerTarget0.processID,
-                fallbackTarget0.processID,
-                fallbackTarget1.processID,
-            ]
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: tab-route-last, workspacePath: /tmp/RouteLast.xcworkspace",
+                    ],
+                ]),
+                upstreamIndex: 2
+            )
         )
+        manager.markXcodeProcessRouteUnavailable(
+            upstreamIndex: 1,
+            reason: "test_discovery_filter"
+        )
+
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        runtimeBox.value = manager
+        let discovery = RuntimeDocumentationTargetDiscovery(
+            base: StubXcodeTargetDiscovery(targets: [routeLast, unavailable, routeFirst]),
+            runtimeBox: runtimeBox
+        )
+
+        #expect(discovery.runningXcodeTargets().map(\.processID) == [
+            routeLast.processID,
+            routeFirst.processID,
+        ])
     }
 
     @Test func documentationCandidatesSkipUnavailableWorkspaceOwner() async throws {
@@ -2951,7 +2934,7 @@ struct RuntimeCoordinatorTests {
             reason: "test_owner_terminated"
         )
 
-        #expect(manager.documentationCandidateProcessOrder() == [badTarget.processID])
+        #expect(manager.documentationCandidateProcessIDs() == Set([badTarget.processID]))
     }
 
     @Test func runtimeDocumentationDiscoveryKeepsLiveTargetsOutsideUsableRouteCandidates()
@@ -2985,25 +2968,20 @@ struct RuntimeCoordinatorTests {
         let runtimeBox = WeakRuntimeCoordinatorBox()
         runtimeBox.value = manager
         let discovery = RuntimeDocumentationTargetDiscovery(
-            base: StubXcodeTargetDiscovery(targets: [ownerTarget, fallbackTarget]),
+            base: StubXcodeTargetDiscovery(targets: [fallbackTarget, ownerTarget]),
             runtimeBox: runtimeBox
         )
 
-        #expect(manager.documentationCandidateProcessOrder() == [ownerTarget.processID])
         #expect(discovery.runningXcodeTargets().map(\.processID) == [
-            ownerTarget.processID,
             fallbackTarget.processID,
+            ownerTarget.processID,
         ])
 
         manager.markUpstreamInitialized(upstreamIndex: 1)
 
-        #expect(manager.documentationCandidateProcessOrder() == [
-            ownerTarget.processID,
-            fallbackTarget.processID,
-        ])
         #expect(discovery.runningXcodeTargets().map(\.processID) == [
-            ownerTarget.processID,
             fallbackTarget.processID,
+            ownerTarget.processID,
         ])
     }
 
@@ -3159,6 +3137,30 @@ struct RuntimeCoordinatorTests {
         }
         #expect(mergedMessage == "\(message0)\n\(message1)")
 
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (
+                    target0,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "XcodeListNavigatorIssues"),
+                        ownerBoundToolDescriptor(name: "XcodeSomeWorkspaceScopedTool"),
+                        toolDescriptor(name: "XcodeRead"),
+                    ]
+                ),
+                (
+                    target1,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "XcodeListNavigatorIssues"),
+                        ownerBoundToolDescriptor(name: "XcodeSomeWorkspaceScopedTool"),
+                        toolDescriptor(name: "XcodeRead"),
+                    ]
+                ),
+            ]
+        )
+
         let tabARequest: [String: Any] = [
             "method": "tools/call",
             "params": [
@@ -3186,9 +3188,29 @@ struct RuntimeCoordinatorTests {
                 ],
             ],
         ]
+        let genericTabARequest: [String: Any] = [
+            "method": "tools/call",
+            "params": [
+                "name": "XcodeRead",
+                "arguments": [
+                    "tabIdentifier": "tab-a",
+                ],
+            ],
+        ]
+        let genericWorkspaceBRequest: [String: Any] = [
+            "method": "tools/call",
+            "params": [
+                "name": "XcodeRead",
+                "arguments": [
+                    "workspacePath": "/Work/B.xcworkspace",
+                ],
+            ],
+        ]
         #expect(manager.preferredUpstreamIndex(for: tabARequest) == 0)
         #expect(manager.preferredUpstreamIndex(for: tabBRequest) == 1)
         #expect(manager.preferredUpstreamIndex(for: workspaceBRequest) == 1)
+        #expect(manager.preferredUpstreamIndex(for: genericTabARequest) == nil)
+        #expect(manager.preferredUpstreamIndex(for: genericWorkspaceBRequest) == nil)
         #expect(manager.preferredUpstreamIndex(for: [tabARequest, tabBRequest]) == nil)
     }
 
@@ -3242,7 +3264,13 @@ struct RuntimeCoordinatorTests {
             return
         }
         #expect(resultMessage == message)
-        #expect(manager.documentationCandidateProcessOrder() == [target.processID])
+        #expect(manager.documentationCandidateProcessIDs() == Set([target.processID]))
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target, 1, [ownerBoundToolDescriptor(name: "XcodeListNavigatorIssues")]),
+            ]
+        )
         #expect(manager.preferredUpstreamIndex(for: [
             "method": "tools/call",
             "params": [
@@ -3314,7 +3342,13 @@ struct RuntimeCoordinatorTests {
             return
         }
         #expect(resultMessage == message)
-        #expect(manager.documentationCandidateProcessOrder() == [target.processID])
+        #expect(manager.documentationCandidateProcessIDs() == Set([target.processID]))
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target, 1, [ownerBoundToolDescriptor(name: "XcodeListNavigatorIssues")]),
+            ]
+        )
         #expect(manager.preferredUpstreamIndex(for: [
             "method": "tools/call",
             "params": [
@@ -3400,6 +3434,22 @@ struct RuntimeCoordinatorTests {
             return
         }
         #expect(mergedMessage == "\(message0)\n\(message1)")
+
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (
+                    target0,
+                    0,
+                    [ownerBoundToolDescriptor(name: "XcodeSomeWorkspaceScopedTool")]
+                ),
+                (
+                    target1,
+                    1,
+                    [ownerBoundToolDescriptor(name: "XcodeSomeWorkspaceScopedTool")]
+                ),
+            ]
+        )
 
         let workspaceRequest: [String: Any] = [
             "method": "tools/call",
@@ -8162,6 +8212,12 @@ struct RuntimeCoordinatorTests {
         )
         defer { manager.shutdownAndWait() }
         manager.markUpstreamInitialized(upstreamIndex: 0)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
         #expect(
             manager.recordXcodeWindowOwners(
                 from: try jsonValue([

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2211,8 +2211,6 @@ struct RuntimeCoordinatorTests {
         let ownerRequest = try await ownerUpstream.nextSent {
             methodName(from: $0) == "tools/list"
         }
-        try await waitForSentCount(fallbackUpstream, count: 2, timeoutSeconds: 2)
-        #expect(await fallbackUpstream.sentCount() == 2)
         await ownerUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -2231,11 +2229,11 @@ struct RuntimeCoordinatorTests {
             "FallbackOnly",
             "OwnerOnly",
         ])
-        #expect(await fallbackUpstream.sentCount() == 2)
+        #expect(await fallbackUpstream.sentCount() == 1)
         #expect(await ownerUpstream.sentCount() == 1)
     }
 
-    @Test func sessionManagerToolsListReturnsLaterUsableRouteWithoutWaitingForEarlierRoute()
+    @Test func sessionManagerToolsListWaitsForUsableRoutesBeforeReturningUnion()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -2266,7 +2264,7 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        _ = try await earlierUpstream.nextSent {
+        let earlierRequest = try await earlierUpstream.nextSent {
             methodName(from: $0) == "tools/list"
         }
         let laterRequest = try await laterUpstream.nextSent {
@@ -2282,11 +2280,21 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
+        await earlierUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: earlierRequest),
+                    tools: [
+                        toolDescriptor(name: "EarlierRouteOnly"),
+                    ]
+                )
+            )
+        )
 
         let result = try await waitWithTimeout("waiting for later route tools/list") {
             try await task.value
         }
-        #expect(toolNames(in: result) == ["LaterRouteOnly"])
+        #expect(toolNames(in: result) == ["EarlierRouteOnly", "LaterRouteOnly"])
         #expect(await earlierUpstream.sentCount() == 1)
         #expect(await laterUpstream.sentCount() == 1)
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
@@ -2354,6 +2362,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(Set(toolNames(in: result)) == Set(["LatestRouteOnly", "OlderRouteOnly"]))
         #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set(["LatestRouteOnly", "OlderRouteOnly"]))
+        #expect(await olderUpstream.sentCount() == 0)
         #expect(await latestUpstream.sentCount() == 1)
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
         let catalogs = manager.debugSnapshot().processToolCatalogs


### PR DESCRIPTION
Purpose
- Keep route catalog ownership separate from workspace/window ownership so process routing exposes the full usable tool union.
- Prevent DocumentationSearch from getting stuck behind an unusable process route when a newer usable route or same-target asset fallback exists.

Changes
- Build tools/list surfaces from all usable process route catalogs instead of returning the first successful route.
- Avoid pinning non-owner-bound tools to workspace/window owners.
- Preserve cached route catalog surfaces when an uncached route refresh fails, while still propagating cancellation.
- Keep DocumentationSearch candidate order focused on latest usable Xcode and same-target asset fallback.
- Add regression tests for route catalog union, partial cached fallback, cancellation, and DocumentationSearch asset fallback ordering.

Testing
- swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyDocumentationProviderTests -Xswiftc -strict-concurrency=minimal
- git diff --check
- codex-review against origin/codex/refactor-layered-runtime-integration: clean