### PR TITLE
Add live proxy tool verifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 .codex/tmp/
 /dist
 /release
+/ProxyToolVerifierOutput/

--- a/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture.xcodeproj/project.pbxproj
+++ b/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture.xcodeproj/project.pbxproj
@@ -1,0 +1,474 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		000000000000000000000101 /* ProxyToolVerifierFixtureApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000201 /* ProxyToolVerifierFixtureApp.swift */; };
+		000000000000000000000102 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000202 /* ContentView.swift */; };
+		000000000000000000000103 /* VerifierCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000203 /* VerifierCore.swift */; };
+		000000000000000000000104 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000204 /* Localizable.xcstrings */; };
+		000000000000000000000105 /* ProxyToolVerifierFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000000000000000000000205 /* ProxyToolVerifierFixtureTests.swift */; };
+		ABB339CE2FF20387003D6ED1 /* ProxyToolVerifierFixture-InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = ABB339CD2FF20387003D6ED1 /* ProxyToolVerifierFixture-InfoPlist.xcstrings */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		000000000000000000000301 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 000000000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 000000000000000000000401;
+			remoteInfo = ProxyToolVerifierFixture;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		000000000000000000000201 /* ProxyToolVerifierFixtureApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyToolVerifierFixtureApp.swift; sourceTree = "<group>"; };
+		000000000000000000000202 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		000000000000000000000203 /* VerifierCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifierCore.swift; sourceTree = "<group>"; };
+		000000000000000000000204 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		000000000000000000000205 /* ProxyToolVerifierFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyToolVerifierFixtureTests.swift; sourceTree = "<group>"; };
+		000000000000000000000206 /* ProxyToolVerifierFixture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProxyToolVerifierFixture.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		000000000000000000000207 /* ProxyToolVerifierFixtureTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProxyToolVerifierFixtureTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		ABB339CD2FF20387003D6ED1 /* ProxyToolVerifierFixture-InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = "ProxyToolVerifierFixture-InfoPlist.xcstrings"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		000000000000000000000501 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		000000000000000000000502 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		000000000000000000000601 = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000602 /* ProxyToolVerifierFixture */,
+				000000000000000000000603 /* ProxyToolVerifierFixtureTests */,
+				000000000000000000000604 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		000000000000000000000602 /* ProxyToolVerifierFixture */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000201 /* ProxyToolVerifierFixtureApp.swift */,
+				000000000000000000000202 /* ContentView.swift */,
+				000000000000000000000203 /* VerifierCore.swift */,
+				000000000000000000000204 /* Localizable.xcstrings */,
+				ABB339CD2FF20387003D6ED1 /* ProxyToolVerifierFixture-InfoPlist.xcstrings */,
+			);
+			path = ProxyToolVerifierFixture;
+			sourceTree = "<group>";
+		};
+		000000000000000000000603 /* ProxyToolVerifierFixtureTests */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000205 /* ProxyToolVerifierFixtureTests.swift */,
+			);
+			path = ProxyToolVerifierFixtureTests;
+			sourceTree = "<group>";
+		};
+		000000000000000000000604 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				000000000000000000000206 /* ProxyToolVerifierFixture.app */,
+				000000000000000000000207 /* ProxyToolVerifierFixtureTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		000000000000000000000401 /* ProxyToolVerifierFixture */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 000000000000000000000701 /* Build configuration list for PBXNativeTarget "ProxyToolVerifierFixture" */;
+			buildPhases = (
+				000000000000000000000801 /* Sources */,
+				000000000000000000000501 /* Frameworks */,
+				000000000000000000000901 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ProxyToolVerifierFixture;
+			productName = ProxyToolVerifierFixture;
+			productReference = 000000000000000000000206 /* ProxyToolVerifierFixture.app */;
+			productType = "com.apple.product-type.application";
+		};
+		000000000000000000000402 /* ProxyToolVerifierFixtureTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 000000000000000000000702 /* Build configuration list for PBXNativeTarget "ProxyToolVerifierFixtureTests" */;
+			buildPhases = (
+				000000000000000000000802 /* Sources */,
+				000000000000000000000502 /* Frameworks */,
+				000000000000000000000902 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				000000000000000000000302 /* PBXTargetDependency */,
+			);
+			name = ProxyToolVerifierFixtureTests;
+			productName = ProxyToolVerifierFixtureTests;
+			productReference = 000000000000000000000207 /* ProxyToolVerifierFixtureTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		000000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2700;
+				LastUpgradeCheck = 2700;
+				TargetAttributes = {
+					000000000000000000000401 = {
+						CreatedOnToolsVersion = 27.0;
+					};
+					000000000000000000000402 = {
+						CreatedOnToolsVersion = 27.0;
+						TestTargetID = 000000000000000000000401;
+					};
+				};
+			};
+			buildConfigurationList = 000000000000000000000700 /* Build configuration list for PBXProject "ProxyToolVerifierFixture" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+				ja,
+			);
+			mainGroup = 000000000000000000000601;
+			productRefGroup = 000000000000000000000604 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				000000000000000000000401 /* ProxyToolVerifierFixture */,
+				000000000000000000000402 /* ProxyToolVerifierFixtureTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		000000000000000000000901 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				000000000000000000000104 /* Localizable.xcstrings in Resources */,
+				ABB339CE2FF20387003D6ED1 /* ProxyToolVerifierFixture-InfoPlist.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		000000000000000000000902 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		000000000000000000000801 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				000000000000000000000101 /* ProxyToolVerifierFixtureApp.swift in Sources */,
+				000000000000000000000102 /* ContentView.swift in Sources */,
+				000000000000000000000103 /* VerifierCore.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		000000000000000000000802 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				000000000000000000000105 /* ProxyToolVerifierFixtureTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		000000000000000000000302 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 000000000000000000000401 /* ProxyToolVerifierFixture */;
+			targetProxy = 000000000000000000000301 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		000000000000000000000A01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		000000000000000000000A02 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		000000000000000000000A03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Proxy Tool Verifier";
+				INFOPLIST_KEY_LSRequiresIPhoneOS = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.xcodemcp.ProxyToolVerifierFixture;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		000000000000000000000A04 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Proxy Tool Verifier";
+				INFOPLIST_KEY_LSRequiresIPhoneOS = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.xcodemcp.ProxyToolVerifierFixture;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		000000000000000000000A05 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.xcodemcp.ProxyToolVerifierFixtureTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ProxyToolVerifierFixture.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ProxyToolVerifierFixture";
+			};
+			name = Debug;
+		};
+		000000000000000000000A06 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.xcodemcp.ProxyToolVerifierFixtureTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ProxyToolVerifierFixture.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ProxyToolVerifierFixture";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		000000000000000000000700 /* Build configuration list for PBXProject "ProxyToolVerifierFixture" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000000000A01 /* Debug */,
+				000000000000000000000A02 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		000000000000000000000701 /* Build configuration list for PBXNativeTarget "ProxyToolVerifierFixture" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000000000A03 /* Debug */,
+				000000000000000000000A04 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		000000000000000000000702 /* Build configuration list for PBXNativeTarget "ProxyToolVerifierFixtureTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				000000000000000000000A05 /* Debug */,
+				000000000000000000000A06 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 000000000000000000000001 /* Project object */;
+}

--- a/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/ContentView.swift
+++ b/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/ContentView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(VerifierCore.message())
+                .font(.headline)
+                .accessibilityIdentifier("verifier-message")
+            Text("\(VerifierCore.number())")
+                .accessibilityIdentifier("verifier-number")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/Localizable.xcstrings
+++ b/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/Localizable.xcstrings
@@ -1,0 +1,23 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "verifier.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifier Title"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Verifier Title JA"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.3"
+}

--- a/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/ProxyToolVerifierFixture-InfoPlist.xcstrings
+++ b/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/ProxyToolVerifierFixture-InfoPlist.xcstrings
@@ -1,0 +1,30 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "Bundle display name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Proxy Tool Verifier"
+          }
+        }
+      }
+    },
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "ProxyToolVerifierFixture"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.3"
+}

--- a/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/ProxyToolVerifierFixtureApp.swift
+++ b/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/ProxyToolVerifierFixtureApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ProxyToolVerifierFixtureApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/VerifierCore.swift
+++ b/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture/VerifierCore.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum VerifierCore {
+    static func message() -> String {
+        String(localized: "verifier.title")
+    }
+
+    static func number() -> Int {
+        42
+    }
+}

