### PR TITLE
Return route catalog on first Xcode process success

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/ControlPlaneCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/ControlPlaneCoordinator.swift
@@ -512,7 +512,9 @@ actor ControlPlaneCoordinator {
     ) {
         guard let load = takeToolsCatalogLoadIfMatching(loadID: loadID) else { return }
         let completedUnderCurrentGeneration = brokerState.generation() == load.startGeneration
-        if case .success(let loaded) = result, let sourceUpstream = loaded.sourceUpstream {
+        if case .success(let loaded) = result,
+           loaded.cacheableAsCanonical,
+           let sourceUpstream = loaded.sourceUpstream {
             brokerState.syncCanonicalToolsCatalog(
                 loaded.rawResult,
                 sourceUpstream: sourceUpstream,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/ControlPlaneSupport.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/ControlPlaneSupport.swift
@@ -25,11 +25,18 @@ struct CanonicalToolsCatalogLoadResult: Sendable {
     let rawResult: JSONValue
     let sourceUpstream: Int?
     let durationMilliseconds: Int
+    let cacheableAsCanonical: Bool
 
-    init(rawResult: JSONValue, sourceUpstream: Int?, durationMilliseconds: Int) {
+    init(
+        rawResult: JSONValue,
+        sourceUpstream: Int?,
+        durationMilliseconds: Int,
+        cacheableAsCanonical: Bool = true
+    ) {
         self.rawResult = rawResult
         self.sourceUpstream = sourceUpstream
         self.durationMilliseconds = durationMilliseconds
+        self.cacheableAsCanonical = cacheableAsCanonical
     }
 }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -179,7 +179,8 @@ extension RuntimeCoordinator {
         requestTimeout: TimeAmount?,
         deadlineUptimeNs: UInt64?,
         startedAt: UInt64,
-        exposedProcessIDs: Set<pid_t>
+        exposedProcessIDs: Set<pid_t>,
+        returnAfterFirstSuccess: Bool = true
     ) async throws -> CanonicalToolsCatalogLoadResult {
         try await withThrowingTaskGroup(
             of: AvailableToolsCatalogOutcome.self,
@@ -218,18 +219,31 @@ extension RuntimeCoordinator {
             }
 
             var failures: [(target: XcodeProcessTarget, upstreamIndex: Int, error: any Error)] = []
+            var firstSuccess: CanonicalToolsCatalogLoadResult?
             while let outcome = try await group.next() {
                 switch outcome {
                 case .success(_, let result):
-                    group.cancelAll()
-                    return availableToolsCatalogSurfaceResult(
-                        startedAt: startedAt,
-                        exposedProcessIDs: exposedProcessIDs,
-                        fallback: result
-                    )
+                    if returnAfterFirstSuccess {
+                        group.cancelAll()
+                        return availableToolsCatalogSurfaceResult(
+                            startedAt: startedAt,
+                            exposedProcessIDs: exposedProcessIDs,
+                            fallback: result
+                        )
+                    }
+                    if firstSuccess == nil {
+                        firstSuccess = result
+                    }
                 case .failure(let route, let upstreamIndex, let error):
                     failures.append((target: route.target, upstreamIndex: upstreamIndex, error: error))
                 }
+            }
+            if let firstSuccess {
+                return availableToolsCatalogSurfaceResult(
+                    startedAt: startedAt,
+                    exposedProcessIDs: exposedProcessIDs,
+                    fallback: firstSuccess
+                )
             }
             if let lastFailure = failures.last {
                 throw ControlPlane.RequestError(
@@ -315,7 +329,8 @@ extension RuntimeCoordinator {
                     requestTimeout: requestTimeout,
                     deadlineUptimeNs: self.deadlineUptimeNanoseconds(for: requestTimeout),
                     startedAt: startedAt,
-                    exposedProcessIDs: exposedProcessIDs
+                    exposedProcessIDs: exposedProcessIDs,
+                    returnAfterFirstSuccess: false
                 )
                 guard result.cacheableAsCanonical,
                       let sourceUpstream = result.sourceUpstream,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -135,6 +135,20 @@ extension RuntimeCoordinator {
         guard uncachedRoutes.isEmpty == false else {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
+        if let surface = currentSurface,
+           let sourceUpstream = surface.sourceUpstream {
+            scheduleAvailableToolsCatalogCompletion(
+                uncachedRoutes,
+                requestTimeout: requestTimeout,
+                exposedProcessIDs: exposedProcessIDs
+            )
+            return CanonicalToolsCatalogLoadResult(
+                rawResult: surface.rawResult,
+                sourceUpstream: sourceUpstream,
+                durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt),
+                cacheableAsCanonical: false
+            )
+        }
 
         do {
             return try await loadAvailableToolsCatalogsInBatch(
@@ -154,7 +168,8 @@ extension RuntimeCoordinator {
             return CanonicalToolsCatalogLoadResult(
                 rawResult: surface.rawResult,
                 sourceUpstream: sourceUpstream,
-                durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt)
+                durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt),
+                cacheableAsCanonical: surface.processIDs == exposedProcessIDs
             )
         }
     }
@@ -240,7 +255,8 @@ extension RuntimeCoordinator {
         return CanonicalToolsCatalogLoadResult(
             rawResult: surface.rawResult,
             sourceUpstream: surface.sourceUpstream ?? fallback.sourceUpstream,
-            durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt)
+            durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt),
+            cacheableAsCanonical: surface.processIDs == exposedProcessIDs
         )
     }
 
@@ -267,8 +283,69 @@ extension RuntimeCoordinator {
         return CanonicalToolsCatalogLoadResult(
             rawResult: surface?.rawResult ?? result.rawResult,
             sourceUpstream: surface?.sourceUpstream ?? sourceUpstream,
-            durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt)
+            durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt),
+            cacheableAsCanonical: surface?.processIDs == exposedProcessIDs
         )
+    }
+
+    private func scheduleAvailableToolsCatalogCompletion(
+        _ routes: [AvailableToolsCatalogRoute],
+        requestTimeout: TimeAmount?,
+        exposedProcessIDs: Set<pid_t>
+    ) {
+        let key = availableToolsCatalogRefreshKey(for: routes)
+        let shouldStart = availableToolsCatalogRefreshKeys.withLockedValue { keys in
+            keys.insert(key).inserted
+        }
+        guard shouldStart else {
+            return
+        }
+        let accepted = addRuntimeTask { [weak self] in
+            guard let self else { return }
+            defer {
+                _ = self.availableToolsCatalogRefreshKeys.withLockedValue { keys in
+                    keys.remove(key)
+                }
+            }
+            let startedAt = self.nowUptimeNanoseconds()
+            let generation = self.canonicalBrokerState.generation()
+            do {
+                let result = try await self.loadAvailableToolsCatalogsInBatch(
+                    routes,
+                    requestTimeout: requestTimeout,
+                    deadlineUptimeNs: self.deadlineUptimeNanoseconds(for: requestTimeout),
+                    startedAt: startedAt,
+                    exposedProcessIDs: exposedProcessIDs
+                )
+                guard result.cacheableAsCanonical,
+                      let sourceUpstream = result.sourceUpstream,
+                      self.canonicalBrokerState.generation() == generation else {
+                    return
+                }
+                self.canonicalBrokerState.syncCanonicalToolsCatalog(
+                    result.rawResult,
+                    sourceUpstream: sourceUpstream,
+                    onlyIfGeneration: generation
+                )
+                await self.controlPlaneCoordinator.syncDebug()
+            } catch is CancellationError {
+            } catch {
+            }
+        }
+        if accepted == false {
+            _ = availableToolsCatalogRefreshKeys.withLockedValue { keys in
+                keys.remove(key)
+            }
+        }
+    }
+
+    private func availableToolsCatalogRefreshKey(
+        for routes: [AvailableToolsCatalogRoute]
+    ) -> String {
+        routes
+            .map { "\($0.target.processID)" }
+            .sorted()
+            .joined(separator: ",")
     }
 
     private func loadToolsCatalogFromAvailableProcessRoute(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -203,23 +203,18 @@ extension RuntimeCoordinator {
             }
 
             var failures: [(target: XcodeProcessTarget, upstreamIndex: Int, error: any Error)] = []
-            var firstSuccess: CanonicalToolsCatalogLoadResult?
             while let outcome = try await group.next() {
                 switch outcome {
                 case .success(_, let result):
-                    if firstSuccess == nil {
-                        firstSuccess = result
-                    }
+                    group.cancelAll()
+                    return availableToolsCatalogSurfaceResult(
+                        startedAt: startedAt,
+                        exposedProcessIDs: exposedProcessIDs,
+                        fallback: result
+                    )
                 case .failure(let route, let upstreamIndex, let error):
                     failures.append((target: route.target, upstreamIndex: upstreamIndex, error: error))
                 }
-            }
-            if let firstSuccess {
-                return availableToolsCatalogSurfaceResult(
-                    startedAt: startedAt,
-                    exposedProcessIDs: exposedProcessIDs,
-                    fallback: firstSuccess
-                )
             }
             if let lastFailure = failures.last {
                 throw ControlPlane.RequestError(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -384,6 +384,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let xcodeProcessRoutes: [XcodeProcessRoute]
     let tabOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
     let workspaceOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
+    let availableToolsCatalogRefreshKeys = NIOLockedValueBox<Set<String>>([])
     let unavailableXcodeProcessRoutes =
         NIOLockedValueBox<[pid_t: UInt64]>([:])
     let prewarmDocumentationProviderOnStartup: Bool

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2085,13 +2085,9 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        let latestRequest = try await latestUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let latestRequest = try await sentValue(from: latestUpstream, at: 0, timeout: .seconds(2))
         #expect(methodName(from: latestRequest) == "tools/list")
-        let olderRequest = try await olderUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let olderRequest = try await sentValue(from: olderUpstream, at: 0, timeout: .seconds(2))
         #expect(methodName(from: olderRequest) == "tools/list")
         await latestUpstream.yield(
             .message(
@@ -2160,9 +2156,8 @@ struct RuntimeCoordinatorTests {
                 requestTimeoutOverride: .seconds(5)
             )
         }
-        let fallbackRequest = try await fallbackUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let fallbackRequest = try await sentValue(from: fallbackUpstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: fallbackRequest) == "tools/list")
         #expect(await ownerUpstream.sentCount() == 0)
         await fallbackUpstream.yield(
             .message(
@@ -2199,9 +2194,8 @@ struct RuntimeCoordinatorTests {
                 requestTimeoutOverride: .seconds(5)
             )
         }
-        let ownerRequest = try await ownerUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let ownerRequest = try await sentValue(from: ownerUpstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: ownerRequest) == "tools/list")
         await ownerUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -2260,13 +2254,10 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        let olderRequest = try await olderUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let olderRequest = try await sentValue(from: olderUpstream, at: 0, timeout: .seconds(2))
         #expect(methodName(from: olderRequest) == "tools/list")
-        let newerRequest = try await newerUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let newerRequest = try await sentValue(from: newerUpstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: newerRequest) == "tools/list")
         await newerUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -2306,9 +2297,8 @@ struct RuntimeCoordinatorTests {
         }
         #expect(toolNames(in: secondResult) == ["NewerRouteOnly"])
 
-        let olderRefreshRequest = try await olderUpstream.nextSent(startingAt: 1) {
-            methodName(from: $0) == "tools/list"
-        }
+        let olderRefreshRequest = try await sentValue(from: olderUpstream, at: 1, timeout: .seconds(2))
+        #expect(methodName(from: olderRefreshRequest) == "tools/list")
         await olderUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -2378,12 +2368,10 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        let middleRequest = try await middleUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
-        let latestRequest = try await latestUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let middleRequest = try await sentValue(from: middleUpstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: middleRequest) == "tools/list")
+        let latestRequest = try await sentValue(from: latestUpstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: latestRequest) == "tools/list")
         await latestUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -2470,9 +2458,8 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        let latestRequest = try await latestUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let latestRequest = try await sentValue(from: latestUpstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: latestRequest) == "tools/list")
         await latestUpstream.yield(
             .message(
                 try JSONSerialization.data(
@@ -2541,9 +2528,8 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        _ = try await latestUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let latestRequest = try await sentValue(from: latestUpstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: latestRequest) == "tools/list")
 
         let result = try await waitWithTimeout("waiting for cached process catalog fallback") {
             try await task.value
@@ -2590,9 +2576,8 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        let goodRequest = try await goodUpstream.nextSent {
-            methodName(from: $0) == "tools/list"
-        }
+        let goodRequest = try await sentValue(from: goodUpstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: goodRequest) == "tools/list")
         await goodUpstream.yield(
             .message(
                 try JSONSerialization.data(

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2110,11 +2110,12 @@ struct RuntimeCoordinatorTests {
         }
         #expect(toolNames(in: result) == ["Only27", "SharedTool"])
         #expect(toolDescription(in: result, name: "SharedTool") == "from-27")
-        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
-        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == [
+        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == nil)
+        #expect(manager.cachedToolsListResult() == nil)
+        #expect(Set(toolNames(in: manager.cachedToolsListResult(forUpstreamIndex: 1) ?? .null)) == Set([
             "Only27",
             "SharedTool",
-        ])
+        ]))
         #expect(await olderUpstream.sentCount() == 1)
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
 
@@ -2124,7 +2125,7 @@ struct RuntimeCoordinatorTests {
         #expect(latestCatalog.toolCount == 2)
         #expect(latestCatalog.tabOwnerCount == 1)
         #expect(latestCatalog.workspaceOwnerCount == 1)
-        #expect(latestCatalog.isCanonicalSource)
+        #expect(latestCatalog.isCanonicalSource == false)
         #expect(latestCatalog.exposurePolicy == "available_route_catalog_surface")
         #expect(latestCatalog.extraBeyondExposedCatalog == [])
         #expect(latestCatalog.schemaConflicts == [])
@@ -2214,11 +2215,16 @@ struct RuntimeCoordinatorTests {
         let ownerResult = try await waitWithTimeout("waiting for owner tools/list") {
             try await ownerTask.value
         }
-        #expect(toolNames(in: ownerResult) == ["FallbackOnly", "OwnerOnly"])
-        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == [
+        #expect(toolNames(in: ownerResult) == ["FallbackOnly"])
+        _ = try await waitWithTimeout("waiting for owner catalog completion") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 1
+            }
+        }
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set([
             "FallbackOnly",
             "OwnerOnly",
-        ])
+        ]))
         #expect(await fallbackUpstream.sentCount() == 1)
         #expect(await ownerUpstream.sentCount() == 1)
     }
@@ -2279,17 +2285,54 @@ struct RuntimeCoordinatorTests {
             try await task.value
         }
         #expect(toolNames(in: result) == ["NewerRouteOnly"])
-        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["NewerRouteOnly"])
+        #expect(manager.cachedToolsListResult() == nil)
+        #expect(toolNames(in: manager.cachedToolsListResult(forUpstreamIndex: 1) ?? .null) == ["NewerRouteOnly"])
         #expect(await olderUpstream.sentCount() == 1)
         #expect(await newerUpstream.sentCount() == 1)
