### PR TITLE
Fix stalled proxy tools list requests

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Broker/JSONRPCResponseRouter.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Broker/JSONRPCResponseRouter.swift
@@ -141,6 +141,25 @@ final class JSONRPCResponseRouter: Sendable {
         return pending != nil
     }
 
+    @discardableResult
+    func failPending(idKey: String, error: Error) -> Bool {
+        let pending = state.withLockedValue { state -> Pending? in
+            if let pending = state.pendingByID.removeValue(forKey: idKey) {
+                return pending
+            }
+            guard let index = state.pendingBatches.firstIndex(where: { pending in
+                pending.responseIDKeys?.contains(idKey) == true
+            }) else {
+                return nil
+            }
+            return state.pendingBatches.remove(at: index)
+        }
+        if let pending {
+            failOnEventLoop(pending, error: error)
+        }
+        return pending != nil
+    }
+
     func handleIncoming(_ data: Data) {
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
             notify(data)

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Broker/LeaseManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Broker/LeaseManager.swift
@@ -69,12 +69,34 @@ final class LeaseManager: Sendable {
     struct ReleaseAction: Sendable {
         let leaseID: LeaseManager.ID
         let sessionID: String
+        let requestIDKey: String?
         let upstreamIndex: Int?
+        let terminalState: LeaseManager.State?
+        let reason: LeaseManager.ReleaseReason?
 
-        init(leaseID: LeaseManager.ID, sessionID: String, upstreamIndex: Int?) {
+        init(
+            leaseID: LeaseManager.ID,
+            sessionID: String,
+            requestIDKey: String?,
+            upstreamIndex: Int?,
+            terminalState: LeaseManager.State?,
+            reason: LeaseManager.ReleaseReason?
+        ) {
             self.leaseID = leaseID
             self.sessionID = sessionID
+            self.requestIDKey = requestIDKey
             self.upstreamIndex = upstreamIndex
+            self.terminalState = terminalState
+            self.reason = reason
+        }
+
+        var shouldFailPendingRequest: Bool {
+            switch terminalState {
+            case .timedOut, .failed, .abandoned:
+                return true
+            case .queued, .active, .completed, nil:
+                return false
+            }
         }
     }
 
@@ -176,7 +198,10 @@ final class LeaseManager: Sendable {
             return LeaseManager.ReleaseAction(
                 leaseID: leaseID,
                 sessionID: record.descriptor.sessionID,
-                upstreamIndex: upstreamIndex
+                requestIDKey: record.requestIDKey,
+                upstreamIndex: upstreamIndex,
+                terminalState: nil,
+                reason: nil
             )
         }
     }
@@ -214,7 +239,10 @@ final class LeaseManager: Sendable {
                     LeaseManager.ReleaseAction(
                         leaseID: leaseID,
                         sessionID: record.descriptor.sessionID,
-                        upstreamIndex: record.upstreamIndex
+                        requestIDKey: record.requestIDKey,
+                        upstreamIndex: record.upstreamIndex,
+                        terminalState: .abandoned,
+                        reason: reason
                     )
                 )
             }
@@ -261,7 +289,10 @@ final class LeaseManager: Sendable {
                     return LeaseManager.ReleaseAction(
                         leaseID: record.leaseID,
                         sessionID: record.descriptor.sessionID,
-                        upstreamIndex: record.upstreamIndex
+                        requestIDKey: record.requestIDKey,
+                        upstreamIndex: record.upstreamIndex,
+                        terminalState: .failed,
+                        reason: reason
                     )
                 case .completed, .timedOut, .failed, .abandoned:
                     return nil
@@ -349,7 +380,10 @@ final class LeaseManager: Sendable {
                 return LeaseManager.ReleaseAction(
                     leaseID: leaseID,
                     sessionID: record.descriptor.sessionID,
-                    upstreamIndex: record.upstreamIndex
+                    requestIDKey: record.requestIDKey,
+                    upstreamIndex: record.upstreamIndex,
+                    terminalState: terminalState,
+                    reason: reason
                 )
 
             case .completed, .timedOut, .failed, .abandoned:

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Logging
 import NIO
+import NIOConcurrencyHelpers
 import XcodeMCPKit
 
 extension ControlPlane {
@@ -23,11 +24,6 @@ extension ControlPlane {
         let responseData: Data
         let upstreamIndex: Int
     }
-}
-
-private enum EventLoopFutureWaitResult<Output: Sendable>: Sendable {
-    case value(Output)
-    case timedOut
 }
 
 /// The one place that decides which JSON-RPC error a control-plane or
@@ -897,29 +893,29 @@ extension RuntimeCoordinator {
         onTimeout: @escaping @Sendable () -> Void = {}
     ) async throws -> Output {
         if let deadlineUptimeNs, let timeout = timeAmount(until: deadlineUptimeNs) {
-            let clock = clock
-            return try await withThrowingTaskGroup(
-                of: EventLoopFutureWaitResult<Output>.self
-            ) { group in
-                group.addTask {
-                    .value(try await future.get())
+            let timeoutFuture = eventLoop.makePromise(of: Output.self)
+            let didComplete = NIOLockedValueBox(false)
+            let timeoutTask = eventLoop.scheduleTask(in: timeout) {
+                let shouldComplete = didComplete.withLockedValue { completed in
+                    guard completed == false else { return false }
+                    completed = true
+                    return true
                 }
-                group.addTask {
-                    await clock.sleep(.nanoseconds(max(0, timeout.nanoseconds)))
-                    try Task.checkCancellation()
-                    return .timedOut
-                }
-                let result = try await group.next()!
-                switch result {
-                case .value(let output):
-                    group.cancelAll()
-                    return output
-                case .timedOut:
-                    onTimeout()
-                    group.cancelAll()
-                    throw TimeoutError()
-                }
+                guard shouldComplete else { return }
+                onTimeout()
+                timeoutFuture.fail(TimeoutError())
             }
+            future.whenComplete { result in
+                let shouldComplete = didComplete.withLockedValue { completed in
+                    guard completed == false else { return false }
+                    completed = true
+                    return true
+                }
+                guard shouldComplete else { return }
+                timeoutTask.cancel()
+                timeoutFuture.completeWith(result)
+            }
+            return try await timeoutFuture.futureResult.get()
         }
         return try await future.get()
     }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -895,7 +895,8 @@ extension RuntimeCoordinator {
         if let deadlineUptimeNs, let timeout = timeAmount(until: deadlineUptimeNs) {
             let timeoutFuture = eventLoop.makePromise(of: Output.self)
             let didComplete = NIOLockedValueBox(false)
-            let timeoutTask = eventLoop.scheduleTask(in: timeout) {
+            let timeoutTask = Task { [clock] in
+                await clock.sleep(.nanoseconds(max(0, timeout.nanoseconds)))
                 let shouldComplete = didComplete.withLockedValue { completed in
                     guard completed == false else { return false }
                     completed = true

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -1114,6 +1114,29 @@ extension RuntimeCoordinator {
                     leaseID: action.leaseID
                 )
             }
+            failPendingRequestIfNeeded(for: action)
+        }
+    }
+
+    private func failPendingRequestIfNeeded(for action: LeaseManager.ReleaseAction) {
+        guard action.shouldFailPendingRequest,
+              let requestIDKey = action.requestIDKey,
+              let session = sessionRegistry.contextIfPresent(id: action.sessionID) else {
+            return
+        }
+        _ = session.router.failPending(idKey: requestIDKey, error: pendingRequestError(for: action))
+    }
+
+    private func pendingRequestError(for action: LeaseManager.ReleaseAction) -> Error {
+        switch action.reason {
+        case .timedOut:
+            return TimeoutError()
+        case .clientDisconnected:
+            return CancellationError()
+        case .upstreamUnavailable, .upstreamExit, .upstreamOverloaded, .stdoutProtocolViolation:
+            return UpstreamSlotScheduler.AcquisitionError.unavailable
+        case .invalidUpstreamResponse, .lateResponse, .completed, nil:
+            return ControlPlane.Error.invalidResponse("request released before response")
         }
     }
 }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -1976,6 +1976,59 @@ struct RuntimeCoordinatorTests {
         #expect(manager.cachedToolsListResult() == nil)
     }
 
+    @Test func processRoutedToolsListRetriesSiblingUpstreamAfterExit() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let target = xcodeProcessTarget(processID: 713, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0, 1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+
+        let task = Task {
+            try await manager.sharedToolsList(
+                sessionID: "session-single-xcode-tools-retry",
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+
+        let firstRequest = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: firstRequest) == "tools/list")
+
+        manager.handleUpstreamExit(1, upstreamIndex: 0)
+
+        let retryRequest = try await sentValue(from: upstream1, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: retryRequest) == "tools/list")
+        await upstream1.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: retryRequest),
+                    tools: [
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                )
+            )
+        )
+
+        let result = try await waitWithTimeout("waiting for process-routed tools/list retry") {
+            try await task.value
+        }
+        #expect(toolNames(in: result) == ["XcodeListWindows"])
+        #expect(manager.debugSnapshot().controlPlane?.phase == "idle")
+        #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [target.processID])
+    }
+
     @Test func sessionManagerLiveXcodeListWindowsTimeoutStartsFreshControlPlaneLoad()
         async throws
     {


### PR DESCRIPTION
Purpose
Fix a proxy control-plane stall where `tools/list` could remain stuck after an upstream request was abandoned or the selected `mcpbridge` exited.

Changes
- Fail pending JSON-RPC router requests when terminal lease releases occur.
- Preserve deterministic timeout behavior by honoring the injected runtime clock.
- Add coverage for process-routed `tools/list` retrying a sibling upstream after exit.

Testing
- `swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- Codex review against `main`: clean