--- a/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixtureTests/ProxyToolVerifierFixtureTests.swift
+++ b/Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixtureTests/ProxyToolVerifierFixtureTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import ProxyToolVerifierFixture
+
+final class ProxyToolVerifierFixtureTests: XCTestCase {
+    func testMessage() {
+        XCTAssertEqual(VerifierCore.number(), 42)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,10 @@ let package = Package(
             name: "xcode-mcp-proxy-install",
             targets: ["XcodeMCPProxyInstall"]
         ),
+        .executable(
+            name: "xcode-mcp-proxy-tool-verifier",
+            targets: ["XcodeMCPProxyToolVerifier"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
@@ -132,6 +136,12 @@ let package = Package(
         .executableTarget(
             name: "XcodeMCPProxyInstall",
             dependencies: ["XcodeMCPProxyKit"],
+            swiftSettings: strictSwiftSettings
+        ),
+        .executableTarget(
+            name: "XcodeMCPProxyToolVerifier",
+            dependencies: ["XcodeMCPKit"],
+            exclude: ["README.md"],
             swiftSettings: strictSwiftSettings
         ),
         .executableTarget(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -41,18 +41,8 @@ extension RuntimeCoordinator {
         routeScope: XcodeListWindowsRouteScope
     ) async throws -> JSONValue {
         let unavailable = unavailableXcodeProcessIDs()
-        let catalogedProcessIDs = processToolCatalogRegistry.processIDsWithCatalog()
-        let catalogProcessIDs = processToolCatalogRegistry.processIDsHavingTool("XcodeListWindows")
-        let routes = xcodeProcessRoutes.enumerated().compactMap { ordinal, route -> XcodeListWindowsRoute? in
+        let usableRoutes = xcodeProcessRoutes.enumerated().compactMap { ordinal, route -> XcodeListWindowsRoute? in
             guard unavailable.contains(route.target.processID) == false else {
-                return nil
-            }
-            guard includesXcodeListWindowsRoute(
-                route,
-                catalogedProcessIDs: catalogedProcessIDs,
-                catalogProcessIDs: catalogProcessIDs,
-                routeScope: routeScope
-            ) else {
                 return nil
             }
             let upstreamIndices = usableInitializedUpstreamIndices(in: route)
@@ -63,6 +53,21 @@ extension RuntimeCoordinator {
                 ordinal: ordinal,
                 target: route.target,
                 upstreamIndices: upstreamIndices
+            )
+        }
+        let usableProcessIDs = Set(usableRoutes.map(\.target.processID))
+        let catalogedProcessIDs =
+            processToolCatalogRegistry.processIDsWithCatalog()
+            .intersection(usableProcessIDs)
+        let catalogProcessIDs =
+            processToolCatalogRegistry.processIDsHavingTool("XcodeListWindows")
+            .intersection(usableProcessIDs)
+        let routes = usableRoutes.filter {
+            includesXcodeListWindowsRoute(
+                $0.target,
+                catalogedProcessIDs: catalogedProcessIDs,
+                catalogProcessIDs: catalogProcessIDs,
+                routeScope: routeScope
             )
         }
 
@@ -140,12 +145,12 @@ extension RuntimeCoordinator {
     }
 
     private func includesXcodeListWindowsRoute(
-        _ route: XcodeProcessRoute,
+        _ target: XcodeProcessTarget,
         catalogedProcessIDs: Set<pid_t>,
         catalogProcessIDs: Set<pid_t>,
         routeScope: XcodeListWindowsRouteScope
     ) -> Bool {
-        let processID = route.target.processID
+        let processID = target.processID
         if catalogProcessIDs.contains(processID) {
             return true
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -35,8 +35,12 @@ extension RuntimeCoordinator {
         deadlineUptimeNs: UInt64?
     ) async throws -> JSONValue {
         let unavailable = unavailableXcodeProcessIDs()
+        let catalogProcessIDs = processToolCatalogRegistry.processIDsHavingTool("XcodeListWindows")
         let routes = xcodeProcessRoutes.enumerated().compactMap { ordinal, route -> XcodeListWindowsRoute? in
             guard unavailable.contains(route.target.processID) == false else {
+                return nil
+            }
+            guard catalogProcessIDs.isEmpty || catalogProcessIDs.contains(route.target.processID) else {
                 return nil
             }
             let upstreamIndices = usableInitializedUpstreamIndices(in: route)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -35,12 +35,13 @@ extension RuntimeCoordinator {
         deadlineUptimeNs: UInt64?
     ) async throws -> JSONValue {
         let unavailable = unavailableXcodeProcessIDs()
+        let catalogedProcessIDs = processToolCatalogRegistry.processIDsWithCatalog()
         let catalogProcessIDs = processToolCatalogRegistry.processIDsHavingTool("XcodeListWindows")
         let routes = xcodeProcessRoutes.enumerated().compactMap { ordinal, route -> XcodeListWindowsRoute? in
             guard unavailable.contains(route.target.processID) == false else {
                 return nil
             }
-            guard catalogProcessIDs.isEmpty || catalogProcessIDs.contains(route.target.processID) else {
+            guard catalogedProcessIDs.isEmpty || catalogProcessIDs.contains(route.target.processID) else {
                 return nil
             }
             let upstreamIndices = usableInitializedUpstreamIndices(in: route)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -25,6 +25,11 @@ extension RuntimeCoordinator {
         case failure(target: XcodeProcessTarget, upstreamIndex: Int, error: any Error)
     }
 
+    enum XcodeListWindowsRouteScope: Sendable {
+        case catalogSurface
+        case ownerDiscovery
+    }
+
     private enum XcodeListWindowsRoutingEligibility {
         case localOnly
         case forwardWholeBatch
@@ -32,7 +37,8 @@ extension RuntimeCoordinator {
     }
 
     func liveXcodeListWindowsAcrossProcessRoutes(
-        deadlineUptimeNs: UInt64?
+        deadlineUptimeNs: UInt64?,
+        routeScope: XcodeListWindowsRouteScope
     ) async throws -> JSONValue {
         let unavailable = unavailableXcodeProcessIDs()
         let catalogedProcessIDs = processToolCatalogRegistry.processIDsWithCatalog()
@@ -41,7 +47,12 @@ extension RuntimeCoordinator {
             guard unavailable.contains(route.target.processID) == false else {
                 return nil
             }
-            guard catalogedProcessIDs.isEmpty || catalogProcessIDs.contains(route.target.processID) else {
+            guard includesXcodeListWindowsRoute(
+                route,
+                catalogedProcessIDs: catalogedProcessIDs,
+                catalogProcessIDs: catalogProcessIDs,
+                routeScope: routeScope
+            ) else {
                 return nil
             }
             let upstreamIndices = usableInitializedUpstreamIndices(in: route)
@@ -125,6 +136,27 @@ extension RuntimeCoordinator {
                 throw lastError
             }
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+    }
+
+    private func includesXcodeListWindowsRoute(
+        _ route: XcodeProcessRoute,
+        catalogedProcessIDs: Set<pid_t>,
+        catalogProcessIDs: Set<pid_t>,
+        routeScope: XcodeListWindowsRouteScope
+    ) -> Bool {
+        let processID = route.target.processID
+        if catalogProcessIDs.contains(processID) {
+            return true
+        }
+        if catalogedProcessIDs.contains(processID) {
+            return false
+        }
+        switch routeScope {
+        case .catalogSurface:
+            return catalogedProcessIDs.isEmpty
+        case .ownerDiscovery:
+            return true
         }
     }
 
@@ -381,8 +413,7 @@ extension RuntimeCoordinator {
             )
         if ownerResolution.unresolved.isEmpty == false {
             if inferredOwnerProcessID == nil {
-                _ = try? await liveXcodeListWindowsResult(
-                    route: .anyHealthy,
+                _ = try? await refreshXcodeWindowOwnersForRouting(
                     requestTimeoutOverride: requestTimeoutOverride
                 )
                 ownerResolution = resolvedOwnerProcessIDs(for: ownerBoundRequests)
@@ -468,6 +499,22 @@ extension RuntimeCoordinator {
         }
 
         return .forwardAny(preferredUpstreamIndices: ownerUpstreamIndices)
+    }
+
+    private func refreshXcodeWindowOwnersForRouting(
+        requestTimeoutOverride: TimeAmount?
+    ) async throws -> JSONValue {
+        let timeout =
+            requestTimeoutOverride
+            ?? MCP.MethodDispatcher.timeoutForMethod(
+                "tools/call",
+                defaultSeconds: config.requestTimeout
+            )
+        let deadline = timeoutDeadline(for: timeout)
+        return try await liveXcodeListWindowsAcrossProcessRoutes(
+            deadlineUptimeNs: deadline,
+            routeScope: .ownerDiscovery
+        )
     }
 
     private func inferredUnambiguousOwnerProcessID(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -70,6 +70,10 @@ extension RuntimeCoordinator {
                 routeScope: routeScope
             )
         }
+        let queriedProcessIDs = Set(routes.map(\.target.processID))
+        for skippedProcessID in usableProcessIDs.subtracting(queriedProcessIDs) {
+            removeXcodeWindowOwners(forProcessID: skippedProcessID)
+        }
 
         guard routes.isEmpty == false else {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -1165,7 +1165,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         switch route {
         case .anyHealthy where xcodeProcessRoutes.isEmpty == false:
             return try await liveXcodeListWindowsAcrossProcessRoutes(
-                deadlineUptimeNs: deadline
+                deadlineUptimeNs: deadline,
+                routeScope: .catalogSurface
             )
         default:
             let result = try await awaitControlPlaneOperation {

--- a/Sources/XcodeMCPProxyToolVerifier/README.md
+++ b/Sources/XcodeMCPProxyToolVerifier/README.md
@@ -1,0 +1,33 @@
+# XcodeMCPProxyToolVerifier
+
+Live verifier for `xcode-mcp-proxy-server`.
+
+```sh
+swift run xcode-mcp-proxy-tool-verifier
+```
+
+The verifier:
+
+- builds the local debug `xcode-mcp-proxy-server`
+- starts it on a verifier-only port
+- opens `XcodeMCPKit.xcworkspace`
+- uses the tracked fixture project in `Fixtures/ProxyToolVerifierFixture`
+- reads the live `tools/list` catalog
+- calls each available tool one at a time
+- writes `ProxyToolVerifierOutput/report.json`
+- prints the tested tool list at the end
+
+Logs, cache files, and reports are written under `ProxyToolVerifierOutput/`,
+which is ignored by git.
+
+`Fixtures/ProxyToolVerifierFixture` is a small tracked Xcode project used only
+by this verifier. It gives the live tools a stable app, scheme, test target,
+SwiftUI preview, and String Catalog to operate on. The verifier restores the
+fixture files it mutates during a run.
+
+Options:
+
+```sh
+swift run xcode-mcp-proxy-tool-verifier --port 18765 --request-timeout 600
+swift run xcode-mcp-proxy-tool-verifier --keep-server
+```

--- a/Sources/XcodeMCPProxyToolVerifier/main.swift
+++ b/Sources/XcodeMCPProxyToolVerifier/main.swift
@@ -1,0 +1,1256 @@
+import Foundation
+import XcodeMCPKit
+
+@main
+struct XcodeMCPProxyToolVerifier {
+    static func main() async {
+        do {
+            let options = try VerifierOptions(arguments: Array(CommandLine.arguments.dropFirst()))
+            let runner = ProxyToolVerifier(options: options)
+            let hasFailures = try await runner.run()
+            Foundation.exit(hasFailures ? 1 : 0)
+        } catch {
+            FileHandle.standardError.write(Data("error: \(errorDescription(error))\n".utf8))
+            Foundation.exit(1)
+        }
+    }
+}
+
+private struct VerifierOptions {
+    var host = "127.0.0.1"
+    var port = 18_765
+    var upstreamProcesses = 2
+    var requestTimeoutSeconds = 600
+    var outputDirectory = URL(fileURLWithPath: "ProxyToolVerifierOutput", isDirectory: true)
+    var keepServer = false
+    var noOpenXcode = false
+    var verbose = false
+
+    init(arguments: [String]) throws {
+        var index = 0
+        while index < arguments.count {
+            let argument = arguments[index]
+            switch argument {
+            case "--host":
+                host = try Self.value(after: argument, in: arguments, index: &index)
+            case "--port":
+                port = try Int(Self.value(after: argument, in: arguments, index: &index))
+                    ?? Self.fail("--port requires an integer")
+            case "--upstream-processes":
+                upstreamProcesses = try Int(Self.value(after: argument, in: arguments, index: &index))
+                    ?? Self.fail("--upstream-processes requires an integer")
+            case "--request-timeout":
+                requestTimeoutSeconds = try Int(Self.value(after: argument, in: arguments, index: &index))
+                    ?? Self.fail("--request-timeout requires an integer")
+            case "--output":
+                outputDirectory = URL(fileURLWithPath: try Self.value(after: argument, in: arguments, index: &index), isDirectory: true)
+            case "--keep-server":
+                keepServer = true
+            case "--no-open-xcode":
+                noOpenXcode = true
+            case "-v", "--verbose":
+                verbose = true
+            case "-h", "--help":
+                print(Self.usage)
+                Foundation.exit(0)
+            default:
+                throw VerifierFailure("unknown argument: \(argument)")
+            }
+            index += 1
+        }
+    }
+
+    var endpoint: URL {
+        URL(string: "http://\(host):\(port)/mcp")!
+    }
+
+    static let usage = """
+    Usage:
+      swift run xcode-mcp-proxy-tool-verifier [options]
+
+    Options:
+      --host host                 Listen host for the debug proxy server. Default: 127.0.0.1
+      --port port                 Dedicated verifier port. Default: 18765
+      --upstream-processes n      Upstream mcpbridge processes per Xcode. Default: 2
+      --request-timeout seconds   XcodeMCP request timeout. Default: 600
+      --output path               Ignored verifier output directory. Default: ProxyToolVerifierOutput
+      --keep-server               Leave the debug proxy server running.
+      --no-open-xcode             Do not open the fixture package in Xcode.
+      -v, --verbose               Print tool arguments and response summaries.
+    """
+
+    private static func value(after flag: String, in arguments: [String], index: inout Int) throws -> String {
+        let valueIndex = index + 1
+        guard valueIndex < arguments.count else {
+            throw VerifierFailure("\(flag) requires a value")
+        }
+        index = valueIndex
+        return arguments[valueIndex]
+    }
+
+    private static func fail<T>(_ message: String) throws -> T {
+        throw VerifierFailure(message)
+    }
+}
+
+private struct ProxyToolVerifier {
+    let options: VerifierOptions
+    let fileManager = FileManager.default
+
+    func run() async throws -> Bool {
+        let repoRoot = try repositoryRoot()
+        let outputRoot = absoluteURL(options.outputDirectory, relativeTo: repoRoot)
+        let fixture = FixtureLayout(repoRoot: repoRoot, outputRoot: outputRoot)
+
+        try prepareOutputDirectory(outputRoot)
+        try prepareFixture(fixture)
+        let fixtureSnapshot = try FixtureSnapshot.capture(fixture)
+        defer {
+            try? fixtureSnapshot.restore()
+        }
+
+        if options.noOpenXcode == false {
+            try openFixtureInXcode(fixture.rootWorkspaceURL)
+        }
+
+        try buildDebugProxyServer(in: repoRoot)
+        let server = try startDebugProxyServer(repoRoot: repoRoot, outputRoot: outputRoot)
+        defer {
+            if options.keepServer == false {
+                server.terminate()
+            }
+        }
+
+        let client = try await connectToProxy()
+        defer {
+            Task {
+                await client.close()
+            }
+        }
+
+        var state = VerificationState(fixture: fixture)
+        let tools = try await client.listTools()
+        state.availableTools = Set(tools.map(\.name))
+        var records: [ToolVerificationRecord] = []
+        let reportURL = outputRoot.appendingPathComponent("report.json")
+
+        func currentReport() -> VerificationReport {
+            VerificationReport(
+                endpoint: options.endpoint.absoluteString,
+                fixturePath: fixture.xcodeProjectURL.path,
+                workspacePath: fixture.rootWorkspaceURL.path,
+                toolCount: tools.count,
+                availableTools: tools.map(\.name).sorted(),
+                toolDescriptors: tools.sorted { $0.name < $1.name },
+                records: records
+            )
+        }
+
+        let executionPlan = toolExecutionOrder(availableTools: state.availableTools)
+        print("Available tools: \(tools.count)")
+        print("Planned tools: \(executionPlan.count)")
+
+        for (index, toolName) in executionPlan.enumerated() {
+            guard state.availableTools.contains(toolName) else {
+                records.append(
+                    ToolVerificationRecord(
+                        name: toolName,
+                        status: .failed,
+                        elapsedSeconds: 0,
+                        detail: "missing from tools/list",
+                        arguments: nil
+                    )
+                )
+                continue
+            }
+            let arguments = state.arguments(for: toolName)
+            print("-> [\(index + 1)/\(executionPlan.count)] \(toolName)")
+            let record = await call(
+                toolName,
+                arguments: arguments,
+                client: client
+            )
+            print("<- [\(record.status.rawValue)] \(toolName) (\(formatSeconds(record.elapsedSeconds)))")
+            records.append(record)
+            state.observe(toolName: toolName, record: record)
+            try writeReport(currentReport(), to: reportURL, announce: false)
+        }
+
+        let report = currentReport()
+        try writeReport(report, to: reportURL)
+        printReport(report)
+        return report.hasHardFailures
+    }
+
+    private func call(
+        _ toolName: String,
+        arguments: [String: MCPJSONValue],
+        client: XcodeMCP
+    ) async -> ToolVerificationRecord {
+        let started = Date()
+        do {
+            let result = try await client.callTool(toolName, arguments: arguments)
+            let elapsed = Date().timeIntervalSince(started)
+            let detail = responseSummary(result)
+            let status = verificationStatus(
+                toolName: toolName,
+                result: result,
+                detail: detail
+            )
+            return ToolVerificationRecord(
+                name: toolName,
+                status: status,
+                elapsedSeconds: elapsed,
+                detail: detail,
+                arguments: arguments,
+                rawResult: result.raw
+            )
+        } catch let error as XcodeMCPError {
+            let elapsed = Date().timeIntervalSince(started)
+            let status: ToolVerificationStatus
+            switch error {
+            case .requestTimedOut:
+                status = .hung
+            case .serverError:
+                status = .rpcError
+            case .closed, .invalidRequest, .invalidResponse, .transportUnavailable:
+                status = .failed
+            }
+            return ToolVerificationRecord(
+                name: toolName,
+                status: status,
+                elapsedSeconds: elapsed,
+                detail: errorDescription(error),
+                arguments: arguments
+            )
+        } catch {
+            let elapsed = Date().timeIntervalSince(started)
+            return ToolVerificationRecord(
+                name: toolName,
+                status: .failed,
+                elapsedSeconds: elapsed,
+                detail: errorDescription(error),
+                arguments: arguments
+            )
+        }
+    }
+
+    private func connectToProxy() async throws -> XcodeMCP {
+        var lastError: (any Error)?
+        for _ in 0..<90 {
+            do {
+                return try await XcodeMCP(
+                    config: .init(
+                        transport: .streamableHTTP(endpoint: options.endpoint),
+                        clientName: "XcodeMCPProxyToolVerifier",
+                        clientVersion: "dev",
+                        requestTimeout: .seconds(options.requestTimeoutSeconds)
+                    )
+                )
+            } catch {
+                lastError = error
+                try await Task.sleep(for: .seconds(1))
+            }
+        }
+        throw VerifierFailure(
+            "proxy did not become ready at \(options.endpoint.absoluteString): \(lastError.map(errorDescription) ?? "unknown error")"
+        )
+    }
+
+    private func prepareOutputDirectory(_ outputRoot: URL) throws {
+        try fileManager.createDirectory(
+            at: outputRoot,
+            withIntermediateDirectories: true
+        )
+    }
+
+    private func prepareFixture(_ fixture: FixtureLayout) throws {
+        guard fileManager.fileExists(atPath: fixture.xcodeProjectURL.path) else {
+            throw VerifierFailure("missing tracked verifier fixture at \(fixture.xcodeProjectURL.path)")
+        }
+        try? fileManager.removeItem(at: fixture.scratchDirectoryURL)
+    }
+
+    private func buildDebugProxyServer(in repoRoot: URL) throws {
+        print("Building debug xcode-mcp-proxy-server...")
+        try runProcess(
+            executable: "/usr/bin/swift",
+            arguments: ["build", "--configuration", "debug", "--product", "xcode-mcp-proxy-server"],
+            currentDirectory: repoRoot
+        )
+    }
+
+    private func startDebugProxyServer(repoRoot: URL, outputRoot: URL) throws -> RunningProcess {
+        let binary = repoRoot.appendingPathComponent(".build/debug/xcode-mcp-proxy-server")
+        guard fileManager.isExecutableFile(atPath: binary.path) else {
+            throw VerifierFailure("debug proxy server binary is missing: \(binary.path)")
+        }
+        let logURL = outputRoot.appendingPathComponent("proxy-server.log")
+        fileManager.createFile(atPath: logURL.path, contents: nil)
+        let logHandle = try FileHandle(forWritingTo: logURL)
+        let process = Process()
+        process.executableURL = binary
+        process.arguments = [
+            "--listen", "\(options.host):\(options.port)",
+            "--upstream-processes", "\(options.upstreamProcesses)",
+            "--auto-approve",
+            "--refresh-code-issues-mode", "proxy",
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["XCODE_MCP_PROXY_CACHE_ROOT"] = outputRoot.appendingPathComponent("cache").path
+        process.environment = environment
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+        try process.run()
+        print("Started debug proxy server: \(options.endpoint.absoluteString)")
+        print("Proxy log: \(logURL.path)")
+        return RunningProcess(process: process, logHandle: logHandle)
+    }
+
+    private func openFixtureInXcode(_ projectURL: URL) throws {
+        if fileManager.isExecutableFile(atPath: "/usr/bin/xed") {
+            try runProcess(
+                executable: "/usr/bin/xed",
+                arguments: ["-b", projectURL.path],
+                currentDirectory: projectURL.deletingLastPathComponent()
+            )
+        } else {
+            try runProcess(
+                executable: "/usr/bin/open",
+                arguments: ["-a", "Xcode", projectURL.path],
+                currentDirectory: projectURL.deletingLastPathComponent()
+            )
+        }
+    }
+
+    private func repositoryRoot() throws -> URL {
+        let cwd = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+        if fileManager.fileExists(atPath: cwd.appendingPathComponent("Package.swift").path) {
+            return cwd
+        }
+        throw VerifierFailure("run from the XcodeMCPKit repository root")
+    }
+
+    private func absoluteURL(_ url: URL, relativeTo base: URL) -> URL {
+        if url.path.hasPrefix("/") {
+            return url
+        }
+        return base.appendingPathComponent(url.path)
+    }
+
+    private func writeReport(_ report: VerificationReport, to url: URL, announce: Bool = true) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(report)
+        try data.write(to: url)
+        if announce {
+            print("Report: \(url.path)")
+        }
+    }
+
+    private func printReport(_ report: VerificationReport) {
+        let counts = Dictionary(grouping: report.records, by: \.status)
+            .mapValues(\.count)
+        print("")
+        print("Summary")
+        for status in ToolVerificationStatus.allCases {
+            print("  \(status.rawValue): \(counts[status, default: 0])")
+        }
+        print("")
+        print("Tools")
+        for record in report.records {
+            let elapsed = formatSeconds(record.elapsedSeconds)
+            print("  [\(record.status.rawValue)] \(record.name) (\(elapsed)) - \(record.detail)")
+            if options.verbose, let arguments = record.arguments {
+                print("    args: \(jsonString(arguments))")
+            }
+        }
+        let testedTools = report.records
+            .map(\.name)
+            .filter { $0 != "tools/list" }
+        print("")
+        print("Tested tools (\(testedTools.count))")
+        for name in testedTools.sorted() {
+            print("  - \(name)")
+        }
+    }
+}
+
+private struct VerificationState {
+    let fixture: FixtureLayout
+    var availableTools: Set<String> = []
+    var tabIdentifier = "windowtab1"
+    var schemeName = "ProxyToolVerifierFixture"
+    var runDestination = "iPhone 17 (27.0)"
+    var testTargetName = "ProxyToolVerifierFixtureTests"
+    var testIdentifier = "ProxyToolVerifierFixtureTests/testMessage()"
+    var interactionSessionIdentifier = "Proxy Tool Verifier \(UUID().uuidString)"
+    var interactionSessionKey = "invalid-verifier-session-key"
+
+    var navigatorRoot: String {
+        "ProxyToolVerifierFixture"
+    }
+
+    func navPath(_ path: String) -> String {
+        "\(navigatorRoot)/\(path)"
+    }
+
+    func arguments(for toolName: String) -> [String: MCPJSONValue] {
+        switch toolName {
+        case "BuildProject":
+            return ["tabIdentifier": .string(tabIdentifier), "buildForTesting": .bool(true)]
+        case "DeviceInteractionEndSession":
+            return ["interactionSessionKey": .string(interactionSessionKey)]
+        case "DeviceInteractionInstallAndRun":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "interactionSessionKey": .string(interactionSessionKey),
+            ]
+        case "DeviceInteractionStartSession":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "sessionIdentifier": .string(interactionSessionIdentifier),
+            ]
+        case "DeviceInteractionSynthesize":
+            return [
+                "interactSessionKey": .string(interactionSessionKey),
+            ]
+        case "DocumentationSearch":
+            return ["query": .string("NavigationStack")]
+        case "GetBuildLog":
+            return ["tabIdentifier": .string(tabIdentifier), "severity": .string("remark")]
+        case "GetConsoleOutput":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "outputType": .string("all"),
+                "tailLimit": .integer(100),
+            ]
+        case "GetCrashIssueLogs":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "signature_name": .string("ProxyVerifierCrashSignature"),
+                "bundle_id": .string("dev.xcodemcp.ProxyToolVerifierFixture"),
+                "platform": .string("macOS"),
+                "app_version": .string("1.0"),
+            ]
+        case "GetFieldPerformanceIssueLogs":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "app_version": .string("1.0"),
+                "signature_name": .string("ProxyVerifierPerformanceSignature"),
+                "diagnostic_type": .string("hangs"),
+                "bundle_id": .string("dev.xcodemcp.ProxyToolVerifierFixture"),
+                "platform": .string("macOS"),
+            ]
+        case "GetFileCompilerFlags":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "targetName": .string("ProxyToolVerifierFixture"),
+                "filePath": .string(navPath("VerifierCore.swift")),
+            ]
+        case "GetTestList":
+            return ["tabIdentifier": .string(tabIdentifier)]
+        case "GetTopCrashIssues":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "count": .integer(1),
+                "bundle_id": .string("dev.xcodemcp.ProxyToolVerifierFixture"),
+                "platform": .string("macOS"),
+            ]
+        case "GetTopFieldPerformanceIssues":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "diagnostic_type": .string("hangs"),
+                "bundle_id": .string("dev.xcodemcp.ProxyToolVerifierFixture"),
+                "platform": .string("macOS"),
+            ]
+        case "InvokeDebuggerCommand":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "command": .string("thread list"),
+                "timeout": .integer(20),
+            ]
+        case "LocalizationPlanner":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "targetLocaleIdentifier": .string("ja"),
+            ]
+        case "RenderPreview":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "sourceFilePath": .string(navPath("ContentView.swift")),
+                "timeout": .integer(180),
+            ]
+        case "RunAllTests":
+            return ["tabIdentifier": .string(tabIdentifier)]
+        case "RunCodeSnippet":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "sourceFilePath": .string(navPath("VerifierCore.swift")),
+                "purpose": .string("Proxy verifier snippet"),
+                "codeSnippet": .string(#"print(VerifierCore.message())"#),
+                "timeout": .integer(120),
+            ]
+        case "RunProject":
+            return ["tabIdentifier": .string(tabIdentifier), "attachDebugger": .bool(true)]
+        case "RunSomeTests":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "tests": .array([
+                    .object([
+                        "targetName": .string(testTargetName),
+                        "testIdentifier": .string(testIdentifier),
+                    ])
+                ]),
+            ]
+        case "StopProject":
+            return ["tabIdentifier": .string(tabIdentifier)]
+        case "StringCatalogContext":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "filePath": .string(navPath("Localizable.xcstrings")),
+                "stringKey": .string("verifier.title"),
+                "targetLocaleIdentifier": .string("ja"),
+            ]
+        case "StringCatalogEdit":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "filePath": .string(navPath("Localizable.xcstrings")),
+                "stringKey": .string("verifier.title"),
+                "targetLocaleIdentifier": .string("ja"),
+                "translation": .string("Verifier Title JA Updated"),
+            ]
+        case "StringCatalogRead":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "filePath": .string(navPath("Localizable.xcstrings")),
+                "targetLocaleIdentifier": .string("ja"),
+                "keyLimit": .integer(20),
+            ]
+        case "UpdateFileCompilerFlags":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "targetName": .string("ProxyToolVerifierFixture"),
+                "filePath": .string(navPath("VerifierCore.swift")),
+                "compilerFlags": .string("-DPROXY_TOOL_VERIFIER"),
+                "appendValue": .bool(false),
+            ]
+        case "XcodeGetCurrentFile":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "includeContent": .bool(false),
+                "includeSelection": .bool(true),
+            ]
+        case "XcodeGlob":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "pattern": .string("**/*.swift"),
+            ]
+        case "XcodeGrep":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "pattern": .string("VerifierCore"),
+                "outputMode": .string("filesWithMatches"),
+                "headLimit": .integer(10),
+            ]
+        case "XcodeListNavigatorIssues":
+            return ["tabIdentifier": .string(tabIdentifier), "severity": .string("remark")]
+        case "XcodeListRunDestinations":
+            return ["tabIdentifier": .string(tabIdentifier), "includeIncompatible": .bool(true)]
+        case "XcodeListSchemes":
+            return ["tabIdentifier": .string(tabIdentifier)]
+        case "XcodeListWindows":
+            return [:]
+        case "XcodeLS":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "path": .string(navigatorRoot),
+                "recursive": .bool(true),
+            ]
+        case "XcodeMakeDir":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "directoryPath": .string(navPath("VerifierScratch")),
+            ]
+        case "XcodeMV":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "sourcePath": .string(navPath("VerifierScratch/probe.txt")),
+                "destinationPath": .string(navPath("VerifierScratch/probe-moved.txt")),
+                "operation": .object(["rawValue": .string("move")]),
+                "overwriteExisting": .bool(true),
+            ]
+        case "XcodeRead":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "filePath": .string(navPath("VerifierCore.swift")),
+                "limit": .integer(40),
+            ]
+        case "XcodeRefreshCodeIssuesInFile":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "filePath": .string(navPath("VerifierCore.swift")),
+            ]
+        case "XcodeRM":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "path": .string(navPath("VerifierScratch/probe-moved.txt")),
+                "recursive": .bool(false),
+                "deleteFiles": .bool(true),
+            ]
+        case "XcodeSwitchRunDestination":
+            return ["tabIdentifier": .string(tabIdentifier), "displayTitle": .string(runDestination)]
+        case "XcodeSwitchScheme":
+            return ["tabIdentifier": .string(tabIdentifier), "schemeName": .string(schemeName)]
+        case "XcodeUpdate":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "filePath": .string(navPath("VerifierScratch/probe.txt")),
+                "oldString": .string("initial"),
+                "newString": .string("updated"),
+                "replaceAll": .bool(false),
+            ]
+        case "XcodeWrite":
+            return [
+                "tabIdentifier": .string(tabIdentifier),
+                "filePath": .string(navPath("VerifierScratch/probe.txt")),
+                "content": .string("proxy verifier initial content\n"),
+            ]
+        default:
+            return [:]
+        }
+    }
+
+    mutating func observe(toolName: String, record: ToolVerificationRecord) {
+        guard let rawResult = record.rawResult else { return }
+        switch toolName {
+        case "XcodeListWindows":
+            if let parsed = parseWindowTab(
+                from: rawResult,
+                fixturePaths: [
+                    fixture.rootWorkspaceURL.path,
+                ],
+                fallbackWorkspaceName: "XcodeMCPKit.xcworkspace"
+            ) {
+                tabIdentifier = parsed
+            }
+        case "XcodeListSchemes":
+            if flattenedText(from: rawResult).contains(schemeName) {
+                break
+            }
+            if let parsed = parseFirstString(named: "schemeName", from: rawResult)
+                ?? parseFirstString(named: "name", from: rawResult) {
+                schemeName = parsed
+            }
+        case "XcodeListRunDestinations":
+            if let parsed = parsePreferredRunDestination(from: rawResult)
+                ?? parseFirstString(named: "activeDestinationDisplayTitle", from: rawResult)
+                ?? parseFirstString(named: "displayTitle", from: rawResult) {
+                runDestination = parsed
+            }
+        case "GetTestList":
+            if let test = parseFirstTest(from: rawResult) {
+                testTargetName = test.targetName
+                testIdentifier = test.identifier
+            }
+        case "DeviceInteractionStartSession":
+            if let key = parseFirstString(named: "interactionSessionKey", from: rawResult)
+                ?? parseFirstString(named: "interactSessionKey", from: rawResult)
+                ?? parseFirstString(named: "sessionKey", from: rawResult) {
+                interactionSessionKey = key
+            }
+        default:
+            break
+        }
+    }
+}
+
+private struct FixtureLayout {
+    let repoRoot: URL
+    let outputRoot: URL
+
+    var rootWorkspaceURL: URL {
+        repoRoot.appendingPathComponent("XcodeMCPKit.xcworkspace", isDirectory: true)
+    }
+
+    var projectRootURL: URL {
+        repoRoot.appendingPathComponent("Fixtures/ProxyToolVerifierFixture", isDirectory: true)
+    }
+
+    var xcodeProjectURL: URL {
+        projectRootURL.appendingPathComponent("ProxyToolVerifierFixture.xcodeproj", isDirectory: true)
+    }
+
+    var scratchDirectoryURL: URL {
+        projectRootURL.appendingPathComponent("ProxyToolVerifierFixture/VerifierScratch", isDirectory: true)
+    }
+
+    var projectFileURL: URL {
+        xcodeProjectURL.appendingPathComponent("project.pbxproj")
+    }
+
+    var localizableCatalogURL: URL {
+        projectRootURL.appendingPathComponent("ProxyToolVerifierFixture/Localizable.xcstrings")
+    }
+
+    var infoPlistCatalogURL: URL {
+        projectRootURL.appendingPathComponent("ProxyToolVerifierFixture/ProxyToolVerifierFixture-InfoPlist.xcstrings")
+    }
+}
+
+private struct FixtureSnapshot {
+    let scratchDirectoryURL: URL
+    let files: [(url: URL, data: Data)]
+
+    static func capture(_ fixture: FixtureLayout) throws -> FixtureSnapshot {
+        try FixtureSnapshot(
+            scratchDirectoryURL: fixture.scratchDirectoryURL,
+            files: [
+                fixture.projectFileURL,
+                fixture.localizableCatalogURL,
+                fixture.infoPlistCatalogURL,
+            ].map { url in
+                (url: url, data: try Data(contentsOf: url))
+            }
+        )
+    }
+
+    func restore() throws {
+        let fileManager = FileManager.default
+        try? fileManager.removeItem(at: scratchDirectoryURL)
+        for file in files {
+            try fileManager.createDirectory(
+                at: file.url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try file.data.write(to: file.url, options: [.atomic])
+        }
+    }
+}
+
+private final class RunningProcess {
+    private let process: Process
+    private let logHandle: FileHandle
+
+    init(process: Process, logHandle: FileHandle) {
+        self.process = process
+        self.logHandle = logHandle
+    }
+
+    func terminate() {
+        if process.isRunning {
+            process.terminate()
+            process.waitUntilExit()
+        }
+        try? logHandle.close()
+    }
+}
+
+private struct VerificationReport: Codable {
+    let endpoint: String
+    let fixturePath: String
+    let workspacePath: String
+    let toolCount: Int
+    let availableTools: [String]
+    let toolDescriptors: [MCPTool]
+    let records: [ToolVerificationRecord]
+
+    var hasHardFailures: Bool {
+        records.contains { $0.status.isHardFailure }
+    }
+}
+
+private struct ToolVerificationRecord: Codable {
+    let name: String
+    let status: ToolVerificationStatus
+    let elapsedSeconds: TimeInterval
+    let detail: String
+    let arguments: [String: MCPJSONValue]?
+    let rawResult: MCPJSONValue?
+
+    init(
+        name: String,
+        status: ToolVerificationStatus,
+        elapsedSeconds: TimeInterval,
+        detail: String,
+        arguments: [String: MCPJSONValue]?,
+        rawResult: MCPJSONValue? = nil
+    ) {
+        self.name = name
+        self.status = status
+        self.elapsedSeconds = elapsedSeconds
+        self.detail = detail
+        self.arguments = arguments
+        self.rawResult = rawResult
+    }
+}
+
+private enum ToolVerificationStatus: String, Codable, CaseIterable {
+    case passed
+    case externalPrerequisite
+    case toolError
+    case rpcError
+    case failed
+    case hung
+
+    var isHardFailure: Bool {
+        switch self {
+        case .passed, .externalPrerequisite:
+            return false
+        case .toolError, .rpcError, .failed, .hung:
+            return true
+        }
+    }
+}
+
+private func verificationStatus(
+    toolName: String,
+    result: MCPToolResult,
+    detail: String
+) -> ToolVerificationStatus {
+    if isExternalPrerequisiteResult(toolName: toolName, detail: detail) {
+        return .externalPrerequisite
+    }
+    if result.isError {
+        return .toolError
+    }
+    if detail.hasPrefix("Failed ") || detail.contains(#""type":"error""#) {
+        return .toolError
+    }
+    return .passed
+}
+
+private func isExternalPrerequisiteResult(toolName: String, detail: String) -> Bool {
+    let appStoreConnectTools: Set<String> = [
+        "GetTopCrashIssues",
+        "GetCrashIssueLogs",
+        "GetTopFieldPerformanceIssues",
+        "GetFieldPerformanceIssueLogs",
+    ]
+    if appStoreConnectTools.contains(toolName) {
+        return detail.contains("Product not found")
+            || detail.contains("not a supported platform")
+            || detail.contains("App Store")
+            || detail.contains("Organizer")
+    }
+
+    let deviceTools: Set<String> = [
+        "DeviceInteractionStartSession",
+        "DeviceInteractionInstallAndRun",
+        "DeviceInteractionSynthesize",
+        "DeviceInteractionEndSession",
+    ]
+    if deviceTools.contains(toolName) {
+        return detail.contains("not supported for Device Interaction")
+            || detail.contains("Session key is invalid")
+            || detail.contains("Session not found")
+    }
+
+    return false
+}
+
+private func toolExecutionOrder(availableTools: Set<String>) -> [String] {
+    let known = orderedKnownToolNames()
+    let plannedKnown = known.filter { availableTools.contains($0) }
+    let unknown = availableTools.subtracting(Set(known)).sorted()
+    return plannedKnown + unknown
+}
+
+private func orderedKnownToolNames() -> [String] {
+    deduplicated(
+        catalogToolNames()
+            + bootstrapToolNames()
+            + navigatorToolNames()
+            + stringCatalogToolNames()
+            + buildToolNames()
+            + runtimeToolNames()
+            + fieldReportToolNames()
+            + deviceInteractionToolNames()
+    )
+}
+
+private func catalogToolNames() -> [String] {
+    [
+        "XcodeListWindows",
+        "XcodeListSchemes",
+        "XcodeListRunDestinations",
+        "DocumentationSearch",
+    ]
+}
+
+private func bootstrapToolNames() -> [String] {
+    [
+        "XcodeListWindows",
+        "XcodeListSchemes",
+        "XcodeListRunDestinations",
+        "XcodeSwitchScheme",
+        "XcodeSwitchRunDestination",
+    ]
+}
+
+private func navigatorToolNames() -> [String] {
+    [
+        "XcodeGlob",
+        "XcodeLS",
+        "XcodeRead",
+        "XcodeGrep",
+        "XcodeGetCurrentFile",
+        "XcodeMakeDir",
+        "XcodeWrite",
+        "XcodeUpdate",
+        "XcodeMV",
+        "XcodeRM",
+        "GetFileCompilerFlags",
+        "UpdateFileCompilerFlags",
+        "XcodeRefreshCodeIssuesInFile",
+        "XcodeListNavigatorIssues",
+    ]
+}
+
+private func stringCatalogToolNames() -> [String] {
+    [
+        "StringCatalogRead",
+        "StringCatalogContext",
+        "StringCatalogEdit",
+        "LocalizationPlanner",
+    ]
+}
+
+private func buildToolNames() -> [String] {
+    [
+        "BuildProject",
+        "GetBuildLog",
+        "GetTestList",
+        "RunSomeTests",
+        "RunAllTests",
+    ]
+}
+
+private func runtimeToolNames() -> [String] {
+    [
+        "RenderPreview",
+        "RunCodeSnippet",
+        "RunProject",
+        "GetConsoleOutput",
+        "InvokeDebuggerCommand",
+        "StopProject",
+    ]
+}
+
+private func fieldReportToolNames() -> [String] {
+    [
+        "GetTopCrashIssues",
+        "GetCrashIssueLogs",
+        "GetTopFieldPerformanceIssues",
+        "GetFieldPerformanceIssueLogs",
+    ]
+}
+
+private func deviceInteractionToolNames() -> [String] {
+    [
+        "DeviceInteractionStartSession",
+        "DeviceInteractionInstallAndRun",
+        "DeviceInteractionSynthesize",
+        "DeviceInteractionEndSession",
+    ]
+}
+
+private func deduplicated(_ values: [String]) -> [String] {
+    var seen: Set<String> = []
+    var result: [String] = []
+    for value in values where seen.insert(value).inserted {
+        result.append(value)
+    }
+    return result
+}
+
+private func responseSummary(_ result: MCPToolResult) -> String {
+    let text = textContent(from: result)
+    if text.isEmpty == false {
+        return abbreviate(text.replacingOccurrences(of: "\n", with: " "), limit: 240)
+    }
+    if let structured = result.structuredContent {
+        return abbreviate(jsonString(structured), limit: 240)
+    }
+    return result.isError ? "tool returned isError=true" : "ok"
+}
+
+private func textContent(from result: MCPToolResult) -> String {
+    result.content.compactMap { item -> String? in
+        switch item {
+        case .text(let text, _):
+            if let object = try? JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any],
+               let message = object["message"] as? String {
+                return message
+            }
+            return text
+        case .resource(_, let text, _, _):
+            return text
+        case .image, .raw:
+            return nil
+        }
+    }
+    .joined(separator: "\n")
+}
+
+private func parseWindowTab(
+    from value: MCPJSONValue,
+    fixturePaths: [String],
+    fallbackWorkspaceName: String
+) -> String? {
+    let normalizedFixturePaths = fixturePaths.map(normalizePath)
+    var fallbackTab: String?
+    for text in allStrings(from: value) {
+        for line in text.split(whereSeparator: \.isNewline) {
+            let lineText = String(line)
+            guard let tab = extractValue(after: "tabIdentifier:", before: ",", in: lineText),
+                  let workspace = extractValue(after: "workspacePath:", before: nil, in: lineText)
+            else {
+                continue
+            }
+            let normalizedWorkspace = normalizePath(workspace)
+            let matchesFixture = normalizedFixturePaths.contains { fixturePath in
+                normalizedWorkspace == fixturePath
+                    || normalizedWorkspace.hasPrefix(fixturePath + "/")
+                    || fixturePath.hasPrefix(normalizedWorkspace + "/")
+            }
+            if matchesFixture {
+                return tab
+            }
+            if fallbackTab == nil, workspace.contains(fallbackWorkspaceName) {
+                fallbackTab = tab
+            }
+        }
+    }
+    return fallbackTab
+}
+
+private func parseFirstString(named key: String, from value: MCPJSONValue) -> String? {
+    if let found = findFirstString(named: key, in: value.jsonObject) {
+        return found
+    }
+    let text = flattenedText(from: value)
+    let pattern = #""\#(key)"\s*:\s*"([^"]+)""#
+    if let regex = try? NSRegularExpression(pattern: pattern),
+       let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..<text.endIndex, in: text)),
+       match.numberOfRanges >= 2,
+       let range = Range(match.range(at: 1), in: text) {
+        return String(text[range])
+    }
+    return nil
+}
+
+private func parseFirstTest(from value: MCPJSONValue) -> (targetName: String, identifier: String)? {
+    guard let tests = findFirstArray(named: "tests", in: value.jsonObject) else {
+        return nil
+    }
+    for item in tests {
+        guard let object = item as? [String: Any],
+              let targetName = object["targetName"] as? String,
+              let identifier = object["identifier"] as? String
+        else {
+            continue
+        }
+        return (targetName, identifier)
+    }
+    return nil
+}
+
+private func parsePreferredRunDestination(from value: MCPJSONValue) -> String? {
+    guard let destinations = findFirstArray(named: "destinations", in: value.jsonObject) else {
+        return nil
+    }
+    let candidates = destinations.compactMap { item -> [String: Any]? in
+        item as? [String: Any]
+    }
+    let preferred = candidates.first { destination in
+        boolValue(destination["isSimulator"]) == true
+            && boolValue(destination["isEligible"]) != false
+            && stringValue(destination["platformIdentifier"]) == "com.apple.platform.iphonesimulator"
+            && osVersionIsAtLeast27(stringValue(destination["osVersion"]))
+    } ?? candidates.first { destination in
+        boolValue(destination["isSimulator"]) == true
+            && boolValue(destination["isEligible"]) != false
+            && stringValue(destination["platformIdentifier"]) == "com.apple.platform.iphonesimulator"
+    } ?? candidates.first { destination in
+        stringValue(destination["displayTitle"]) == "My Mac"
+    }
+    return preferred.flatMap { stringValue($0["displayTitle"]) }
+}
+
+private func findFirstString(named key: String, in value: Any) -> String? {
+    if let object = value as? [String: Any] {
+        if let value = object[key] as? String {
+            return value
+        }
+        for child in object.values {
+            if let found = findFirstString(named: key, in: child) {
+                return found
+            }
+        }
+    } else if let array = value as? [Any] {
+        for child in array {
+            if let found = findFirstString(named: key, in: child) {
+                return found
+            }
+        }
+    } else if let text = value as? String,
+              let data = text.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) {
+        return findFirstString(named: key, in: object)
+    }
+    return nil
+}
+
+private func findFirstArray(named key: String, in value: Any) -> [Any]? {
+    if let object = value as? [String: Any] {
+        if let value = object[key] as? [Any] {
+            return value
+        }
+        for child in object.values {
+            if let found = findFirstArray(named: key, in: child) {
+                return found
+            }
+        }
+    } else if let array = value as? [Any] {
+        for child in array {
+            if let found = findFirstArray(named: key, in: child) {
+                return found
+            }
+        }
+    } else if let text = value as? String,
+              let data = text.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) {
+        return findFirstArray(named: key, in: object)
+    }
+    return nil
+}
+
+private func flattenedText(from value: MCPJSONValue) -> String {
+    allStrings(from: value).joined(separator: "\n")
+}
+
+private func allStrings(from value: MCPJSONValue) -> [String] {
+    var parts: [String] = []
+    collectText(value.jsonObject, into: &parts)
+    return parts
+}
+
+private func collectText(_ value: Any, into parts: inout [String]) {
+    if let string = value as? String {
+        parts.append(string)
+        if let data = string.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data) {
+            collectText(object, into: &parts)
+        }
+    } else if let object = value as? [String: Any] {
+        for value in object.values {
+            collectText(value, into: &parts)
+        }
+    } else if let array = value as? [Any] {
+        for value in array {
+            collectText(value, into: &parts)
+        }
+    }
+}
+
+private func extractValue(after marker: String, before endMarker: String?, in text: String) -> String? {
+    guard let markerRange = text.range(of: marker) else { return nil }
+    let tail = text[markerRange.upperBound...]
+    let valueSlice: Substring
+    if let endMarker, let endRange = tail.range(of: endMarker) {
+        valueSlice = tail[..<endRange.lowerBound]
+    } else {
+        valueSlice = tail[...]
+    }
+    let trimmed = valueSlice.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}
+
+private func normalizePath(_ path: String) -> String {
+    URL(fileURLWithPath: path).standardizedFileURL.path
+}
+
+private func stringValue(_ value: Any?) -> String? {
+    value as? String
+}
+
+private func boolValue(_ value: Any?) -> Bool? {
+    if let bool = value as? Bool {
+        return bool
+    }
+    if let number = value as? NSNumber {
+        return number.boolValue
+    }
+    return nil
+}
+
+private func osVersionIsAtLeast27(_ value: String?) -> Bool {
+    guard let value else { return false }
+    let components = value.split(separator: ".").compactMap { Int($0) }
+    guard let major = components.first else { return false }
+    return major >= 27
+}
+
+private func runProcess(
+    executable: String,
+    arguments: [String],
+    currentDirectory: URL
+) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    process.currentDirectoryURL = currentDirectory
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        throw VerifierFailure(
+            "\(executable) \(arguments.joined(separator: " ")) failed with exit code \(process.terminationStatus)"
+        )
+    }
+}
+
+private func jsonString(_ value: MCPJSONValue) -> String {
+    if let data = try? JSONEncoder().encode(value),
+       let string = String(data: data, encoding: .utf8) {
+        return string
+    }
+    return String(describing: value)
+}
+
+private func jsonString(_ value: [String: MCPJSONValue]) -> String {
+    if let data = try? JSONEncoder().encode(value),
+       let string = String(data: data, encoding: .utf8) {
+        return string
+    }
+    return String(describing: value)
+}
+
+private func abbreviate(_ value: String, limit: Int) -> String {
+    guard value.count > limit else { return value }
+    return String(value.prefix(limit - 3)) + "..."
+}
+
+private func formatSeconds(_ seconds: TimeInterval) -> String {
+    let hundredths = Int((seconds * 100).rounded())
+    let whole = hundredths / 100
+    let fraction = abs(hundredths % 100)
+    let fractionText = fraction < 10 ? "0\(fraction)" : "\(fraction)"
+    return "\(whole).\(fractionText)s"
+}
+
+private func errorDescription(_ error: any Error) -> String {
+    let nsError = error as NSError
+    if nsError.localizedDescription.isEmpty == false {
+        return nsError.localizedDescription
+    }
+    return String(describing: error)
+}
+
+private struct VerifierFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/Sources/XcodeMCPProxyToolVerifier/main.swift
+++ b/Sources/XcodeMCPProxyToolVerifier/main.swift
@@ -163,7 +163,7 @@ private struct ProxyToolVerifier {
                 )
                 continue
             }