-        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
+        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == nil)
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
         #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [
             newerTarget.processID,
         ])
+
+        let secondResult = try await waitWithTimeout(
+            "waiting for cached partial tools/list while older route refreshes",
+            timeout: .seconds(1)
+        ) {
+            try await manager.sharedToolsList(
+                sessionID: "session-process-catalog-refresh-missing-route",
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+        #expect(toolNames(in: secondResult) == ["NewerRouteOnly"])
+
+        let olderRefreshRequest = try await olderUpstream.nextSent(startingAt: 1) {
+            methodName(from: $0) == "tools/list"
+        }
+        await olderUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: olderRefreshRequest),
+                    tools: [
+                        toolDescriptor(name: "OlderRouteOnly"),
+                    ]
+                )
+            )
+        )
+        _ = try await waitWithTimeout("waiting for completed process catalog cache") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 1
+            }
+        }
+        let fullResult = try await manager.sharedToolsList(
+            sessionID: "session-process-catalog-after-missing-route-refresh",
+            requestTimeoutOverride: .seconds(5)
+        )
+        #expect(Set(toolNames(in: fullResult)) == Set(["NewerRouteOnly", "OlderRouteOnly"]))
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set(["NewerRouteOnly", "OlderRouteOnly"]))
     }
 
-    @Test func sessionManagerToolsListUnionsCachedProcessCatalogWithFreshRoute()
+    @Test func sessionManagerToolsListCompletesCachedProcessCatalogWithFreshRoute()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -2345,14 +2388,20 @@ struct RuntimeCoordinatorTests {
             )
         )
 
