### PR TITLE
[codex] Make control-plane cancellation cleanup deterministic

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/ControlPlaneCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/ControlPlaneCoordinator.swift
@@ -484,7 +484,6 @@ actor ControlPlaneCoordinator {
             load.foregroundWaiterCount = max(0, load.foregroundWaiterCount - 1)
         }
         let shouldCancel = shouldCancelToolsCatalogLoadAfterWaiterRemoval(load)
-        waiter.continuation.resume(throwing: error)
         if shouldCancel {
             clearToolsCatalogLoadState(loadID: loadID)
             cancelToolsCatalogLoad(load, error: CancellationError())
@@ -492,6 +491,7 @@ actor ControlPlaneCoordinator {
             setToolsCatalogLoadState(load)
         }
         syncDebug()
+        waiter.continuation.resume(throwing: error)
     }
 
     func cancelToolsCatalogWaiter(waiterID: WaiterID) {
@@ -534,7 +534,6 @@ actor ControlPlaneCoordinator {
         guard var load = windowLoads[route], load.loadID == loadID else { return }
         guard let waiter = load.waiters.removeValue(forKey: waiterID) else { return }
         waiter.timeoutTask?.cancel()
-        waiter.continuation.resume(throwing: error)
         if load.waiters.isEmpty {
             windowLoads.removeValue(forKey: route)
             cancelWindowLoad(load, error: CancellationError())
@@ -542,6 +541,7 @@ actor ControlPlaneCoordinator {
             windowLoads[route] = load
         }
         syncDebug()
+        waiter.continuation.resume(throwing: error)
     }
 
     func cancelWindowWaiter(
@@ -570,6 +570,9 @@ actor ControlPlaneCoordinator {
         let waiters = Array(load.waiters.values)
         for waiter in waiters {
             waiter.timeoutTask?.cancel()
+        }
+        syncDebug()
+        for waiter in waiters {
             switch (result, completedUnderCurrentGeneration) {
             case (.success(let loaded), true):
                 waiter.continuation.resume(returning: loaded.rawResult)
@@ -579,7 +582,6 @@ actor ControlPlaneCoordinator {
                 waiter.continuation.resume(throwing: error)
             }
         }
-        syncDebug()
     }
 
     func completeWindowLoad(
@@ -593,6 +595,9 @@ actor ControlPlaneCoordinator {
         let waiters = Array(load.waiters.values)
         for waiter in waiters {
             waiter.timeoutTask?.cancel()
+        }
+        syncDebug()
+        for waiter in waiters {
             switch (result, completedUnderCurrentGeneration) {
             case (.success(let loaded), true):
                 waiter.continuation.resume(returning: loaded)
@@ -602,6 +607,5 @@ actor ControlPlaneCoordinator {
                 waiter.continuation.resume(throwing: error)
             }
         }
-        syncDebug()
     }
 }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -1708,6 +1708,11 @@ struct RuntimeCoordinatorTests {
         await #expect(throws: CancellationError.self) {
             _ = try await task.value
         }
+        _ = try await waitWithTimeout("waiting for cancelled tools/list waiter cleanup") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.toolsCatalog == 0 && $0.inFlightControlPlaneRequests.isEmpty
+            }
+        }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
@@ -1837,6 +1842,12 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError for promoted waiter but received \(error)")
         }
 
+        _ = try await waitWithTimeout("waiting for first promoted tools/list waiter cleanup") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.toolsCatalog == 1
+            }
+        }
+
         secondTask.cancel()
         do {
             _ = try await secondTask.value
@@ -1846,6 +1857,11 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError for promoted waiter but received \(error)")
         }
 
+        _ = try await waitWithTimeout("waiting for promoted tools/list waiter cleanup") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.toolsCatalog == 0 && $0.inFlightControlPlaneRequests.isEmpty
+            }
+        }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
@@ -5459,6 +5475,11 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError but received \(error)")
         }
 
+        _ = try await waitWithTimeout("waiting for cancelled XcodeListWindows waiter cleanup") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.windows == 0 && $0.inFlightControlPlaneRequests.isEmpty
+            }
+        }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 
@@ -5517,6 +5538,12 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError for promoted XcodeListWindows waiter but received \(error)")
         }
 
+        _ = try await waitWithTimeout("waiting for first promoted XcodeListWindows waiter cleanup") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.windows == 1
+            }
+        }
+
         secondTask.cancel()
         do {
             _ = try await secondTask.value
@@ -5526,6 +5553,11 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected CancellationError for promoted XcodeListWindows waiter but received \(error)")
         }
 
+        _ = try await waitWithTimeout("waiting for promoted XcodeListWindows waiter cleanup") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.windows == 0 && $0.inFlightControlPlaneRequests.isEmpty
+            }
+        }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
     }
 


### PR DESCRIPTION
## Summary
- Make ControlPlaneCoordinator update waiter/load state, RPC cancellation, lease cleanup, and debug snapshots before resuming waiter continuations.
- Update cancellation and promoted-waiter tests to wait for explicit debug-mirror state instead of treating task completion as cleanup completion.

## Root Cause
The promoted XcodeListWindows cancellation test could hang because cancellation resumed the waiter continuation before the control-plane owner state and correlated upstream cleanup were observably complete. Under CI scheduling, the test could move into teardown while cleanup was still queued on the actor.

## Validation
- swift test --filter sessionManagerPromotedLiveXcodeListWindowsCancellationRemovesMigratedWaiter -Xswiftc -strict-concurrency=minimal
- swift test --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal
- swift test --no-parallel --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal
- swift test --no-parallel -Xswiftc -strict-concurrency=minimal
- swift test -Xswiftc -strict-concurrency=minimal
- git diff --check

Related CI investigation: https://github.com/lynnswap/XcodeMCPKit/actions/runs/28419528587/job/84209534944