-            let arguments = state.arguments(for: toolName)
+            let arguments = try state.arguments(for: toolName)
             print("-> [\(index + 1)/\(executionPlan.count)] \(toolName)")
             let record = await call(
                 toolName,
@@ -172,7 +172,7 @@ private struct ProxyToolVerifier {
             )
             print("<- [\(record.status.rawValue)] \(toolName) (\(formatSeconds(record.elapsedSeconds)))")
             records.append(record)
-            state.observe(toolName: toolName, record: record)
+            try state.observe(toolName: toolName, record: record)
             try writeReport(currentReport(), to: reportURL, announce: false)
         }
 
@@ -293,6 +293,7 @@ private struct ProxyToolVerifier {
         process.arguments = [
             "--listen", "\(options.host):\(options.port)",
             "--upstream-processes", "\(options.upstreamProcesses)",
+            "--request-timeout", "\(options.requestTimeoutSeconds)",
             "--auto-approve",
             "--refresh-code-issues-mode", "proxy",
         ]
@@ -379,7 +380,7 @@ private struct ProxyToolVerifier {
 private struct VerificationState {
     let fixture: FixtureLayout
     var availableTools: Set<String> = []
-    var tabIdentifier = "windowtab1"
+    var tabIdentifier: String?
     var schemeName = "ProxyToolVerifierFixture"
     var runDestination = "iPhone 17 (27.0)"
     var testTargetName = "ProxyToolVerifierFixtureTests"
@@ -395,245 +396,231 @@ private struct VerificationState {
         "\(navigatorRoot)/\(path)"
     }
 
-    func arguments(for toolName: String) -> [String: MCPJSONValue] {
+    func arguments(for toolName: String) throws -> [String: MCPJSONValue] {
         switch toolName {
         case "BuildProject":
-            return ["tabIdentifier": .string(tabIdentifier), "buildForTesting": .bool(true)]
+            return try withTab(["buildForTesting": .bool(true)])
         case "DeviceInteractionEndSession":
             return ["interactionSessionKey": .string(interactionSessionKey)]
         case "DeviceInteractionInstallAndRun":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "interactionSessionKey": .string(interactionSessionKey),
-            ]
+            ])
         case "DeviceInteractionStartSession":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "sessionIdentifier": .string(interactionSessionIdentifier),
-            ]
+            ])
         case "DeviceInteractionSynthesize":
             return [
-                "interactSessionKey": .string(interactionSessionKey),
+                "interactionSessionKey": .string(interactionSessionKey),
             ]
         case "DocumentationSearch":
             return ["query": .string("NavigationStack")]
         case "GetBuildLog":
