### PR TITLE
Bound non-live test waits

### DIFF
--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -692,7 +692,7 @@ struct RuntimeCoordinatorTests {
         #expect(acceptedResult == .accepted)
         #expect(session.serverRequestTracker.lookup(clientID: clientID) == nil)
 
-        let forwarded = try await upstream.nextSent(at: 3)
+        let forwarded = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
         let forwardedObject = try #require(
             JSONSerialization.jsonObject(with: forwarded, options: []) as? [String: Any]
         )
@@ -3627,9 +3627,16 @@ struct RuntimeCoordinatorTests {
                 requestTimeoutOverride: .seconds(2)
             )
         }
-        let firstRequest = try await upstream0.nextSent(startingAt: firstUpstream0StartIndex) {
-            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
-        }
+        let firstRequest = try await sentValue(
+            from: upstream0,
+            startingAt: firstUpstream0StartIndex,
+            matching: {
+                methodName(from: $0) == "tools/call"
+                    && toolCallName(from: $0) == "XcodeListWindows"
+            },
+            timeout: .seconds(2),
+            description: "waiting for first XcodeListWindows fanout request"
+        )
         #expect(await upstream1.sentCount() == firstUpstream1StartIndex)
         await upstream0.yield(
             .message(
@@ -3651,12 +3658,26 @@ struct RuntimeCoordinatorTests {
                 requestTimeoutOverride: .seconds(2)
             )
         }
-        let secondRequest0 = try await upstream0.nextSent(startingAt: secondUpstream0StartIndex) {
-            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
-        }
-        let secondRequest1 = try await upstream1.nextSent(startingAt: secondUpstream1StartIndex) {
-            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
-        }
+        let secondRequest0 = try await sentValue(
+            from: upstream0,
+            startingAt: secondUpstream0StartIndex,
+            matching: {
+                methodName(from: $0) == "tools/call"
+                    && toolCallName(from: $0) == "XcodeListWindows"
+            },
+            timeout: .seconds(2),
+            description: "waiting for second XcodeListWindows fanout request on upstream 0"
+        )
+        let secondRequest1 = try await sentValue(
+            from: upstream1,
+            startingAt: secondUpstream1StartIndex,
+            matching: {
+                methodName(from: $0) == "tools/call"
+                    && toolCallName(from: $0) == "XcodeListWindows"
+            },
+            timeout: .seconds(2),
+            description: "waiting for second XcodeListWindows fanout request on upstream 1"
+        )
         await upstream0.yield(
             .message(
                 try makeXcodeListWindowsResponse(
@@ -7355,15 +7376,13 @@ struct RuntimeCoordinatorTests {
         let serverInfo = try #require(result["serverInfo"] as? [String: Any])
         #expect(serverInfo["name"] as? String == "cached-handshake")
 
-        let secondWarmRetry = try await waitWithTimeout(
-            "primary should start another warm initialize after overload",
-            timeout: .seconds(2)
-        ) {
-            try await upstream0.nextSent(
-                startingAt: 3,
-                matching: { methodName(from: $0) == "initialize" }
-            )
-        }
+        let secondWarmRetry = try await sentValue(
+            from: upstream0,
+            startingAt: 3,
+            matching: { methodName(from: $0) == "initialize" },
+            timeout: .seconds(2),
+            description: "primary should start another warm initialize after overload"
+        )
         #expect(methodName(from: secondWarmRetry) == "initialize")
     }
 

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 
@@ -17,6 +18,17 @@ struct PublicProductContractTests {
             packageURL: fixture.url,
             logURL: fixture.url.appendingPathComponent("swift-build.log")
         )
+
+        if result.timedOut {
+            Issue.record(
+                """
+                swift build timed out after \(Int(result.timeoutSeconds)) seconds:
+                \(result.output)
+                """
+            )
+            #expect(!result.timedOut)
+            return
+        }
 
         if result.exitCode != 0 {
             Issue.record("swift build failed with exit code \(result.exitCode):\n\(result.output)")
@@ -115,10 +127,21 @@ struct PublicProductContractTests {
         """
     }
 
-    private func runSwiftBuild(packageURL: URL, logURL: URL) throws -> CommandResult {
+    private func runSwiftBuild(
+        packageURL: URL,
+        logURL: URL,
+        timeoutSeconds: TimeInterval = 180
+    ) throws -> CommandResult {
         FileManager.default.createFile(atPath: logURL.path, contents: nil)
         let output = try FileHandle(forWritingTo: logURL)
-        defer { try? output.close() }
+        var outputClosed = false
+        func closeOutput() {
+            guard !outputClosed else {
+                return
+            }
+            outputClosed = true
+            try? output.close()
+        }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -139,19 +162,47 @@ struct PublicProductContractTests {
         process.standardOutput = output
         process.standardError = output
 
+        let exitSemaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            exitSemaphore.signal()
+        }
+
         try process.run()
-        process.waitUntilExit()
+        let timedOut = exitSemaphore.wait(timeout: .now() + timeoutSeconds) == .timedOut
+        if timedOut {
+            terminate(process, exitSemaphore: exitSemaphore)
+        }
+        closeOutput()
+        let exitCode: Int32 = process.isRunning ? -1 : process.terminationStatus
 
         return CommandResult(
-            exitCode: process.terminationStatus,
-            output: (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+            exitCode: exitCode,
+            output: (try? String(contentsOf: logURL, encoding: .utf8)) ?? "",
+            timedOut: timedOut,
+            timeoutSeconds: timeoutSeconds
         )
+    }
+
+    private func terminate(_ process: Process, exitSemaphore: DispatchSemaphore) {
+        guard process.isRunning else {
+            return
+        }
+
+        process.terminate()
+        if exitSemaphore.wait(timeout: .now() + 5) == .success {
+            return
+        }
+
+        kill(process.processIdentifier, SIGKILL)
+        _ = exitSemaphore.wait(timeout: .now() + 5)
     }
 }
 
 private struct CommandResult {
     let exitCode: Int32
     let output: String
+    let timedOut: Bool
+    let timeoutSeconds: TimeInterval
 }
 
 private struct TemporaryDirectory {

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -2454,3 +2454,27 @@ func sentMessage(
         try await upstream.nextSent(matching: predicate)
     }
 }
+
+func sentValue(
+    from upstream: TestUpstreamClient,
+    startingAt index: Int,
+    matching predicate: @escaping @Sendable (Data) -> Bool,
+    timeout: Duration = .seconds(5),
+    description: String = "waiting for matching sent message"
+) async throws -> Data {
+    try await waitWithTimeout(description, timeout: timeout) {
+        try await upstream.nextSent(startingAt: index, matching: predicate)
+    }
+}
+
+func sentValue(
+    from upstream: ToggleableOverloadUpstreamClient,
+    startingAt index: Int,
+    matching predicate: @escaping @Sendable (Data) -> Bool,
+    timeout: Duration = .seconds(5),
+    description: String = "waiting for matching sent message"
+) async throws -> Data {
+    try await waitWithTimeout(description, timeout: timeout) {
+        try await upstream.nextSent(startingAt: index, matching: predicate)
+    }
+}


### PR DESCRIPTION
## Purpose
Remove remaining unbounded waits from non-live tests so deterministic test synchronization fails with useful diagnostics instead of hanging indefinitely.

## Changes
- Add bounded timeout handling around the public product contract fixture `swift build`, including combined stdout/stderr in timeout failures.
- Add bounded matching sent-message helpers for runtime coordinator test support.
- Replace direct unbounded `nextSent` waits in runtime coordinator tests with timeout-guarded helpers.

## Testing
- `swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter 'ProxyRuntimeCoordinatorTests.RuntimeCoordinatorTests/sessionManagerSkipsUninitializedProcessRoutesDuringWindowFanout' -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `git diff --check HEAD~1 HEAD`
- `codex-review --uncommitted`
- `codex-review --base origin/codex/refactor-layered-runtime-integration`