### PR TITLE
Refactor public Swift configuration API names

### DIFF
--- a/Sources/XcodeMCPKit/Internal/ClientRuntime/XcodeMCPTransport.swift
+++ b/Sources/XcodeMCPKit/Internal/ClientRuntime/XcodeMCPTransport.swift
@@ -19,7 +19,7 @@ package final class UpstreamProcessXcodeMCPTransport: XcodeMCPTransport {
     private let bridgeTask: Task<Void, Never>
 
     package static func start(config: UpstreamProcess.Config) async throws -> UpstreamProcessXcodeMCPTransport {
-        let session = try await UpstreamProcess(config: config).startSession()
+        let session = try await UpstreamProcess(configuration: config).startSession()
         return UpstreamProcessXcodeMCPTransport(session: session)
     }
 

--- a/Sources/XcodeMCPKit/Internal/ProcessRuntime/Bridge/UpstreamProcess.swift
+++ b/Sources/XcodeMCPKit/Internal/ProcessRuntime/Bridge/UpstreamProcess.swift
@@ -306,12 +306,12 @@ package struct UpstreamProcess: UpstreamSessionFactory {
 
     private let config: Config
 
-    package init(config: Config) {
-        self.config = config
+    package init(configuration: Config) {
+        self.config = configuration
     }
 
     package func startSession() async throws -> any UpstreamSession {
-        try await ProcessBackedUpstreamSession.start(config: config)
+        try await ProcessBackedUpstreamSession.start(configuration: config)
     }
 }
 
@@ -338,14 +338,16 @@ package actor ProcessBackedUpstreamSession: UpstreamSession {
     private var didFinishEvents = false
     private var isStopping = false
 
-    package static func start(config: UpstreamProcess.Config) async throws -> ProcessBackedUpstreamSession {
-        let session = ProcessBackedUpstreamSession(config: config)
+    package static func start(
+        configuration: UpstreamProcess.Config
+    ) async throws -> ProcessBackedUpstreamSession {
+        let session = ProcessBackedUpstreamSession(configuration: configuration)
         try await session.runProcess()
         return session
     }
 
-    private init(config: UpstreamProcess.Config) {
-        self.config = config
+    private init(configuration: UpstreamProcess.Config) {
+        self.config = configuration
 
         var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
         self.events = AsyncStream { continuation in

--- a/Sources/XcodeMCPKit/README.md
+++ b/Sources/XcodeMCPKit/README.md
@@ -11,6 +11,7 @@ running `xcode-mcp-proxy-server` Streamable HTTP endpoint.
 The public API is intentionally small:
 
 - `XcodeMCP`, the top-level async client
+- `XcodeMCPConfiguration`, for transport and initialize settings
 - `MCPJSONValue`, for dynamic MCP payloads
 - `MCPTool`, `MCPToolResult`, `MCPContent`, and `MCPProgress`
 - `XcodeMCPError`
@@ -31,13 +32,12 @@ Add the `XcodeMCPKit` product to your target, then construct a client:
 ```swift
 import XcodeMCPKit
 
-let config = XcodeMCP.Configuration(
-    transport: .localBridge(.defaultMCPBridge),
+let config = XcodeMCPConfiguration(
     clientName: "MyApp",
     clientVersion: "1.0"
 )
 
-let xcode = try await XcodeMCP(config: config)
+let xcode = try await XcodeMCP(configuration: config)
 let tools = try await xcode.listTools()
 
 if tools.contains(where: { $0.name == "DocumentationSearch" }) {
@@ -63,7 +63,7 @@ await xcode.close()
 To use a running `xcode-mcp-proxy-server`, configure Streamable HTTP:
 
 ```swift
-let config = XcodeMCP.Configuration(
+let config = XcodeMCPConfiguration(
     transport: .streamableHTTP(
         endpoint: URL(string: "http://127.0.0.1:8765/mcp")!
     ),
@@ -71,13 +71,13 @@ let config = XcodeMCP.Configuration(
     clientVersion: "1.0"
 )
 
-let xcode = try await XcodeMCP(config: config)
+let xcode = try await XcodeMCP(configuration: config)
 ```
 
 Discovery files written by the proxy are supported as well:
 
 ```swift
-let config = XcodeMCP.Configuration(
+let config = XcodeMCPConfiguration(
     transport: .streamableHTTP(
         discoveryFile: URL(fileURLWithPath: "/tmp/xcode-mcp/endpoint.json")
     )
@@ -88,7 +88,7 @@ For the standard proxy discovery location, including
 `XCODE_MCP_PROXY_DISCOVERY_FILE` and `XCODE_MCP_PROXY_CACHE_ROOT` overrides, use:
 
 ```swift
-let config = XcodeMCP.Configuration(
+let config = XcodeMCPConfiguration(
     transport: .streamableHTTPProxyDiscovery()
 )
 ```
@@ -132,14 +132,13 @@ try await xcode.notify(
 
 ## Configuration
 
-`XcodeMCP.Configuration` controls transport selection and MCP initialization:
+`XcodeMCPConfiguration` controls transport selection and MCP initialization:
 
 - `transport` chooses `.localBridge(...)`, `.streamableHTTP(endpoint:)`,
   `.streamableHTTP(discoveryFile:)`, or `.streamableHTTPProxyDiscovery()`.
-- The compatibility `bridge` property still chooses the upstream bridge for
-  local process transport. The default is Xcode's `/usr/bin/xcrun mcpbridge`.
-- Use bridge `.custom(command:arguments:environment:)` only when embedding a
-  non-default bridge command.
+- The default transport is Xcode's `/usr/bin/xcrun mcpbridge`.
+- Use `.localBridge(.custom(command:arguments:environment:))` only when
+  embedding a non-default bridge command.
 - `clientName`, `clientVersion`, and `capabilities` are sent in `initialize`.
 - `requestTimeout` bounds requests when non-`nil`.
 

--- a/Sources/XcodeMCPKit/XcodeMCP.swift
+++ b/Sources/XcodeMCPKit/XcodeMCP.swift
@@ -1,5 +1,150 @@
 import Foundation
 
+/// Settings used to connect to and initialize an MCP endpoint.
+///
+/// The default configuration starts `xcrun mcpbridge` with the current process
+/// environment and a conservative per-request timeout. Use
+/// ``XcodeMCPConfiguration/Transport/streamableHTTP(endpoint:)`` to connect to
+/// a proxy Streamable HTTP endpoint instead.
+public struct XcodeMCPConfiguration: Equatable, Sendable {
+    /// Upstream bridge process policy.
+    public enum Bridge: Equatable, Sendable {
+        /// Use Xcode's default `xcrun mcpbridge` invocation.
+        case defaultMCPBridge
+
+        /// Use an explicit upstream bridge command.
+        case custom(
+            command: String,
+            arguments: [String],
+            environment: [String: String]
+        )
+
+        package var invocation: MCPBridgeInvocation {
+            switch self {
+            case .defaultMCPBridge:
+                return .defaultMCPBridge
+            case .custom(let command, let arguments, _):
+                return MCPBridgeInvocation(command: command, arguments: arguments)
+            }
+        }
+
+        package var command: String {
+            invocation.command
+        }
+
+        package var arguments: [String] {
+            invocation.arguments
+        }
+
+        package var environment: [String: String] {
+            switch self {
+            case .defaultMCPBridge:
+                return ProcessInfo.processInfo.environment
+            case .custom(_, _, let environment):
+                return environment
+            }
+        }
+
+        package var maxQueuedWriteBytes: Int {
+            4 * 1024 * 1024
+        }
+    }
+
+    /// Transport used to reach the Xcode MCP server.
+    public struct Transport: Equatable, Sendable {
+        package enum Storage: Equatable, Sendable {
+            case localBridge(Bridge)
+            case streamableHTTP(endpoint: URL)
+            case streamableHTTPDiscoveryFile(URL)
+        }
+
+        package let storage: Storage
+
+        package init(storage: Storage) {
+            self.storage = storage
+        }
+
+        /// Launch and talk to a local bridge process over stdio.
+        public static func localBridge(_ bridge: Bridge = .defaultMCPBridge) -> Self {
+            Self(storage: .localBridge(bridge))
+        }
+
+        /// Connect to a concrete Streamable HTTP MCP endpoint.
+        public static func streamableHTTP(endpoint: URL) -> Self {
+            Self(storage: .streamableHTTP(endpoint: endpoint))
+        }
+
+        /// Connect to the Streamable HTTP endpoint recorded in a proxy
+        /// discovery file.
+        ///
+        /// The discovery file uses the same shape written by
+        /// `xcode-mcp-proxy-server startAndWriteDiscovery()`.
+        public static func streamableHTTP(discoveryFile: URL) -> Self {
+            Self(storage: .streamableHTTPDiscoveryFile(discoveryFile))
+        }
+
+        /// Connect to the Streamable HTTP proxy endpoint discovered from the
+        /// standard proxy discovery file location.
+        ///
+        /// The file path honors `XCODE_MCP_PROXY_DISCOVERY_FILE` first, then
+        /// `XCODE_MCP_PROXY_CACHE_ROOT`, and otherwise uses the default user
+        /// caches location used by `xcode-mcp-proxy-server`.
+        ///
+        /// - Parameter environment: Environment used to resolve proxy discovery
+        ///   overrides.
+        public static func streamableHTTPProxyDiscovery(
+            environment: [String: String] = ProcessInfo.processInfo.environment
+        ) -> Self {
+            .streamableHTTP(discoveryFile: Discovery.defaultFileURL(environment: environment))
+        }
+    }
+
+    /// Transport used to reach the Xcode MCP server.
+    public var transport: Transport
+
+    /// Client name sent in the MCP `initialize` request.
+    public var clientName: String
+
+    /// Client version sent in the MCP `initialize` request.
+    public var clientVersion: String
+
+    /// Additional MCP client capabilities sent during initialization.
+    ///
+    /// Values are encoded as raw MCP JSON. Capabilities that require
+    /// server-to-client handlers, such as `roots`, `sampling`, and
+    /// `elicitation`, are intentionally not exposed by this API.
+    public var capabilities: [String: MCPJSONValue]
+
+    /// Maximum duration to wait for each request.
+    ///
+    /// Set this to `nil` to disable client-side request timeouts.
+    public var requestTimeout: Duration?
+
+    /// Creates a configuration for the selected transport.
+    ///
+    /// - Parameters:
+    ///   - transport: Transport used to reach the Xcode MCP server.
+    ///   - clientName: Client name sent in the MCP `initialize` request.
+    ///   - clientVersion: Client version sent in the MCP `initialize` request.
+    ///   - capabilities: Additional MCP client capabilities encoded as raw MCP
+    ///     JSON.
+    ///   - requestTimeout: Maximum duration to wait for each request, or `nil`
+    ///     to disable client-side request timeouts.
+    public init(
+        transport: Transport = .localBridge(),
+        clientName: String = "XcodeMCPKit",
+        clientVersion: String = "dev",
+        capabilities: [String: MCPJSONValue] = [:],
+        requestTimeout: Duration? = .seconds(60)
+    ) {
+        self.transport = transport
+        self.clientName = clientName
+        self.clientVersion = clientVersion
+        self.capabilities = capabilities
+        self.requestTimeout = requestTimeout
+    }
+}
+
 /// A high-level client for Xcode MCP.
 ///
 /// `XcodeMCP` connects through the configured transport, performs the MCP
@@ -36,182 +181,6 @@ import Foundation
 /// await xcode.close()
 /// ```
 public actor XcodeMCP {
-    /// Settings used to connect to and initialize an MCP endpoint.
-    ///
-    /// The default configuration starts `xcrun mcpbridge` with the current
-    /// process environment and a conservative per-request timeout. Use
-    /// ``Transport/streamableHTTP(endpoint:)`` to connect to a proxy
-    /// Streamable HTTP endpoint instead.
-    public struct Configuration: Equatable, Sendable {
-        /// Transport used to reach the Xcode MCP server.
-        public enum Transport: Equatable, Sendable {
-            /// Launch and talk to a local bridge process over stdio.
-            case localBridge(Bridge)
-
-            /// Connect to a concrete Streamable HTTP MCP endpoint.
-            case streamableHTTP(endpoint: URL)
-
-            /// Connect to the Streamable HTTP endpoint recorded in a proxy
-            /// discovery file.
-            case streamableHTTPDiscoveryFile(URL)
-
-            /// Connect to the Streamable HTTP endpoint recorded in a proxy
-            /// discovery file.
-            ///
-            /// The discovery file uses the same shape written by
-            /// `xcode-mcp-proxy-server startAndWriteDiscovery()`.
-            public static func streamableHTTP(discoveryFile: URL) -> Self {
-                .streamableHTTPDiscoveryFile(discoveryFile)
-            }
-
-            /// Connect to the Streamable HTTP proxy endpoint discovered from
-            /// the standard proxy discovery file location.
-            ///
-            /// The file path honors `XCODE_MCP_PROXY_DISCOVERY_FILE` first,
-            /// then `XCODE_MCP_PROXY_CACHE_ROOT`, and otherwise uses the
-            /// default user caches location used by `xcode-mcp-proxy-server`.
-            ///
-            /// - Parameter environment: Environment used to resolve proxy
-            ///   discovery overrides.
-            public static func streamableHTTPProxyDiscovery(
-                environment: [String: String] = ProcessInfo.processInfo.environment
-            ) -> Self {
-                .streamableHTTP(discoveryFile: Discovery.defaultFileURL(environment: environment))
-            }
-        }
-
-        /// Upstream bridge process policy.
-        public enum Bridge: Equatable, Sendable {
-            /// Use Xcode's default `xcrun mcpbridge` invocation.
-            case defaultMCPBridge
-
-            /// Use an explicit upstream bridge command.
-            case custom(
-                command: String,
-                arguments: [String],
-                environment: [String: String]
-            )
-
-            package var invocation: MCPBridgeInvocation {
-                switch self {
-                case .defaultMCPBridge:
-                    return .defaultMCPBridge
-                case .custom(let command, let arguments, _):
-                    return MCPBridgeInvocation(command: command, arguments: arguments)
-                }
-            }
-
-            package var command: String {
-                invocation.command
-            }
-
-            package var arguments: [String] {
-                invocation.arguments
-            }
-
-            package var environment: [String: String] {
-                switch self {
-                case .defaultMCPBridge:
-                    return ProcessInfo.processInfo.environment
-                case .custom(_, _, let environment):
-                    return environment
-                }
-            }
-
-            package var maxQueuedWriteBytes: Int {
-                4 * 1024 * 1024
-            }
-        }
-
-        /// Transport used to reach the Xcode MCP server.
-        public var transport: Transport
-
-        /// Bridge process policy.
-        ///
-        /// This compatibility property reads and writes the local bridge used
-        /// by ``Transport/localBridge(_:)``. Setting it switches the
-        /// configuration back to local process transport.
-        public var bridge: Bridge {
-            get {
-                guard case .localBridge(let bridge) = transport else {
-                    return .defaultMCPBridge
-                }
-                return bridge
-            }
-            set {
-                transport = .localBridge(newValue)
-            }
-        }
-
-        /// Client name sent in the MCP `initialize` request.
-        public var clientName: String
-
-        /// Client version sent in the MCP `initialize` request.
-        public var clientVersion: String
-
-        /// Additional MCP client capabilities sent during initialization.
-        ///
-        /// Values are encoded as raw MCP JSON. Capabilities that require
-        /// server-to-client handlers, such as `roots`, `sampling`, and
-        /// `elicitation`, are intentionally not exposed by this API.
-        public var capabilities: [String: MCPJSONValue]
-
-        /// Maximum duration to wait for each request.
-        ///
-        /// Set this to `nil` to disable client-side request timeouts.
-        public var requestTimeout: Duration?
-
-        /// Creates a local bridge configuration.
-        ///
-        /// - Parameters:
-        ///   - bridge: Upstream bridge process policy.
-        ///   - clientName: Client name sent in the MCP `initialize` request.
-        ///   - clientVersion: Client version sent in the MCP `initialize`
-        ///     request.
-        ///   - capabilities: Additional MCP client capabilities encoded as raw
-        ///     MCP JSON.
-        ///   - requestTimeout: Maximum duration to wait for each request, or
-        ///     `nil` to disable client-side request timeouts.
-        public init(
-            bridge: Bridge = .defaultMCPBridge,
-            clientName: String = "XcodeMCPKit",
-            clientVersion: String = "dev",
-            capabilities: [String: MCPJSONValue] = [:],
-            requestTimeout: Duration? = .seconds(60)
-        ) {
-            self.transport = .localBridge(bridge)
-            self.clientName = clientName
-            self.clientVersion = clientVersion
-            self.capabilities = capabilities
-            self.requestTimeout = requestTimeout
-        }
-
-        /// Creates a configuration for the selected transport.
-        ///
-        /// - Parameters:
-        ///   - transport: Transport used to reach the Xcode MCP server.
-        ///   - clientName: Client name sent in the MCP `initialize` request.
-        ///   - clientVersion: Client version sent in the MCP `initialize`
-        ///     request.
-        ///   - capabilities: Additional MCP client capabilities encoded as raw
-        ///     MCP JSON.
-        ///   - requestTimeout: Maximum duration to wait for each request, or
-        ///     `nil` to disable client-side request timeouts.
-        public init(
-            transport: Transport,
-            clientName: String = "XcodeMCPKit",
-            clientVersion: String = "dev",
-            capabilities: [String: MCPJSONValue] = [:],
-            requestTimeout: Duration? = .seconds(60)
-        ) {
-            self.transport = transport
-            self.clientName = clientName
-            self.clientVersion = clientVersion
-            self.capabilities = capabilities
-            self.requestTimeout = requestTimeout
-        }
-    }
-
     private let session: InitializedMCPClientSession
 
     /// Connects to the configured MCP transport and returns an initialized
@@ -223,21 +192,21 @@ public actor XcodeMCP {
     /// `notifications/initialized`. If initialization fails, the transport is
     /// closed before the error is rethrown.
     ///
-    /// - Parameter config: Connection and initialization settings.
-    public init(config: Configuration = Configuration()) async throws {
+    /// - Parameter configuration: Connection and initialization settings.
+    public init(configuration: XcodeMCPConfiguration = XcodeMCPConfiguration()) async throws {
         try await self.init(
-            config: config,
+            configuration: configuration,
             streamableHTTPDiscoveryResolver: .liveValue
         )
     }
 
     package init(
-        config: Configuration = Configuration(),
+        configuration: XcodeMCPConfiguration = XcodeMCPConfiguration(),
         streamableHTTPDiscoveryResolver: StreamableHTTPDiscoveryResolver
     ) async throws {
         do {
             let transport: any XcodeMCPTransport
-            switch config.transport {
+            switch configuration.transport.storage {
             case .localBridge(let bridge):
                 transport = try await UpstreamProcessXcodeMCPTransport.start(
                     command: bridge.command,
@@ -248,30 +217,33 @@ public actor XcodeMCP {
             case .streamableHTTP(let endpoint):
                 transport = try await StreamableHTTPXcodeMCPTransport.start(
                     endpoint: endpoint,
-                    requestTimeout: config.requestTimeout
+                    requestTimeout: configuration.requestTimeout
                 )
             case .streamableHTTPDiscoveryFile(let discoveryFile):
                 transport = try await StreamableHTTPXcodeMCPTransport.start(
                     discoveryFile: discoveryFile,
-                    requestTimeout: config.requestTimeout,
+                    requestTimeout: configuration.requestTimeout,
                     discoveryResolver: streamableHTTPDiscoveryResolver
                 )
             }
-            try await self.init(config: config, transport: transport)
+            try await self.init(configuration: configuration, transport: transport)
         } catch {
             throw Self.publicError(from: error)
         }
     }
 
-    package init(config: Configuration = Configuration(), transport: any XcodeMCPTransport) async throws {
+    package init(
+        configuration: XcodeMCPConfiguration = XcodeMCPConfiguration(),
+        transport: any XcodeMCPTransport
+    ) async throws {
         do {
             self.session = try await InitializedMCPClientSession(
                 transport: transport,
                 configuration: InitializedMCPClientSession.Configuration(
-                    clientName: config.clientName,
-                    clientVersion: config.clientVersion,
-                    capabilities: config.capabilities.mapValues(\.jsonValue),
-                    requestTimeout: config.requestTimeout
+                    clientName: configuration.clientName,
+                    clientVersion: configuration.clientVersion,
+                    capabilities: configuration.capabilities.mapValues(\.jsonValue),
+                    requestTimeout: configuration.requestTimeout
                 )
             )
         } catch {

--- a/Sources/XcodeMCPKitTesting/XcodeMCPTestRuntime.swift
+++ b/Sources/XcodeMCPKitTesting/XcodeMCPTestRuntime.swift
@@ -156,11 +156,11 @@ public actor XcodeMCPTestRuntime {
     /// `notifications/initialized` handshake. Tests can inspect
     /// ``recordedMessages()`` to assert request shape.
     public func makeClient(
-        config: XcodeMCP.Configuration = XcodeMCP.Configuration()
+        configuration: XcodeMCPConfiguration = XcodeMCPConfiguration()
     ) async throws -> XcodeMCP {
         let transport = XcodeMCPTestTransport(runtime: self)
         transportContinuations[transport.id] = transport.continuation
-        return try await XcodeMCP(config: config, transport: transport)
+        return try await XcodeMCP(configuration: configuration, transport: transport)
     }
 
     /// Replaces the tool catalog returned from `tools/list`.

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
@@ -53,7 +53,7 @@ enum MCPBridgeRuntime {
                         xcodeTarget: target
                     )
                     upstreams.append(
-                        ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig))
+                        ManagedUpstreamSlot(factory: UpstreamProcess(configuration: upstreamConfig))
                     )
                     slotIDs.append(UpstreamSlotID(rawValue: upstreamIndex))
                 }
@@ -70,7 +70,7 @@ enum MCPBridgeRuntime {
                     xcodeTarget: nil
                 )
                 upstreams.append(
-                    ManagedUpstreamSlot(factory: UpstreamProcess(config: upstreamConfig))
+                    ManagedUpstreamSlot(factory: UpstreamProcess(configuration: upstreamConfig))
                 )
             }
         }
@@ -95,7 +95,7 @@ enum MCPBridgeRuntime {
         xcodeTarget: XcodeProcessTarget,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment
     ) -> any UpstreamSessionFactory {
-        UpstreamProcess(config: makeDefaultUpstreamConfig(
+        UpstreamProcess(configuration: makeDefaultUpstreamConfig(
             config: config,
             xcodeTarget: xcodeTarget,
             baseEnvironment: baseEnvironment

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/MCP/MCPForwardingService.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/MCP/MCPForwardingService.swift
@@ -17,11 +17,11 @@ struct MCPForwardingService: Sendable {
     private let upstreamRuntime: ProxyUpstreamRequestRuntime
     private let toolSurface: ToolSurface
 
-    init(config: ProxyConfig, sessionManager: any RuntimeMCPForwardingPort) {
-        self.config = config
+    init(configuration: ProxyConfig, sessionManager: any RuntimeMCPForwardingPort) {
+        self.config = configuration
         self.sessionManager = sessionManager
         self.upstreamRuntime = ProxyUpstreamRequestRuntime(port: sessionManager)
-        self.toolSurface = ToolSurface(config: config, sessionManager: sessionManager)
+        self.toolSurface = ToolSurface(config: configuration, sessionManager: sessionManager)
     }
 
     func prepareRequest(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor.swift
@@ -82,7 +82,7 @@ final class ClientMCPRequestExecutor: Sendable {
             logger: ProxyLogging.make("http.local")
         )
         self.forwardingService = MCPForwardingService(
-            config: config,
+            configuration: config,
             sessionManager: sessionManager
         )
         self.refreshWorkflow = RefreshCodeIssues.Workflow(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -527,7 +527,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         let brokerState = CanonicalBrokerState()
         self.canonicalBrokerState = brokerState
         self.initializeManager = InitializeManager(brokerState: brokerState)
-        self.sessionRegistry = SessionRegistry(config: config)
+        self.sessionRegistry = SessionRegistry(configuration: config)
         self.debugRecorder = ProxyDebugRecorder(upstreamCount: upstreams.count)
         self.leaseManager = LeaseManager()
         self.upstreamRouter = UpstreamRouter(upstreamCount: upstreams.count)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Session/SessionRegistry.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Session/SessionRegistry.swift
@@ -18,8 +18,8 @@ final class SessionRegistry: Sendable {
     private let state = NIOLockedValueBox(State())
     private let config: ProxyConfig
 
-    init(config: ProxyConfig) {
-        self.config = config
+    init(configuration: ProxyConfig) {
+        self.config = configuration
     }
 
     func session(id: String) -> SessionContext {

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -12,10 +12,13 @@ compose the STDIO adapter and installer flows.
 The public API includes:
 
 - `XcodeMCPProxyServer`, the embeddable proxy server lifecycle object
+- `XcodeMCPProxyServerConfiguration`, the embeddable server configuration
 - `XcodeMCPProxyServer.resolveLaunchPlan(...)` for launcher argv/environment
   normalization
 - `XcodeMCPProxyStdioAdapter`, the STDIO compatibility adapter
+- `XcodeMCPProxyStdioAdapterConfiguration`, the adapter configuration
 - `XcodeMCPProxyAdapterEndpointResolver`, the adapter endpoint resolver
+- `XcodeMCPProxyAdapterEndpointResolutionOptions`, endpoint resolution inputs
 - `XcodeMCPProxyInstaller`, the install plan and copy/build API
 
 For most users, the root README's `xcode-mcp-proxy-server` command is simpler.
@@ -31,15 +34,15 @@ directly:
 ```swift
 import XcodeMCPProxyKit
 
-let config = XcodeMCPProxyServer.Configuration(
-    bind: .localhost(port: 8765),
+let config = XcodeMCPProxyServerConfiguration(
+    bindAddress: .localhost(port: 8765),
     upstream: .defaultMCPBridge(processesPerXcode: 1),
     limits: .init(maxBodyBytes: 1_048_576, requestTimeout: 300),
     discovery: .init(fileURL: URL(fileURLWithPath: "/tmp/xcode-mcp-proxy.json")),
-    approval: .manual
+    approvalPolicy: .manual
 )
 
-let server = XcodeMCPProxyServer(config: config)
+let server = XcodeMCPProxyServer(configuration: config)
 let endpoint = try server.startAndWriteDiscovery()
 print("Listening on \(endpoint.url)")
 
@@ -58,14 +61,14 @@ look up the running HTTP endpoint.
 
 ## Configuration
 
-Use `XcodeMCPProxyServer.Configuration` to configure the server:
+Use `XcodeMCPProxyServerConfiguration` to configure the server:
 
-- `bind` chooses the HTTP bind address.
+- `bindAddress` chooses the HTTP bind address.
 - `upstream` chooses the upstream MCP bridge and process count.
 - `limits` bounds request timeout and body size.
 - `discovery` overrides the endpoint discovery file.
-- `approval` controls Xcode permission dialog automation.
-- `features.refreshCodeIssuesMode` selects proxy diagnostics or upstream
+- `approvalPolicy` controls Xcode permission dialog automation.
+- `featurePolicy.refreshCodeIssuesMode` selects proxy diagnostics or upstream
   forwarding for `XcodeRefreshCodeIssuesInFile`.
 - `toolPolicy.disabledToolNames` hides tools from `tools/list` and rejects
   matching `tools/call` requests locally.
@@ -81,7 +84,7 @@ initialize handshake fields.
 import XcodeMCPKit
 import XcodeMCPProxyKit
 
-let config = XcodeMCPProxyServer.Configuration(
+let config = XcodeMCPProxyServerConfiguration(
     configurationFilePath: "/etc/xcode-mcp/proxy.toml",
     toolPolicy: .init(
         disabledToolNames: ["RunAllTests", "RunSomeTests"]
@@ -133,13 +136,13 @@ case .showVersion:
 case .dryRun:
     print(plan.resolvedDryRunCommandLine ?? "")
 case .start:
-    let server = XcodeMCPProxyServer(config: plan.configuration!)
+    let server = XcodeMCPProxyServer(configuration: plan.configuration!)
     _ = try server.startAndWriteDiscovery()
     try await server.wait()
 }
 ```
 
-`LaunchPlan` exposes the resolved server `Configuration`, normalized
+`LaunchPlan` exposes the resolved server `XcodeMCPProxyServerConfiguration`, normalized
 `LaunchOptions`, stable dry-run command line, and display text. Port-in-use
 messages are represented by `XcodeMCPProxyServer.PortInUseError`, and product
 version information is available through `XcodeMCPProxyServer.productMetadata`.

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyInstaller.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyInstaller.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+/// Destination and mode settings for a source install.
+public struct XcodeMCPProxyInstallerConfiguration: Equatable, Sendable {
+    /// Install prefix used when ``binaryDirectory`` is not set.
+    public var prefix: String?
+
+    /// Explicit binary directory. This takes precedence over ``prefix``.
+    public var binaryDirectory: String?
+
+    /// Whether to only compute and print the install plan.
+    public var dryRun: Bool
+
+    /// Creates installer configuration.
+    public init(
+        prefix: String? = nil,
+        binaryDirectory: String? = nil,
+        dryRun: Bool = false
+    ) {
+        self.prefix = prefix
+        self.binaryDirectory = binaryDirectory
+        self.dryRun = dryRun
+    }
+}
+
 /// Installer facade for Xcode MCP proxy executables.
 public struct XcodeMCPProxyInstaller: Sendable {
     /// Top-level action for an installer invocation.
@@ -32,7 +55,7 @@ public struct XcodeMCPProxyInstaller: Sendable {
 
         /// Installer configuration. This is present for `.install` plans and
         /// absent for display-only plans.
-        public let configuration: Configuration?
+        public let configuration: XcodeMCPProxyInstallerConfiguration?
 
         /// Normalized launch options.
         public let options: LaunchOptions
@@ -46,7 +69,7 @@ public struct XcodeMCPProxyInstaller: Sendable {
         /// Creates an installer launch plan.
         public init(
             action: LaunchAction,
-            configuration: Configuration?,
+            configuration: XcodeMCPProxyInstallerConfiguration?,
             options: LaunchOptions,
             usage: String,
             versionLine: String
@@ -56,25 +79,6 @@ public struct XcodeMCPProxyInstaller: Sendable {
             self.options = options
             self.usage = usage
             self.versionLine = versionLine
-        }
-    }
-
-    /// Destination and mode settings for a source install.
-    public struct Configuration: Equatable, Sendable {
-        /// Install prefix used when ``bindir`` is not set.
-        public var prefix: String?
-
-        /// Explicit binary directory. This takes precedence over ``prefix``.
-        public var bindir: String?
-
-        /// Whether to only compute and print the install plan.
-        public var dryRun: Bool
-
-        /// Creates installer configuration.
-        public init(prefix: String? = nil, bindir: String? = nil, dryRun: Bool = false) {
-            self.prefix = prefix
-            self.bindir = bindir
-            self.dryRun = dryRun
         }
     }
 
@@ -144,10 +148,13 @@ public struct XcodeMCPProxyInstaller: Sendable {
     ]
 
     /// Installer configuration.
-    public var configuration: Configuration
+    public var configuration: XcodeMCPProxyInstallerConfiguration
 
     /// Creates an installer facade.
-    public init(configuration: Configuration = Configuration()) {
+    public init(
+        configuration: XcodeMCPProxyInstallerConfiguration =
+            XcodeMCPProxyInstallerConfiguration()
+    ) {
         self.configuration = configuration
     }
 
@@ -223,10 +230,10 @@ public struct XcodeMCPProxyInstaller: Sendable {
     package static func parseLaunchConfiguration(
         _ arguments: [String],
         environment: [String: String]
-    ) throws -> Configuration {
-        var configuration = Configuration(
+    ) throws -> XcodeMCPProxyInstallerConfiguration {
+        var configuration = XcodeMCPProxyInstallerConfiguration(
             prefix: environment["PREFIX"],
-            bindir: environment["BINDIR"],
+            binaryDirectory: environment["BINDIR"],
             dryRun: false
         )
 
@@ -246,7 +253,7 @@ public struct XcodeMCPProxyInstaller: Sendable {
                 guard index + 1 < arguments.count else {
                     throw Error.message("\(argument) requires a value")
                 }
-                configuration.bindir = arguments[index + 1]
+                configuration.binaryDirectory = arguments[index + 1]
                 index += 2
             case "--dry-run":
                 configuration.dryRun = true
@@ -267,7 +274,7 @@ public struct XcodeMCPProxyInstaller: Sendable {
         let sourceDirectory = executableURL.deletingLastPathComponent()
         let binDirectory = Self.resolveBinDirectory(
             prefix: configuration.prefix,
-            bindir: configuration.bindir
+            binaryDirectory: configuration.binaryDirectory
         )
         let binaries = Self.binaryNames.map { name in
             Binary(
@@ -285,8 +292,8 @@ public struct XcodeMCPProxyInstaller: Sendable {
 
     /// Builds release products when needed and installs the proxy executables.
     ///
-    /// When ``Configuration/dryRun`` is true this method prints the dry-run plan
-    /// and does not create directories or copy files.
+    /// When ``XcodeMCPProxyInstallerConfiguration/dryRun`` is true this method
+    /// prints the dry-run plan and does not create directories or copy files.
     public func install(
         executableURL: URL,
         stdout: (String) -> Void = { print($0) }
@@ -344,11 +351,11 @@ public struct XcodeMCPProxyInstaller: Sendable {
 
     /// Resolves the destination binary directory.
     ///
-    /// `bindir` takes precedence over `prefix`; otherwise this returns
+    /// `binaryDirectory` takes precedence over `prefix`; otherwise this returns
     /// `~/.local/bin`.
-    public static func resolveBinDirectory(prefix: String?, bindir: String?) -> URL {
-        if let bindir {
-            return URL(fileURLWithPath: expandPath(bindir), isDirectory: true)
+    public static func resolveBinDirectory(prefix: String?, binaryDirectory: String?) -> URL {
+        if let binaryDirectory {
+            return URL(fileURLWithPath: expandPath(binaryDirectory), isDirectory: true)
         }
 
         let defaultPrefix = prefix ?? "\(NSHomeDirectory())/.local"
@@ -399,12 +406,12 @@ extension XcodeMCPProxyInstaller {
         package struct Dependencies {
             package var executableURL: () -> URL?
             package var install:
-                (XcodeMCPProxyInstaller.Configuration, URL, (String) -> Void) throws -> Void
+                (XcodeMCPProxyInstallerConfiguration, URL, (String) -> Void) throws -> Void
 
             package init(
                 executableURL: @escaping () -> URL?,
                 install: @escaping (
-                    XcodeMCPProxyInstaller.Configuration,
+                    XcodeMCPProxyInstallerConfiguration,
                     URL,
                     (String) -> Void
                 ) throws -> Void

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Launch.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Launch.swift
@@ -1,35 +1,35 @@
 import Foundation
 
-extension XcodeMCPProxyServer {
-    /// Product metadata exposed by the server-side kit.
-    public struct ProductMetadata: Equatable, Sendable {
-        /// Product name shown in server startup summaries.
-        public let name: String
+/// Product metadata exposed by `XcodeMCPProxyKit`.
+public struct XcodeMCPProxyProductMetadata: Equatable, Sendable {
+    /// Product name shown in startup summaries.
+    public let name: String
 
-        /// Resolved package version.
-        public let version: String
+    /// Resolved package version.
+    public let version: String
 
-        /// Creates product metadata.
-        public init(name: String = "XcodeMCPProxyKit", version: String) {
-            self.name = name
-            self.version = version
-        }
-
-        /// Formats a CLI-compatible version line.
-        public func versionLine(arguments: [String], defaultExecutableName: String) -> String {
-            "\(executableName(arguments: arguments, defaultExecutableName: defaultExecutableName)) \(version)"
-        }
-
-        private func executableName(arguments: [String], defaultExecutableName: String) -> String {
-            guard let rawExecutable = arguments.first, !rawExecutable.isEmpty else {
-                return defaultExecutableName
-            }
-
-            let name = URL(fileURLWithPath: rawExecutable).lastPathComponent
-            return name.isEmpty ? defaultExecutableName : name
-        }
+    /// Creates product metadata.
+    public init(name: String = "XcodeMCPProxyKit", version: String) {
+        self.name = name
+        self.version = version
     }
 
+    /// Formats a CLI-compatible version line.
+    public func versionLine(arguments: [String], defaultExecutableName: String) -> String {
+        "\(executableName(arguments: arguments, defaultExecutableName: defaultExecutableName)) \(version)"
+    }
+
+    private func executableName(arguments: [String], defaultExecutableName: String) -> String {
+        guard let rawExecutable = arguments.first, !rawExecutable.isEmpty else {
+            return defaultExecutableName
+        }
+
+        let name = URL(fileURLWithPath: rawExecutable).lastPathComponent
+        return name.isEmpty ? defaultExecutableName : name
+    }
+}
+
+extension XcodeMCPProxyServer {
     /// Resolved top-level action for a server launch invocation.
     public enum LaunchAction: Equatable, Sendable {
         /// Print usage and exit.
@@ -71,7 +71,7 @@ extension XcodeMCPProxyServer {
 
         /// Public server configuration. This is present for `.start` and
         /// `.dryRun` plans and absent for display-only plans.
-        public let configuration: Configuration?
+        public let configuration: XcodeMCPProxyServerConfiguration?
 
         /// Normalized launch options.
         public let options: LaunchOptions
@@ -88,7 +88,7 @@ extension XcodeMCPProxyServer {
         /// Creates a launch plan.
         public init(
             action: LaunchAction,
-            configuration: Configuration?,
+            configuration: XcodeMCPProxyServerConfiguration?,
             options: LaunchOptions,
             resolvedDryRunCommandLine: String?,
             usage: String,
@@ -145,8 +145,8 @@ extension XcodeMCPProxyServer {
     }
 
     /// Resolved XcodeMCPProxyKit product metadata.
-    public static var productMetadata: ProductMetadata {
-        ProductMetadata(version: ProxyBuildInfo.version)
+    public static var productMetadata: XcodeMCPProxyProductMetadata {
+        XcodeMCPProxyProductMetadata(version: ProxyBuildInfo.version)
     }
 
     /// CLI usage for `xcode-mcp-proxy-server`.
@@ -242,7 +242,7 @@ extension XcodeMCPProxyServer {
             )
         }
 
-        let configuration = Configuration(serverProxyConfig: proxyConfig)
+        let configuration = XcodeMCPProxyServerConfiguration(serverProxyConfig: proxyConfig)
         let dryRun = parsed.dryRun || isTruthy(environment["DRY_RUN"])
         let options = LaunchOptions(
             executableName: displayOptions.executableName,
@@ -328,17 +328,17 @@ extension XcodeMCPProxyServer {
 
     package static func resolvedDryRunCommandLine(
         options: ParsedLaunchOptions,
-        configuration: Configuration
+        configuration: XcodeMCPProxyServerConfiguration
     ) -> String {
         var parts = ["xcode-mcp-proxy-server"] + options.forwardedArguments
         if options.hasConfigFlag == false, let configPath = configuration.configurationFilePath {
             parts += ["--config", configPath]
         }
         if options.hasRefreshCodeIssuesModeFlag == false,
-           configuration.features.refreshCodeIssuesMode != .proxy {
+           configuration.featurePolicy.refreshCodeIssuesMode != .proxy {
             parts += [
                 "--refresh-code-issues-mode",
-                configuration.features.refreshCodeIssuesMode.rawValue,
+                configuration.featurePolicy.refreshCodeIssuesMode.rawValue,
             ]
         }
         return parts.joined(separator: " ")

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Launcher.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer+Launcher.swift
@@ -6,13 +6,13 @@ extension XcodeMCPProxyServer {
 
     package struct Launcher {
         package struct Dependencies {
-            package var makeServer: (XcodeMCPProxyServer.Configuration) -> any LaunchServer
+            package var makeServer: (XcodeMCPProxyServerConfiguration) -> any LaunchServer
             package var isAddressAlreadyInUse: (Swift.Error) -> Bool
             package var forceRestartExistingServer: (_ host: String, _ port: Int, _ stderr: (String) -> Void) -> Bool
             package var detectExistingServerProcessIDs: (_ host: String, _ port: Int) -> [Int]
 
             package init(
-                makeServer: @escaping (XcodeMCPProxyServer.Configuration) -> any LaunchServer,
+                makeServer: @escaping (XcodeMCPProxyServerConfiguration) -> any LaunchServer,
                 isAddressAlreadyInUse: @escaping (Swift.Error) -> Bool,
                 forceRestartExistingServer: @escaping (
                     _ host: String,
@@ -31,7 +31,7 @@ extension XcodeMCPProxyServer {
                 let existingServerController = XcodeMCPProxyServer.ExistingServerController.liveValue
                 return Self(
                     makeServer: { config in
-                        XcodeMCPProxyServer(config: config)
+                        XcodeMCPProxyServer(configuration: config)
                     },
                     isAddressAlreadyInUse: XcodeMCPProxyServer.isAddressAlreadyInUse,
                     forceRestartExistingServer: { host, port, stderr in
@@ -102,10 +102,10 @@ extension XcodeMCPProxyServer {
                 )
             }
 
-            if plan.options.forceRestart, serverConfig.bind.port > 0 {
+            if plan.options.forceRestart, serverConfig.bindAddress.port > 0 {
                 _ = dependencies.forceRestartExistingServer(
-                    serverConfig.bind.host,
-                    serverConfig.bind.port,
+                    serverConfig.bindAddress.host,
+                    serverConfig.bindAddress.port,
                     stderr
                 )
             }
@@ -116,13 +116,13 @@ extension XcodeMCPProxyServer {
                 try await server.wait()
                 return 0
             } catch {
-                if serverConfig.bind.port > 0, dependencies.isAddressAlreadyInUse(error) {
+                if serverConfig.bindAddress.port > 0, dependencies.isAddressAlreadyInUse(error) {
                     let diagnostic = XcodeMCPProxyServer.PortInUseError(
-                        host: serverConfig.bind.host,
-                        port: serverConfig.bind.port,
+                        host: serverConfig.bindAddress.host,
+                        port: serverConfig.bindAddress.port,
                         processIdentifiers: dependencies.detectExistingServerProcessIDs(
-                            serverConfig.bind.host,
-                            serverConfig.bind.port
+                            serverConfig.bindAddress.host,
+                            serverConfig.bindAddress.port
                         )
                     )
                     stderr(diagnostic.description)

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -4,13 +4,336 @@ import NIO
 import NIOHTTP1
 import XcodeMCPKit
 
+/// Public configuration for an embedded Xcode MCP proxy server.
+///
+/// This type is the stable server configuration surface for
+/// `XcodeMCPProxyKit`. Lower-level parser, discovery, filesystem, and
+/// session-routing types stay internal to the targets that own them.
+public struct XcodeMCPProxyServerConfiguration: Equatable, Sendable {
+    /// Address that the Streamable HTTP server binds.
+    public struct BindAddress: Equatable, Sendable {
+        /// Hostname or IP address for the server socket.
+        public var host: String
+
+        /// TCP port for the server socket.
+        ///
+        /// Use `0` to request an ephemeral port from the operating system.
+        public var port: Int
+
+        /// Creates a bind address.
+        public init(host: String = "localhost", port: Int = 8765) {
+            self.host = host
+            self.port = port
+        }
+
+        /// Creates a loopback bind address.
+        public static func localhost(port: Int = 8765) -> Self {
+            Self(host: "localhost", port: port)
+        }
+    }
+
+    /// Upstream `mcpbridge` process policy.
+    public enum Upstream: Equatable, Sendable {
+        /// Use Xcode's default `xcrun mcpbridge` invocation.
+        case defaultMCPBridge(processesPerXcode: Int = 1, sessionID: String? = nil)
+
+        /// Use an explicit upstream command and arguments.
+        case custom(
+            command: String,
+            arguments: [String],
+            processesPerXcode: Int = 1,
+            sessionID: String? = nil
+        )
+
+        var invocation: MCPBridgeInvocation {
+            switch self {
+            case .defaultMCPBridge:
+                return .defaultMCPBridge
+            case .custom(let command, let arguments, _, _):
+                return MCPBridgeInvocation(command: command, arguments: arguments)
+            }
+        }
+
+        var command: String {
+            invocation.command
+        }
+
+        var arguments: [String] {
+            invocation.arguments
+        }
+
+        var processesPerXcode: Int {
+            switch self {
+            case .defaultMCPBridge(let count, _), .custom(_, _, let count, _):
+                return count
+            }
+        }
+
+        var sessionID: String? {
+            switch self {
+            case .defaultMCPBridge(_, let sessionID), .custom(_, _, _, let sessionID):
+                return sessionID
+            }
+        }
+    }
+
+    /// Request and payload limits enforced by the proxy.
+    public struct Limits: Equatable, Sendable {
+        /// Maximum accepted HTTP request body size in bytes.
+        public var maxBodyBytes: Int
+
+        /// Request timeout in seconds.
+        public var requestTimeout: TimeInterval
+
+        /// Creates proxy request limits.
+        public init(maxBodyBytes: Int = 1_048_576, requestTimeout: TimeInterval = 300) {
+            self.maxBodyBytes = maxBodyBytes
+            self.requestTimeout = requestTimeout
+        }
+
+        /// Default proxy limits.
+        public static let `default` = Self()
+    }
+
+    /// Endpoint discovery file policy.
+    public struct Discovery: Equatable, Sendable {
+        /// Optional discovery file URL.
+        ///
+        /// `nil` uses the default discovery location.
+        public var fileURL: URL?
+
+        /// Creates a discovery policy.
+        public init(fileURL: URL? = nil) {
+            self.fileURL = fileURL
+        }
+
+        /// Uses the default discovery file location.
+        public static let `default` = Self()
+    }
+
+    /// Xcode permission dialog automation policy.
+    public enum ApprovalPolicy: Equatable, Sendable {
+        /// Do not automate the Xcode permission dialog.
+        case manual
+
+        /// Try to approve the Xcode permission dialog automatically.
+        ///
+        /// This requires macOS Accessibility permission for the host process.
+        case automatic
+    }
+
+    /// How `XcodeRefreshCodeIssuesInFile` requests are served.
+    public enum RefreshCodeIssuesMode: String, Equatable, Sendable {
+        /// Serve refresh-code-issues requests through proxy diagnostics.
+        case proxy
+
+        /// Forward refresh-code-issues requests to the upstream Xcode MCP
+        /// bridge.
+        case upstream
+    }
+
+    /// Optional proxy features that affect tool behavior.
+    public struct FeaturePolicy: Equatable, Sendable {
+        /// Whether the proxy should prewarm the upstream tools list.
+        public var prewarmToolsList: Bool
+
+        /// Refresh-code-issues handling mode.
+        public var refreshCodeIssuesMode: RefreshCodeIssuesMode
+
+        /// Creates a feature policy.
+        public init(
+            prewarmToolsList: Bool = true,
+            refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy
+        ) {
+            self.prewarmToolsList = prewarmToolsList
+            self.refreshCodeIssuesMode = refreshCodeIssuesMode
+        }
+
+        /// Default feature policy.
+        public static let `default` = Self()
+    }
+
+    /// Tool visibility policy applied by the proxy.
+    public struct ToolPolicy: Equatable, Sendable {
+        /// Tool names hidden from `tools/list` results and rejected for
+        /// `tools/call` requests.
+        ///
+        /// Names are normalized when the server builds its runtime config:
+        /// surrounding whitespace is trimmed and empty names are ignored.
+        public var disabledToolNames: Set<String>
+
+        /// Creates a tool policy.
+        public init(disabledToolNames: Set<String> = []) {
+            self.disabledToolNames = disabledToolNames
+        }
+
+        /// Default tool policy.
+        public static let `default` = Self()
+    }
+
+    /// Initialize handshake overrides sent from the proxy to upstream
+    /// `mcpbridge` processes.
+    ///
+    /// Non-`nil` properties override the matching values loaded from
+    /// ``configurationFilePath``. Properties left as `nil` keep the file value
+    /// when present, otherwise the proxy's built-in default is used.
+    public struct InitializeHandshake: Equatable, Sendable {
+        /// Upstream client information for the initialize handshake.
+        public struct ClientInfo: Equatable, Sendable {
+            /// Client name to advertise to the upstream MCP bridge.
+            public var name: String?
+
+            /// Client version to advertise to the upstream MCP bridge.
+            public var version: String?
+
+            /// Creates upstream client information.
+            public init(name: String? = nil, version: String? = nil) {
+                self.name = name
+                self.version = version
+            }
+        }
+
+        /// Protocol version to send in initialize params.
+        public var protocolVersion: String?
+
+        /// Client info to send in initialize params.
+        public var clientInfo: ClientInfo?
+
+        /// Capability object to send in initialize params.
+        public var capabilities: [String: MCPJSONValue]?
+
+        /// Creates initialize handshake overrides.
+        public init(
+            protocolVersion: String? = nil,
+            clientInfo: ClientInfo? = nil,
+            capabilities: [String: MCPJSONValue]? = nil
+        ) {
+            self.protocolVersion = protocolVersion
+            self.clientInfo = clientInfo
+            self.capabilities = capabilities
+        }
+    }
+
+    /// HTTP bind address.
+    public var bindAddress: BindAddress
+
+    /// Upstream bridge process policy.
+    public var upstream: Upstream
+
+    /// Request and payload limits.
+    public var limits: Limits
+
+    /// Optional TOML configuration path for initialize overrides and disabled
+    /// tools.
+    public var configurationFilePath: String?
+
+    /// Explicit tool visibility policy.
+    ///
+    /// `nil` keeps disabled tools loaded from ``configurationFilePath``. A
+    /// non-`nil` policy overrides the file's `[tools].disabled` list.
+    public var toolPolicy: ToolPolicy?
+
+    /// Explicit initialize handshake override.
+    ///
+    /// Non-`nil` fields override the matching file-backed
+    /// `[upstream_handshake]` fields. Fields left `nil` keep the file value
+    /// when present, otherwise the built-in default is used.
+    public var initializeHandshake: InitializeHandshake?
+
+    /// Endpoint discovery policy.
+    public var discovery: Discovery
+
+    /// Permission dialog automation policy.
+    public var approvalPolicy: ApprovalPolicy
+
+    /// Optional proxy feature policy.
+    public var featurePolicy: FeaturePolicy
+
+    /// Creates a public proxy server configuration.
+    ///
+    /// - Parameters:
+    ///   - bindAddress: HTTP bind address.
+    ///   - upstream: Upstream bridge process policy.
+    ///   - limits: Request and payload limits.
+    ///   - configurationFilePath: Optional TOML configuration path.
+    ///   - discovery: Endpoint discovery policy.
+    ///   - approvalPolicy: Permission dialog automation policy.
+    ///   - featurePolicy: Optional proxy feature policy.
+    ///   - toolPolicy: Explicit tool visibility policy.
+    ///   - initializeHandshake: Explicit upstream initialize handshake override.
+    public init(
+        bindAddress: BindAddress = .localhost(),
+        upstream: Upstream = .defaultMCPBridge(),
+        limits: Limits = .default,
+        configurationFilePath: String? = nil,
+        discovery: Discovery = .default,
+        approvalPolicy: ApprovalPolicy = .manual,
+        featurePolicy: FeaturePolicy = .default,
+        toolPolicy: ToolPolicy? = nil,
+        initializeHandshake: InitializeHandshake? = nil
+    ) {
+        self.bindAddress = bindAddress
+        self.upstream = upstream
+        self.limits = limits
+        self.configurationFilePath = configurationFilePath
+        self.toolPolicy = toolPolicy
+        self.initializeHandshake = initializeHandshake
+        self.discovery = discovery
+        self.approvalPolicy = approvalPolicy
+        self.featurePolicy = featurePolicy
+    }
+
+    init(serverProxyConfig proxyConfig: ProxyConfig) {
+        self.init(
+            bindAddress: BindAddress(
+                host: proxyConfig.listenHost,
+                port: proxyConfig.listenPort
+            ),
+            upstream: .custom(
+                command: proxyConfig.upstreamCommand,
+                arguments: proxyConfig.upstreamArgs,
+                processesPerXcode: proxyConfig.upstreamProcessCount,
+                sessionID: proxyConfig.upstreamSessionID
+            ),
+            limits: Limits(
+                maxBodyBytes: proxyConfig.maxBodyBytes,
+                requestTimeout: proxyConfig.requestTimeout
+            ),
+            configurationFilePath: proxyConfig.configPath,
+            discovery: Discovery(fileURL: proxyConfig.discoveryFileURL),
+            approvalPolicy: proxyConfig.autoApproveXcodeDialog ? .automatic : .manual,
+            featurePolicy: FeaturePolicy(
+                prewarmToolsList: proxyConfig.prewarmToolsList,
+                refreshCodeIssuesMode: RefreshCodeIssuesMode(proxyConfig.refreshCodeIssuesMode)
+            )
+        )
+    }
+
+    var listenHost: String { bindAddress.host }
+    var listenPort: Int { bindAddress.port }
+    var upstreamCommand: String { upstream.command }
+    var upstreamArguments: [String] { upstream.arguments }
+    var upstreamProcessCount: Int { upstream.processesPerXcode }
+    var upstreamSessionID: String? { upstream.sessionID }
+    var maxBodyBytes: Int { limits.maxBodyBytes }
+    var requestTimeout: TimeInterval { limits.requestTimeout }
+    var configPath: String? { configurationFilePath }
+    var discoveryFileURL: URL? { discovery.fileURL }
+    var prewarmToolsList: Bool { featurePolicy.prewarmToolsList }
+    var autoApproveXcodeDialog: Bool { approvalPolicy == .automatic }
+    var refreshCodeIssuesMode: RefreshCodeIssuesMode {
+        featurePolicy.refreshCodeIssuesMode
+    }
+}
+
 /// Embeddable Streamable HTTP proxy server for Xcode MCP.
 ///
 /// `XcodeMCPProxyServer` is the library boundary used by the
-/// `xcode-mcp-proxy-server` executable. Construct it with ``Configuration``,
-/// call ``startAndWriteDiscovery()`` or ``start()``, then keep the process
-/// alive with ``wait()`` until your application decides to call ``shutdown()``.
-/// Both start methods return the resolved endpoint.
+/// `xcode-mcp-proxy-server` executable. Construct it with
+/// ``XcodeMCPProxyServerConfiguration``, call ``startAndWriteDiscovery()`` or
+/// ``start()``, then keep the process alive with ``wait()`` until your
+/// application decides to call ``shutdown()``. Both start methods return the
+/// resolved endpoint.
 ///
 /// The server exposes the proxy lifecycle. CLI parsing, STDIO adapter behavior,
 /// and internal session routing are intentionally handled outside this public
@@ -68,330 +391,6 @@ public final class XcodeMCPProxyServer {
 
         /// The server is already shutting down.
         case shutdownInProgress
-    }
-
-    /// Public configuration for an embedded Xcode MCP proxy server.
-    ///
-    /// This type is the stable server configuration surface for
-    /// `XcodeMCPProxyKit`. Lower-level parser, discovery, filesystem, and
-    /// session-routing types stay internal to the targets that own
-    /// them.
-    public struct Configuration: Equatable, Sendable {
-        /// Address that the Streamable HTTP server binds.
-        public struct BindAddress: Equatable, Sendable {
-            /// Hostname or IP address for the server socket.
-            public var host: String
-
-            /// TCP port for the server socket.
-            ///
-            /// Use `0` to request an ephemeral port from the operating system.
-            public var port: Int
-
-            /// Creates a bind address.
-            public init(host: String = "localhost", port: Int = 8765) {
-                self.host = host
-                self.port = port
-            }
-
-            /// Creates a loopback bind address.
-            public static func localhost(port: Int = 8765) -> Self {
-                Self(host: "localhost", port: port)
-            }
-        }
-
-        /// Upstream `mcpbridge` process policy.
-        public enum Upstream: Equatable, Sendable {
-            /// Use Xcode's default `xcrun mcpbridge` invocation.
-            case defaultMCPBridge(processesPerXcode: Int = 1, sessionID: String? = nil)
-
-            /// Use an explicit upstream command and arguments.
-            case custom(
-                command: String,
-                arguments: [String],
-                processesPerXcode: Int = 1,
-                sessionID: String? = nil
-            )
-
-            var invocation: MCPBridgeInvocation {
-                switch self {
-                case .defaultMCPBridge:
-                    return .defaultMCPBridge
-                case .custom(let command, let arguments, _, _):
-                    return MCPBridgeInvocation(command: command, arguments: arguments)
-                }
-            }
-
-            var command: String {
-                invocation.command
-            }
-
-            var arguments: [String] {
-                invocation.arguments
-            }
-
-            var processesPerXcode: Int {
-                switch self {
-                case .defaultMCPBridge(let count, _), .custom(_, _, let count, _):
-                    return count
-                }
-            }
-
-            var sessionID: String? {
-                switch self {
-                case .defaultMCPBridge(_, let sessionID), .custom(_, _, _, let sessionID):
-                    return sessionID
-                }
-            }
-        }
-
-        /// Request and payload limits enforced by the proxy.
-        public struct Limits: Equatable, Sendable {
-            /// Maximum accepted HTTP request body size in bytes.
-            public var maxBodyBytes: Int
-
-            /// Request timeout in seconds.
-            public var requestTimeout: TimeInterval
-
-            /// Creates proxy request limits.
-            public init(maxBodyBytes: Int = 1_048_576, requestTimeout: TimeInterval = 300) {
-                self.maxBodyBytes = maxBodyBytes
-                self.requestTimeout = requestTimeout
-            }
-
-            /// Default proxy limits.
-            public static let `default` = Self()
-        }
-
-        /// Endpoint discovery file policy.
-        public struct Discovery: Equatable, Sendable {
-            /// Optional discovery file URL.
-            ///
-            /// `nil` uses the default discovery location.
-            public var fileURL: URL?
-
-            /// Creates a discovery policy.
-            public init(fileURL: URL? = nil) {
-                self.fileURL = fileURL
-            }
-
-            /// Uses the default discovery file location.
-            public static let `default` = Self()
-        }
-
-        /// Xcode permission dialog automation policy.
-        public enum ApprovalPolicy: Equatable, Sendable {
-            /// Do not automate the Xcode permission dialog.
-            case manual
-
-            /// Try to approve the Xcode permission dialog automatically.
-            ///
-            /// This requires macOS Accessibility permission for the host process.
-            case automatic
-        }
-
-        /// How `XcodeRefreshCodeIssuesInFile` requests are served.
-        public enum RefreshCodeIssuesMode: String, Equatable, Sendable {
-            /// Serve refresh-code-issues requests through proxy diagnostics.
-            case proxy
-
-            /// Forward refresh-code-issues requests to the upstream Xcode MCP
-            /// bridge.
-            case upstream
-        }
-
-        /// Optional proxy features that affect tool behavior.
-        public struct FeaturePolicy: Equatable, Sendable {
-            /// Whether the proxy should prewarm the upstream tools list.
-            public var prewarmToolsList: Bool
-
-            /// Refresh-code-issues handling mode.
-            public var refreshCodeIssuesMode: RefreshCodeIssuesMode
-
-            /// Creates a feature policy.
-            public init(
-                prewarmToolsList: Bool = true,
-                refreshCodeIssuesMode: RefreshCodeIssuesMode = .proxy
-            ) {
-                self.prewarmToolsList = prewarmToolsList
-                self.refreshCodeIssuesMode = refreshCodeIssuesMode
-            }
-
-            /// Default feature policy.
-            public static let `default` = Self()
-        }
-
-        /// Tool visibility policy applied by the proxy.
-        public struct ToolPolicy: Equatable, Sendable {
-            /// Tool names hidden from `tools/list` results and rejected for
-            /// `tools/call` requests.
-            ///
-            /// Names are normalized when the server builds its runtime config:
-            /// surrounding whitespace is trimmed and empty names are ignored.
-            public var disabledToolNames: Set<String>
-
-            /// Creates a tool policy.
-            public init(disabledToolNames: Set<String> = []) {
-                self.disabledToolNames = disabledToolNames
-            }
-
-            /// Default tool policy.
-            public static let `default` = Self()
-        }
-
-        /// Initialize handshake overrides sent from the proxy to upstream
-        /// `mcpbridge` processes.
-        ///
-        /// Non-`nil` properties override the matching values loaded from
-        /// ``configurationFilePath``. Properties left as `nil` keep the file
-        /// value when present, otherwise the proxy's built-in default is used.
-        public struct InitializeHandshake: Equatable, Sendable {
-            /// Upstream client information for the initialize handshake.
-            public struct ClientInfo: Equatable, Sendable {
-                /// Client name to advertise to the upstream MCP bridge.
-                public var name: String?
-
-                /// Client version to advertise to the upstream MCP bridge.
-                public var version: String?
-
-                /// Creates upstream client information.
-                public init(name: String? = nil, version: String? = nil) {
-                    self.name = name
-                    self.version = version
-                }
-            }
-
-            /// Protocol version to send in initialize params.
-            public var protocolVersion: String?
-
-            /// Client info to send in initialize params.
-            public var clientInfo: ClientInfo?
-
-            /// Capability object to send in initialize params.
-            public var capabilities: [String: MCPJSONValue]?
-
-            /// Creates initialize handshake overrides.
-            public init(
-                protocolVersion: String? = nil,
-                clientInfo: ClientInfo? = nil,
-                capabilities: [String: MCPJSONValue]? = nil
-            ) {
-                self.protocolVersion = protocolVersion
-                self.clientInfo = clientInfo
-                self.capabilities = capabilities
-            }
-        }
-
-        /// HTTP bind address.
-        public var bind: BindAddress
-
-        /// Upstream bridge process policy.
-        public var upstream: Upstream
-
-        /// Request and payload limits.
-        public var limits: Limits
-
-        /// Optional TOML configuration path for initialize overrides and
-        /// disabled tools.
-        public var configurationFilePath: String?
-
-        /// Explicit tool visibility policy.
-        ///
-        /// `nil` keeps disabled tools loaded from ``configurationFilePath``.
-        /// A non-`nil` policy overrides the file's `[tools].disabled` list.
-        public var toolPolicy: ToolPolicy?
-
-        /// Explicit initialize handshake override.
-        ///
-        /// Non-`nil` fields override the matching file-backed
-        /// `[upstream_handshake]` fields. Fields left `nil` keep the file
-        /// value when present, otherwise the built-in default is used.
-        public var initializeHandshake: InitializeHandshake?
-
-        /// Endpoint discovery policy.
-        public var discovery: Discovery
-
-        /// Permission dialog automation policy.
-        public var approval: ApprovalPolicy
-
-        /// Optional proxy feature policy.
-        public var features: FeaturePolicy
-
-        /// Creates a public proxy server configuration.
-        ///
-        /// - Parameters:
-        ///   - bind: HTTP bind address.
-        ///   - upstream: Upstream bridge process policy.
-        ///   - limits: Request and payload limits.
-        ///   - configurationFilePath: Optional TOML configuration path.
-        ///   - discovery: Endpoint discovery policy.
-        ///   - approval: Permission dialog automation policy.
-        ///   - features: Optional proxy feature policy.
-        ///   - toolPolicy: Explicit tool visibility policy.
-        ///   - initializeHandshake: Explicit upstream initialize handshake
-        ///     override.
-        public init(
-            bind: BindAddress = .localhost(),
-            upstream: Upstream = .defaultMCPBridge(),
-            limits: Limits = .default,
-            configurationFilePath: String? = nil,
-            discovery: Discovery = .default,
-            approval: ApprovalPolicy = .manual,
-            features: FeaturePolicy = .default,
-            toolPolicy: ToolPolicy? = nil,
-            initializeHandshake: InitializeHandshake? = nil
-        ) {
-            self.bind = bind
-            self.upstream = upstream
-            self.limits = limits
-            self.configurationFilePath = configurationFilePath
-            self.toolPolicy = toolPolicy
-            self.initializeHandshake = initializeHandshake
-            self.discovery = discovery
-            self.approval = approval
-            self.features = features
-        }
-
-        init(serverProxyConfig proxyConfig: ProxyConfig) {
-            self.init(
-                bind: BindAddress(
-                    host: proxyConfig.listenHost,
-                    port: proxyConfig.listenPort
-                ),
-                upstream: .custom(
-                    command: proxyConfig.upstreamCommand,
-                    arguments: proxyConfig.upstreamArgs,
-                    processesPerXcode: proxyConfig.upstreamProcessCount,
-                    sessionID: proxyConfig.upstreamSessionID
-                ),
-                limits: Limits(
-                    maxBodyBytes: proxyConfig.maxBodyBytes,
-                    requestTimeout: proxyConfig.requestTimeout
-                ),
-                configurationFilePath: proxyConfig.configPath,
-                discovery: Discovery(fileURL: proxyConfig.discoveryFileURL),
-                approval: proxyConfig.autoApproveXcodeDialog ? .automatic : .manual,
-                features: FeaturePolicy(
-                    prewarmToolsList: proxyConfig.prewarmToolsList,
-                    refreshCodeIssuesMode: RefreshCodeIssuesMode(proxyConfig.refreshCodeIssuesMode)
-                )
-            )
-        }
-
-        var listenHost: String { bind.host }
-        var listenPort: Int { bind.port }
-        var upstreamCommand: String { upstream.command }
-        var upstreamArguments: [String] { upstream.arguments }
-        var upstreamProcessCount: Int { upstream.processesPerXcode }
-        var upstreamSessionID: String? { upstream.sessionID }
-        var maxBodyBytes: Int { limits.maxBodyBytes }
-        var requestTimeout: TimeInterval { limits.requestTimeout }
-        var configPath: String? { configurationFilePath }
-        var discoveryFileURL: URL? { discovery.fileURL }
-        var prewarmToolsList: Bool { features.prewarmToolsList }
-        var autoApproveXcodeDialog: Bool { approval == .automatic }
-        var refreshCodeIssuesMode: RefreshCodeIssuesMode {
-            features.refreshCodeIssuesMode
-        }
     }
 
     struct Dependencies: Sendable {
@@ -480,10 +479,13 @@ public final class XcodeMCPProxyServer {
 
     /// Creates a proxy server with live runtime dependencies.
     ///
-    /// - Parameter config: Public HTTP, upstream bridge, discovery, and
+    /// - Parameter configuration: Public HTTP, upstream bridge, discovery, and
     ///   lifecycle settings.
-    public convenience init(config: Configuration = Configuration()) {
-        let proxyConfig = ProxyConfig(config)
+    public convenience init(
+        configuration: XcodeMCPProxyServerConfiguration =
+            XcodeMCPProxyServerConfiguration()
+    ) {
+        let proxyConfig = ProxyConfig(configuration)
         self.init(proxyConfig: proxyConfig, dependencies: .live(config: proxyConfig))
     }
 
@@ -502,8 +504,8 @@ public final class XcodeMCPProxyServer {
     ///
     /// This is the usual entry point for embedded users. It binds HTTP
     /// channels, starts the proxy runtime, writes the discovery file configured
-    /// by ``Configuration/discovery``, logs a startup summary, and returns the
-    /// resolved endpoint.
+    /// by ``XcodeMCPProxyServerConfiguration/discovery``, logs a startup
+    /// summary, and returns the resolved endpoint.
     ///
     /// Each server instance can be started once. A second call to this method
     /// or to ``start()`` throws ``LifecycleError/alreadyStarted``.
@@ -774,7 +776,7 @@ public final class XcodeMCPProxyServer {
 }
 
 private extension ProxyConfig {
-    init(_ config: XcodeMCPProxyServer.Configuration) {
+    init(_ config: XcodeMCPProxyServerConfiguration) {
         self.init(
             listenHost: config.listenHost,
             listenPort: config.listenPort,
@@ -798,7 +800,7 @@ private extension ProxyConfig {
 }
 
 private extension ProxyConfig.File.InitializeHandshakeOverride {
-    init(_ handshake: XcodeMCPProxyServer.Configuration.InitializeHandshake) {
+    init(_ handshake: XcodeMCPProxyServerConfiguration.InitializeHandshake) {
         self.init(
             protocolVersion: handshake.protocolVersion,
             clientName: handshake.clientInfo?.name,
@@ -830,7 +832,7 @@ private extension ProxyConfig.File.Value {
 }
 
 private extension ProxyConfig.RefreshCodeIssuesMode {
-    init(_ mode: XcodeMCPProxyServer.Configuration.RefreshCodeIssuesMode) {
+    init(_ mode: XcodeMCPProxyServerConfiguration.RefreshCodeIssuesMode) {
         switch mode {
         case .proxy:
             self = .proxy
@@ -840,7 +842,7 @@ private extension ProxyConfig.RefreshCodeIssuesMode {
     }
 }
 
-private extension XcodeMCPProxyServer.Configuration.RefreshCodeIssuesMode {
+private extension XcodeMCPProxyServerConfiguration.RefreshCodeIssuesMode {
     init(_ mode: ProxyConfig.RefreshCodeIssuesMode) {
         switch mode {
         case .proxy:

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyStdioAdapter.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyStdioAdapter.swift
@@ -1,6 +1,39 @@
 import Foundation
 import Logging
 
+/// Inputs used to resolve the Streamable HTTP endpoint for the STDIO adapter.
+public struct XcodeMCPProxyAdapterEndpointResolutionOptions: Equatable, Sendable {
+    /// Optional explicit endpoint string, usually from `--url` or `--stdio`.
+    public var explicitURL: String?
+
+    /// Label used in validation errors for ``explicitURL``.
+    public var explicitURLLabel: String
+
+    /// Environment used for `XCODE_MCP_PROXY_ENDPOINT` and discovery path overrides.
+    public var environment: [String: String]
+
+    /// Optional discovery file URL. `nil` derives the file from the environment.
+    public var discoveryFileURL: URL?
+
+    /// Fallback endpoint when no explicit, environment, or discovery endpoint is available.
+    public var fallbackURL: URL
+
+    /// Creates endpoint resolution options.
+    public init(
+        explicitURL: String? = nil,
+        explicitURLLabel: String = "explicit URL",
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        discoveryFileURL: URL? = nil,
+        fallbackURL: URL = XcodeMCPProxyAdapterEndpointResolver.defaultEndpointURL
+    ) {
+        self.explicitURL = explicitURL
+        self.explicitURLLabel = explicitURLLabel
+        self.environment = environment
+        self.discoveryFileURL = discoveryFileURL
+        self.fallbackURL = fallbackURL
+    }
+}
+
 /// Resolved upstream endpoint for the STDIO compatibility adapter.
 public struct XcodeMCPProxyAdapterEndpoint: Equatable, Sendable {
     /// Source that selected the endpoint.
@@ -33,39 +66,6 @@ public struct XcodeMCPProxyAdapterEndpoint: Equatable, Sendable {
 
 /// Resolves the Streamable HTTP endpoint used by the STDIO adapter.
 public struct XcodeMCPProxyAdapterEndpointResolver: Sendable {
-    /// Endpoint resolution inputs.
-    public struct Configuration: Equatable, Sendable {
-        /// Optional explicit endpoint string, usually from `--url` or `--stdio`.
-        public var explicitURL: String?
-
-        /// Label used in validation errors for ``explicitURL``.
-        public var explicitURLLabel: String
-
-        /// Environment used for `XCODE_MCP_PROXY_ENDPOINT` and discovery path overrides.
-        public var environment: [String: String]
-
-        /// Optional discovery file URL. `nil` derives the file from the environment.
-        public var discoveryFileURL: URL?
-
-        /// Fallback endpoint when no explicit, environment, or discovery endpoint is available.
-        public var fallbackURL: URL
-
-        /// Creates endpoint resolution configuration.
-        public init(
-            explicitURL: String? = nil,
-            explicitURLLabel: String = "explicit URL",
-            environment: [String: String] = ProcessInfo.processInfo.environment,
-            discoveryFileURL: URL? = nil,
-            fallbackURL: URL = XcodeMCPProxyAdapterEndpointResolver.defaultEndpointURL
-        ) {
-            self.explicitURL = explicitURL
-            self.explicitURLLabel = explicitURLLabel
-            self.environment = environment
-            self.discoveryFileURL = discoveryFileURL
-            self.fallbackURL = fallbackURL
-        }
-    }
-
     /// Endpoint resolution errors.
     public enum Error: Swift.Error, CustomStringConvertible, Equatable {
         /// A configured endpoint was not an HTTP or HTTPS URL.
@@ -109,17 +109,18 @@ public struct XcodeMCPProxyAdapterEndpointResolver: Sendable {
 
     /// Resolves the endpoint using explicit value, environment, discovery, then fallback.
     public func resolve(
-        _ configuration: Configuration = Configuration()
+        _ options: XcodeMCPProxyAdapterEndpointResolutionOptions =
+            XcodeMCPProxyAdapterEndpointResolutionOptions()
     ) throws -> XcodeMCPProxyAdapterEndpoint {
-        if let explicit = Self.nonEmpty(configuration.explicitURL) {
+        if let explicit = Self.nonEmpty(options.explicitURL) {
             return XcodeMCPProxyAdapterEndpoint(
-                url: try Self.parseHTTPURL(explicit, label: configuration.explicitURLLabel),
+                url: try Self.parseHTTPURL(explicit, label: options.explicitURLLabel),
                 source: .explicit
             )
         }
 
         if let raw = Self.nonEmpty(
-            configuration.environment[Self.endpointEnvironmentVariable]
+            options.environment[Self.endpointEnvironmentVariable]
         ) {
             return XcodeMCPProxyAdapterEndpoint(
                 url: try Self.parseHTTPURL(raw, label: Self.endpointEnvironmentVariable),
@@ -127,19 +128,19 @@ public struct XcodeMCPProxyAdapterEndpointResolver: Sendable {
             )
         }
 
-        let discoveryFileURL = configuration.discoveryFileURL
-            ?? Self.discoveryFileURL(environment: configuration.environment)
+        let discoveryFileURL = options.discoveryFileURL
+            ?? Self.discoveryFileURL(environment: options.environment)
         if let record = discoveryClient.read(discoveryFileURL),
             let resolved = try? Self.parseHTTPURL(record.url, label: "discovery")
         {
             return XcodeMCPProxyAdapterEndpoint(url: resolved, source: .discovery)
         }
 
-        guard Self.isHTTPURL(configuration.fallbackURL) else {
+        guard Self.isHTTPURL(options.fallbackURL) else {
             throw Error.invalidURL(label: "fallback")
         }
         return XcodeMCPProxyAdapterEndpoint(
-            url: configuration.fallbackURL,
+            url: options.fallbackURL,
             source: .fallback
         )
     }
@@ -162,6 +163,24 @@ public struct XcodeMCPProxyAdapterEndpointResolver: Sendable {
             return nil
         }
         return value
+    }
+}
+
+/// Configuration for a STDIO adapter instance.
+public struct XcodeMCPProxyStdioAdapterConfiguration: Equatable, Sendable {
+    /// Endpoint resolution options.
+    public var endpoint: XcodeMCPProxyAdapterEndpointResolutionOptions
+
+    /// HTTP request timeout used when forwarding STDIO messages.
+    public var requestTimeout: TimeInterval
+
+    /// Creates STDIO adapter configuration.
+    public init(
+        endpoint: XcodeMCPProxyAdapterEndpointResolutionOptions = .init(),
+        requestTimeout: TimeInterval = 300
+    ) {
+        self.endpoint = endpoint
+        self.requestTimeout = requestTimeout
     }
 }
 
@@ -201,7 +220,7 @@ public final class XcodeMCPProxyStdioAdapter: Sendable {
 
         /// Public adapter configuration. This is present for `.start` plans and
         /// absent for display-only plans.
-        public let configuration: Configuration?
+        public let configuration: XcodeMCPProxyStdioAdapterConfiguration?
 
         /// Resolved upstream endpoint. This is present for `.start` plans.
         public let endpoint: XcodeMCPProxyAdapterEndpoint?
@@ -218,7 +237,7 @@ public final class XcodeMCPProxyStdioAdapter: Sendable {
         /// Creates an adapter launch plan.
         public init(
             action: LaunchAction,
-            configuration: Configuration?,
+            configuration: XcodeMCPProxyStdioAdapterConfiguration?,
             endpoint: XcodeMCPProxyAdapterEndpoint?,
             options: LaunchOptions,
             usage: String,
@@ -293,24 +312,6 @@ public final class XcodeMCPProxyStdioAdapter: Sendable {
         }
     }
 
-    /// Configuration for a STDIO adapter instance.
-    public struct Configuration: Equatable, Sendable {
-        /// Endpoint resolution configuration.
-        public var endpoint: XcodeMCPProxyAdapterEndpointResolver.Configuration
-
-        /// HTTP request timeout used when forwarding STDIO messages.
-        public var requestTimeout: TimeInterval
-
-        /// Creates STDIO adapter configuration.
-        public init(
-            endpoint: XcodeMCPProxyAdapterEndpointResolver.Configuration = .init(),
-            requestTimeout: TimeInterval = 300
-        ) {
-            self.endpoint = endpoint
-            self.requestTimeout = requestTimeout
-        }
-    }
-
     /// Resolved Streamable HTTP endpoint used by this adapter.
     public let endpoint: XcodeMCPProxyAdapterEndpoint
 
@@ -318,7 +319,8 @@ public final class XcodeMCPProxyStdioAdapter: Sendable {
 
     /// Creates an adapter by resolving the endpoint from configuration.
     public convenience init(
-        configuration: Configuration = Configuration(),
+        configuration: XcodeMCPProxyStdioAdapterConfiguration =
+            XcodeMCPProxyStdioAdapterConfiguration(),
         input: FileHandle = .standardInput,
         output: FileHandle = .standardOutput
     ) throws {
@@ -540,12 +542,12 @@ public final class XcodeMCPProxyStdioAdapter: Sendable {
         }
 
         let parsed = try parseLaunchOptions(arguments)
-        let endpointConfiguration = XcodeMCPProxyAdapterEndpointResolver.Configuration(
+        let endpointConfiguration = XcodeMCPProxyAdapterEndpointResolutionOptions(
             explicitURL: parsed.explicitURL,
             explicitURLLabel: parsed.explicitURLLabel,
             environment: environment
         )
-        let configuration = Configuration(
+        let configuration = XcodeMCPProxyStdioAdapterConfiguration(
             endpoint: endpointConfiguration,
             requestTimeout: parsed.requestTimeout
         )

--- a/Sources/XcodeMCPProxyToolVerifier/main.swift
+++ b/Sources/XcodeMCPProxyToolVerifier/main.swift
@@ -246,7 +246,7 @@ private struct ProxyToolVerifier {
             }
             do {
                 return try await XcodeMCP(
-                    config: .init(
+                        configuration: .init(
                         transport: .streamableHTTP(endpoint: options.endpoint),
                         clientName: "XcodeMCPProxyToolVerifier",
                         clientVersion: "dev",

--- a/Tests/ProxyCLITests/InstallerFacadeIntegrationTests.swift
+++ b/Tests/ProxyCLITests/InstallerFacadeIntegrationTests.swift
@@ -11,7 +11,7 @@ struct InstallerFacadeIntegrationTests {
         let output = CapturedLines()
         let bindir = tempDir.url.appendingPathComponent("bin", isDirectory: true)
         try XcodeMCPProxyInstaller(
-            configuration: .init(prefix: nil, bindir: bindir.path, dryRun: true)
+            configuration: .init(prefix: nil, binaryDirectory: bindir.path, dryRun: true)
         ).install(
             executableURL: tempDir.url.appendingPathComponent("xcode-mcp-proxy-install"),
             fileManager: .default,
@@ -44,7 +44,7 @@ struct InstallerFacadeIntegrationTests {
         let output = CapturedLines()
         let buildCalls = Counter()
         try XcodeMCPProxyInstaller(
-            configuration: .init(prefix: nil, bindir: installDir.url.path, dryRun: false)
+            configuration: .init(prefix: nil, binaryDirectory: installDir.url.path, dryRun: false)
         ).install(
             executableURL: installerURL,
             fileManager: .default,

--- a/Tests/ProxyCLITests/InstallerFacadeTests.swift
+++ b/Tests/ProxyCLITests/InstallerFacadeTests.swift
@@ -48,12 +48,12 @@ struct InstallerFacadeTests {
         let options = try #require(plan.configuration)
 
         #expect(options.prefix == "/tmp/prefix")
-        #expect(options.bindir == "/tmp/bin")
+        #expect(options.binaryDirectory == "/tmp/bin")
         #expect(options.dryRun == true)
         #expect(
             XcodeMCPProxyInstaller.resolveBinDirectory(
                 prefix: options.prefix,
-                bindir: options.bindir
+                binaryDirectory: options.binaryDirectory
             ).path == "/tmp/bin"
         )
     }
@@ -62,7 +62,7 @@ struct InstallerFacadeTests {
         let home = NSHomeDirectory()
         let resolved = XcodeMCPProxyInstaller.resolveBinDirectory(
             prefix: "~/custom",
-            bindir: nil
+            binaryDirectory: nil
         )
 
         #expect(resolved.path == "\(home)/custom/bin")
@@ -85,7 +85,7 @@ struct InstallerFacadeTests {
 
         #expect(throws: XcodeMCPProxyInstaller.Error.self) {
             try XcodeMCPProxyInstaller(
-                configuration: .init(prefix: nil, bindir: tempDir.path, dryRun: false)
+                configuration: .init(prefix: nil, binaryDirectory: tempDir.path, dryRun: false)
             ).install(
                 executableURL: executableURL,
                 fileManager: .default,
@@ -135,7 +135,7 @@ struct InstallerFacadeTests {
     @Test func installerPlanUsesBinaryListAndBindirPriority() throws {
         let executableURL = URL(fileURLWithPath: "/tmp/repo/.build/release/xcode-mcp-proxy-install")
         let installer = XcodeMCPProxyInstaller(
-            configuration: .init(prefix: "/tmp/prefix", bindir: "/tmp/bin", dryRun: true)
+            configuration: .init(prefix: "/tmp/prefix", binaryDirectory: "/tmp/bin", dryRun: true)
         )
         let plan = installer.plan(executableURL: executableURL)
 

--- a/Tests/ProxyCLITests/ServerLauncherIntegrationTests.swift
+++ b/Tests/ProxyCLITests/ServerLauncherIntegrationTests.swift
@@ -53,8 +53,8 @@ struct ServerLauncherIntegrationTests {
         #expect(exitCode == 0)
         #expect(restarted.snapshot() == ["127.0.0.1:8766"])
         let config = try #require(fakeServer.recordedConfig())
-        #expect(config.bind.host == "127.0.0.1")
-        #expect(config.bind.port == 8766)
+        #expect(config.bindAddress.host == "127.0.0.1")
+        #expect(config.bindAddress.port == 8766)
         #expect(config.limits.requestTimeout == 12)
         #expect(fakeServer.startCount() == 1)
         #expect(fakeServer.waitCount() == 1)
@@ -65,7 +65,7 @@ private func makeIntegrationServerLauncher(
     forceRestartExistingServer: @escaping (_ host: String, _ port: Int, _ stderr: (String) -> Void) -> Bool = {
         _, _, _ in false
     },
-    makeServer: @escaping (XcodeMCPProxyServer.Configuration) -> any XcodeMCPProxyServer.LaunchServer = { _ in
+    makeServer: @escaping (XcodeMCPProxyServerConfiguration) -> any XcodeMCPProxyServer.LaunchServer = { _ in
         IntegrationRecordingProxyServer()
     }
 ) -> XcodeMCPProxyServer.Launcher {
@@ -81,11 +81,11 @@ private func makeIntegrationServerLauncher(
 
 private final class IntegrationRecordingProxyServer: XcodeMCPProxyServer.LaunchServer {
     private let lock = NSLock()
-    private var config: XcodeMCPProxyServer.Configuration?
+    private var config: XcodeMCPProxyServerConfiguration?
     private var started = 0
     private var waited = 0
 
-    func record(config: XcodeMCPProxyServer.Configuration) {
+    func record(config: XcodeMCPProxyServerConfiguration) {
         withLock {
             self.config = config
         }
@@ -102,7 +102,7 @@ private final class IntegrationRecordingProxyServer: XcodeMCPProxyServer.LaunchS
         incrementWaitCount()
     }
 
-    func recordedConfig() -> XcodeMCPProxyServer.Configuration? {
+    func recordedConfig() -> XcodeMCPProxyServerConfiguration? {
         withLock { config }
     }
 

--- a/Tests/ProxyCLITests/ServerRunnerTests.swift
+++ b/Tests/ProxyCLITests/ServerRunnerTests.swift
@@ -23,10 +23,10 @@ struct ServerRunnerTests {
         #expect(plan.action == .dryRun)
         #expect(plan.options.forceRestart == true)
         #expect(plan.options.dryRun == true)
-        #expect(config.bind.host == "127.0.0.1")
-        #expect(config.bind.port == 9000)
-        #expect(config.approval == .automatic)
-        #expect(config.features.refreshCodeIssuesMode == .upstream)
+        #expect(config.bindAddress.host == "127.0.0.1")
+        #expect(config.bindAddress.port == 9000)
+        #expect(config.approvalPolicy == .automatic)
+        #expect(config.featurePolicy.refreshCodeIssuesMode == .upstream)
         #expect(
             plan.resolvedDryRunCommandLine ==
                 "xcode-mcp-proxy-server --listen 127.0.0.1:9000 --auto-approve --refresh-code-issues-mode upstream"
@@ -46,10 +46,10 @@ struct ServerRunnerTests {
 
         let config = try #require(plan.configuration)
         #expect(plan.action == .start)
-        #expect(config.bind.host == "127.0.0.1")
-        #expect(config.bind.port == 9999)
+        #expect(config.bindAddress.host == "127.0.0.1")
+        #expect(config.bindAddress.port == 9999)
         #expect(config.configurationFilePath == "/tmp/proxy-config.toml")
-        #expect(config.features.refreshCodeIssuesMode == .upstream)
+        #expect(config.featurePolicy.refreshCodeIssuesMode == .upstream)
         #expect(
             plan.resolvedDryRunCommandLine ==
                 "xcode-mcp-proxy-server --listen 127.0.0.1:9999 --config /tmp/proxy-config.toml --refresh-code-issues-mode upstream"
@@ -88,8 +88,8 @@ struct ServerRunnerTests {
         )
 
         let config = try #require(plan.configuration)
-        #expect(config.bind.host == "127.0.0.1")
-        #expect(config.bind.port == 9999)
+        #expect(config.bindAddress.host == "127.0.0.1")
+        #expect(config.bindAddress.port == 9999)
     }
 
     @Test func serverRunnerPrintsVersionBeforeValidation() async throws {
@@ -207,8 +207,8 @@ struct ServerRunnerTests {
         #expect(exitCode == 0)
         #expect(restarted.snapshot() == ["127.0.0.1:9000"])
         let config = try #require(fakeServer.recordedConfig())
-        #expect(config.bind.host == "127.0.0.1")
-        #expect(config.bind.port == 9000)
+        #expect(config.bindAddress.host == "127.0.0.1")
+        #expect(config.bindAddress.port == 9000)
         #expect(fakeServer.startCount() == 1)
         #expect(fakeServer.waitCount() == 1)
     }
@@ -352,7 +352,7 @@ private func makeServerLauncher(
     forceRestartExistingServer: @escaping (_ host: String, _ port: Int, _ stderr: (String) -> Void) -> Bool = {
         _, _, _ in false
     },
-    makeServer: @escaping (XcodeMCPProxyServer.Configuration) -> any XcodeMCPProxyServer.LaunchServer = { _ in
+    makeServer: @escaping (XcodeMCPProxyServerConfiguration) -> any XcodeMCPProxyServer.LaunchServer = { _ in
         RecordingProxyServer()
     },
     isAddressAlreadyInUse: @escaping (Swift.Error) -> Bool = { _ in false },
@@ -388,10 +388,10 @@ private final class FailingProxyServer: XcodeMCPProxyServer.LaunchServer {
 
 private final class RecordingProxyServer: XcodeMCPProxyServer.LaunchServer {
     private let state = LockedBox(
-        (config: Optional<XcodeMCPProxyServer.Configuration>.none, startCount: 0, waitCount: 0)
+        (config: Optional<XcodeMCPProxyServerConfiguration>.none, startCount: 0, waitCount: 0)
     )
 
-    func record(config: XcodeMCPProxyServer.Configuration) {
+    func record(config: XcodeMCPProxyServerConfiguration) {
         state.withValue { value in
             value.config = config
         }
@@ -410,7 +410,7 @@ private final class RecordingProxyServer: XcodeMCPProxyServer.LaunchServer {
         }
     }
 
-    func recordedConfig() -> XcodeMCPProxyServer.Configuration? {
+    func recordedConfig() -> XcodeMCPProxyServerConfiguration? {
         state.snapshot().config
     }
 

--- a/Tests/ProxyHTTPGatewayTests/DisabledToolHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/DisabledToolHTTPTests.swift
@@ -26,7 +26,7 @@ extension HTTPHandlerTests {
         """.write(to: configURL, atomically: true, encoding: .utf8)
 
         let publicServer = XcodeMCPProxyServer(
-            config: .init(
+            configuration: .init(
                 configurationFilePath: configURL.path,
                 toolPolicy: .init(disabledToolNames: [" RunAllTests ", ""])
             )

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -2520,7 +2520,7 @@ struct HTTPHandlerTests {
         let config = makeConfig()
         let sessionManager = TestRuntimeCoordinator(config: config)
         let forwardingService = MCPForwardingService(
-            config: config,
+            configuration: config,
             sessionManager: sessionManager
         )
 

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -2299,7 +2299,7 @@ extension HTTPHandlerTests {
         )
         sessionManager.setInitialized(true)
         let forwardingService = MCPForwardingService(
-            config: config,
+            configuration: config,
             sessionManager: sessionManager
         )
         let eventLoop = EmbeddedEventLoop()
@@ -2435,7 +2435,7 @@ extension HTTPHandlerTests {
         sessionManager.setAvailableUpstreamIndices([1])
 
         let forwardingService = MCPForwardingService(
-            config: config,
+            configuration: config,
             sessionManager: sessionManager
         )
 
@@ -2484,7 +2484,7 @@ extension HTTPHandlerTests {
         sessionManager.setPreferredUpstreamIndex(0)
 
         let forwardingService = MCPForwardingService(
-            config: config,
+            configuration: config,
             sessionManager: sessionManager
         )
 
@@ -2535,7 +2535,7 @@ extension HTTPHandlerTests {
         sessionManager.setToolRoutingDecision(.forward(preferredUpstreamIndex: 0))
 
         let forwardingService = MCPForwardingService(
-            config: config,
+            configuration: config,
             sessionManager: sessionManager
         )
 

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -143,7 +143,7 @@ struct XcodeMCPProxyServerTests {
             refreshCodeIssuesMode: .upstream
         )
 
-        let config = XcodeMCPProxyServer.Configuration(serverProxyConfig: proxyConfig)
+        let config = XcodeMCPProxyServerConfiguration(serverProxyConfig: proxyConfig)
 
         #expect(config.listenHost == "127.0.0.1")
         #expect(config.listenPort == 9876)

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -5804,9 +5804,9 @@ struct RuntimeCoordinatorTests {
         defer { try? FileManager.default.removeItem(atPath: configPath) }
 
         let publicServer = XcodeMCPProxyServer(
-            config: .init(
+            configuration: .init(
                 configurationFilePath: configPath,
-                features: .init(prewarmToolsList: false),
+                featurePolicy: .init(prewarmToolsList: false),
                 initializeHandshake: .init(
                     clientInfo: .init(name: "typed-proxy"),
                     capabilities: [

--- a/Tests/ProxyToolSurfaceTests/ToolSurfaceTests.swift
+++ b/Tests/ProxyToolSurfaceTests/ToolSurfaceTests.swift
@@ -8,7 +8,7 @@ import XcodeMCPKit
 @Suite(.serialized)
 struct ToolSurfaceTests {
     @Test func toolSurfaceNormalizesStructuredContentFromTextJSON() throws {
-        let sessionManager = ToolSurfaceRuntimeCoordinator(config: makeToolSurfaceConfig())
+        let sessionManager = ToolSurfaceRuntimeCoordinator(configuration: makeToolSurfaceConfig())
         sessionManager.setCachedToolsListResult(
             try #require(
                 JSONValue(any: [
@@ -60,7 +60,7 @@ struct ToolSurfaceTests {
     }
 
     @Test func toolSurfaceIgnoresNonTextContentDuringNormalization() throws {
-        let sessionManager = ToolSurfaceRuntimeCoordinator(config: makeToolSurfaceConfig())
+        let sessionManager = ToolSurfaceRuntimeCoordinator(configuration: makeToolSurfaceConfig())
         sessionManager.setCachedToolsListResult(
             try #require(
                 JSONValue(any: [
@@ -111,7 +111,7 @@ struct ToolSurfaceTests {
     }
 
     @Test func toolSurfaceNormalizesMissingGetBuildLogLines() throws {
-        let sessionManager = ToolSurfaceRuntimeCoordinator(config: makeToolSurfaceConfig())
+        let sessionManager = ToolSurfaceRuntimeCoordinator(configuration: makeToolSurfaceConfig())
         sessionManager.setCachedToolsListResult(
             try #require(
                 JSONValue(any: [
@@ -172,7 +172,7 @@ struct ToolSurfaceTests {
     @Test func toolSurfaceRewritesToolsListAndExtractsCanonicalCatalog() throws {
         var config = makeToolSurfaceConfig()
         config.disabledToolNames = ["RunAllTests"]
-        let sessionManager = ToolSurfaceRuntimeCoordinator(config: config)
+        let sessionManager = ToolSurfaceRuntimeCoordinator(configuration: config)
         let surface = ToolSurface(config: config, sessionManager: sessionManager)
 
         let upstreamData = try JSONSerialization.data(
@@ -217,7 +217,7 @@ struct ToolSurfaceTests {
     }
 
     @Test func toolSurfaceNormalizesMixedBatchUsingCatalogFromSamePayload() throws {
-        let sessionManager = ToolSurfaceRuntimeCoordinator(config: makeToolSurfaceConfig())
+        let sessionManager = ToolSurfaceRuntimeCoordinator(configuration: makeToolSurfaceConfig())
         let surface = ToolSurface(
             config: makeToolSurfaceConfig(),
             sessionManager: sessionManager
@@ -280,7 +280,7 @@ struct ToolSurfaceTests {
     }
 
     @Test func toolSurfaceSeedsCanonicalCatalogFromFirstToolsListInBatch() throws {
-        let sessionManager = ToolSurfaceRuntimeCoordinator(config: makeToolSurfaceConfig())
+        let sessionManager = ToolSurfaceRuntimeCoordinator(configuration: makeToolSurfaceConfig())
         let surface = ToolSurface(
             config: makeToolSurfaceConfig(),
             sessionManager: sessionManager
@@ -343,7 +343,7 @@ struct ToolSurfaceTests {
     }
 
     @Test func toolSurfaceNormalizesUsingSourceProcessCatalog() throws {
-        let sessionManager = ToolSurfaceRuntimeCoordinator(config: makeToolSurfaceConfig())
+        let sessionManager = ToolSurfaceRuntimeCoordinator(configuration: makeToolSurfaceConfig())
         sessionManager.setCachedToolsListResult(
             try #require(
                 JSONValue(any: [
@@ -424,7 +424,7 @@ struct ToolSurfaceTests {
     }
 
     @Test func toolSurfaceTreatsOnlySyntheticOverloadErrorAsBackpressure() throws {
-        let sessionManager = ToolSurfaceRuntimeCoordinator(config: makeToolSurfaceConfig())
+        let sessionManager = ToolSurfaceRuntimeCoordinator(configuration: makeToolSurfaceConfig())
         let surface = ToolSurface(
             config: makeToolSurfaceConfig(),
             sessionManager: sessionManager
@@ -474,8 +474,8 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
     private var cachedToolsList: JSONValue?
     private var cachedToolsListsByUpstream: [Int: JSONValue] = [:]
 
-    init(config: ProxyConfig) {
-        self.config = config
+    init(configuration: ProxyConfig) {
+        self.config = configuration
     }
 
     func session(id: String) -> SessionContext { SessionContext(id: id, config: config) }

--- a/Tests/PublicProductContractTests/PublicProductContractTests.swift
+++ b/Tests/PublicProductContractTests/PublicProductContractTests.swift
@@ -599,8 +599,8 @@ func compileOnlyClientDomainSurface() throws {
         ],
     ]
 
-    let config = XcodeMCP.Configuration(
-        bridge: .defaultMCPBridge,
+    let config = XcodeMCPConfiguration(
+        transport: .localBridge(),
         clientName: "PublicContractClient",
         clientVersion: "1.0",
         capabilities: [
@@ -610,25 +610,25 @@ func compileOnlyClientDomainSurface() throws {
         ],
         requestTimeout: .seconds(1)
     )
-    let customBridgeConfig = XcodeMCP.Configuration(
-        bridge: .custom(
+    let customBridgeConfig = XcodeMCPConfiguration(
+        transport: .localBridge(.custom(
             command: "/usr/bin/env",
             arguments: ["printf"],
             environment: ["PUBLIC_CONTRACT": "1"]
-        )
+        ))
     )
 
     let endpoint = URL(string: "http://127.0.0.1:8765/mcp")!
-    let httpConfig = XcodeMCP.Configuration(
+    let httpConfig = XcodeMCPConfiguration(
         transport: .streamableHTTP(endpoint: endpoint),
         clientName: "PublicHTTPContractClient",
         clientVersion: "1.0",
         requestTimeout: .seconds(1)
     )
-    let discoveryConfig = XcodeMCP.Configuration(
+    let discoveryConfig = XcodeMCPConfiguration(
         transport: .streamableHTTP(discoveryFile: URL(fileURLWithPath: "/tmp/xcode-mcp/endpoint.json"))
     )
-    let proxyDiscoveryConfig = XcodeMCP.Configuration(
+    let proxyDiscoveryConfig = XcodeMCPConfiguration(
         transport: .streamableHTTPProxyDiscovery(
             environment: [
                 "XCODE_MCP_PROXY_DISCOVERY_FILE": "/tmp/xcode-mcp/proxy-endpoint.json",
@@ -742,8 +742,8 @@ func compileOnlyClientDomainSurface() throws {
     )
 }
 
-func compileOnlyClientLifecycleSurface(config: XcodeMCP.Configuration) async throws {
-    let client = try await XcodeMCP(config: config)
+func compileOnlyClientLifecycleSurface(config: XcodeMCPConfiguration) async throws {
+    let client = try await XcodeMCP(configuration: config)
     _ = try await client.listTools()
     _ = try await client.callTool(
         "DocumentationSearch",
@@ -829,8 +829,8 @@ private let xcodeMCPProxyKitOnlyClientSource = """
 import XcodeMCPProxyKit
 
 func compileOnlyProxyProductOnlySurface() {
-    let config = XcodeMCPProxyServer.Configuration()
-    let server = XcodeMCPProxyServer(config: config)
+    let config = XcodeMCPProxyServerConfiguration()
+    let server = XcodeMCPProxyServer(configuration: config)
     let installer = XcodeMCPProxyInstaller()
 
     _ = (
@@ -848,8 +848,8 @@ import XcodeMCPKit
 import XcodeMCPProxyKit
 
 func compileOnlyProxyConfigurationSurface() {
-    let config = XcodeMCPProxyServer.Configuration(
-        bind: .init(host: "127.0.0.1", port: 0),
+    let config = XcodeMCPProxyServerConfiguration(
+        bindAddress: .init(host: "127.0.0.1", port: 0),
         upstream: .defaultMCPBridge(
             processesPerXcode: 1,
             sessionID: "session-1"
@@ -857,8 +857,8 @@ func compileOnlyProxyConfigurationSurface() {
         limits: .init(maxBodyBytes: 1_048_576, requestTimeout: 120),
         configurationFilePath: "/tmp/xcode-mcp-config.toml",
         discovery: .init(fileURL: URL(fileURLWithPath: "/tmp/xcode-mcp-discovery.json")),
-        approval: .manual,
-        features: .init(
+        approvalPolicy: .manual,
+        featurePolicy: .init(
             prewarmToolsList: false,
             refreshCodeIssuesMode: .proxy
         ),
@@ -880,7 +880,7 @@ func compileOnlyProxyConfigurationSurface() {
             ]
         )
     )
-    let customUpstreamConfig = XcodeMCPProxyServer.Configuration(
+    let customUpstreamConfig = XcodeMCPProxyServerConfiguration(
         upstream: .custom(
             command: "/usr/bin/env",
             arguments: ["printf"],
@@ -893,19 +893,19 @@ func compileOnlyProxyConfigurationSurface() {
     let typedHandshake = config.initializeHandshake
     let typedCapabilities: [String: MCPJSONValue]? = typedHandshake?.capabilities
     let metadataIsNull = typedCapabilities?["experimental"]?.objectValue?["metadata"]?.isNull
-    let upstreamMode = XcodeMCPProxyServer.Configuration.RefreshCodeIssuesMode.upstream
-    let server = XcodeMCPProxyServer(config: config)
-    let endpointConfig = XcodeMCPProxyAdapterEndpointResolver.Configuration(
+    let upstreamMode = XcodeMCPProxyServerConfiguration.RefreshCodeIssuesMode.upstream
+    let server = XcodeMCPProxyServer(configuration: config)
+    let endpointConfig = XcodeMCPProxyAdapterEndpointResolutionOptions(
         explicitURL: "http://localhost:8765/mcp",
         environment: [:]
     )
     let endpoint = try? XcodeMCPProxyAdapterEndpointResolver().resolve(endpointConfig)
-    let adapterConfig = XcodeMCPProxyStdioAdapter.Configuration(
+    let adapterConfig = XcodeMCPProxyStdioAdapterConfiguration(
         endpoint: endpointConfig,
         requestTimeout: 30
     )
     let installer = XcodeMCPProxyInstaller(
-        configuration: .init(prefix: "/tmp/xcode-mcp", bindir: nil, dryRun: true)
+        configuration: .init(prefix: "/tmp/xcode-mcp", binaryDirectory: nil, dryRun: true)
     )
     let plan = installer.plan(
         executableURL: URL(fileURLWithPath: "/tmp/repo/.build/release/xcode-mcp-proxy-install")

--- a/Tests/XcodeMCPKitTestingTests/XcodeMCPKitTestingTests.swift
+++ b/Tests/XcodeMCPKitTestingTests/XcodeMCPKitTestingTests.swift
@@ -8,7 +8,7 @@ struct XcodeMCPKitTestingTests {
         let runtime = XcodeMCPTestRuntime()
 
         let client = try await runtime.makeClient(
-            config: .init(
+                configuration: .init(
                 clientName: "TestingClient",
                 clientVersion: "1.0",
                 capabilities: [
@@ -229,9 +229,9 @@ struct XcodeMCPKitTestingTests {
             )
         }
 
-        let config = XcodeMCP.Configuration(requestTimeout: .seconds(1))
-        let firstClient = try await runtime.makeClient(config: config)
-        let secondClient = try await runtime.makeClient(config: config)
+        let config = XcodeMCPConfiguration(requestTimeout: .seconds(1))
+        let firstClient = try await runtime.makeClient(configuration: config)
+        let secondClient = try await runtime.makeClient(configuration: config)
         defer {
             Task {
                 await firstClient.close()

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -8,7 +8,7 @@ struct XcodeMCPTests {
     @Test func asyncInitializerPerformsMCPHandshake() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(
-            config: .init(
+                configuration: .init(
                 clientName: "UnitTestClient",
                 clientVersion: "1.2.3",
                 capabilities: [
@@ -342,7 +342,7 @@ struct XcodeMCPTests {
     @Test func cancelledRequestCancelsInFlightTransportSend() async throws {
         let transport = HangingSendXcodeMCPTransport()
         let xcode = try await XcodeMCP(
-            config: .init(requestTimeout: nil),
+                configuration: .init(requestTimeout: nil),
             transport: transport
         )
 
@@ -603,7 +603,7 @@ struct XcodeMCPTests {
     }
 
     @Test func streamableHTTPProxyDiscoveryUsesStandardProxyDiscoveryEnvironment() throws {
-        let explicitDiscovery = XcodeMCP.Configuration.Transport.streamableHTTPProxyDiscovery(
+        let explicitDiscovery = XcodeMCPConfiguration.Transport.streamableHTTPProxyDiscovery(
             environment: [
                 "XCODE_MCP_PROXY_DISCOVERY_FILE": "/tmp/public-contract/endpoint.json",
                 "XCODE_MCP_PROXY_CACHE_ROOT": "/tmp/ignored-cache-root",
@@ -615,7 +615,7 @@ struct XcodeMCPTests {
             )
         )
 
-        let cacheRootDiscovery = XcodeMCP.Configuration.Transport.streamableHTTPProxyDiscovery(
+        let cacheRootDiscovery = XcodeMCPConfiguration.Transport.streamableHTTPProxyDiscovery(
             environment: [
                 "XCODE_MCP_PROXY_CACHE_ROOT": "/tmp/public-contract-cache",
             ]
@@ -655,7 +655,7 @@ struct XcodeMCPTests {
             "Streamable HTTP discovery file is missing, stale, or invalid: \(fileURL.path)"
         )) {
             _ = try await XcodeMCP(
-                config: .init(
+                    configuration: .init(
                     transport: .streamableHTTP(discoveryFile: fileURL),
                     requestTimeout: .seconds(2)
                 ),
@@ -680,7 +680,7 @@ struct XcodeMCPTests {
             requestTimeout: .seconds(2)
         )
         let xcode = try await XcodeMCP(
-            config: .init(
+                configuration: .init(
                 transport: .streamableHTTP(endpoint: endpoint),
                 clientName: "HTTPContractClient",
                 requestTimeout: .seconds(2)
@@ -735,7 +735,7 @@ struct XcodeMCPTests {
             requestTimeout: .seconds(2)
         )
         let xcode = try await XcodeMCP(
-            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
         )
 
@@ -783,7 +783,7 @@ struct XcodeMCPTests {
             requestTimeout: .seconds(2)
         )
         let xcode = try await XcodeMCP(
-            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
         )
 
@@ -822,7 +822,7 @@ struct XcodeMCPTests {
         )
         let xcode = try await waitWithTimeout("SSE initialize response was not delivered") {
             try await XcodeMCP(
-                config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                    configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
                 transport: transport
             )
         }
@@ -848,7 +848,7 @@ struct XcodeMCPTests {
             requestTimeout: .seconds(2)
         )
         let xcode = try await XcodeMCP(
-            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
         )
 
@@ -892,7 +892,7 @@ struct XcodeMCPTests {
             requestTimeout: .seconds(2)
         )
         let xcode = try await XcodeMCP(
-            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
         )
 
@@ -933,7 +933,7 @@ struct XcodeMCPTests {
             }
         )
         let xcode = try await XcodeMCP(
-            config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
         )
         defer {
@@ -980,7 +980,7 @@ struct XcodeMCPTests {
             data: nil
         )) {
             _ = try await XcodeMCP(
-                config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                    configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
                 transport: transport
             )
         }
@@ -1010,7 +1010,7 @@ struct XcodeMCPTests {
             data: nil
         )) {
             _ = try await XcodeMCP(
-                config: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
+                    configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
                 transport: transport
             )
         }

--- a/Tests/XcodeMCPProcessRuntimeTests/UpstreamProcessTests.swift
+++ b/Tests/XcodeMCPProcessRuntimeTests/UpstreamProcessTests.swift
@@ -278,14 +278,14 @@ private func makeFakeUpstreamSession(
         clock: clock,
         driverFactory: StaticUpstreamProcessDriverFactory(fakeDriver)
     )
-    return try await UpstreamProcess(config: config).startSession()
+    return try await UpstreamProcess(configuration: config).startSession()
 }
 
 private func withLiveUpstreamSession<T: Sendable>(
     config: UpstreamProcess.Config,
     _ body: @escaping @Sendable (any UpstreamSession) async throws -> T
 ) async throws -> T {
-    let session = try await UpstreamProcess(config: config).startSession()
+    let session = try await UpstreamProcess(configuration: config).startSession()
     do {
         let result = try await body(session)
         await session.stop()


### PR DESCRIPTION
## Purpose
Make the public Swift API naming match Apple-platform conventions by moving user-constructed nested configuration types to top-level XcodeMCP-prefixed types. This is an intentional breaking API cleanup with no compatibility shims.

## Changes
- Rename public client and proxy configuration surfaces to top-level XcodeMCP...Configuration / options types.
- Replace public config: initializers with configuration: and update public labels such as bindAddress, approvalPolicy, featurePolicy, and binaryDirectory.
- Keep CLI flags, TOML keys, and MCP wire behavior unchanged while updating internal references, docs, and public contract tests.

## Testing
- swift test --filter PublicProductContractTests -Xswiftc -strict-concurrency=minimal
- swift test -Xswiftc -strict-concurrency=minimal
- scripts/check.sh
- rg "XcodeMCP\.Configuration|XcodeMCPProxyServer\.Configuration|init\(config:" Sources Tests README.md Docs