-            return ["tabIdentifier": .string(tabIdentifier), "severity": .string("remark")]
+            return try withTab(["severity": .string("remark")])
         case "GetConsoleOutput":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "outputType": .string("all"),
                 "tailLimit": .integer(100),
-            ]
+            ])
         case "GetCrashIssueLogs":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "signature_name": .string("ProxyVerifierCrashSignature"),
                 "bundle_id": .string("dev.xcodemcp.ProxyToolVerifierFixture"),
                 "platform": .string("macOS"),
                 "app_version": .string("1.0"),
-            ]
+            ])
         case "GetFieldPerformanceIssueLogs":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "app_version": .string("1.0"),
                 "signature_name": .string("ProxyVerifierPerformanceSignature"),
                 "diagnostic_type": .string("hangs"),
                 "bundle_id": .string("dev.xcodemcp.ProxyToolVerifierFixture"),
                 "platform": .string("macOS"),
-            ]
+            ])
         case "GetFileCompilerFlags":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "targetName": .string("ProxyToolVerifierFixture"),
                 "filePath": .string(navPath("VerifierCore.swift")),
-            ]
+            ])
         case "GetTestList":
-            return ["tabIdentifier": .string(tabIdentifier)]
+            return try withTab()
         case "GetTopCrashIssues":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "count": .integer(1),
                 "bundle_id": .string("dev.xcodemcp.ProxyToolVerifierFixture"),
                 "platform": .string("macOS"),