-        let result = try await waitWithTimeout("waiting for deterministic process catalog union") {
+        let result = try await waitWithTimeout("waiting for cached process catalog surface") {
             try await task.value
         }
 
-        #expect(Set(toolNames(in: result)) == Set(["LatestRouteOnly", "OlderRouteOnly"]))
-        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set(["LatestRouteOnly", "OlderRouteOnly"]))
+        #expect(toolNames(in: result) == ["OlderRouteOnly"])
+        #expect(manager.cachedToolsListResult() == nil)
         #expect(await olderUpstream.sentCount() == 0)
         #expect(await latestUpstream.sentCount() == 1)
+        _ = try await waitWithTimeout("waiting for completed process catalog cache") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 1
+            }
+        }
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set(["LatestRouteOnly", "OlderRouteOnly"]))
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
         let catalogs = manager.debugSnapshot().processToolCatalogs
         #expect(catalogs.count == 2)
@@ -2421,16 +2470,17 @@ struct RuntimeCoordinatorTests {
         }
 
         #expect(toolNames(in: result) == ["OlderRouteOnly"])
-        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["OlderRouteOnly"])
+        #expect(manager.cachedToolsListResult() == nil)
+        #expect(toolNames(in: manager.cachedToolsListResult(forUpstreamIndex: 0) ?? .null) == ["OlderRouteOnly"])
         #expect(await olderUpstream.sentCount() == 0)
         #expect(await latestUpstream.sentCount() == 1)
