### PR TITLE
Remove deterministic wait hangs

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/HTTPGateway/HTTP/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/HTTPGateway/HTTP/HTTPHandler.swift
@@ -41,7 +41,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
         refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil,
         refreshCodeIssuesClock: ClockClient = .liveValue,
-        usesSynchronousLocalResolution: Bool = false
+        eventLoopCompletionExecutor: EventLoopCompletionExecutor = .eventLoop
     ) {
         let refreshCoordinator =
             refreshCodeIssuesCoordinator
@@ -64,7 +64,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
             refreshCodeIssuesDebugState: refreshDebugState,
             refreshCodeIssuesClock: refreshCodeIssuesClock,
-            usesSynchronousLocalResolution: usesSynchronousLocalResolution,
+            eventLoopCompletionExecutor: eventLoopCompletionExecutor,
             logger: ProxyLogging.make("http")
         )
         self.responseWriter = HTTPResponseWriter(logger: ProxyLogging.make("http.response"))

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/EventLoopCompletionExecutor.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/EventLoopCompletionExecutor.swift
@@ -1,0 +1,17 @@
+import NIO
+
+final class EventLoopCompletionExecutor: @unchecked Sendable {
+    private let executeImpl: (EventLoop, @escaping () -> Void) -> Void
+
+    init(_ execute: @escaping (EventLoop, @escaping () -> Void) -> Void) {
+        self.executeImpl = execute
+    }
+
+    func execute(on eventLoop: EventLoop, _ operation: @escaping () -> Void) {
+        executeImpl(eventLoop, operation)
+    }
+
+    static let eventLoop = EventLoopCompletionExecutor { eventLoop, operation in
+        eventLoop.execute(operation)
+    }
+}

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/MCP/LocalMCPResponder.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/MCP/LocalMCPResponder.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Logging
 import NIO