-            ]
+            ])
         case "GetTopFieldPerformanceIssues":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "diagnostic_type": .string("hangs"),
                 "bundle_id": .string("dev.xcodemcp.ProxyToolVerifierFixture"),
                 "platform": .string("macOS"),
-            ]
+            ])
         case "InvokeDebuggerCommand":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "command": .string("thread list"),
                 "timeout": .integer(20),
-            ]
+            ])
         case "LocalizationPlanner":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "targetLocaleIdentifier": .string("ja"),
-            ]
+            ])
         case "RenderPreview":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "sourceFilePath": .string(navPath("ContentView.swift")),
                 "timeout": .integer(180),
-            ]
+            ])
         case "RunAllTests":
-            return ["tabIdentifier": .string(tabIdentifier)]
+            return try withTab()
         case "RunCodeSnippet":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "sourceFilePath": .string(navPath("VerifierCore.swift")),
                 "purpose": .string("Proxy verifier snippet"),
                 "codeSnippet": .string(#"print(VerifierCore.message())"#),
                 "timeout": .integer(120),
-            ]
+            ])
         case "RunProject":
-            return ["tabIdentifier": .string(tabIdentifier), "attachDebugger": .bool(true)]
+            return try withTab(["attachDebugger": .bool(true)])
         case "RunSomeTests":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "tests": .array([
                     .object([
                         "targetName": .string(testTargetName),
                         "testIdentifier": .string(testIdentifier),
                     ])
                 ]),