-        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 0)
+        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == nil)
         #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [
             olderTarget.processID,
         ])
     }
 
-    @Test func sessionManagerToolsListDoesNotReturnCachedProcessCatalogWhenFreshRouteIsCancelled()
+    @Test func sessionManagerToolsListReturnsCachedProcessCatalogWhileFreshRouteRefreshIsPending()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -2471,11 +2521,11 @@ struct RuntimeCoordinatorTests {
         _ = try await latestUpstream.nextSent {
             methodName(from: $0) == "tools/list"
         }
-        task.cancel()
 
-        await #expect(throws: CancellationError.self) {
-            _ = try await task.value
+        let result = try await waitWithTimeout("waiting for cached process catalog fallback") {
+            try await task.value
         }
+        #expect(toolNames(in: result) == ["OlderRouteOnly"])
         #expect(await olderUpstream.sentCount() == 0)
         #expect(await latestUpstream.sentCount() == 1)
         #expect(manager.cachedToolsListResult() == nil)

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2332,22 +2332,25 @@ struct RuntimeCoordinatorTests {
         #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set(["NewerRouteOnly", "OlderRouteOnly"]))
     }
 
-    @Test func sessionManagerToolsListCompletesCachedProcessCatalogWithFreshRoute()
+    @Test func sessionManagerToolsListCompletesCachedProcessCatalogWithFreshRoutes()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let olderUpstream = TestUpstreamClient()
+        let middleUpstream = TestUpstreamClient()
         let latestUpstream = TestUpstreamClient()
         let olderTarget = xcodeProcessTarget(processID: 66339, xcodeVersion: "26.6")
+        let middleTarget = xcodeProcessTarget(processID: 70339, xcodeVersion: "26.9")
         let latestTarget = xcodeProcessTarget(processID: 80426, xcodeVersion: "27.0")
         let manager = RuntimeCoordinator(
             config: makeConfig(requestTimeout: 5),
             eventLoop: eventLoop,
-            upstreams: [olderUpstream, latestUpstream],
+            upstreams: [olderUpstream, middleUpstream, latestUpstream],
             xcodeProcessRoutes: [
-                XcodeProcessRoute(target: latestTarget, upstreamIndices: [1]),
+                XcodeProcessRoute(target: latestTarget, upstreamIndices: [2]),
+                XcodeProcessRoute(target: middleTarget, upstreamIndices: [1]),
                 XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
             ],
             startImmediately: false
@@ -2355,6 +2358,7 @@ struct RuntimeCoordinatorTests {
         defer { manager.shutdownAndWait() }
         manager.markUpstreamInitialized(upstreamIndex: 0)
         manager.markUpstreamInitialized(upstreamIndex: 1)
+        manager.markUpstreamInitialized(upstreamIndex: 2)
         let olderCatalog = try jsonValue([
             "tools": [
                 toolDescriptor(name: "OlderRouteOnly"),
@@ -2374,6 +2378,9 @@ struct RuntimeCoordinatorTests {
             )
         }
 
+        let middleRequest = try await middleUpstream.nextSent {
+            methodName(from: $0) == "tools/list"
+        }
         let latestRequest = try await latestUpstream.nextSent {
             methodName(from: $0) == "tools/list"
         }
@@ -2387,6 +2394,16 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
+        await middleUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: middleRequest),
+                    tools: [
+                        toolDescriptor(name: "MiddleRouteOnly"),
+                    ]
+                )
+            )
+        )
 
         let result = try await waitWithTimeout("waiting for cached process catalog surface") {
             try await task.value
@@ -2395,17 +2412,23 @@ struct RuntimeCoordinatorTests {
         #expect(toolNames(in: result) == ["OlderRouteOnly"])
         #expect(manager.cachedToolsListResult() == nil)
         #expect(await olderUpstream.sentCount() == 0)
+        #expect(await middleUpstream.sentCount() == 1)
         #expect(await latestUpstream.sentCount() == 1)
         _ = try await waitWithTimeout("waiting for completed process catalog cache") {
             try await manager.controlPlaneDebugMirror.waitForSnapshot {
-                $0.canonicalToolsSourceUpstream == 1
+                $0.canonicalToolsSourceUpstream == 2
             }
         }
-        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set(["LatestRouteOnly", "OlderRouteOnly"]))
-        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set([
+            "LatestRouteOnly",
+            "MiddleRouteOnly",
+            "OlderRouteOnly",
+        ]))
+        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 2)
         let catalogs = manager.debugSnapshot().processToolCatalogs
