### PR TITLE
test: make deterministic waits fail fast

### DIFF
--- a/Tests/ProxyCLITests/StdioAdapterFacadeIntegrationTests.swift
+++ b/Tests/ProxyCLITests/StdioAdapterFacadeIntegrationTests.swift
@@ -140,7 +140,7 @@ struct StdioAdapterFacadeIntegrationTests {
                 _ = try await waitWithTimeout("waiting for hanging DELETE") {
                     try await server.recorder.nextRequest { $0.httpMethod == "DELETE" }
                 }
-                await shutdownClocks.timeoutClock.sleep(untilSuspendedBy: 1)
+                try await shutdownClocks.timeoutClock.sleep(untilSuspendedBy: 1)
                 advanceStdioAdapterShutdownClocks(shutdownClocks, by: .milliseconds(250))
             }
         )
@@ -240,7 +240,7 @@ struct StdioAdapterFacadeIntegrationTests {
                 _ = try await waitWithTimeout("waiting for long-running tools/call") {
                     try await server.recorder.nextRequest { $0.bodyMethod == "tools/call" }
                 }
-                await shutdownClocks.timeoutClock.sleep(untilSuspendedBy: 1)
+                try await shutdownClocks.timeoutClock.sleep(untilSuspendedBy: 1)
                 advanceStdioAdapterShutdownClocks(shutdownClocks, by: .seconds(1))
                 _ = try await waitWithTimeout("waiting for DELETE after drain timeout") {
                     try await server.recorder.nextRequest { $0.httpMethod == "DELETE" }

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -1004,7 +1004,7 @@ struct DocumentationProviderTests {
         try await waitWithTimeout("waiting for queued documentation provider route") {
             try await queuedRequestLabels.nextValue(at: 0)
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: .milliseconds(10)
@@ -1967,7 +1967,7 @@ struct DocumentationProviderTests {
         await documentationProvider.setToolListUpdate(
             .available(documentationDescriptor(version: "27.0"))
         )
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: RuntimeCoordinator.documentationProviderDiscoveryPollInterval
@@ -2091,7 +2091,7 @@ struct DocumentationProviderTests {
         try await waitWithTimeout("waiting for first transient descriptor refresh") {
             try await transport.waitForToolsListCount(1)
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: .milliseconds(250)
@@ -2305,7 +2305,7 @@ struct DocumentationProviderTests {
         try await waitWithTimeout("waiting for documentation repair to suspend") {
             try await repairGate.waitUntilWaiting(for: target.processID, count: 1)
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: .milliseconds(20)
@@ -3291,7 +3291,7 @@ struct DocumentationProviderTests {
         try await waitWithTimeout("waiting for local DocumentationSearch process to suspend") {
             try await runGate.waitUntilWaiting(for: 1, count: 1)
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: .milliseconds(20)
@@ -3389,7 +3389,7 @@ struct DocumentationProviderTests {
                 requestTimeoutOverride: .seconds(1)
             )
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
             by: .seconds(1),
@@ -4010,7 +4010,7 @@ struct DocumentationProviderTests {
                 method: "tools/call"
             )
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: .milliseconds(100)
@@ -4408,7 +4408,7 @@ struct DocumentationProviderTests {
         try await waitWithTimeout("waiting for shared preparation to suspend") {
             try await startGate.waitUntilWaiting(for: target.processID, count: 1)
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: .milliseconds(1)
@@ -4497,7 +4497,7 @@ struct DocumentationProviderTests {
             try await waitWithTimeout("waiting for shared preparation to suspend") {
                 try await startGate.waitUntilWaiting(for: target.processID, count: 1)
             }
-            await advanceRuntimeCoordinatorTimeout(
+            try await advanceRuntimeCoordinatorTimeout(
                 timeoutClock: timeoutClock,
                 uptimeClock: uptimeClock,
                 by: .milliseconds(1)
@@ -4589,7 +4589,7 @@ struct DocumentationProviderTests {
                 method: "tools/call"
             )
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: .milliseconds(1)

--- a/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
@@ -836,10 +836,10 @@ extension HTTPHandlerTests {
             )
             #expect(abandonedLease.releaseReason == "clientDisconnected")
             #expect(sessionManager.sentToolNames().isEmpty)
-            try await group.shutdownGracefully()
+            try await shutdown(group)
         } catch {
             await documentationRelease.signal()
-            try? await group.shutdownGracefully()
+            try? await shutdown(group)
             throw error
         }
     }
@@ -928,10 +928,10 @@ extension HTTPHandlerTests {
             )
             #expect(abandonedLease.releaseReason == "clientDisconnected")
             #expect(sessionManager.sentToolNames() == ["OtherAllowedTool"])
-            try await group.shutdownGracefully()
+            try await shutdown(group)
         } catch {
             await documentationRelease.signal()
-            try? await group.shutdownGracefully()
+            try? await shutdown(group)
             throw error
         }
     }

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -1122,11 +1122,11 @@ struct HTTPHandlerTests {
             let lease = try #require(sessionManager.leaseDebugSnapshots().first)
             #expect(lease.state == .timedOut)
         } catch {
-            await shutdown(group)
+            try? await shutdown(group)
             throw error
         }
 
-        await shutdown(group)
+        try await shutdown(group)
     }
 
     @Test func httpPostRequiresBothJSONAndEventStreamAcceptTypes() async throws {
@@ -1556,10 +1556,10 @@ struct HTTPHandlerTests {
             )
             #expect(sessionManager.sentMethods().isEmpty)
         } catch {
-            try? await group.shutdownGracefully()
+            try? await shutdown(group)
             throw error
         }
-        try await group.shutdownGracefully()
+        try await shutdown(group)
     }
 
     @Test func httpToolRoutingLocalXcodeListWindowsReturnsAggregatedResult() async throws {
@@ -1632,10 +1632,10 @@ struct HTTPHandlerTests {
             #expect(sessionManager.sentToolRequests() == ["XcodeListWindows@1"])
             #expect(sessionManager.assignedUpstreamIDCount() == 0)
         } catch {
-            try? await group.shutdownGracefully()
+            try? await shutdown(group)
             throw error
         }
-        try await group.shutdownGracefully()
+        try await shutdown(group)
     }
 
     @Test func httpOverloadedErrorResponseDoesNotMarkRequestSuccess() async throws {

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -2240,7 +2240,7 @@ extension HTTPHandlerTests {
             )
         }
 
-        await clock.sleep(untilSuspendedBy: 1)
+        try await clock.sleep(untilSuspendedBy: 1)
         clock.advance(by: .milliseconds(50))
 
         let result = await requestTask.value

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -277,7 +277,7 @@ struct XcodeMCPProxyServerTests {
 
         try? await server.shutdown()
         try? await blocker.close().get()
-        await shutdown(blockerGroup)
+        try await shutdown(blockerGroup)
     }
 
     @Test func startRejectsRepeatedStartsOnSameServerInstance() async throws {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -868,7 +868,7 @@ struct RuntimeCoordinatorTests {
         let initialUpstreamID = try extractUpstreamID(from: initialInitialize)
 
         await upstream.overloadNextInitializedNotificationSend()
-        await timeoutClock.sleep(untilSuspendedBy: 1)
+        try await timeoutClock.sleep(untilSuspendedBy: 1)
         timeoutClock.advance(by: .milliseconds(150))
         await upstream.yield(.message(try makeInitializeResponse(id: initialUpstreamID)))
 
@@ -877,7 +877,7 @@ struct RuntimeCoordinatorTests {
         let retriedInitialize = try #require(await upstream.sentValue(at: 2))
         let retriedUpstreamID = try extractUpstreamID(from: retriedInitialize)
 
-        await timeoutClock.sleep(untilSuspendedBy: 1)
+        try await timeoutClock.sleep(untilSuspendedBy: 1)
         timeoutClock.advance(by: .milliseconds(180))
         await upstream.yield(.message(try makeInitializeResponse(id: retriedUpstreamID)))
         try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
@@ -1328,7 +1328,7 @@ struct RuntimeCoordinatorTests {
         )
         #expect((await upstream.sent()).count == 1)
 
-        await timeoutClock.sleep(untilSuspendedBy: 1)
+        try await timeoutClock.sleep(untilSuspendedBy: 1)
         timeoutClock.advance(by: .seconds(1))
         await #expect(throws: TimeoutError.self) {
             try await future.get()
@@ -1402,7 +1402,7 @@ struct RuntimeCoordinatorTests {
             "waiting for initialize timeout sleeper",
             timeout: .seconds(2)
         ) {
-            await timeoutClock.sleep(untilSuspendedBy: 1)
+            try await timeoutClock.sleep(untilSuspendedBy: 1)
         }
 
         manager.removeSession(id: sessionID)
@@ -1513,7 +1513,7 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
         let firstRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: firstRequest) == "tools/list")
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
             by: .seconds(5)
@@ -1533,7 +1533,7 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
         let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/list")
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
             by: .seconds(5)
@@ -1894,7 +1894,7 @@ struct RuntimeCoordinatorTests {
                 $0.waiterCounts.toolsCatalog == 1
             }
         }
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
             by: .seconds(5),
@@ -1914,7 +1914,7 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
         let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/list")
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
             by: .seconds(5)
@@ -2013,7 +2013,7 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
         let firstRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: firstRequest) == "tools/call")
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
             by: .seconds(5)
@@ -2033,7 +2033,7 @@ struct RuntimeCoordinatorTests {
         try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
         let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/call")
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
             by: .seconds(5)
@@ -2694,7 +2694,7 @@ struct RuntimeCoordinatorTests {
         }
 
         _ = try await sentValue(from: firstUpstream, at: 0, timeout: .seconds(2))
-        await advanceRuntimeCoordinatorTimeout(
+        try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
             by: .milliseconds(100)
@@ -5595,7 +5595,7 @@ struct RuntimeCoordinatorTests {
             count: 1,
             description: "waiting for eager initialize request"
         )
-        await timeoutClock.sleep(untilSuspendedBy: 1)
+        try await timeoutClock.sleep(untilSuspendedBy: 1)
         timeoutClock.advance(by: .milliseconds(100))
         try await initializeCleanupCompleted.wait(
             description: "waiting for eager initialize timeout cleanup"

--- a/Tests/ProxyRuntimeCoordinatorTests/UpstreamReadinessTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/UpstreamReadinessTests.swift
@@ -406,7 +406,7 @@ extension RuntimeCoordinatorTests {
             requestObject: makeInitializeRequest(id: 1),
             on: eventLoop
         )
-        await clock.sleep(untilSuspendedBy: 1)
+        try await clock.sleep(untilSuspendedBy: 1)
         clock.advance(by: .milliseconds(60))
         await #expect(throws: TimeoutError.self) {
             _ = try await future.get()
@@ -418,7 +418,7 @@ extension RuntimeCoordinatorTests {
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
-        await clock.sleep(untilSuspendedBy: 1)
+        try await clock.sleep(untilSuspendedBy: 1)
         clock.advance(by: .milliseconds(60))
         await #expect(throws: TimeoutError.self) {
             _ = try await retryFuture.get()

--- a/Tests/ProxyStdioAdapterTests/StdioAdapterIntegrationTests.swift
+++ b/Tests/ProxyStdioAdapterTests/StdioAdapterIntegrationTests.swift
@@ -163,7 +163,7 @@ private func waitUntilDrainSleepSuspended(
     _ clocks: ControlledStdioAdapterShutdownClocks
 ) async throws {
     try await waitWithTimeout("waiting for adapter drain timeout sleep") {
-        await clocks.timeoutClock.sleep(untilSuspendedBy: 1)
+        try await clocks.timeoutClock.sleep(untilSuspendedBy: 1)
     }
 }
 

--- a/Tests/ProxyToolSurfaceTests/RefreshCodeIssuesCoordinatorTests.swift
+++ b/Tests/ProxyToolSurfaceTests/RefreshCodeIssuesCoordinatorTests.swift
@@ -167,7 +167,7 @@ struct RefreshCodeIssuesCoordinatorTests {
         }
 
         _ = try await nextQueuedKey(queuedKeys, at: 0, "waiting for timed waiter to queue")
-        await clock.sleep(untilSuspendedBy: 1)
+        try await clock.sleep(untilSuspendedBy: 1)
         clock.advance(by: .milliseconds(50))
         _ = try await nextRecorded(outcomes, at: 0, "waiting for timed-out waiter to finish")
         #expect(await outcomes.snapshot() == ["timed-out"])

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -449,11 +449,18 @@ private final class SpawnedProcessGroup: @unchecked Sendable {
 
     private func reap() {
         var status: Int32 = 0
-        let waitedPID = unsafe waitpid(pid, &status, 0)
-        if waitedPID == pid {
-            lock.lock()
-            waitStatus = status
-            lock.unlock()
+        while true {
+            let waitedPID = unsafe waitpid(pid, &status, 0)
+            if waitedPID == pid {
+                lock.lock()
+                waitStatus = status
+                lock.unlock()
+                break
+            }
+            if waitedPID == -1, errno == EINTR {
+                continue
+            }
+            break
         }
         exitSemaphore.signal()
     }

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -370,6 +370,15 @@ private final class SpawnedProcessGroup: @unchecked Sendable {
         arguments: [String],
         outputFD: CInt
     ) throws -> SpawnedProcessGroup {
+        let pid = try unsafe spawnPOSIX(executable: executable, arguments: arguments, outputFD: outputFD)
+        return SpawnedProcessGroup(pid: pid)
+    }
+
+    @unsafe private static func spawnPOSIX(
+        executable: String,
+        arguments: [String],
+        outputFD: CInt
+    ) throws -> pid_t {
         var fileActions: posix_spawn_file_actions_t?
         var attr: posix_spawnattr_t?
 
@@ -404,27 +413,37 @@ private final class SpawnedProcessGroup: @unchecked Sendable {
             operation: "posix_spawnattr_setflags"
         )
 
-        var cArguments: [UnsafeMutablePointer<CChar>] = []
+        var cArguments = unsafe [UnsafeMutablePointer<CChar>]()
+        func freeCArguments() {
+            var index = 0
+            while index < (unsafe cArguments.count) {
+                unsafe free(cArguments[index])
+                index += 1
+            }
+        }
+
         for argument in arguments {
             guard let cArgument = unsafe strdup(argument) else {
-                for cArgument in unsafe cArguments {
-                    free(cArgument)
-                }
+                freeCArguments()
                 throw POSIXCommandError(operation: "strdup argument", code: ENOMEM)
             }
-            cArguments.append(cArgument)
+            unsafe cArguments.append(cArgument)
         }
         defer {
-            for cArgument in unsafe cArguments {
-                free(cArgument)
-            }
+            freeCArguments()
         }
-        var argv = unsafe cArguments.map { Optional($0) }
-        argv.append(nil)
+
+        var argv = unsafe [UnsafeMutablePointer<CChar>?]()
+        var argumentIndex = 0
+        while argumentIndex < (unsafe cArguments.count) {
+            unsafe argv.append(cArguments[argumentIndex])
+            argumentIndex += 1
+        }
+        unsafe argv.append(nil)
 
         var pid: pid_t = 0
-        let spawnResult = executable.withCString { executablePath in
-            argv.withUnsafeMutableBufferPointer { argvBuffer in
+        let spawnResult = unsafe executable.withCString { executablePath in
+            unsafe argv.withUnsafeMutableBufferPointer { argvBuffer in
                 unsafe posix_spawnp(
                     &pid,
                     executablePath,
@@ -436,7 +455,7 @@ private final class SpawnedProcessGroup: @unchecked Sendable {
             }
         }
         try checkPOSIX(spawnResult, operation: "posix_spawnp \(executable)")
-        return SpawnedProcessGroup(pid: pid)
+        return pid
     }
 
     func wait(timeoutSeconds: TimeInterval) -> (exitCode: Int32, timedOut: Bool) {

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -230,52 +230,37 @@ struct PublicProductContractTests {
         ],
         timeoutSeconds: TimeInterval = 180
     ) throws -> CommandResult {
-        FileManager.default.createFile(atPath: logURL.path, contents: nil)
-        let output = try FileHandle(forWritingTo: logURL)
-        var outputClosed = false
-        func closeOutput() {
-            guard !outputClosed else {
-                return
-            }
-            outputClosed = true
-            try? output.close()
+        let outputFD = unsafe open(logURL.path, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR)
+        guard outputFD >= 0 else {
+            throw POSIXCommandError(operation: "open \(logURL.path)", code: errno)
+        }
+        defer {
+            close(outputFD)
         }
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [
-            "swift",
-            "build",
-            "--package-path",
-            packageURL.path,
-        ] + targets.flatMap { ["--target", $0] } + [
-            "-Xswiftc",
-            "-strict-concurrency=minimal",
-        ]
-        process.standardOutput = output
-        process.standardError = output
-
-        let exitSemaphore = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in
-            exitSemaphore.signal()
-        }
-
-        try process.run()
-        let timedOut = exitSemaphore.wait(timeout: .now() + timeoutSeconds) == .timedOut
-        if timedOut {
-            terminate(process, exitSemaphore: exitSemaphore)
-        }
-        closeOutput()
-        let exitCode: Int32 = process.isRunning ? -1 : process.terminationStatus
+        let process = try SpawnedProcessGroup.spawn(
+            executable: "/usr/bin/env",
+            arguments: [
+                "env",
+                "swift",
+                "build",
+                "--package-path",
+                packageURL.path,
+            ] + targets.flatMap { ["--target", $0] } + [
+                "-Xswiftc",
+                "-strict-concurrency=minimal",
+            ],
+            outputFD: outputFD
+        )
+        let waitResult = process.wait(timeoutSeconds: timeoutSeconds)
 
         return CommandResult(
-            exitCode: exitCode,
+            exitCode: waitResult.exitCode,
             output: (try? String(contentsOf: logURL, encoding: .utf8)) ?? "",
-            timedOut: timedOut,
+            timedOut: waitResult.timedOut,
             timeoutSeconds: timeoutSeconds
         )
     }
-
     private func expectBuildSucceeded(_ result: CommandResult, context: String) {
         if result.timedOut {
             Issue.record(
@@ -365,18 +350,167 @@ struct PublicProductContractTests {
         #expect(reportedExpectedFailure)
     }
 
-    private func terminate(_ process: Process, exitSemaphore: DispatchSemaphore) {
-        guard process.isRunning else {
+}
+
+private final class SpawnedProcessGroup: @unchecked Sendable {
+    private let pid: pid_t
+    private let exitSemaphore = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var waitStatus: Int32?
+
+    private init(pid: pid_t) {
+        self.pid = pid
+        DispatchQueue.global(qos: .utility).async {
+            self.reap()
+        }
+    }
+
+    static func spawn(
+        executable: String,
+        arguments: [String],
+        outputFD: CInt
+    ) throws -> SpawnedProcessGroup {
+        var fileActions: posix_spawn_file_actions_t?
+        var attr: posix_spawnattr_t?
+
+        try checkPOSIX(
+            unsafe posix_spawn_file_actions_init(&fileActions),
+            operation: "posix_spawn_file_actions_init"
+        )
+        defer {
+            unsafe posix_spawn_file_actions_destroy(&fileActions)
+        }
+
+        try checkPOSIX(
+            unsafe posix_spawn_file_actions_adddup2(&fileActions, outputFD, STDOUT_FILENO),
+            operation: "posix_spawn_file_actions_adddup2 stdout"
+        )
+        try checkPOSIX(
+            unsafe posix_spawn_file_actions_adddup2(&fileActions, outputFD, STDERR_FILENO),
+            operation: "posix_spawn_file_actions_adddup2 stderr"
+        )
+
+        try checkPOSIX(unsafe posix_spawnattr_init(&attr), operation: "posix_spawnattr_init")
+        defer {
+            unsafe posix_spawnattr_destroy(&attr)
+        }
+
+        try checkPOSIX(
+            unsafe posix_spawnattr_setpgroup(&attr, 0),
+            operation: "posix_spawnattr_setpgroup"
+        )
+        try checkPOSIX(
+            unsafe posix_spawnattr_setflags(&attr, Int16(POSIX_SPAWN_SETPGROUP)),
+            operation: "posix_spawnattr_setflags"
+        )
+
+        var cArguments: [UnsafeMutablePointer<CChar>] = []
+        for argument in arguments {
+            guard let cArgument = unsafe strdup(argument) else {
+                for cArgument in unsafe cArguments {
+                    free(cArgument)
+                }
+                throw POSIXCommandError(operation: "strdup argument", code: ENOMEM)
+            }
+            cArguments.append(cArgument)
+        }
+        defer {
+            for cArgument in unsafe cArguments {
+                free(cArgument)
+            }
+        }
+        var argv = unsafe cArguments.map { Optional($0) }
+        argv.append(nil)
+
+        var pid: pid_t = 0
+        let spawnResult = executable.withCString { executablePath in
+            argv.withUnsafeMutableBufferPointer { argvBuffer in
+                unsafe posix_spawnp(
+                    &pid,
+                    executablePath,
+                    &fileActions,
+                    &attr,
+                    argvBuffer.baseAddress,
+                    environ
+                )
+            }
+        }
+        try checkPOSIX(spawnResult, operation: "posix_spawnp \(executable)")
+        return SpawnedProcessGroup(pid: pid)
+    }
+
+    func wait(timeoutSeconds: TimeInterval) -> (exitCode: Int32, timedOut: Bool) {
+        let timedOut = exitSemaphore.wait(timeout: .now() + timeoutSeconds) == .timedOut
+        if timedOut {
+            terminateProcessGroup()
+        }
+        return (Self.exitCode(from: currentWaitStatus()), timedOut)
+    }
+
+    private func reap() {
+        var status: Int32 = 0
+        let waitedPID = unsafe waitpid(pid, &status, 0)
+        if waitedPID == pid {
+            lock.lock()
+            waitStatus = status
+            lock.unlock()
+        }
+        exitSemaphore.signal()
+    }
+
+    private func terminateProcessGroup() {
+        guard currentWaitStatus() == nil else {
             return
         }
 
-        process.terminate()
+        signalProcessGroup(SIGTERM)
         if exitSemaphore.wait(timeout: .now() + 5) == .success {
             return
         }
 
-        kill(process.processIdentifier, SIGKILL)
+        signalProcessGroup(SIGKILL)
         _ = exitSemaphore.wait(timeout: .now() + 5)
+    }
+
+    private func signalProcessGroup(_ signal: Int32) {
+        if kill(-pid, signal) == -1, errno != ESRCH {
+            kill(pid, signal)
+        }
+    }
+
+    private func currentWaitStatus() -> Int32? {
+        lock.lock()
+        defer { lock.unlock() }
+        return waitStatus
+    }
+
+    private static func exitCode(from waitStatus: Int32?) -> Int32 {
+        guard let waitStatus else {
+            return -1
+        }
+        let status = waitStatus & 0x7f
+        if status == 0 {
+            return (waitStatus >> 8) & 0xff
+        }
+        if status != 0x7f {
+            return 128 + status
+        }
+        return -1
+    }
+
+    private static func checkPOSIX(_ result: Int32, operation: String) throws {
+        guard result == 0 else {
+            throw POSIXCommandError(operation: operation, code: result)
+        }
+    }
+}
+
+private struct POSIXCommandError: Error, CustomStringConvertible {
+    let operation: String
+    let code: Int32
+
+    var description: String {
+        "\(operation) failed: \(unsafe String(cString: strerror(code)))"
     }
 }
 

--- a/Tests/XcodeMCPCoreTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPCoreTestSupport/AsyncTestSupport.swift
@@ -157,23 +157,71 @@ package func waitWithTimeout<T: Sendable>(
     timeout: Duration = .seconds(5),
     operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
+    let race = TimeoutRace<T>()
     let clock = ContinuousClock()
-
-    return try await withThrowingTaskGroup(of: T.self) { group in
-        group.addTask {
-            try await operation()
+    let operationTask = Task {
+        do {
+            race.complete(.success(try await operation()))
+        } catch {
+            race.complete(.failure(error))
         }
-        group.addTask {
+    }
+    let timeoutTask = Task {
+        do {
             try await clock.sleep(until: clock.now.advanced(by: timeout))
-            throw AsyncTestTimeoutError(description: description)
+            race.complete(.failure(AsyncTestTimeoutError(description: description)))
+        } catch {
+            return
         }
+    }
 
-        guard let result = try await group.next() else {
-            throw AsyncTestTimeoutError(description: description)
+    return try await withTaskCancellationHandler {
+        defer {
+            operationTask.cancel()
+            timeoutTask.cancel()
         }
+        return try await withCheckedThrowingContinuation { continuation in
+            race.install(continuation)
+        }
+    } onCancel: {
+        operationTask.cancel()
+        timeoutTask.cancel()
+        race.complete(.failure(CancellationError()))
+    }
+}
 
-        group.cancelAll()
-        return result
+private final class TimeoutRace<T: Sendable>: @unchecked Sendable {
+    private struct State {
+        var continuation: CheckedContinuation<T, Error>?
+        var result: Result<T, Error>?
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    func install(_ continuation: CheckedContinuation<T, Error>) {
+        let result = state.withLockedValue { state -> Result<T, Error>? in
+            guard let result = state.result else {
+                state.continuation = continuation
+                return nil
+            }
+            return result
+        }
+        if let result {
+            continuation.resume(with: result)
+        }
+    }
+
+    func complete(_ result: Result<T, Error>) {
+        let continuation = state.withLockedValue { state -> CheckedContinuation<T, Error>? in
+            guard state.result == nil else {
+                return nil
+            }
+            state.result = result
+            let continuation = state.continuation
+            state.continuation = nil
+            return continuation
+        }
+        continuation?.resume(with: result)
     }
 }
 
@@ -188,7 +236,7 @@ package final class TestClock: Clock, @unchecked Sendable {
 
     private struct SuspensionWaiter {
         let minimumSleepers: Int
-        let continuation: CheckedContinuation<Void, Never>
+        let continuation: CheckedContinuation<Void, Error>
     }
 
     private struct State {
@@ -230,12 +278,21 @@ package final class TestClock: Clock, @unchecked Sendable {
 
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                let continuations = state.withLockedValue { state -> [CheckedContinuation<Void, Never>] in
+                var shouldCancel = false
+                let continuations = state.withLockedValue { state -> [CheckedContinuation<Void, Error>] in
+                    guard Task.isCancelled == false else {
+                        shouldCancel = true
+                        return []
+                    }
                     state.sleepers[token] = SleepWaiter(deadline: deadline, continuation: continuation)
                     return Self.resumeReadySuspensionWaiters(state: &state)
                 }
+                if shouldCancel {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
                 for continuation in continuations {
-                    continuation.resume()
+                    continuation.resume(returning: ())
                 }
             }
         } onCancel: {
@@ -261,7 +318,23 @@ package final class TestClock: Clock, @unchecked Sendable {
         }
     }
 
-    package func sleep(untilSuspendedBy minimumSleepers: Int) async {
+    package func sleep(
+        untilSuspendedBy minimumSleepers: Int,
+        timeout: Duration = .seconds(5),
+        description: String? = nil
+    ) async throws {
+        let description = description
+            ?? "timed out waiting for \(minimumSleepers) suspended fake clock sleeper(s)"
+        try await waitWithTimeout(description, timeout: timeout) {
+            try await self.waitUntilSuspendedBy(minimumSleepers)
+        }
+    }
+
+    private func waitUntilSuspendedBy(_ minimumSleepers: Int) async throws {
+        guard minimumSleepers > 0 else {
+            return
+        }
+
         let token = state.withLockedValue { state -> UInt64? in
             guard state.sleepers.count < minimumSleepers else {
                 return nil
@@ -275,26 +348,40 @@ package final class TestClock: Clock, @unchecked Sendable {
             return
         }
 
-        await withCheckedContinuation { continuation in
-            let shouldResume = state.withLockedValue { state in
-                if state.sleepers.count >= minimumSleepers {
-                    return true
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                var shouldCancel = false
+                let shouldResume = state.withLockedValue { state in
+                    if state.sleepers.count >= minimumSleepers {
+                        return true
+                    }
+                    guard Task.isCancelled == false else {
+                        shouldCancel = true
+                        return false
+                    }
+                    state.suspensionWaiters[token] = SuspensionWaiter(
+                        minimumSleepers: minimumSleepers,
+                        continuation: continuation
+                    )
+                    return false
                 }
-                state.suspensionWaiters[token] = SuspensionWaiter(
-                    minimumSleepers: minimumSleepers,
-                    continuation: continuation
-                )
-                return false
+                if shouldCancel {
+                    continuation.resume(throwing: CancellationError())
+                } else if shouldResume {
+                    continuation.resume(returning: ())
+                }
             }
-            if shouldResume {
-                continuation.resume()
+        } onCancel: {
+            let waiter = state.withLockedValue { state in
+                state.suspensionWaiters.removeValue(forKey: token)
             }
+            waiter?.continuation.resume(throwing: CancellationError())
         }
     }
 
     private static func resumeReadySuspensionWaiters(
         state: inout State
-    ) -> [CheckedContinuation<Void, Never>] {
+    ) -> [CheckedContinuation<Void, Error>] {
         let readyTokens = state.suspensionWaiters.compactMap { token, waiter in
             state.sleepers.count >= waiter.minimumSleepers ? token : nil
         }

--- a/Tests/XcodeMCPCoreTests/AsyncTestSupportTests.swift
+++ b/Tests/XcodeMCPCoreTests/AsyncTestSupportTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import XcodeMCPCoreTestSupport
+
+@Suite struct AsyncTestSupportTests {
+    @Test func waitWithTimeoutFailsFastWhenOperationIgnoresCancellation() async throws {
+        let releaseGate = CancellationIgnoringGate()
+
+        await #expect(throws: AsyncTestTimeoutError.self) {
+            _ = try await waitWithTimeout(
+                "operation ignored cancellation",
+                timeout: .milliseconds(10)
+            ) {
+                await releaseGate.wait()
+                return true
+            }
+        }
+
+        await releaseGate.signal()
+    }
+
+    @Test func testClockSuspensionWaitFailsFastWhenSleeperNeverRegisters() async {
+        let clock = TestClock()
+
+        await #expect(throws: AsyncTestTimeoutError.self) {
+            try await clock.sleep(
+                untilSuspendedBy: 1,
+                timeout: .milliseconds(10),
+                description: "sleeper never registered"
+            )
+        }
+    }
+}
+
+private actor CancellationIgnoringGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func signal() {
+        continuation?.resume()
+        continuation = nil
+    }
+}

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -2219,20 +2219,74 @@ private func waitWithTimeout<T: Sendable>(
     timeout: Duration = .seconds(2),
     operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
+    let race = XcodeMCPTestTimeoutRace<T>()
     let clock = ContinuousClock()
-
-    return try await withThrowingTaskGroup(of: T.self) { group in
-        group.addTask {
-            try await operation()
+    let operationTask = Task {
+        do {
+            race.complete(.success(try await operation()))
+        } catch {
+            race.complete(.failure(error))
         }
-        group.addTask {
+    }
+    let timeoutTask = Task {
+        do {
             try await clock.sleep(until: clock.now.advanced(by: timeout))
-            throw XcodeMCPError.invalidResponse(description)
+            race.complete(.failure(XcodeMCPError.invalidResponse(description)))
+        } catch {
+            return
         }
+    }
 
-        let result = try await group.next()!
-        group.cancelAll()
-        return result
+    return try await withTaskCancellationHandler {
+        defer {
+            operationTask.cancel()
+            timeoutTask.cancel()
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            race.install(continuation)
+        }
+    } onCancel: {
+        operationTask.cancel()
+        timeoutTask.cancel()
+        race.complete(.failure(CancellationError()))
+    }
+}
+
+private final class XcodeMCPTestTimeoutRace<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var result: Result<T, Error>?
+
+    func install(_ continuation: CheckedContinuation<T, Error>) {
+        let result: Result<T, Error>? = withLock {
+            guard let storedResult = self.result else {
+                self.continuation = continuation
+                return nil
+            }
+            return storedResult
+        }
+        if let result {
+            continuation.resume(with: result)
+        }
+    }
+
+    func complete(_ result: Result<T, Error>) {
+        let continuation = withLock {
+            guard self.result == nil else {
+                return nil as CheckedContinuation<T, Error>?
+            }
+            self.result = result
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+        continuation?.resume(with: result)
+    }
+
+    private func withLock<Value>(_ body: () -> Value) -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
     }
 }
 

--- a/Tests/XcodeMCPProcessRuntimeTests/UpstreamProcessTests.swift
+++ b/Tests/XcodeMCPProcessRuntimeTests/UpstreamProcessTests.swift
@@ -154,7 +154,7 @@ struct UpstreamProcessTests {
         fakeDriver.emitStdout(Data(try makeJSONRPCResponse(id: 20, text: "parent").utf8))
         _ = await events.nextMessage()
         fakeDriver.emitTermination(status: 0)
-        await drainClock.sleep(untilSuspendedBy: 1)
+        try await drainClock.sleep(untilSuspendedBy: 1)
 
         #expect(!events.snapshot().contains(where: isExitEvent))
         drainClock.advance(by: .seconds(10))

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -17,7 +17,10 @@ extension RuntimeCoordinator {
             await shutdown()
             semaphore.signal()
         }
-        semaphore.wait()
+        waitForTestSemaphore(
+            semaphore,
+            description: "timed out waiting for RuntimeCoordinator.shutdown()"
+        )
     }
 
     func drainRuntimeTasksAndWaitForTesting() {
@@ -27,7 +30,10 @@ extension RuntimeCoordinator {
             await drain.wait()
             semaphore.signal()
         }
-        semaphore.wait()
+        waitForTestSemaphore(
+            semaphore,
+            description: "timed out waiting for RuntimeCoordinator runtime task drain"
+        )
     }
 }
 
@@ -2197,8 +2203,8 @@ func advanceRuntimeCoordinatorTimeout(
     uptimeClock: TestUptimeClock,
     by duration: Duration,
     suspendedSleepers: Int = 1
-) async {
-    await timeoutClock.sleep(untilSuspendedBy: suspendedSleepers)
+) async throws {
+    try await timeoutClock.sleep(untilSuspendedBy: suspendedSleepers)
     uptimeClock.advance(by: duration)
     timeoutClock.advance(by: duration)
 }

--- a/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
@@ -2,6 +2,7 @@ import Dispatch
 import Foundation
 import NIO
 import NIOConcurrencyHelpers
+import Testing
 import XcodeMCPCoreTestSupport
 
 package typealias AsyncTestTimeoutError = XcodeMCPCoreTestSupport.AsyncTestTimeoutError
@@ -262,21 +263,48 @@ package func waitWithTimeout<T: Sendable>(
     )
 }
 
-package func shutdown(_ group: EventLoopGroup) async {
-    await withCheckedContinuation { continuation in
-        group.shutdownGracefully { _ in
-            continuation.resume()
+package func shutdown(_ group: EventLoopGroup, timeout: Duration = .seconds(5)) async throws {
+    try await waitWithTimeout(
+        "timed out waiting for event loop group shutdown",
+        timeout: timeout
+    ) {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            group.shutdownGracefully { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
         }
+    }
+}
+
+package func waitForTestSemaphore(
+    _ semaphore: DispatchSemaphore,
+    timeout: TimeInterval = 10,
+    description: String
+) {
+    if semaphore.wait(timeout: .now() + timeout) == .timedOut {
+        Issue.record(AsyncTestTimeoutError(description: description))
     }
 }
 
 package func shutdownAndWait(_ group: EventLoopGroup) {
     let semaphore = DispatchSemaphore(value: 0)
     Task.detached(priority: .userInitiated) {
-        await shutdown(group)
+        do {
+            try await shutdown(group)
+        } catch {
+            Issue.record("event loop group shutdown failed: \(error)")
+        }
         semaphore.signal()
     }
-    semaphore.wait()
+    waitForTestSemaphore(
+        semaphore,
+        description: "timed out waiting for event loop group shutdown task"
+    )
 }
 
 package func makeTestURLSession(
@@ -389,7 +417,13 @@ package func shutdownHTTPTestServer(
         shutdownError = error
     }
 
-    await shutdown(group)
+    do {
+        try await shutdown(group, timeout: timeout)
+    } catch {
+        if shutdownError == nil {
+            shutdownError = error
+        }
+    }
 
     if let shutdownError {
         throw shutdownError


### PR DESCRIPTION
Purpose
- Ensure deterministic test waits and teardown helpers fail fast instead of hanging on cancellation-uncooperative work or missing fake-clock sleepers.
- Preserve the public product boundary introduced on the integration branch.

Changes
- Replace task-group timeout helpers with fail-fast task races that do not await the losing operation during timeout unwind.
- Bound TestClock sleeper registration waits, semaphore teardown waits, and event-loop group shutdown waits.
- Run public product contract builds in their own process group and terminate the group on timeout.
- Update affected deterministic test call sites for throwing bounded waits.

Testing
- swift test --filter XcodeMCPCoreTests -Xswiftc -strict-concurrency=minimal
- swift test --filter XcodeMCPKitTests -Xswiftc -strict-concurrency=minimal
- swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyCLITests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyStdioAdapterTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyDocumentationProviderTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyToolSurfaceTests -Xswiftc -strict-concurrency=minimal
- swift test --filter XcodeMCPProcessRuntimeTests -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyIntegrationTests -Xswiftc -strict-concurrency=minimal
- git diff --check
- codex-review against origin/codex/refactor-layered-runtime-integration: no findings