-            ]
+            ])
         case "StopProject":
-            return ["tabIdentifier": .string(tabIdentifier)]
+            return try withTab()
         case "StringCatalogContext":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "filePath": .string(navPath("Localizable.xcstrings")),
                 "stringKey": .string("verifier.title"),
                 "targetLocaleIdentifier": .string("ja"),
-            ]
+            ])
         case "StringCatalogEdit":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "filePath": .string(navPath("Localizable.xcstrings")),
                 "stringKey": .string("verifier.title"),
                 "targetLocaleIdentifier": .string("ja"),
                 "translation": .string("Verifier Title JA Updated"),
-            ]
+            ])
         case "StringCatalogRead":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "filePath": .string(navPath("Localizable.xcstrings")),
                 "targetLocaleIdentifier": .string("ja"),
                 "keyLimit": .integer(20),
-            ]
+            ])
         case "UpdateFileCompilerFlags":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "targetName": .string("ProxyToolVerifierFixture"),
                 "filePath": .string(navPath("VerifierCore.swift")),
                 "compilerFlags": .string("-DPROXY_TOOL_VERIFIER"),
                 "appendValue": .bool(false),
-            ]
+            ])
         case "XcodeGetCurrentFile":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "includeContent": .bool(false),
                 "includeSelection": .bool(true),