-        #expect(catalogs.count == 2)
+        #expect(catalogs.count == 3)
         #expect(try #require(catalogs.first { $0.processID == olderTarget.processID }).toolCount == 1)
+        #expect(try #require(catalogs.first { $0.processID == middleTarget.processID }).toolCount == 1)
         #expect(try #require(catalogs.first { $0.processID == latestTarget.processID }).toolCount == 1)
     }
 

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2092,6 +2092,7 @@ struct RuntimeCoordinatorTests {
         let olderRequest = try await olderUpstream.nextSent {
             methodName(from: $0) == "tools/list"
         }
+        #expect(methodName(from: olderRequest) == "tools/list")
         await latestUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -2103,41 +2104,30 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
-        await olderUpstream.yield(
-            .message(
-                try makeDocumentationToolsListResponse(
-                    id: try extractUpstreamID(from: olderRequest),
-                    tools: [
-                        toolDescriptor(name: "SharedTool", description: "from-26"),
-                        toolDescriptor(name: "Only26", description: "old-only"),
-                    ],
-                )
-            )
-        )
 
         let result = try await waitWithTimeout("waiting for process-routed tools/list") {
             try await task.value
         }
-        #expect(toolNames(in: result) == ["Only26", "Only27", "SharedTool"])
+        #expect(toolNames(in: result) == ["Only27", "SharedTool"])
         #expect(toolDescription(in: result, name: "SharedTool") == "from-27")
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
         #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == [
-            "Only26",
             "Only27",
             "SharedTool",
         ])
         #expect(await olderUpstream.sentCount() == 1)
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
 
         let catalogs = manager.debugSnapshot().processToolCatalogs