-import NIOConcurrencyHelpers
 import XcodeMCPKit
 
 enum LocalPostHandling {
@@ -18,28 +17,23 @@ enum LocalPostHandling {
 struct LocalMCPResponder {
     private typealias LocalResultOperation = @Sendable () async throws -> JSONValue
 
-    private struct EmbeddedTestResolutionError: Error {}
-
     private let sessionManager: any RuntimeClientLocalMCPResponderPort
     private let refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode
     private let disabledToolNames: Set<String>
-    /// EmbeddedChannel-based tests cannot complete promises from another
-    /// thread, so they opt in to a synchronous resolution path explicitly
-    /// instead of production code sniffing the event-loop type.
-    private let usesSynchronousLocalResolution: Bool
+    private let eventLoopCompletionExecutor: EventLoopCompletionExecutor
     private let logger: Logger
 
     init(
         sessionManager: any RuntimeClientLocalMCPResponderPort,
         refreshCodeIssuesMode: ProxyConfig.RefreshCodeIssuesMode,
         disabledToolNames: Set<String>,
-        usesSynchronousLocalResolution: Bool = false,
+        eventLoopCompletionExecutor: EventLoopCompletionExecutor = .eventLoop,
         logger: Logger
     ) {
         self.sessionManager = sessionManager
         self.refreshCodeIssuesMode = refreshCodeIssuesMode
         self.disabledToolNames = disabledToolNames
-        self.usesSynchronousLocalResolution = usesSynchronousLocalResolution
+        self.eventLoopCompletionExecutor = eventLoopCompletionExecutor
         self.logger = logger
     }
 
@@ -190,36 +184,22 @@ struct LocalMCPResponder {
         eventLoop: EventLoop,
         operation: @escaping LocalResultOperation
     ) -> LocalPostHandling {
-        if usesSynchronousLocalResolution {
-            do {
-                let result = try Self.waitForAsyncResult(operation)
-                let data = try Self.encodeResultData(id: originalID, result: result)
-                return .immediateResponse(data: data, sessionID: sessionID)
-            } catch {
-                let data = try? Self.encodeErrorData(id: originalID, error: error)
-                if let data {
-                    return .immediateResponse(data: data, sessionID: sessionID)
-                }
-                return Self.fallbackLocalError(id: originalID, sessionID: sessionID)
-            }
-        }
-
         let promise = eventLoop.makePromise(of: ByteBuffer.self)
         Task {
             do {
                 let result = try await operation()
                 let buffer = try Self.encodeResultBuffer(id: originalID, result: result)
-                eventLoop.execute {
+                eventLoopCompletionExecutor.execute(on: eventLoop) {
                     promise.succeed(buffer)
                 }
             } catch {
                 do {
                     let buffer = try Self.encodeErrorBuffer(id: originalID, error: error)
-                    eventLoop.execute {
+                    eventLoopCompletionExecutor.execute(on: eventLoop) {
                         promise.succeed(buffer)
                     }
                 } catch {
-                    eventLoop.execute {
+                    eventLoopCompletionExecutor.execute(on: eventLoop) {
                         promise.fail(error)
                     }
                 }
@@ -272,41 +252,4 @@ struct LocalMCPResponder {
         )
     }
 
-    private static func fallbackLocalError(
-        id: JSONRPC.ID,
-        sessionID: String
-    ) -> LocalPostHandling {
-        .mcpError(
-            id: id,
-            code: -32000,
-            message: "upstream timeout",
-            sessionID: sessionID
-        )
-    }
-
-    private static func waitForAsyncResult<Output: Sendable>(
-        _ operation: @escaping @Sendable () async throws -> Output
-    ) throws -> Output {
-        let semaphore = DispatchSemaphore(value: 0)
-        let resultBox = NIOLockedValueBox<Result<Output, Error>?>(nil)
-        Task {
-            let result: Result<Output, Error>
-            do {
-                result = .success(try await operation())
-            } catch {
-                result = .failure(error)
-            }
-            resultBox.withLockedValue { stored in
-                stored = result
-            }
-            semaphore.signal()
-        }
-        semaphore.wait()
-        return try resultBox.withLockedValue { stored in
-            guard let stored else {
-                throw EmbeddedTestResolutionError()
-            }
-            return try stored.get()
-        }
-    }
 }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+ForwardExecutor.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+ForwardExecutor.swift
@@ -90,7 +90,7 @@ extension ClientMCPRequestExecutor {
                         cancellationHandle: cancellationHandle
                     )
                     let wasCancelled = Task.isCancelled
-                    eventLoop.execute {
+                    eventLoopCompletionExecutor.execute(on: eventLoop) {
                         if wasCancelled {
                             cancellationHandle?.markCompleted()
                             promise.succeed(.empty(status: .accepted, sessionID: sessionID))
@@ -212,7 +212,7 @@ extension ClientMCPRequestExecutor {
 
                 let wasCancelled = Task.isCancelled
                 let mergedPayloadInputs = payloads + [localResponseData]
-                eventLoop.execute {
+                eventLoopCompletionExecutor.execute(on: eventLoop) {
                     if wasCancelled {
                         cancellationHandle?.markCompleted()
                         promise.succeed(.empty(status: .accepted, sessionID: sessionID))

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+LocalHandling.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+LocalHandling.swift
@@ -152,7 +152,6 @@ extension ClientMCPRequestExecutor {
             )
         }
 
-        let allowLocalToolRoutes = !usesSynchronousLocalResolution
         var didBlockItem = false
         var blockedResponseObjects: [[String: Any]] = []
         var toolsListRequests: [[String: Any]] = []
@@ -174,10 +173,10 @@ extension ClientMCPRequestExecutor {
                         toolName: toolName
                     )
                 )
-            } else if allowLocalToolRoutes, isToolsListRequest(object) {
+            } else if isToolsListRequest(object) {
                 toolsListRequests.append(object)
                 routedObjects.append(object)
-            } else if allowLocalToolRoutes, isDocumentationSearchRequest(object) {
+            } else if isDocumentationSearchRequest(object) {
                 documentationRequests.append(object)
                 routedObjects.append(object)
             } else {
@@ -253,7 +252,7 @@ extension ClientMCPRequestExecutor {
         let promise = eventLoop.makePromise(of: LocalToolBatchResult.self)
         let task = Task { [self] in
             guard !Task.isCancelled else {
-                eventLoop.execute {
+                eventLoopCompletionExecutor.execute(on: eventLoop) {
                     promise.fail(CancellationError())
                 }
                 return
@@ -267,7 +266,7 @@ extension ClientMCPRequestExecutor {
                 deadline: deadline
             )
             let wasCancelled = Task.isCancelled
-            eventLoop.execute {
+            eventLoopCompletionExecutor.execute(on: eventLoop) {
                 if wasCancelled {
                     promise.fail(CancellationError())
                     return

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor.swift
@@ -50,10 +50,10 @@ final class ClientMCPRequestExecutor: Sendable {
 
     let sessionManager: any RuntimeClientMCPRequestPort
     let disabledToolNames: Set<String>
-    let usesSynchronousLocalResolution: Bool
     let localResponder: LocalMCPResponder
     let forwardingService: MCPForwardingService
     let refreshWorkflow: RefreshCodeIssues.Workflow
+    let eventLoopCompletionExecutor: EventLoopCompletionExecutor
     let requestTimeoutSeconds: TimeInterval
     let deadlineClock: ClockClient
     let logger: Logger
@@ -66,19 +66,19 @@ final class ClientMCPRequestExecutor: Sendable {
         refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState,
         refreshCodeIssuesClock: ClockClient = .liveValue,
         deadlineClock: ClockClient = .liveValue,
-        usesSynchronousLocalResolution: Bool = false,
+        eventLoopCompletionExecutor: EventLoopCompletionExecutor = .eventLoop,
         logger: Logger = ProxyLogging.make("http")
     ) {
         self.requestTimeoutSeconds = config.requestTimeout
         self.deadlineClock = deadlineClock
         self.sessionManager = sessionManager
         self.disabledToolNames = config.disabledToolNames
-        self.usesSynchronousLocalResolution = usesSynchronousLocalResolution
+        self.eventLoopCompletionExecutor = eventLoopCompletionExecutor
         self.localResponder = LocalMCPResponder(
             sessionManager: sessionManager,
             refreshCodeIssuesMode: config.refreshCodeIssuesMode,
             disabledToolNames: config.disabledToolNames,
-            usesSynchronousLocalResolution: usesSynchronousLocalResolution,
+            eventLoopCompletionExecutor: eventLoopCompletionExecutor,
             logger: ProxyLogging.make("http.local")
         )
         self.forwardingService = MCPForwardingService(
@@ -687,7 +687,7 @@ final class ClientMCPRequestExecutor: Sendable {
                             )
                         }
                     }
-                    eventLoop.execute {
+                    eventLoopCompletionExecutor.execute(on: eventLoop) {
                         cancellationHandle.markCompleted()
                         self.sessionManager.completeRequestLease(leaseID)
                         promise.succeed(
@@ -726,7 +726,7 @@ final class ClientMCPRequestExecutor: Sendable {
         let routingTask = Task { [self] in
             let routingTimeout = remainingRequestTimeout(until: forwardingDeadline)
             if forwardingDeadline != nil, routingTimeout == nil {
-                eventLoop.execute {
+                eventLoopCompletionExecutor.execute(on: eventLoop) {
                     makeForwardingTimeoutFuture().cascade(to: routingPromise)
                 }
                 return
@@ -735,7 +735,7 @@ final class ClientMCPRequestExecutor: Sendable {
                 for: forwardedRequestJSON,
                 requestTimeoutOverride: routingTimeout
             )
-            eventLoop.execute {
+            eventLoopCompletionExecutor.execute(on: eventLoop) {
                 makeRoutingFuture(decision: decision).cascade(to: routingPromise)
             }
         }

--- a/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/DocumentationSearchRoutingTests.swift
@@ -963,7 +963,7 @@ extension HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Content-Type") == "application/json")
 
@@ -993,7 +993,7 @@ extension HTTPHandlerTests {
         ]]
         try postJSONArray(payload, sessionID: "session-batch-resources", to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         assertBatchRejected(response)
     }
 }

--- a/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPConcurrencyTests.swift
@@ -163,8 +163,7 @@ struct HTTPConcurrencyTests {
             refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState(
                 defaultRequestTimeoutSeconds: config.requestTimeout
             ),
-            deadlineClock: deadlineClock.client,
-            usesSynchronousLocalResolution: true
+            deadlineClock: deadlineClock.client
         )
         let sessionID = "session-queued-timeout-budget"
 
@@ -1812,12 +1811,11 @@ private func addEmbeddedHTTPHandler(
     config: ProxyConfig,
     sessionManager: any RuntimeCoordinating
 ) throws {
-    let handler = HTTPHandler(
+    try addHTTPHandler(
+        to: channel,
         config: config,
-        sessionManager: sessionManager,
-        usesSynchronousLocalResolution: true
+        sessionManager: sessionManager
     )
-    try channel.pipeline.addHandler(handler).wait()
 }
 
 private func postEmbeddedJSON(
@@ -1843,6 +1841,11 @@ private func postEmbeddedJSON(
 private func collectEmbeddedResponse(
     from channel: EmbeddedChannel
 ) throws -> (head: HTTPResponseHead, body: String) {
+    drainEmbeddedCompletions(for: channel)
+    channel.embeddedEventLoop.run()
+    drainEmbeddedCompletions(for: channel)
+    channel.embeddedEventLoop.run()
+
     var responseHead: HTTPResponseHead?
     var bodyBuffer = channel.allocator.buffer(capacity: 0)
 

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import NIO
 import NIOConcurrencyHelpers
@@ -14,6 +15,37 @@ enum HTTPTestError: Error {
 }
 
 private let httpTestSessionRegistry = NIOLockedValueBox<[String: any RuntimeCoordinating]>([:])
+private let embeddedCompletionExecutors = NIOLockedValueBox<
+    [ObjectIdentifier: EmbeddedEventLoopCompletionExecutor]
+>([:])
+
+private final class EmbeddedEventLoopCompletionExecutor: @unchecked Sendable {
+    private let lock = NSLock()
+    private var operations: [() -> Void] = []
+
+    var executor: EventLoopCompletionExecutor {
+        EventLoopCompletionExecutor { [weak self] _, operation in
+            self?.enqueue(operation)
+        }
+    }
+
+    func enqueue(_ operation: @escaping () -> Void) {
+        lock.withLock {
+            operations.append(operation)
+        }
+    }
+
+    func drain() {
+        let pending = lock.withLock { () -> [() -> Void] in
+            let pending = operations
+            operations.removeAll()
+            return pending
+        }
+        for operation in pending {
+            operation()
+        }
+    }
+}
 
 private func registerHTTPTestServer(
     url: URL,
@@ -28,6 +60,27 @@ private func unregisterHTTPTestServer(url: URL) {
     _ = httpTestSessionRegistry.withLockedValue { registry in
         registry.removeValue(forKey: url.absoluteString)
     }
+}
+
+private func registerEmbeddedCompletionExecutor(
+    _ executor: EmbeddedEventLoopCompletionExecutor,
+    for channel: EmbeddedChannel
+) {
+    embeddedCompletionExecutors.withLockedValue { executors in
+        executors[ObjectIdentifier(channel)] = executor
+    }
+}
+
+private func embeddedCompletionExecutor(
+    for channel: EmbeddedChannel
+) -> EmbeddedEventLoopCompletionExecutor? {
+    embeddedCompletionExecutors.withLockedValue { executors in
+        executors[ObjectIdentifier(channel)]
+    }
+}
+
+func drainEmbeddedCompletions(for channel: EmbeddedChannel) {
+    embeddedCompletionExecutor(for: channel)?.drain()
 }
 
 private func prepareHTTPTestSession(url: URL, sessionID: String) {
@@ -1051,46 +1104,73 @@ func addHTTPHandler(
     refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
     refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil
 ) throws {
+    let completionExecutor = EmbeddedEventLoopCompletionExecutor()
+    registerEmbeddedCompletionExecutor(completionExecutor, for: channel)
     let handler = HTTPHandler(
         config: config,
         sessionManager: sessionManager,
         refreshCodeIssuesCoordinator: refreshCodeIssuesCoordinator,
         refreshCodeIssuesTargetResolver: refreshCodeIssuesTargetResolver,
         refreshCodeIssuesDebugState: refreshCodeIssuesDebugState,
-        usesSynchronousLocalResolution: true
+        eventLoopCompletionExecutor: completionExecutor.executor
     )
     try channel.pipeline.addHandler(handler).wait()
 }
 
-func collectResponse(from channel: EmbeddedChannel) throws -> (
+func collectResponse(
+    from channel: EmbeddedChannel,
+    timeout: Duration = .seconds(2)
+) async throws -> (
     head: HTTPResponseHead, body: String
 ) {
-    channel.embeddedEventLoop.run()
-
     var responseHead: HTTPResponseHead?
     var bodyBuffer = channel.allocator.buffer(capacity: 0)
+    var sawEnd = false
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
 
-    while let part = try channel.readOutbound(as: HTTPServerResponsePart.self) {
-        switch part {
-        case .head(let head):
-            responseHead = head
-        case .body(let body):
-            switch body {
-            case .byteBuffer(var buffer):
-                bodyBuffer.writeBuffer(&buffer)
-            case .fileRegion:
-                break
+    while true {
+        drainEmbeddedCompletions(for: channel)
+        channel.embeddedEventLoop.run()
+        drainEmbeddedCompletions(for: channel)
+        channel.embeddedEventLoop.run()
+
+        while let part = try channel.readOutbound(as: HTTPServerResponsePart.self) {
+            switch part {
+            case .head(let head):
+                responseHead = head
+            case .body(let body):
+                switch body {
+                case .byteBuffer(var buffer):
+                    bodyBuffer.writeBuffer(&buffer)
+                case .fileRegion:
+                    break
+                }
+            case .end:
+                sawEnd = true
             }
-        case .end:
-            break
         }
-    }
 
-    guard let responseHead else {
-        throw HTTPTestError.missingResponseHead
+        if let responseHead,
+            sawEnd || SelfContainedHTTPResponse.isOpenSSE(responseHead, bodyBuffer: bodyBuffer)
+        {
+            let body = bodyBuffer.readString(length: bodyBuffer.readableBytes) ?? ""
+            return (responseHead, body)
+        }
+        guard clock.now < deadline else {
+            throw AsyncTestTimeoutError(description: "timed out waiting for embedded HTTP response")
+        }
+        sched_yield()
     }
-    let body = bodyBuffer.readString(length: bodyBuffer.readableBytes) ?? ""
-    return (responseHead, body)
+}
+
+private enum SelfContainedHTTPResponse {
+    static func isOpenSSE(_ head: HTTPResponseHead, bodyBuffer: ByteBuffer) -> Bool {
+        guard head.headers.first(name: "Content-Type") == "text/event-stream" else {
+            return false
+        }
+        return bodyBuffer.readableBytes > 0
+    }
 }
 
 func advanceEventLoopTime(on channel: EmbeddedChannel, by amount: TimeAmount) {
@@ -1383,7 +1463,7 @@ func makeDebugSnapshotURL(from mcpURL: URL, includeSensitive: Bool = false) -> U
 typealias AsyncSignal = TestSignal
 typealias SyncSignal = TestSignal
 
-func initializeHTTPChannel(_ channel: EmbeddedChannel) throws -> String {
+func initializeHTTPChannel(_ channel: EmbeddedChannel) async throws -> String {
     let initPayload: [String: Any] = [
         "jsonrpc": "2.0",
         "id": 1,
@@ -1402,7 +1482,7 @@ func initializeHTTPChannel(_ channel: EmbeddedChannel) throws -> String {
     try channel.writeInbound(HTTPServerRequestPart.body(initBody))
     try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-    let initResponse = try collectResponse(from: channel)
+    let initResponse = try await collectResponse(from: channel)
     return try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 }
 

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -22,7 +22,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.body == "ok")
     }
@@ -38,7 +38,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Content-Type") == "application/json")
 
@@ -68,7 +68,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
 
         let decoder = JSONDecoder()
@@ -92,7 +92,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .notFound)
         #expect(response.body == "not found")
     }
@@ -143,7 +143,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .notFound)
         #expect(response.body == "not found")
     }
@@ -285,7 +285,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .notAcceptable)
         #expect(response.body.contains("text/event-stream"))
     }
@@ -306,7 +306,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .notAcceptable)
     }
 
@@ -326,7 +326,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .notAcceptable)
         #expect(response.body == "client must accept application/json and text/event-stream")
     }
@@ -358,7 +358,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Mcp-Session-Id")?.isEmpty == false)
     }
@@ -379,7 +379,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .unsupportedMediaType)
     }
 
@@ -405,7 +405,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .badRequest)
         #expect(response.body == "session id required")
     }
@@ -434,7 +434,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .notFound)
         #expect(response.body == "session not found")
     }
@@ -445,7 +445,7 @@ struct HTTPHandlerTests {
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
 
         let payload: [String: Any] = [
             "jsonrpc": "2.0",
@@ -463,7 +463,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .badRequest)
         #expect(response.body == "protocol version required")
     }
@@ -474,7 +474,7 @@ struct HTTPHandlerTests {
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
 
         let payload: [String: Any] = [
             "jsonrpc": "2.0",
@@ -493,7 +493,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .badRequest)
         #expect(response.body == "protocol version mismatch")
     }
@@ -504,7 +504,7 @@ struct HTTPHandlerTests {
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
 
         var deleteHead = HTTPRequestHead(version: .http1_1, method: .DELETE, uri: "/mcp")
         deleteHead.headers.add(name: "MCP-Session-Id", value: sessionID)
@@ -512,7 +512,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(deleteHead))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let deleteResponse = try collectResponse(from: channel)
+        let deleteResponse = try await collectResponse(from: channel)
         #expect(deleteResponse.head.status == .ok)
         #expect(sessionManager.hasSession(id: sessionID) == false)
 
@@ -523,7 +523,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(sseHead))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let afterDeleteResponse = try collectResponse(from: channel)
+        let afterDeleteResponse = try await collectResponse(from: channel)
         #expect(afterDeleteResponse.head.status == .notFound)
         #expect(afterDeleteResponse.body == "session not found")
     }
@@ -541,7 +541,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(deleteHead))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let deleteResponse = try collectResponse(from: channel)
+        let deleteResponse = try await collectResponse(from: channel)
         #expect(deleteResponse.head.status == .ok)
         #expect(sessionManager.hasSession(id: "uninitialized-session") == false)
     }
@@ -555,7 +555,7 @@ struct HTTPHandlerTests {
 
         try writeInitializePost(to: channel, origin: "https://example.invalid")
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
         #expect(response.body == "origin not allowed")
         #expect(sessionManager.isInitialized() == false)
@@ -570,7 +570,7 @@ struct HTTPHandlerTests {
 
         try writeInitializePost(to: channel, origin: "http://127.attacker.example:8765")
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
         #expect(response.body == "origin not allowed")
         #expect(sessionManager.isInitialized() == false)
@@ -590,7 +590,7 @@ struct HTTPHandlerTests {
             origin: "http://localhost"
         )
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
         #expect(response.body == "origin not allowed")
         #expect(sessionManager.isInitialized() == false)
@@ -611,7 +611,7 @@ struct HTTPHandlerTests {
             origin: "http://192.0.2.10:8765"
         )
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
         #expect(response.body == "origin not allowed")
         #expect(sessionManager.isInitialized() == false)
@@ -632,7 +632,7 @@ struct HTTPHandlerTests {
             origin: "http://attacker.example:8765"
         )
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
         #expect(response.body == "origin not allowed")
         #expect(sessionManager.isInitialized() == false)
@@ -653,7 +653,7 @@ struct HTTPHandlerTests {
             origin: "http://localhost:8765"
         )
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Mcp-Session-Id") != nil)
     }
@@ -673,7 +673,7 @@ struct HTTPHandlerTests {
             origin: "http://192.0.2.10:8765"
         )
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Mcp-Session-Id") != nil)
     }
@@ -693,7 +693,7 @@ struct HTTPHandlerTests {
             origin: "http://example.invalid:8765"
         )
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .forbidden)
         #expect(response.body == "origin not allowed")
         #expect(sessionManager.isInitialized() == false)
@@ -715,7 +715,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .payloadTooLarge)
     }
 
@@ -750,7 +750,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Mcp-Session-Id")?.isEmpty == false)
 
@@ -770,7 +770,7 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
         let chooseCountBeforeResponse = sessionManager.chooseUpstreamIndexCallCount()
         let clientID = sessionManager.session(id: sessionID).serverRequestTracker.record(
             upstreamID: JSONRPC.ID(any: NSNumber(value: 99))!,
@@ -784,7 +784,7 @@ struct HTTPHandlerTests {
         ]
         try postJSON(payload, sessionID: sessionID, to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .accepted)
         #expect(response.body.isEmpty)
         #expect(sessionManager.chooseUpstreamIndexCallCount() == chooseCountBeforeResponse)
@@ -804,7 +804,7 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
         let session = sessionManager.session(id: sessionID)
         let clientID = session.serverRequestTracker.record(
             upstreamID: JSONRPC.ID(any: NSNumber(value: 99))!,
@@ -818,13 +818,13 @@ struct HTTPHandlerTests {
             "result": ["ok": true],
         ]
         try postJSON(payload, sessionID: sessionID, to: channel)
-        let rejected = try collectResponse(from: channel)
+        let rejected = try await collectResponse(from: channel)
         #expect(rejected.head.status == .serviceUnavailable)
         #expect(rejected.body == "upstream unavailable")
         #expect(session.serverRequestTracker.lookup(clientID: clientID) != nil)
 
         try postJSON(payload, sessionID: sessionID, to: channel)
-        let accepted = try collectResponse(from: channel)
+        let accepted = try await collectResponse(from: channel)
         #expect(accepted.head.status == .accepted)
         #expect(accepted.body.isEmpty)
         #expect(session.serverRequestTracker.lookup(clientID: clientID) == nil)
@@ -838,7 +838,7 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
         let payload: [String: Any] = [
             "jsonrpc": "2.0",
             "id": "xcode-mcp-proxy.server-request.999",
@@ -846,7 +846,7 @@ struct HTTPHandlerTests {
         ]
         try postJSON(payload, sessionID: sessionID, to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .accepted)
         #expect(response.body.isEmpty)
         #expect(sessionManager.sentUpstreamCount() == 0)
@@ -859,14 +859,14 @@ struct HTTPHandlerTests {
         let sessionManager = TestRuntimeCoordinator(config: config)
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
         let payload: [String: Any] = [
             "jsonrpc": "2.0",
             "id": 123,
         ]
         try postJSON(payload, sessionID: sessionID, to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         let responseObject = try #require(
             JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
@@ -909,7 +909,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Content-Type") == "application/json")
     }
@@ -943,7 +943,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Mcp-Session-Id") == nil)
         let object =
@@ -978,7 +978,7 @@ struct HTTPHandlerTests {
         ]
         try postJSONArray(payload, sessionID: nil, to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         assertBatchRejected(response)
         #expect(sessionManager.isInitialized() == false)
     }
@@ -1000,7 +1000,7 @@ struct HTTPHandlerTests {
         ]
         try postJSONArray(payload, sessionID: "session-batch", to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         assertBatchRejected(response)
         #expect(sessionManager.sentUpstreamCount() == 0)
     }
@@ -1029,7 +1029,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(initHead))
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 
         let payload: [String: Any] = [
@@ -1054,7 +1054,7 @@ struct HTTPHandlerTests {
         #expect(sessionManager.mappedUpstreamRequestCount() == 0)
         advanceEventLoopTime(on: channel, by: .milliseconds(300))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Content-Type") == "application/json")
         let object =
@@ -1153,7 +1153,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(initHead))
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 
         let payload: [String: Any] = [
@@ -1173,7 +1173,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .notAcceptable)
         #expect(response.head.headers.first(name: "Content-Type") == "text/plain; charset=utf-8")
         #expect(response.body == "client must accept application/json and text/event-stream")
@@ -1203,7 +1203,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(initHead))
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 
         let payload: [[String: Any]] = [
@@ -1228,7 +1228,7 @@ struct HTTPHandlerTests {
         #expect(sessionManager.mappedUpstreamRequestCount() == 0)
         advanceEventLoopTime(on: channel, by: .milliseconds(300))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         assertBatchRejected(response)
         #expect(sessionManager.requestTimeoutNotificationCount() == 0)
         #expect(sessionManager.mappedUpstreamRequestCount() == 0)
@@ -1258,7 +1258,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(initHead))
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 
         sessionManager.setAvailableUpstreamIndex(nil)
@@ -1280,7 +1280,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         let object =
             try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
@@ -1314,7 +1314,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(initHead))
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 
         sessionManager.setAvailableUpstreamIndex(nil)
@@ -1331,7 +1331,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(malformedBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         let object =
             try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
@@ -1673,7 +1673,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(initHead))
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 
         let payload: [String: Any] = [
@@ -1693,7 +1693,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         let object =
             try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
@@ -1731,7 +1731,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         let returnedSessionID = try #require(response.head.headers.first(name: "Mcp-Session-Id"))
         #expect(returnedSessionID.isEmpty == false)
@@ -1756,7 +1756,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Content-Type") == "text/event-stream")
         #expect(response.body.contains(": ok"))
@@ -1793,7 +1793,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -1816,7 +1816,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(toolsBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let toolsResponse = try collectResponse(from: channel)
+        let toolsResponse = try await collectResponse(from: channel)
         #expect(toolsResponse.head.status == .ok)
 
         let responseObject =
@@ -1866,7 +1866,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -1892,7 +1892,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(toolsBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let toolsResponse = try collectResponse(from: channel)
+        let toolsResponse = try await collectResponse(from: channel)
         #expect(toolsResponse.head.status == .ok)
 
         let responseObject =
@@ -1931,7 +1931,7 @@ struct HTTPHandlerTests {
         ]]
         try postJSONArray(payload, sessionID: "session-batch-tools-list", to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         assertBatchRejected(response)
         #expect(sessionManager.sentUpstreamCount() == 0)
     }
@@ -1974,7 +1974,7 @@ struct HTTPHandlerTests {
         ]]
         try postJSONArray(payload, sessionID: "session-forwarded-batch-tools-list", to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         assertBatchRejected(response)
         #expect(sessionManager.sentUpstreamCount() == 0)
     }
@@ -2016,7 +2016,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -2042,7 +2042,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(toolsBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let toolsResponse = try collectResponse(from: channel)
+        let toolsResponse = try await collectResponse(from: channel)
         #expect(toolsResponse.head.status == .ok)
         #expect(sessionManager.cachedToolsListResult() != nil)
         #expect(sessionManager.sentUpstreamCount() == 1)
@@ -2068,7 +2068,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(toolsBody2))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let toolsResponse2 = try collectResponse(from: channel)
+        let toolsResponse2 = try await collectResponse(from: channel)
         #expect(toolsResponse2.head.status == .ok)
         #expect(sessionManager.sentUpstreamCount() == 1)
     }
@@ -2115,7 +2115,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 
         let toolsPayload: [String: Any] = [
@@ -2136,7 +2136,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(toolsBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         let object =
             try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
             as? [String: Any]
@@ -2185,7 +2185,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = try #require(initResponse.head.headers.first(name: "Mcp-Session-Id"))
 
         let toolsPayload: [String: Any] = [
@@ -2206,7 +2206,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(toolsBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         let object =
             try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
             as? [String: Any]
@@ -2248,7 +2248,7 @@ struct HTTPHandlerTests {
         }
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
         try postJSON(
             [
                 "jsonrpc": "2.0",
@@ -2259,7 +2259,7 @@ struct HTTPHandlerTests {
             to: channel
         )
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         let object = try #require(
             try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
                 as? [String: Any]
@@ -2303,7 +2303,7 @@ struct HTTPHandlerTests {
         )
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
 
-        let sessionID = try initializeHTTPChannel(channel)
+        let sessionID = try await initializeHTTPChannel(channel)
         try postJSON(
             [
                 "jsonrpc": "2.0",
@@ -2314,7 +2314,7 @@ struct HTTPHandlerTests {
             to: channel
         )
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         let object = try #require(
             try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
                 as? [String: Any]
@@ -2356,7 +2356,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -2378,7 +2378,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(toolsBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let toolsResponse = try collectResponse(from: channel)
+        let toolsResponse = try await collectResponse(from: channel)
         #expect(toolsResponse.head.status == .ok)
         #expect(toolsResponse.head.headers.first(name: "Content-Type") == "application/json")
     }
@@ -2470,7 +2470,7 @@ struct HTTPHandlerTests {
         ]]
         try postJSONArray(payload, sessionID: "session-forwarded-batch-resources-list", to: channel)
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         assertBatchRejected(response)
         #expect(sessionManager.sentUpstreamCount() == 0)
     }
@@ -2609,7 +2609,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Content-Type") == "application/json")
 
@@ -2661,7 +2661,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -2684,7 +2684,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
 
         let object =
@@ -2739,7 +2739,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -2762,7 +2762,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
 
         let object =
@@ -2812,7 +2812,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -2835,7 +2835,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
 
         let object =
@@ -2887,7 +2887,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -2910,7 +2910,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
 
         let object =
@@ -2966,7 +2966,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(initBody))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let initResponse = try collectResponse(from: channel)
+        let initResponse = try await collectResponse(from: channel)
         let sessionID = initResponse.head.headers.first(name: "Mcp-Session-Id")
         #expect(sessionID?.isEmpty == false)
 
@@ -2989,7 +2989,7 @@ struct HTTPHandlerTests {
         try channel.writeInbound(HTTPServerRequestPart.body(body))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
 
-        let response = try collectResponse(from: channel)
+        let response = try await collectResponse(from: channel)
         #expect(response.head.status == .ok)
 
         let object =

--- a/Tests/XcodeMCPCoreTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPCoreTestSupport/AsyncTestSupport.swift
@@ -279,7 +279,12 @@ package final class TestClock: Clock, @unchecked Sendable {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 var shouldCancel = false
+                var shouldResume = false
                 let continuations = state.withLockedValue { state -> [CheckedContinuation<Void, Error>] in
+                    guard deadline > state.now else {
+                        shouldResume = true
+                        return []
+                    }
                     guard Task.isCancelled == false else {
                         shouldCancel = true
                         return []
@@ -289,6 +294,10 @@ package final class TestClock: Clock, @unchecked Sendable {
                 }
                 if shouldCancel {
                     continuation.resume(throwing: CancellationError())
+                    return
+                }
+                if shouldResume {
+                    continuation.resume(returning: ())
                     return
                 }
                 for continuation in continuations {

--- a/Tests/XcodeMCPProcessRuntimeTests/DeterministicTestSupport.swift
+++ b/Tests/XcodeMCPProcessRuntimeTests/DeterministicTestSupport.swift
@@ -1,17 +1,18 @@
 import Foundation
+import XcodeMCPCoreTestSupport
 
 final class DeterministicRecorder<Value: Sendable>: @unchecked Sendable {
     private struct IndexedWaiter {
         let id: UUID
         let index: Int
-        let continuation: CheckedContinuation<Value, Never>
+        let continuation: CheckedContinuation<Value, Error>
     }
 
     private struct MatchingWaiter {
         let id: UUID
         let startingAt: Int
         let predicate: @Sendable (Value) -> Bool
-        let continuation: CheckedContinuation<Value, Never>
+        let continuation: CheckedContinuation<Value, Error>
     }
 
     private let lock = NSLock()
@@ -20,93 +21,163 @@ final class DeterministicRecorder<Value: Sendable>: @unchecked Sendable {
     private var matchingWaiters: [MatchingWaiter] = []
 
     func record(_ value: Value) {
-        let resumes = lock.withLock { () -> (indexed: [CheckedContinuation<Value, Never>], matching: [CheckedContinuation<Value, Never>]) in
+        let resumes = lock.withLock { () -> (
+            indexed: [(CheckedContinuation<Value, Error>, Value)],
+            matching: [(CheckedContinuation<Value, Error>, Value)]
+        ) in
             let index = values.count
             values.append(value)
 
-            var indexedResumes: [CheckedContinuation<Value, Never>] = []
+            var indexedResumes: [(CheckedContinuation<Value, Error>, Value)] = []
             indexedWaiters.removeAll { waiter in
                 guard waiter.index <= index else {
                     return false
                 }
-                indexedResumes.append(waiter.continuation)
+                indexedResumes.append((waiter.continuation, values[waiter.index]))
                 return true
             }
 
-            var matchingResumes: [CheckedContinuation<Value, Never>] = []
+            var matchingResumes: [(CheckedContinuation<Value, Error>, Value)] = []
             matchingWaiters.removeAll { waiter in
                 guard index >= waiter.startingAt, waiter.predicate(value) else {
                     return false
                 }
-                matchingResumes.append(waiter.continuation)
+                matchingResumes.append((waiter.continuation, value))
                 return true
             }
 
             return (indexedResumes, matchingResumes)
         }
 
-        for continuation in resumes.indexed {
+        for (continuation, value) in resumes.indexed {
             continuation.resume(returning: value)
         }
-        for continuation in resumes.matching {
+        for (continuation, value) in resumes.matching {
             continuation.resume(returning: value)
         }
     }
 
-    func nextValue(at index: Int) async -> Value {
+    func nextValue(
+        at index: Int,
+        timeout: Duration = .seconds(2)
+    ) async throws -> Value {
+        try await waitWithTimeout(
+            "timed out waiting for recorded value at index \(index)",
+            timeout: timeout
+        ) {
+            try await self.waitForValue(at: index)
+        }
+    }
+
+    private func waitForValue(at index: Int) async throws -> Value {
         if let existing = value(at: index) {
             return existing
         }
 
         let waiterID = UUID()
-        return await withCheckedContinuation { continuation in
-            let existing = lock.withLock { () -> Value? in
-                if values.indices.contains(index) {
-                    return values[index]
-                }
-                indexedWaiters.append(
-                    IndexedWaiter(
-                        id: waiterID,
-                        index: index,
-                        continuation: continuation
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                var shouldCancel = false
+                let existing = lock.withLock { () -> Value? in
+                    if values.indices.contains(index) {
+                        return values[index]
+                    }
+                    guard Task.isCancelled == false else {
+                        shouldCancel = true
+                        return nil
+                    }
+                    indexedWaiters.append(
+                        IndexedWaiter(
+                            id: waiterID,
+                            index: index,
+                            continuation: continuation
+                        )
                     )
-                )
-                return nil
+                    return nil
+                }
+                if let existing {
+                    continuation.resume(returning: existing)
+                } else if shouldCancel {
+                    continuation.resume(throwing: CancellationError())
+                }
             }
-            if let existing {
-                continuation.resume(returning: existing)
-            }
+        } onCancel: {
+            self.cancelIndexedWaiter(id: waiterID)
         }
     }
 
     func nextValue(
         startingAt startIndex: Int = 0,
+        timeout: Duration = .seconds(2),
+        matching predicate: @escaping @Sendable (Value) -> Bool = { _ in true }
+    ) async throws -> Value {
+        try await waitWithTimeout(
+            "timed out waiting for matching recorded value",
+            timeout: timeout
+        ) {
+            try await self.waitForValue(startingAt: startIndex, matching: predicate)
+        }
+    }
+
+    private func waitForValue(
+        startingAt startIndex: Int,
         matching predicate: @escaping @Sendable (Value) -> Bool
-    ) async -> Value {
+    ) async throws -> Value {
         if let existing = firstValue(startingAt: startIndex, matching: predicate) {
             return existing
         }
 
         let waiterID = UUID()
-        return await withCheckedContinuation { continuation in
-            let existing = lock.withLock { () -> Value? in
-                if let existing = firstValueLocked(startingAt: startIndex, matching: predicate) {
-                    return existing
-                }
-                matchingWaiters.append(
-                    MatchingWaiter(
-                        id: waiterID,
-                        startingAt: startIndex,
-                        predicate: predicate,
-                        continuation: continuation
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                var shouldCancel = false
+                let existing = lock.withLock { () -> Value? in
+                    if let existing = firstValueLocked(startingAt: startIndex, matching: predicate) {
+                        return existing
+                    }
+                    guard Task.isCancelled == false else {
+                        shouldCancel = true
+                        return nil
+                    }
+                    matchingWaiters.append(
+                        MatchingWaiter(
+                            id: waiterID,
+                            startingAt: startIndex,
+                            predicate: predicate,
+                            continuation: continuation
+                        )
                     )
-                )
+                    return nil
+                }
+                if let existing {
+                    continuation.resume(returning: existing)
+                } else if shouldCancel {
+                    continuation.resume(throwing: CancellationError())
+                }
+            }
+        } onCancel: {
+            self.cancelMatchingWaiter(id: waiterID)
+        }
+    }
+
+    private func cancelIndexedWaiter(id: UUID) {
+        let waiter = lock.withLock { () -> IndexedWaiter? in
+            guard let index = indexedWaiters.firstIndex(where: { $0.id == id }) else {
                 return nil
             }
-            if let existing {
-                continuation.resume(returning: existing)
-            }
+            return indexedWaiters.remove(at: index)
         }
+        waiter?.continuation.resume(throwing: CancellationError())
+    }
+
+    private func cancelMatchingWaiter(id: UUID) {
+        let waiter = lock.withLock { () -> MatchingWaiter? in
+            guard let index = matchingWaiters.firstIndex(where: { $0.id == id }) else {
+                return nil
+            }
+            return matchingWaiters.remove(at: index)
+        }
+        waiter?.continuation.resume(throwing: CancellationError())
     }
 
     func snapshot() -> [Value] {

--- a/Tests/XcodeMCPProcessRuntimeTests/ProcessRunnerTests.swift
+++ b/Tests/XcodeMCPProcessRuntimeTests/ProcessRunnerTests.swift
@@ -23,7 +23,7 @@ struct ProcessRunnerTests {
             task.cancel()
         }
 
-        let request = await fakeDriver.nextStartedRequest()
+        let request = try await fakeDriver.nextStartedRequest()
         #expect(request.label == "fake-output")
         #expect(request.executablePath == "/fake/tool")
         #expect(request.arguments == ["--flag"])
@@ -59,9 +59,9 @@ struct ProcessRunnerTests {
             task.cancel()
         }
 
-        _ = await fakeDriver.nextStartedRequest()
-        #expect(await fakeDriver.nextInputWrite() == "request-body")
-        _ = await fakeDriver.nextStdinClose()
+        _ = try await fakeDriver.nextStartedRequest()
+        #expect(try await fakeDriver.nextInputWrite() == "request-body")
+        _ = try await fakeDriver.nextStdinClose()
         #expect(fakeDriver.snapshot().closeStdinCount == 1)
 
         fakeDriver.emitTermination(status: 0)
@@ -95,7 +95,7 @@ struct ProcessRunnerTests {
             task.cancel()
         }
 
-        _ = await fakeDriver.nextStartedRequest()
+        _ = try await fakeDriver.nextStartedRequest()
         let timeout = try await scheduler.nextScheduled(.timeout)
         #expect(timeout.delayNanoseconds == timeoutNanoseconds)
         timeout.fire()
@@ -131,7 +131,7 @@ struct ProcessRunnerTests {
             )
         }
 
-        _ = await fakeDriver.nextStartedRequest()
+        _ = try await fakeDriver.nextStartedRequest()
         task.cancel()
 
         await #expect(throws: CancellationError.self) {
@@ -302,16 +302,16 @@ private final class FakeProcessRunnerDriver: ProcessRunnerProcessDriving, @unche
         stderrContinuation.finish()
     }
 
-    func nextStartedRequest() async -> ProcessRequest {
-        await startedRequests.nextValue(at: 0)
+    func nextStartedRequest() async throws -> ProcessRequest {
+        try await startedRequests.nextValue(at: 0)
     }
 
-    func nextInputWrite() async -> String {
-        await inputWrites.nextValue(at: 0)
+    func nextInputWrite() async throws -> String {
+        try await inputWrites.nextValue(at: 0)
     }
 
-    func nextStdinClose() async -> Int {
-        await stdinCloses.nextValue(at: 0)
+    func nextStdinClose() async throws -> Int {
+        try await stdinCloses.nextValue(at: 0)
     }
 
     func snapshot() -> Snapshot {
@@ -373,6 +373,18 @@ private final class TestProcessRunnerDelayScheduler: ProcessRunnerDelaySchedulin
     }
 
     fileprivate func nextScheduled(
+        _ kind: ProcessRunnerScheduledDelayKind,
+        timeout: Duration = .seconds(2)
+    ) async throws -> ScheduledDelay {
+        try await waitWithTimeout(
+            "timed out waiting for scheduled \(kind) delay",
+            timeout: timeout
+        ) {
+            try await self.waitForScheduled(kind)
+        }
+    }
+
+    private func waitForScheduled(
         _ kind: ProcessRunnerScheduledDelayKind
     ) async throws -> ScheduledDelay {
         if let scheduledDelay = removeScheduledDelay(kind) {
@@ -382,11 +394,30 @@ private final class TestProcessRunnerDelayScheduler: ProcessRunnerDelaySchedulin
         let waiterID = UUID()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
+                var shouldCancel = false
                 if let scheduledDelay = removeScheduledDelay(kind) {
                     continuation.resume(returning: scheduledDelay)
                     return
                 }
-                appendWaiter(Waiter(id: waiterID, kind: kind, continuation: continuation))
+                let scheduledDelay = locked { () -> ScheduledDelay? in
+                    if let index = scheduledDelays.firstIndex(where: { $0.kind == kind }) {
+                        return scheduledDelays.remove(at: index)
+                    } else if Task.isCancelled {
+                        shouldCancel = true
+                    } else {
+                        waiters.append(
+                            Waiter(id: waiterID, kind: kind, continuation: continuation)
+                        )
+                    }
+                    return nil
+                }
+                if let scheduledDelay {
+                    continuation.resume(returning: scheduledDelay)
+                    return
+                }
+                if shouldCancel {
+                    continuation.resume(throwing: CancellationError())
+                }
             }
         } onCancel: {
             self.cancelWaiter(id: waiterID)
@@ -417,12 +448,6 @@ private final class TestProcessRunnerDelayScheduler: ProcessRunnerDelaySchedulin
                 return nil
             }
             return scheduledDelays.remove(at: index)
-        }
-    }
-
-    private func appendWaiter(_ waiter: Waiter) {
-        locked {
-            waiters.append(waiter)
         }
     }
 

--- a/Tests/XcodeMCPProcessRuntimeTests/UpstreamProcessTests.swift
+++ b/Tests/XcodeMCPProcessRuntimeTests/UpstreamProcessTests.swift
@@ -23,7 +23,7 @@ struct UpstreamProcessTests {
         let splitIndex = first.utf8.index(first.utf8.startIndex, offsetBy: 4096)
         fakeDriver.emitStdout(Data(first.utf8[..<splitIndex]))
 
-        let buffered = await events.nextEvent {
+        let buffered = try await events.nextEvent {
             if case .stdoutBufferSize(let size) = $0 {
                 return size > 0
             }
@@ -62,11 +62,11 @@ struct UpstreamProcessTests {
         }
 
         fakeDriver.emitStderr(Data("warning one\nfatal".utf8))
-        let first = await events.nextStderr()
+        let first = try await events.nextStderr()
         #expect(first == "warning one")
 
         fakeDriver.emitStderr(Data(String(repeating: "x", count: 20_000).utf8))
-        let large = await events.nextStderr(startingAt: 1)
+        let large = try await events.nextStderr(startingAt: 1)
         #expect(large.contains("[truncated]"))
 
         fakeDriver.emitTermination(status: 0)
@@ -152,14 +152,14 @@ struct UpstreamProcessTests {
         }
 
         fakeDriver.emitStdout(Data(try makeJSONRPCResponse(id: 20, text: "parent").utf8))
-        _ = await events.nextMessage()
+        _ = try await events.nextMessage()
         fakeDriver.emitTermination(status: 0)
         try await drainClock.sleep(untilSuspendedBy: 1)
 
         #expect(!events.snapshot().contains(where: isExitEvent))
         drainClock.advance(by: .seconds(10))
 
-        let exit = await events.nextEvent(matching: isExitEvent)
+        let exit = try await events.nextEvent(matching: isExitEvent)
         #expect(isExitEvent(exit))
         let allEvents = await events.finishedEvents()
         #expect(allEvents.last.map(isExitEvent) == true)
@@ -178,7 +178,7 @@ struct UpstreamProcessTests {
         }
 
         fakeDriver.emitStdout(Data("Content-Length: nope\r\n\r\n{}".utf8))
-        let violation = await events.nextEvent {
+        let violation = try await events.nextEvent {
             if case .stdoutProtocolViolation = $0 {
                 return true
             }
@@ -474,12 +474,14 @@ private final class UpstreamEventRecorder: @unchecked Sendable {
         }
     }
 
-    func nextEvent(matching predicate: @escaping @Sendable (Upstream.Event) -> Bool) async -> Upstream.Event {
-        await recorder.nextValue(matching: predicate)
+    func nextEvent(
+        matching predicate: @escaping @Sendable (Upstream.Event) -> Bool
+    ) async throws -> Upstream.Event {
+        try await recorder.nextValue(matching: predicate)
     }
 
-    func nextMessage(startingAt startIndex: Int = 0) async -> String {
-        let event = await recorder.nextValue(startingAt: startIndex) {
+    func nextMessage(startingAt startIndex: Int = 0) async throws -> String {
+        let event = try await recorder.nextValue(startingAt: startIndex) {
             if case .message = $0 {
                 return true
             }
@@ -491,8 +493,8 @@ private final class UpstreamEventRecorder: @unchecked Sendable {
         return String(decoding: data, as: UTF8.self)
     }
 
-    func nextStderr(startingAt startIndex: Int = 0) async -> String {
-        let event = await recorder.nextValue(startingAt: startIndex) {
+    func nextStderr(startingAt startIndex: Int = 0) async throws -> String {
+        let event = try await recorder.nextValue(startingAt: startIndex) {
             if case .stderr = $0 {
                 return true
             }


### PR DESCRIPTION
## Purpose
Fix deterministic-wait audit findings by removing the test-only synchronous local MCP bridge from production request handling and making test synchronization fail fast instead of hanging.

## Changes
- Removed `usesSynchronousLocalResolution` and the unbounded semaphore bridge from local MCP response handling.
- Added an injectable event-loop completion executor so EmbeddedChannel tests can drain async completions on the embedded event-loop thread.
- Fixed `TestClock.sleep` to resume immediately when a deadline expires before continuation registration.
- Made ProcessRuntime deterministic recorders and delay scheduler waits bounded, cancellable, and cleanup-safe.

## Testing
- `swift test --filter ProxyHTTPGatewayTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPCoreTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodeMCPProcessRuntimeTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- codex-review against `codex/refactor-layered-runtime-integration`: no findings