### PR TITLE
Wait for async Streamable HTTP session requests in tests

### DIFF
--- a/Tests/ProxyCLITests/StdioAdapterFacadeIntegrationTests.swift
+++ b/Tests/ProxyCLITests/StdioAdapterFacadeIntegrationTests.swift
@@ -281,7 +281,20 @@ struct StdioAdapterFacadeIntegrationTests {
         let result = try await StdioAdapterFacadeHarness.run(
             responseMode: responseMode,
             stdinLines: [initializeRequest, toolsListRequest],
-            timeoutDescription: "STDIO adapter should finish after stdin closes"
+            timeoutDescription: "STDIO adapter should finish after stdin closes",
+            closeInputBeforeRunning: false,
+            whileRunning: { server in
+                _ = try await waitWithTimeout(
+                    "waiting for SSE GET before closing stdin"
+                ) {
+                    try await server.recorder.nextRequest { $0.httpMethod == "GET" }
+                }
+            },
+            afterInputClosed: { server in
+                _ = try await waitWithTimeout("waiting for session DELETE") {
+                    try await server.recorder.nextRequest { $0.httpMethod == "DELETE" }
+                }
+            }
         )
 
         #expect(result.exitCode == 0)

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -688,8 +688,14 @@ struct XcodeMCPTests {
             transport: transport
         )
 
+        let get = try await waitWithTimeout("event stream GET was not opened") {
+            try await server.nextRequest { $0.httpMethod == "GET" }
+        }
         _ = try await xcode.listTools()
         await xcode.close()
+        let delete = try await waitWithTimeout("session DELETE was not sent") {
+            try await server.nextRequest { $0.httpMethod == "DELETE" }
+        }
 
         let requests = await server.recordedRequests()
         let initialize = try #require(requests.firstJSONRPC(method: "initialize"))
@@ -709,13 +715,11 @@ struct XcodeMCPTests {
         #expect(list.header("MCP-Session-Id") == "session-http-1")
         #expect(list.header("MCP-Protocol-Version") == "2025-06-18")
 
-        let get = try #require(requests.first(where: { $0.httpMethod == "GET" }))
         #expect(get.timeoutInterval.isInfinite)
         #expect(get.header("Accept") == "text/event-stream")
         #expect(get.header("MCP-Session-Id") == "session-http-1")
         #expect(get.header("MCP-Protocol-Version") == "2025-06-18")
 
-        let delete = try #require(requests.first(where: { $0.httpMethod == "DELETE" }))
         #expect(delete.header("MCP-Session-Id") == "session-http-1")
         #expect(delete.header("MCP-Protocol-Version") == "2025-06-18")
     }


### PR DESCRIPTION
## Purpose

Stabilize CI by making Streamable HTTP tests wait for asynchronously started session requests before asserting recorded request history.

## Changes

- Wait for the XcodeMCPKit Streamable HTTP SSE GET before closing the client, then wait for session DELETE before checking headers.
- Apply the same request-observation synchronization to the STDIO adapter facade round-trip helper for JSON and SSE response modes.
- Keep the change scoped to test synchronization; no production behavior changed.

## Testing

- `swift test --no-parallel --filter XcodeMCPTests/streamableHTTPSendsSessionHeadersAndDeletesOnClose -Xswiftc -strict-concurrency=minimal`
- `swift test --no-parallel --filter StdioAdapterFacadeIntegrationTests -Xswiftc -strict-concurrency=minimal`
- `swift test --no-parallel -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`
- Codex review: clean