### PR TITLE
Move discovery liveness checks to runtime

### DIFF
--- a/Sources/XcodeMCPCore/Discovery.swift
+++ b/Sources/XcodeMCPCore/Discovery.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import Network
 
@@ -61,7 +60,6 @@ package enum Discovery {
     package static func read(overrideURL: URL? = nil) -> DiscoveryRecord? {
         let url = fileURL(overrideURL)
         guard let record = try? loadRecord(from: url) else { return nil }
-        guard isProcessAlive(record.pid) else { return nil }
         guard isLoopbackURL(record.url) else { return nil }
         return record
     }
@@ -105,15 +103,6 @@ package enum Discovery {
     package static func persist(record: DiscoveryRecord, to url: URL) throws {
         let data = try encoder.encode(record)
         try data.write(to: url, options: [.atomic])
-    }
-
-    package static func isProcessAlive(_ pid: Int) -> Bool {
-        guard pid > 0 else { return false }
-        let result = kill(pid_t(pid), 0)
-        if result == 0 {
-            return true
-        }
-        return errno == EPERM
     }
 
     private static let encoder: JSONEncoder = {

--- a/Sources/XcodeMCPKit/Internal/ClientRuntime/StreamableHTTPXcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/Internal/ClientRuntime/StreamableHTTPXcodeMCPTransport.swift
@@ -2,6 +2,43 @@ import XcodeMCPCore
 import XcodeMCPProcessRuntime
 import Foundation
 
+package struct StreamableHTTPDiscoveryResolver: Sendable {
+    private let readRecord: @Sendable (_ discoveryFile: URL) -> DiscoveryRecord?
+    private let isProcessAlive: @Sendable (_ processID: Int) -> Bool
+
+    package static let liveValue = Self(processControl: .liveValue)
+
+    package init(
+        processControl: ProcessControlClient,
+        readRecord: @escaping @Sendable (_ discoveryFile: URL) -> DiscoveryRecord? = {
+            Discovery.read(overrideURL: $0)
+        }
+    ) {
+        self.readRecord = readRecord
+        self.isProcessAlive = { processControl.isProcessAlive($0) }
+    }
+
+    package init(
+        readRecord: @escaping @Sendable (_ discoveryFile: URL) -> DiscoveryRecord? = {
+            Discovery.read(overrideURL: $0)
+        },
+        isProcessAlive: @escaping @Sendable (_ processID: Int) -> Bool
+    ) {
+        self.readRecord = readRecord
+        self.isProcessAlive = isProcessAlive
+    }
+
+    package func endpoint(from discoveryFile: URL) -> URL? {
+        guard let record = readRecord(discoveryFile),
+              isProcessAlive(record.pid),
+              let endpoint = URL(string: record.url)
+        else {
+            return nil
+        }
+        return endpoint
+    }
+}
+
 package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @unchecked Sendable {
     package nonisolated let events: AsyncStream<XcodeMCPTransportEvent>
 
@@ -23,11 +60,10 @@ package final class StreamableHTTPXcodeMCPTransport: XcodeMCPTransport, @uncheck
 
     package static func start(
         discoveryFile: URL,
-        requestTimeout: Duration?
+        requestTimeout: Duration?,
+        discoveryResolver: StreamableHTTPDiscoveryResolver = .liveValue
     ) async throws -> StreamableHTTPXcodeMCPTransport {
-        guard let record = Discovery.read(overrideURL: discoveryFile),
-              let endpoint = URL(string: record.url)
-        else {
+        guard let endpoint = discoveryResolver.endpoint(from: discoveryFile) else {
             throw MCPBridgeRuntimeError.invalidRequest(
                 "Streamable HTTP discovery file is missing, stale, or invalid: \(discoveryFile.path)"
             )

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -227,6 +227,16 @@ public actor XcodeMCP {
     ///
     /// - Parameter config: Connection and initialization settings.
     public init(config: Configuration = Configuration()) async throws {
+        try await self.init(
+            config: config,
+            streamableHTTPDiscoveryResolver: .liveValue
+        )
+    }
+
+    package init(
+        config: Configuration = Configuration(),
+        streamableHTTPDiscoveryResolver: StreamableHTTPDiscoveryResolver
+    ) async throws {
         do {
             let transport: any XcodeMCPTransport
             switch config.transport {
@@ -245,7 +255,8 @@ public actor XcodeMCP {
             case .streamableHTTPDiscoveryFile(let discoveryFile):
                 transport = try await StreamableHTTPXcodeMCPTransport.start(
                     discoveryFile: discoveryFile,
-                    requestTimeout: config.requestTimeout
+                    requestTimeout: config.requestTimeout,
+                    discoveryResolver: streamableHTTPDiscoveryResolver
                 )
             }
             try await self.init(config: config, transport: transport)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Support/DiscoveryClient.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Support/DiscoveryClient.swift
@@ -56,7 +56,7 @@ struct DiscoveryClient: DependencyClient {
             try FileManager.default.createDirectory(at: $0, withIntermediateDirectories: true)
         },
         isProcessAlive: @escaping @Sendable (_ pid: Int) -> Bool = {
-            Discovery.isProcessAlive($0)
+            ProcessControlClient.liveValue.isProcessAlive($0)
         },
         now: @escaping @Sendable () -> Date = {
             Date()

--- a/Tests/XcodeMCPCoreTests/DiscoveryTests.swift
+++ b/Tests/XcodeMCPCoreTests/DiscoveryTests.swift
@@ -71,7 +71,7 @@ struct DiscoveryTests {
         #expect(Discovery.read(overrideURL: url) == nil)
     }
 
-    @Test func discoveryRejectsDeadPID() async throws {
+    @Test func discoveryReadDoesNotOwnProcessLiveness() async throws {
         let url = makeTempDiscoveryURL()
         defer { cleanupTempDiscoveryURL(url) }
         let record = DiscoveryRecord(
@@ -82,7 +82,7 @@ struct DiscoveryTests {
             updatedAt: Date()
         )
         try Discovery.write(record: record, overrideURL: url)
-        #expect(Discovery.read(overrideURL: url) == nil)
+        #expect(Discovery.read(overrideURL: url)?.pid == record.pid)
     }
 
     @Test func discoveryAllowsIPv4LoopbackRange() async throws {

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -630,6 +630,42 @@ struct XcodeMCPTests {
         )
     }
 
+    @Test func streamableHTTPDiscoveryRejectsStaleRecordBeforeConnecting() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileURL = directory.appendingPathComponent("endpoint.json")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let record = DiscoveryRecord(
+            url: "http://127.0.0.1:8765/mcp",
+            host: "127.0.0.1",
+            port: 8765,
+            pid: 12345,
+            updatedAt: Date(timeIntervalSince1970: 0)
+        )
+        try Discovery.write(record: record, overrideURL: fileURL)
+
+        let liveness = DiscoveryLivenessProbe(isAlive: false)
+        let resolver = StreamableHTTPDiscoveryResolver(
+            isProcessAlive: { pid in
+                liveness.isProcessAlive(pid)
+            }
+        )
+
+        await #expect(throws: XcodeMCPError.invalidRequest(
+            "Streamable HTTP discovery file is missing, stale, or invalid: \(fileURL.path)"
+        )) {
+            _ = try await XcodeMCP(
+                config: .init(
+                    transport: .streamableHTTP(discoveryFile: fileURL),
+                    requestTimeout: .seconds(2)
+                ),
+                streamableHTTPDiscoveryResolver: resolver
+            )
+        }
+        #expect(liveness.checkedProcessIDs() == [record.pid])
+    }
+
     @Test func streamableHTTPSendsSessionHeadersAndDeletesOnClose() async throws {
         let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
         let server = FakeStreamableHTTPServer(progressDelivery: .none)
@@ -953,6 +989,29 @@ struct XcodeMCPTests {
 }
 
 private final class DeinitProbe: @unchecked Sendable {}
+
+private final class DiscoveryLivenessProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let isAlive: Bool
+    private var processIDs: [Int] = []
+
+    init(isAlive: Bool) {
+        self.isAlive = isAlive
+    }
+
+    func isProcessAlive(_ processID: Int) -> Bool {
+        lock.withLock {
+            processIDs.append(processID)
+        }
+        return isAlive
+    }
+
+    func checkedProcessIDs() -> [Int] {
+        lock.withLock {
+            processIDs
+        }
+    }
+}
 
 private actor HangingSendXcodeMCPTransport: XcodeMCPTransport {
     nonisolated let events: AsyncStream<XcodeMCPTransportEvent>


### PR DESCRIPTION
Purpose
- Keep XcodeMCPCore discovery parsing free of process syscalls.
- Preserve stale proxy discovery rejection in XcodeMCPKit and XcodeMCPProxyKit through runtime-owned liveness checks.

Changes
- Remove Darwin process liveness from Discovery.read.
- Add an internal StreamableHTTP discovery resolver that composes ProcessControlClient without exposing it publicly.
- Update ProxyKit DiscoveryClient to use ProcessControlClient for stale PID checks.
- Add Core, SDK, and ProxyKit contract tests for discovery parsing and stale endpoint rejection.

Testing
- swift test --filter XcodeMCPCoreTests -Xswiftc -strict-concurrency=minimal
- swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyIntegrationTests.DiscoveryTests -Xswiftc -strict-concurrency=minimal
- git diff --check
- codex-review against origin/codex/refactor-layered-runtime-integration: clean