-            ]
+            ])
         case "XcodeGlob":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "pattern": .string("**/*.swift"),
-            ]
+            ])
         case "XcodeGrep":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "pattern": .string("VerifierCore"),
                 "outputMode": .string("filesWithMatches"),
                 "headLimit": .integer(10),
-            ]
+            ])
         case "XcodeListNavigatorIssues":
-            return ["tabIdentifier": .string(tabIdentifier), "severity": .string("remark")]
+            return try withTab(["severity": .string("remark")])
         case "XcodeListRunDestinations":
-            return ["tabIdentifier": .string(tabIdentifier), "includeIncompatible": .bool(true)]
+            return try withTab(["includeIncompatible": .bool(true)])
         case "XcodeListSchemes":
-            return ["tabIdentifier": .string(tabIdentifier)]
+            return try withTab()
         case "XcodeListWindows":
             return [:]
         case "XcodeLS":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "path": .string(navigatorRoot),
                 "recursive": .bool(true),
-            ]
+            ])
         case "XcodeMakeDir":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "directoryPath": .string(navPath("VerifierScratch")),
-            ]
+            ])
         case "XcodeMV":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "sourcePath": .string(navPath("VerifierScratch/probe.txt")),
                 "destinationPath": .string(navPath("VerifierScratch/probe-moved.txt")),
                 "operation": .object(["rawValue": .string("move")]),
                 "overwriteExisting": .bool(true),
-            ]
+            ])
         case "XcodeRead":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "filePath": .string(navPath("VerifierCore.swift")),
                 "limit": .integer(40),
-            ]
+            ])
         case "XcodeRefreshCodeIssuesInFile":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "filePath": .string(navPath("VerifierCore.swift")),
-            ]
+            ])
         case "XcodeRM":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "path": .string(navPath("VerifierScratch/probe-moved.txt")),
                 "recursive": .bool(false),
                 "deleteFiles": .bool(true),
-            ]
+            ])
         case "XcodeSwitchRunDestination":
-            return ["tabIdentifier": .string(tabIdentifier), "displayTitle": .string(runDestination)]
+            return try withTab(["displayTitle": .string(runDestination)])
         case "XcodeSwitchScheme":
-            return ["tabIdentifier": .string(tabIdentifier), "schemeName": .string(schemeName)]
+            return try withTab(["schemeName": .string(schemeName)])
         case "XcodeUpdate":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "filePath": .string(navPath("VerifierScratch/probe.txt")),
                 "oldString": .string("initial"),
                 "newString": .string("updated"),
                 "replaceAll": .bool(false),
-            ]
+            ])
         case "XcodeWrite":
-            return [
-                "tabIdentifier": .string(tabIdentifier),
+            return try withTab([
                 "filePath": .string(navPath("VerifierScratch/probe.txt")),
                 "content": .string("proxy verifier initial content\n"),
-            ]
+            ])
         default:
             return [:]
         }
     }
 
