### PR TITLE
Drain control-plane cancellation tasks during shutdown

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/ControlPlaneCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/ControlPlaneCoordinator.swift
@@ -15,6 +15,20 @@ actor ControlPlaneCoordinator {
         ) async throws -> JSONValue
     typealias UpstreamHandshakeStatesProvider = @Sendable () -> [String: String]
 
+    struct Drain: Sendable {
+        private let completionTasks: [Task<Void, Never>]
+
+        init(completionTasks: [Task<Void, Never>]) {
+            self.completionTasks = completionTasks
+        }
+
+        func wait() async {
+            for task in completionTasks {
+                await task.value
+            }
+        }
+    }
+
     enum Phase: String, Sendable {
         case idle
         case loadingToolsCatalog = "loading_tools_catalog"
@@ -81,6 +95,8 @@ actor ControlPlaneCoordinator {
     var toolsCatalogLoad: ToolsCatalogLoadState?
     var prewarmToolsCatalogLoad: ToolsCatalogLoadState?
     var windowLoads: [ControlPlane.Route: WindowLoadState] = [:]
+    var completionTasks: [UUID: Task<Void, Never>] = [:]
+    var acceptsNewLoads = true
 
     init(
         brokerState: CanonicalBrokerState,
@@ -103,6 +119,9 @@ actor ControlPlaneCoordinator {
     }
 
     func toolsCatalog(deadlineUptimeNs: UInt64?) async throws -> JSONValue {
+        guard acceptsNewLoads else {
+            throw CancellationError()
+        }
         cancelInvalidatedLoads()
         if let rawResult = brokerState.toolsCatalogRaw() {
             return rawResult
@@ -139,6 +158,9 @@ actor ControlPlaneCoordinator {
         route: ControlPlane.Route,
         deadlineUptimeNs: UInt64?
     ) async throws -> JSONValue {
+        guard acceptsNewLoads else {
+            throw CancellationError()
+        }
         cancelInvalidatedLoads()
         let requestedTimeout = sharedRequestTimeout(for: deadlineUptimeNs)
         let requestedPromotionDeadlineUptimeNs = promotionDeadlineUptimeNs(
@@ -169,6 +191,9 @@ actor ControlPlaneCoordinator {
     }
 
     func prewarmToolsCatalogIfNeeded(deadlineUptimeNs: UInt64?) async -> JSONValue? {
+        guard acceptsNewLoads else {
+            return nil
+        }
         cancelInvalidatedLoads()
         if let rawResult = brokerState.toolsCatalogRaw() {
             syncDebug()
@@ -236,6 +261,20 @@ actor ControlPlaneCoordinator {
         syncDebug()
     }
 
+    func beginShutdown(
+        reason: String,
+        clearInitialize: Bool = false,
+        clearToolsCatalog: Bool = true
+    ) -> Drain {
+        acceptsNewLoads = false
+        invalidate(
+            reason: reason,
+            clearInitialize: clearInitialize,
+            clearToolsCatalog: clearToolsCatalog
+        )
+        return Drain(completionTasks: Array(completionTasks.values))
+    }
+
     func cancelLoadsStartedBeforeGeneration(
         _ generation: UInt64,
         reason _: String
@@ -268,7 +307,7 @@ actor ControlPlaneCoordinator {
         case .prewarm:
             prewarmToolsCatalogLoad = load
         }
-        Task { [loadID] in
+        let completionTask = Task { [loadID] in
             let result: Result<CanonicalToolsCatalogLoadResult, Error>
             do {
                 result = .success(try await task.value)
@@ -276,7 +315,9 @@ actor ControlPlaneCoordinator {
                 result = .failure(error)
             }
             self.completeToolsCatalogLoad(loadID: loadID, result: result)
+            self.finishCompletionTask(loadID: loadID)
         }
+        completionTasks[loadID] = completionTask
         syncDebug()
         return loadID
     }
@@ -300,7 +341,7 @@ actor ControlPlaneCoordinator {
             task: task,
             startGeneration: brokerState.generation()
         )
-        Task { [route, loadID] in
+        let completionTask = Task { [route, loadID] in
             let result: Result<JSONValue, Error>
             do {
                 result = .success(try await task.value)
@@ -308,9 +349,15 @@ actor ControlPlaneCoordinator {
                 result = .failure(error)
             }
             self.completeWindowLoad(route: route, loadID: loadID, result: result)
+            self.finishCompletionTask(loadID: loadID)
         }
+        completionTasks[loadID] = completionTask
         syncDebug()
         return loadID
+    }
+
+    func finishCompletionTask(loadID: UUID) {
+        completionTasks.removeValue(forKey: loadID)
     }
 
     func ensureToolsCatalogForegroundLoad(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -747,15 +747,15 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         documentationPrewarmTask?.cancel()
         upstreamReadinessCoordinator.shutdown()
 
+        let runtimeDrain = runtimeTasks.beginShutdown()
         canonicalBrokerState.reset()
         processToolCatalogRegistry.reset()
-        await controlPlaneCoordinator.invalidate(
+        let controlPlaneDrain = await controlPlaneCoordinator.beginShutdown(
             reason: "shutdown",
             clearInitialize: true,
             clearToolsCatalog: true
         )
 
-        let runtimeDrain = runtimeTasks.beginShutdown()
         await withTaskGroup(of: Void.self) { group in
             for upstream in upstreams {
                 group.addTask {
@@ -774,6 +774,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             }
         }
         await upstreamEventTasks.shutdown()
+        await controlPlaneDrain.wait()
         await runtimeDrain.wait()
     }
 

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -5476,6 +5476,65 @@ struct RuntimeCoordinatorTests {
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
+    @Test func shutdownDrainsCancelledLiveXcodeListWindowsLoadWithoutUpstreamResponse()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        var didShutdown = false
+        defer {
+            if didShutdown == false {
+                manager.shutdownAndWait()
+            }
+        }
+
+        let initFuture = manager.registerInitialize(
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let initRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let initUpstreamID = try extractUpstreamID(from: initRequest)
+        await upstream.yield(.message(try makeInitializeResponse(id: initUpstreamID)))
+        _ = try await initFuture.get()
+        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
+
+        let task = Task {
+            try await manager.liveXcodeListWindowsResult(
+                route: .anyHealthy,
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+        let request = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        #expect(methodName(from: request) == "tools/call")
+
+        task.cancel()
+        try await waitWithTimeout(
+            "waiting for shutdown to drain cancelled XcodeListWindows load",
+            timeout: .seconds(2)
+        ) {
+            await manager.shutdown()
+        }
+        didShutdown = true
+
+        do {
+            _ = try await waitWithTimeout(
+                "waiting for cancelled XcodeListWindows task",
+                timeout: .seconds(2)
+            ) {
+                try await task.value
+            }
+            Issue.record("cancelled XcodeListWindows waiter should not complete successfully")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("expected CancellationError but received \(error)")
+        }
+    }
+
     @Test func controlPlaneRPCHandleCancelBeforeQueueStartCapturesQueuedState() {
         let handle = ControlPlane.RPCHandle()
         let cancellation = NIOLockedValueBox<ControlPlane.RPCCancelSnapshot?>(nil)


### PR DESCRIPTION
## Purpose

Fix a CI timeout class where a cancelled control-plane waiter could leave its loader/completion task untracked, allowing runtime shutdown to proceed without waiting for the corresponding RPC cancellation to reach a terminal state.

## Changes

- Add internal control-plane load lifecycle tracking with `Drain`, `completionTasks`, and `acceptsNewLoads`.
- Reject new tools/catalog and list-windows loads after control-plane shutdown begins.
- Track load completion tasks until the worker task reaches terminal state, including cancelled, replaced, promoted, and invalidated loads.
- Update `RuntimeCoordinator.shutdown()` ordering so control-plane drain is acquired before upstream teardown and awaited before runtime drain completion.
- Add a deterministic regression test for cancelling `liveXcodeListWindows` with no upstream response, then shutting down.

## Testing

- `swift test --filter RuntimeCoordinatorTests/shutdownDrainsCancelledLiveXcodeListWindowsLoadWithoutUpstreamResponse -Xswiftc -strict-concurrency=minimal`
- `swift test --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- cancellation-focused filter loop: 20/20 passed
- `swift test --no-parallel -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`
- Codex review: no findings