-        #expect(catalogs.count == 2)
+        #expect(catalogs.count == 1)
         let latestCatalog = try #require(catalogs.first { $0.processID == latestTarget.processID })
         #expect(latestCatalog.toolCount == 2)
         #expect(latestCatalog.tabOwnerCount == 1)
         #expect(latestCatalog.workspaceOwnerCount == 1)
         #expect(latestCatalog.isCanonicalSource)
         #expect(latestCatalog.exposurePolicy == "available_route_catalog_surface")
-        #expect(latestCatalog.extraBeyondExposedCatalog == ["Only26"])
-        #expect(latestCatalog.schemaConflicts == ["SharedTool"])
+        #expect(latestCatalog.extraBeyondExposedCatalog == [])
+        #expect(latestCatalog.schemaConflicts == [])
     }
 
     @Test func sessionManagerToolsListUnionsFallbackCatalogAfterOwnerIsLearned()
@@ -2233,23 +2223,23 @@ struct RuntimeCoordinatorTests {
         #expect(await ownerUpstream.sentCount() == 1)
     }
 
-    @Test func sessionManagerToolsListWaitsForUsableRoutesBeforeReturningUnion()
+    @Test func sessionManagerToolsListReturnsNewerProcessCatalogBeforeStalledOlderRoute()
         async throws
     {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
-        let earlierUpstream = TestUpstreamClient()
-        let laterUpstream = TestUpstreamClient()
-        let earlierTarget = xcodeProcessTarget(processID: 66338, xcodeVersion: "26.6")
-        let laterTarget = xcodeProcessTarget(processID: 80425, xcodeVersion: "27.0")
+        let olderUpstream = TestUpstreamClient()
+        let newerUpstream = TestUpstreamClient()
+        let olderTarget = xcodeProcessTarget(processID: 66338, xcodeVersion: "26.6")
+        let newerTarget = xcodeProcessTarget(processID: 80425, xcodeVersion: "27.0")
         let manager = RuntimeCoordinator(
             config: makeConfig(requestTimeout: 5),
             eventLoop: eventLoop,
-            upstreams: [earlierUpstream, laterUpstream],
+            upstreams: [olderUpstream, newerUpstream],
             xcodeProcessRoutes: [
-                XcodeProcessRoute(target: earlierTarget, upstreamIndices: [0]),
-                XcodeProcessRoute(target: laterTarget, upstreamIndices: [1]),
+                XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: newerTarget, upstreamIndices: [1]),
             ],
             startImmediately: false
         )