-    mutating func observe(toolName: String, record: ToolVerificationRecord) {
+    private func withTab(_ arguments: [String: MCPJSONValue] = [:]) throws -> [String: MCPJSONValue] {
+        guard let tabIdentifier else {
+            throw VerifierFailure(
+                "fixture Xcode tab has not been resolved; refusing to call tab-scoped tool"
+            )
+        }
+        var result = arguments
+        result["tabIdentifier"] = .string(tabIdentifier)
+        return result
+    }
+
+    mutating func observe(toolName: String, record: ToolVerificationRecord) throws {
         guard let rawResult = record.rawResult else { return }
         switch toolName {
         case "XcodeListWindows":
-            if let parsed = parseWindowTab(
+            guard let parsed = parseWindowTab(
                 from: rawResult,
                 fixturePaths: [
                     fixture.rootWorkspaceURL.path,
-                ],
-                fallbackWorkspaceName: "XcodeMCPKit.xcworkspace"
-            ) {
-                tabIdentifier = parsed
+                ]
+            ) else {
+                throw VerifierFailure(
+                    "XcodeListWindows did not report fixture workspace at "
+                        + "\(fixture.rootWorkspaceURL.path); refusing to run tab-scoped tools"
+                )
             }
+            tabIdentifier = parsed
         case "XcodeListSchemes":
             if flattenedText(from: rawResult).contains(schemeName) {
                 break
@@ -995,11 +982,9 @@ private func textContent(from result: MCPToolResult) -> String {
 
 private func parseWindowTab(
     from value: MCPJSONValue,
-    fixturePaths: [String],
-    fallbackWorkspaceName: String
+    fixturePaths: [String]
 ) -> String? {
     let normalizedFixturePaths = fixturePaths.map(normalizePath)
-    var fallbackTab: String?
     for text in allStrings(from: value) {
         for line in text.split(whereSeparator: \.isNewline) {
             let lineText = String(line)
@@ -1017,12 +1002,9 @@ private func parseWindowTab(
             if matchesFixture {
                 return tab
             }
-            if fallbackTab == nil, workspace.contains(fallbackWorkspaceName) {
-                fallbackTab = tab
-            }
         }
     }
-    return fallbackTab
+    return nil
 }
 
 private func parseFirstString(named key: String, from value: MCPJSONValue) -> String? {

--- a/Sources/XcodeMCPProxyToolVerifier/main.swift
+++ b/Sources/XcodeMCPProxyToolVerifier/main.swift
@@ -121,7 +121,7 @@ private struct ProxyToolVerifier {
             }
         }
 
-        let client = try await connectToProxy()
+        let client = try await connectToProxy(server: server)
         defer {
             Task {
                 await client.close()
@@ -235,9 +235,15 @@ private struct ProxyToolVerifier {
         }
     }
 
-    private func connectToProxy() async throws -> XcodeMCP {
+    private func connectToProxy(server: RunningProcess) async throws -> XcodeMCP {
         var lastError: (any Error)?
         for _ in 0..<90 {
+            guard server.isRunning else {
+                throw VerifierFailure(
+                    "debug proxy server exited before becoming ready with status "
+                        + "\(server.terminationStatus)"
+                )
+            }
             do {
                 return try await XcodeMCP(
                     config: .init(
@@ -285,6 +291,7 @@ private struct ProxyToolVerifier {
         guard fileManager.isExecutableFile(atPath: binary.path) else {
             throw VerifierFailure("debug proxy server binary is missing: \(binary.path)")
         }
+        try assertTCPPortAvailable(host: options.host, port: options.port)
         let logURL = outputRoot.appendingPathComponent("proxy-server.log")
         fileManager.createFile(atPath: logURL.path, contents: nil)
         let logHandle = try FileHandle(forWritingTo: logURL)
@@ -302,7 +309,18 @@ private struct ProxyToolVerifier {
         process.environment = environment
         process.standardOutput = logHandle
         process.standardError = logHandle
-        try process.run()
+        do {
+            try process.run()
+        } catch {
+            try? logHandle.close()
+            throw error
+        }
+        guard process.isRunning else {
+            try? logHandle.close()
+            throw VerifierFailure(
+                "debug proxy server exited immediately with status \(process.terminationStatus)"
+            )
+        }
         print("Started debug proxy server: \(options.endpoint.absoluteString)")
         print("Proxy log: \(logURL.path)")
         return RunningProcess(process: process, logHandle: logHandle)
@@ -722,6 +740,14 @@ private final class RunningProcess {
     init(process: Process, logHandle: FileHandle) {
         self.process = process
         self.logHandle = logHandle
+    }
+
+    var isRunning: Bool {
+        process.isRunning
+    }
+
+    var terminationStatus: Int32 {
+        process.terminationStatus
     }
 
     func terminate() {
@@ -1190,6 +1216,22 @@ private func runProcess(
             "\(executable) \(arguments.joined(separator: " ")) failed with exit code \(process.terminationStatus)"
         )
     }
+}
+
+private func assertTCPPortAvailable(host: String, port: Int) throws {
+    guard (0...Int(UInt16.max)).contains(port) else {
+        throw VerifierFailure(
+            "verifier endpoint \(host):\(port) is invalid; --port must fit in UInt16"
+        )
+    }
+    guard let port = UInt16(exactly: port),
+          let probe = SocketPort(tcpPort: port) else {
+        throw VerifierFailure(
+            "verifier endpoint \(host):\(port) is already in use; "
+                + "choose --port or stop the existing server"
+        )
+    }
+    probe.invalidate()
 }
 
 private func jsonString(_ value: MCPJSONValue) -> String {

--- a/Sources/XcodeMCPProxyToolVerifier/main.swift
+++ b/Sources/XcodeMCPProxyToolVerifier/main.swift
@@ -1240,6 +1240,11 @@ private func formatSeconds(_ seconds: TimeInterval) -> String {
 }
 
 private func errorDescription(_ error: any Error) -> String {
+    if let localizedError = error as? any LocalizedError,
+       let description = localizedError.errorDescription,
+       description.isEmpty == false {
+        return description
+    }
     let nsError = error as NSError
     if nsError.localizedDescription.isEmpty == false {
         return nsError.localizedDescription
@@ -1247,8 +1252,9 @@ private func errorDescription(_ error: any Error) -> String {
     return String(describing: error)
 }
 
-private struct VerifierFailure: Error, CustomStringConvertible {
+private struct VerifierFailure: LocalizedError, CustomStringConvertible {
     let description: String
+    var errorDescription: String? { description }
 
     init(_ description: String) {
         self.description = description

--- a/Sources/XcodeMCPProxyToolVerifier/main.swift
+++ b/Sources/XcodeMCPProxyToolVerifier/main.swift
@@ -1003,7 +1003,7 @@ private func parseWindowTab(
     for text in allStrings(from: value) {
         for line in text.split(whereSeparator: \.isNewline) {
             let lineText = String(line)
-            guard let tab = extractValue(after: "tabIdentifier:", before: ",", in: lineText),
+            guard let tab = extractValue(after: "tabIdentifier:", before: ", workspacePath: ", in: lineText),
                   let workspace = extractValue(after: "workspacePath:", before: nil, in: lineText)
             else {
                 continue

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -4640,6 +4640,87 @@ struct RuntimeCoordinatorTests {
         #expect(message.contains("tab-b"))
     }
 
+    @Test func liveXcodeListWindowsClearsOwnersForCatalogFilteredRoutes() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let target0 = xcodeProcessTarget(processID: 626, xcodeVersion: "26.6")
+        let target1 = xcodeProcessTarget(processID: 627, xcodeVersion: "27.0")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target0, upstreamIndices: [0]),
+                XcodeProcessRoute(target: target1, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (target1, 1, [toolDescriptor(name: "XcodeListWindows")]),
+            ]
+        )
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: stale-tab, workspacePath: /Work/Stale.xcworkspace",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+        #expect(
+            manager.preferredUpstreamIndex(
+                for: toolsCallObject(
+                    id: 1101,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": "stale-tab"]
+                )
+            ) == 0
+        )
+
+        let task = Task {
+            try await manager.liveXcodeListWindowsResult(
+                route: .anyHealthy,
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+
+        let request = try await upstream1.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        #expect(await upstream0.sentCount() == 0)
+
+        await upstream1.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: request),
+                    message: "* tabIdentifier: live-tab, workspacePath: /Work/Live.xcworkspace"
+                )
+            )
+        )
+
+        _ = try await task.value
+        #expect(
+            manager.preferredUpstreamIndex(
+                for: toolsCallObject(
+                    id: 1102,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": "stale-tab"]
+                )
+            ) == nil
+        )
+    }
+
     @Test func liveXcodeListWindowsSkipsCatalogedRoutesWithoutTool() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -4576,6 +4576,70 @@ struct RuntimeCoordinatorTests {
         #expect(message.contains("tab-a"))
     }
 
+    @Test func liveXcodeListWindowsIgnoresCatalogsFromUnavailableRoutes() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let target0 = xcodeProcessTarget(processID: 624, xcodeVersion: "27.0")
+        let target1 = xcodeProcessTarget(processID: 625, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target0, upstreamIndices: [0]),
+                XcodeProcessRoute(target: target1, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target0, 0, [toolDescriptor(name: "DocumentationSearch")]),
+            ]
+        )
+        manager.markXcodeProcessRouteUnavailable(
+            upstreamIndex: 0,
+            reason: "test_unavailable"
+        )
+
+        let task = Task {
+            try await manager.liveXcodeListWindowsResult(
+                route: .anyHealthy,
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+
+        let request = try await upstream1.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        #expect(await upstream0.sentCount() == 0)
+
+        await upstream1.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: request),
+                    message: "* tabIdentifier: tab-b, workspacePath: /Work/B.xcworkspace"
+                )
+            )
+        )
+
+        let result = try await task.value
+        #expect(await upstream0.sentCount() == 0)
+        guard case .object(let object) = result,
+              case .object(let structuredContent)? = object["structuredContent"],
+              case .string(let message)? = structuredContent["message"] else {
+            Issue.record("expected structured XcodeListWindows message")
+            return
+        }
+        #expect(message.contains("tab-b"))
+    }
+
     @Test func liveXcodeListWindowsSkipsCatalogedRoutesWithoutTool() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -3814,8 +3814,22 @@ struct RuntimeCoordinatorTests {
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
-                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
-                (target1, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (
+                    target0,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+                (
+                    target1,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
             ]
         )
         #expect(
@@ -3903,8 +3917,22 @@ struct RuntimeCoordinatorTests {
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
-                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
-                (target1, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (
+                    target0,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+                (
+                    target1,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
             ]
         )
         manager.markXcodeProcessRouteUnavailable(
@@ -3964,7 +3992,14 @@ struct RuntimeCoordinatorTests {
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
-                (target, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (
+                    target,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
             ]
         )
 
@@ -4110,8 +4145,22 @@ struct RuntimeCoordinatorTests {
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
-                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
-                (target1, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (
+                    target0,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+                (
+                    target1,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
             ]
         )
         #expect(
@@ -4808,8 +4857,22 @@ struct RuntimeCoordinatorTests {
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
-                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
-                (target1, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (
+                    target0,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+                (
+                    target1,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
             ]
         )
 
@@ -4855,6 +4918,67 @@ struct RuntimeCoordinatorTests {
         #expect(preferredUpstreamIndices == [1])
     }
 
+    @Test func ownerBoundRefreshUsesUncatalogedRoutesForOwnerDiscovery() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let target0 = xcodeProcessTarget(processID: 625, xcodeVersion: "27.0")
+        let target1 = xcodeProcessTarget(processID: 626, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target0, upstreamIndices: [0]),
+                XcodeProcessRoute(target: target1, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
+
+        let task = Task {
+            await manager.toolRoutingDecision(
+                for: toolsCallObject(
+                    id: 109,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": "tab-uncataloged"]
+                ),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+
+        let request1 = try await upstream1.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        #expect(await upstream0.sentCount() == 0)
+        await upstream1.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: request1),
+                    message: "* tabIdentifier: tab-uncataloged, "
+                        + "workspacePath: /Work/Uncataloged.xcworkspace"
+                )
+            )
+        )
+
+        let decision = await task.value
+        guard case .forwardAny(let preferredUpstreamIndices) = decision else {
+            Issue.record("expected uncataloged owner discovery route to forward")
+            return
+        }
+        #expect(preferredUpstreamIndices == [1])
+    }
+
     @Test func ownerBoundToolRejectsWhenOwnerCannotBeResolvedAfterRefresh() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -4879,8 +5003,22 @@ struct RuntimeCoordinatorTests {
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
-                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
-                (target1, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (
+                    target0,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+                (
+                    target1,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
             ]
         )
 

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -4467,6 +4467,66 @@ struct RuntimeCoordinatorTests {
         }
     }
 
+    @Test func liveXcodeListWindowsAggregatesOnlyCatalogAdvertisedRoutes() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let target0 = xcodeProcessTarget(processID: 620, xcodeVersion: "27.0")
+        let target1 = xcodeProcessTarget(processID: 621, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target0, upstreamIndices: [0]),
+                XcodeProcessRoute(target: target1, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target0, 0, [toolDescriptor(name: "XcodeListWindows")]),
+            ]
+        )
+
+        let task = Task {
+            try await manager.liveXcodeListWindowsResult(
+                route: .anyHealthy,
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+
+        let request = try await upstream0.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        #expect(await upstream1.sentCount() == 0)
+
+        await upstream0.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: request),
+                    message: "* tabIdentifier: tab-a, workspacePath: /Work/A.xcworkspace"
+                )
+            )
+        )
+
+        let result = try await task.value
+        #expect(await upstream1.sentCount() == 0)
+        guard case .object(let object) = result,
+              case .object(let structuredContent)? = object["structuredContent"],
+              case .string(let message)? = structuredContent["message"] else {
+            Issue.record("expected structured XcodeListWindows message")
+            return
+        }
+        #expect(message.contains("tab-a"))
+    }
+
     @Test func publicXcodeListWindowsMixedNonToolBatchIsRejected() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -4527,6 +4527,45 @@ struct RuntimeCoordinatorTests {
         #expect(message.contains("tab-a"))
     }
 
+    @Test func liveXcodeListWindowsSkipsCatalogedRoutesWithoutTool() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let target0 = xcodeProcessTarget(processID: 622, xcodeVersion: "27.0")
+        let target1 = xcodeProcessTarget(processID: 623, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target0, upstreamIndices: [0]),
+                XcodeProcessRoute(target: target1, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target0, 0, [toolDescriptor(name: "DocumentationSearch")]),
+                (target1, 1, [toolDescriptor(name: "BuildProject")]),
+            ]
+        )
+
+        await #expect(throws: UpstreamSlotScheduler.AcquisitionError.unavailable) {
+            _ = try await manager.liveXcodeListWindowsResult(
+                route: .anyHealthy,
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+        #expect(await upstream0.sentCount() == 0)
+        #expect(await upstream1.sentCount() == 0)
+    }
+
     @Test func publicXcodeListWindowsMixedNonToolBatchIsRejected() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/XcodeMCPKit.xcworkspace/contents.xcworkspacedata
+++ b/XcodeMCPKit.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:">
+   </FileRef>
+   <FileRef
+      location = "group:Fixtures/ProxyToolVerifierFixture/ProxyToolVerifierFixture.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
## Summary
- Add a debug-build live verifier executable for the proxy server that starts the local product, opens the tracked workspace fixture, calls the live tool catalog, and executes available tools sequentially.
- Add tracked verifier fixture resources and workspace entries so the verifier can run from the repository without relying on installed commands.
- Tighten XcodeListWindows routing so public aggregation follows the advertised catalog surface while owner-bound route discovery can still inspect uncataloged healthy routes.

## Validation
- `swift test --filter 'liveXcodeListWindows|ownerBound.*Refresh|sessionManagerKeepsWindowlessProcessRouteAvailable' -Xswiftc -strict-concurrency=minimal`
- `swift build --product xcode-mcp-proxy-tool-verifier -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- codex-review against `main`: clean, no findings

## Notes
- Live verifier output is written under `ProxyToolVerifierOutput/`, which is ignored by git.
- The verifier does not pin a fixed tool count; it uses the live `tools/list` result for the selected Xcode environment.