@@ -2264,40 +2254,39 @@ struct RuntimeCoordinatorTests {
             )
         }
 
-        let earlierRequest = try await earlierUpstream.nextSent {
+        let olderRequest = try await olderUpstream.nextSent {
             methodName(from: $0) == "tools/list"
         }
-        let laterRequest = try await laterUpstream.nextSent {
+        #expect(methodName(from: olderRequest) == "tools/list")
+        let newerRequest = try await newerUpstream.nextSent {
             methodName(from: $0) == "tools/list"
         }
-        await laterUpstream.yield(
+        await newerUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
-                    id: try extractUpstreamID(from: laterRequest),
+                    id: try extractUpstreamID(from: newerRequest),
                     tools: [
-                        toolDescriptor(name: "LaterRouteOnly"),
-                    ]
-                )
-            )
-        )
-        await earlierUpstream.yield(
-            .message(
-                try makeDocumentationToolsListResponse(
-                    id: try extractUpstreamID(from: earlierRequest),
-                    tools: [
-                        toolDescriptor(name: "EarlierRouteOnly"),
+                        toolDescriptor(name: "NewerRouteOnly"),
                     ]
                 )
             )
         )
 
-        let result = try await waitWithTimeout("waiting for later route tools/list") {
+        let result = try await waitWithTimeout(
+            "waiting for newer route tools/list before older route completes",
+            timeout: .seconds(1)
+        ) {
             try await task.value
         }
-        #expect(toolNames(in: result) == ["EarlierRouteOnly", "LaterRouteOnly"])
-        #expect(await earlierUpstream.sentCount() == 1)
-        #expect(await laterUpstream.sentCount() == 1)
+        #expect(toolNames(in: result) == ["NewerRouteOnly"])
+        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["NewerRouteOnly"])
+        #expect(await olderUpstream.sentCount() == 1)
+        #expect(await newerUpstream.sentCount() == 1)
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
+        #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [
+            newerTarget.processID,
+        ])
     }
 
     @Test func sessionManagerToolsListUnionsCachedProcessCatalogWithFreshRoute()


### PR DESCRIPTION
Purpose

Fix route/catalog fan-out so tools/list can return a usable partial catalog promptly when one Xcode process route succeeds, without waiting for stalled older/no-workspace routes.

Changes

- Return the available process catalog surface on the first successful route and cancel the foreground batch work.
- Keep partial catalog surfaces out of the canonical tools cache until all eligible process routes are represented.
- Add RuntimeCoordinator-owned background completion for missing process catalogs, with de-duplicated refresh work.
- Update regression coverage for stalled older routes, cached partial surfaces, failed refreshes, and multi-route background completion.

Testing

- swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyDocumentationProviderTests -Xswiftc -strict-concurrency=minimal
- git diff --check
- codex-review against origin/codex/refactor-layered-runtime-integration