### PR TITLE
Search latest documentation assets directly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -73,6 +73,7 @@ let package = Package(
         .target(
             name: "XcodeMCPProxyKit",
             dependencies: [
+                "XcodeMCPDocumentationSearchPrivate",
                 "XcodeMCPKit",
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIO", package: "swift-nio"),
@@ -83,8 +84,22 @@ let package = Package(
             ],
             exclude: ["README.md"],
             swiftSettings: strictSwiftSettings,
+            linkerSettings: [
+                .linkedLibrary("sqlite3"),
+            ],
             plugins: [
                 .plugin(name: "ProxyBuildInfoPlugin"),
+            ]
+        ),
+        .target(
+            name: "XcodeMCPDocumentationSearchPrivate",
+            path: "Sources/XcodeMCPDocumentationSearchPrivate",
+            publicHeadersPath: "include",
+            cSettings: [
+                .unsafeFlags(["-fobjc-arc", "-fblocks"]),
+            ],
+            linkerSettings: [
+                .linkedFramework("Foundation"),
             ]
         ),
         .target(
@@ -119,7 +134,10 @@ let package = Package(
                 .product(name: "NIOEmbedded", package: "swift-nio"),
             ],
             path: "Tests/XcodeMCPProxyInternalTestSupport",
-            swiftSettings: strictSwiftSettings
+            swiftSettings: strictSwiftSettings,
+            linkerSettings: [
+                .linkedLibrary("sqlite3"),
+            ]
         ),
         .executableTarget(
             name: "XcodeMCPProxyCLI",

--- a/Package.swift
+++ b/Package.swift
@@ -95,9 +95,6 @@ let package = Package(
             name: "XcodeMCPDocumentationSearchPrivate",
             path: "Sources/XcodeMCPDocumentationSearchPrivate",
             publicHeadersPath: "include",
-            cSettings: [
-                .unsafeFlags(["-fobjc-arc", "-fblocks"]),
-            ],
             linkerSettings: [
                 .linkedFramework("Foundation"),
             ]

--- a/Sources/XcodeMCPDocumentationSearchPrivate/XcodeMCPDocumentationSearchPrivate.m
+++ b/Sources/XcodeMCPDocumentationSearchPrivate/XcodeMCPDocumentationSearchPrivate.m
@@ -1,0 +1,412 @@
+#import "XcodeMCPDocumentationSearchPrivate.h"
+
+#import <Foundation/Foundation.h>
+#import <dlfcn.h>
+#import <objc/message.h>
+#import <stdint.h>
+
+@interface MADTextInput : NSObject
+- (instancetype)initWithText:(NSString *)text;
+@end
+
+@interface MADTextEmbeddingRequest : NSObject
+@property(nonatomic) unsigned long long version;
+@property(nonatomic) BOOL extendedContextLength;
+@property(nonatomic) BOOL allowTruncation;
+@property(readonly, nonatomic) NSArray *embeddingResults;
+@end
+
+@interface MADService : NSObject
++ (instancetype)service;
+- (int)performRequests:(NSArray *)requests
+            textInputs:(NSArray *)textInputs
+     completionHandler:(void (^)(void))handler;
+@end
+
+@interface VSKConfig : NSObject
+- (instancetype)initWithBaseDirectory:(NSURL *)url
+                             readOnly:(BOOL)readOnly
+              perConnectionPeakMemory:(NSNumber *)memory
+                                error:(NSError **)error;
+@end
+
+@interface VSKClient : NSObject
+- (instancetype)initWithConfig:(VSKConfig *)config error:(NSError **)error;
+- (NSArray *)searchByVector:(NSData *)vector
+           attributeFilters:(NSArray *)filters
+                      limit:(int)limit
+             includePayload:(BOOL)includePayload
+             numberOfProbes:(NSNumber *)numberOfProbes
+                  batchSize:(NSNumber *)batchSize
+       numConcurrentReaders:(NSNumber *)numConcurrentReaders
+                      error:(NSError **)error;
+@end
+
+static NSString *XCDocStringFromCString(const char *value) {
+    if (value == NULL) {
+        return nil;
+    }
+    return [NSString stringWithUTF8String:value];
+}
+
+static char *XCDocCopyCString(NSString *value) {
+    if (value == nil) {
+        return NULL;
+    }
+    const char *utf8 = [value UTF8String];
+    if (utf8 == NULL) {
+        return NULL;
+    }
+    return strdup(utf8);
+}
+
+static char *XCDocCopyError(NSString *message) {
+    return XCDocCopyCString(message ?: @"unknown private documentation search error");
+}
+
+static BOOL XCDocLoadFramework(NSString *path, char **errorMessage) {
+    if (dlopen(path.fileSystemRepresentation, RTLD_NOW) != NULL) {
+        return YES;
+    }
+    if (errorMessage != NULL) {
+        *errorMessage = XCDocCopyError([NSString stringWithFormat:@"dlopen failed for %@: %s", path, dlerror()]);
+    }
+    return NO;
+}
+
+static BOOL XCDocLoadRequiredFrameworks(char **errorMessage) {
+    static dispatch_once_t onceToken;
+    static BOOL loaded;
+    static char *loadErrorMessage;
+    dispatch_once(&onceToken, ^{
+        char *error = NULL;
+        loaded = XCDocLoadFramework(@"/System/Library/PrivateFrameworks/MediaAnalysisServices.framework/MediaAnalysisServices", &error)
+            && XCDocLoadFramework(@"/System/Library/PrivateFrameworks/MediaAnalysis.framework/MediaAnalysis", &error)
+            && XCDocLoadFramework(@"/System/Library/PrivateFrameworks/VectorSearch.framework/VectorSearch", &error);
+        if (!loaded) {
+            loadErrorMessage = error;
+        } else if (error != NULL) {
+            free(error);
+        }
+    });
+    if (!loaded && errorMessage != NULL) {
+        *errorMessage = XCDocCopyError(
+            loadErrorMessage != NULL
+                ? [NSString stringWithUTF8String:loadErrorMessage]
+                : @"failed to load private documentation search frameworks"
+        );
+    }
+    return loaded;
+}
+
+static VSKClient *XCDocCachedVectorSearchClient(NSString *databasePath, char **errorMessage) {
+    static dispatch_once_t onceToken;
+    static NSMutableDictionary<NSString *, VSKClient *> *clientsByPath;
+    static NSLock *lock;
+    dispatch_once(&onceToken, ^{
+        clientsByPath = [NSMutableDictionary dictionary];
+        lock = [NSLock new];
+    });
+
+    [lock lock];
+    VSKClient *cachedClient = clientsByPath[databasePath];
+    [lock unlock];
+    if (cachedClient != nil) {
+        return cachedClient;
+    }
+
+    NSError *error = nil;
+    VSKConfig *config = [[NSClassFromString(@"VSKConfig") alloc]
+        initWithBaseDirectory:[NSURL fileURLWithPath:databasePath isDirectory:YES]
+                     readOnly:YES
+      perConnectionPeakMemory:nil
+                        error:&error];
+    if (config == nil) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError([NSString stringWithFormat:@"VectorSearch config failed: %@", error]);
+        }
+        return nil;
+    }
+    VSKClient *client = [[NSClassFromString(@"VSKClient") alloc] initWithConfig:config error:&error];
+    if (client == nil) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError([NSString stringWithFormat:@"VectorSearch client failed: %@", error]);
+        }
+        return nil;
+    }
+
+    [lock lock];
+    VSKClient *existingClient = clientsByPath[databasePath];
+    if (existingClient == nil) {
+        clientsByPath[databasePath] = client;
+        existingClient = client;
+    }
+    [lock unlock];
+    return existingClient;
+}
+
+static unsigned long long XCDocEmbeddingVersionFromClass(NSString *className) {
+    Class cls = NSClassFromString(className);
+    if (cls == Nil || ![cls respondsToSelector:@selector(embeddingVersion)]) {
+        return 0;
+    }
+    unsigned long long (*send)(id, SEL) = (unsigned long long (*)(id, SEL))objc_msgSend;
+    return send(cls, @selector(embeddingVersion));
+}
+
+static unsigned long long XCDocEmbeddingVersionForModel(NSString *modelName) {
+    NSString *normalized = modelName.lowercaseString;
+    if ([normalized isEqualToString:@"md7v2"]) {
+        unsigned long long version = XCDocEmbeddingVersionFromClass(@"MADTextEmbeddingThresholdMD7v2");
+        return version != 0 ? version : 9;
+    }
+    if ([normalized isEqualToString:@"md6"]) {
+        unsigned long long version = XCDocEmbeddingVersionFromClass(@"MADTextEmbeddingThresholdMD6");
+        return version != 0 ? version : 7;
+    }
+    if ([normalized isEqualToString:@"md5"]) {
+        unsigned long long version = XCDocEmbeddingVersionFromClass(@"MADTextEmbeddingThresholdMD5");
+        return version != 0 ? version : 5;
+    }
+    if ([normalized isEqualToString:@"md4"]) {
+        unsigned long long version = XCDocEmbeddingVersionFromClass(@"MADTextEmbeddingThresholdMD4");
+        return version != 0 ? version : 4;
+    }
+    if ([normalized isEqualToString:@"md3"]) {
+        unsigned long long version = XCDocEmbeddingVersionFromClass(@"MADTextEmbeddingThresholdMD3");
+        return version != 0 ? version : 3;
+    }
+    Class analyzer = NSClassFromString(@"VCPMediaAnalyzer");
+    if (analyzer != Nil && [analyzer respondsToSelector:@selector(getUnifiedEmbeddingVersion)]) {
+        unsigned long long (*send)(id, SEL) = (unsigned long long (*)(id, SEL))objc_msgSend;
+        return send(analyzer, @selector(getUnifiedEmbeddingVersion));
+    }
+    return 0;
+}
+
+static float XCDocFloat32FromFloat16(uint16_t half) {
+    uint16_t halfExponent = half & 0x7C00u;
+    uint16_t halfSignificand = half & 0x03FFu;
+    uint32_t floatSign = ((uint32_t)half & 0x8000u) << 16;
+    uint32_t bits;
+    if (halfExponent == 0) {
+        if (halfSignificand == 0) {
+            bits = floatSign;
+        } else {
+            int shift = __builtin_clz(halfSignificand) - 21;
+            halfSignificand <<= shift;
+            uint32_t exponent = (uint32_t)(127 - 15 - shift + 1);
+            uint32_t significand = ((uint32_t)halfSignificand & 0x03FFu) << 13;
+            bits = floatSign | (exponent << 23) | significand;
+        }
+    } else if (halfExponent == 0x7C00u) {
+        bits = floatSign | 0x7F800000u | ((uint32_t)halfSignificand << 13);
+    } else {
+        uint32_t exponent = (uint32_t)(halfExponent >> 10) + (127 - 15);
+        uint32_t significand = (uint32_t)halfSignificand << 13;
+        bits = floatSign | (exponent << 23) | significand;
+    }
+    float value;
+    memcpy(&value, &bits, sizeof(value));
+    return value;
+}
+
+static NSData *XCDocFloat32DataFromEmbeddingData(NSData *data, char **errorMessage) {
+    if (data.length == 512 * sizeof(float)) {
+        return data;
+    }
+    if (data.length != 512 * sizeof(uint16_t)) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError([NSString stringWithFormat:@"unexpected embedding byte count: %lu", (unsigned long)data.length]);
+        }
+        return nil;
+    }
+    NSMutableData *floatData = [NSMutableData dataWithLength:512 * sizeof(float)];
+    const uint16_t *source = data.bytes;
+    float *destination = floatData.mutableBytes;
+    for (NSUInteger index = 0; index < 512; index += 1) {
+        destination[index] = XCDocFloat32FromFloat16(source[index]);
+    }
+    return floatData;
+}
+
+static NSData *XCDocCopyQueryEmbedding(
+    NSString *query,
+    NSString *modelName,
+    double timeoutSeconds,
+    char **errorMessage
+) {
+    Class requestClass = NSClassFromString(@"MADTextEmbeddingRequest");
+    Class inputClass = NSClassFromString(@"MADTextInput");
+    Class serviceClass = NSClassFromString(@"MADService");
+    if (requestClass == Nil || inputClass == Nil || serviceClass == Nil) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError(@"MediaAnalysisServices embedding classes are unavailable");
+        }
+        return nil;
+    }
+
+    unsigned long long version = XCDocEmbeddingVersionForModel(modelName);
+    if (version == 0) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError([NSString stringWithFormat:@"unsupported embedding model: %@", modelName ?: @""]);
+        }
+        return nil;
+    }
+
+    MADTextEmbeddingRequest *request = [requestClass new];
+    request.version = version;
+    request.extendedContextLength = YES;
+    request.allowTruncation = YES;
+    MADTextInput *input = [[inputClass alloc] initWithText:query];
+    MADService *service = [serviceClass service];
+    if (service == nil || input == nil) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError(@"failed to initialize MediaAnalysisServices embedding request");
+        }
+        return nil;
+    }
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    [service performRequests:@[request] textInputs:@[input] completionHandler:^{
+        dispatch_semaphore_signal(semaphore);
+    }];
+
+    int64_t timeoutNanoseconds = timeoutSeconds > 0
+        ? (int64_t)(timeoutSeconds * (double)NSEC_PER_SEC)
+        : 30LL * NSEC_PER_SEC;
+    intptr_t waitResult = dispatch_semaphore_wait(
+        semaphore,
+        dispatch_time(DISPATCH_TIME_NOW, timeoutNanoseconds)
+    );
+    if (waitResult != 0) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError(@"embedding request timed out");
+        }
+        return nil;
+    }
+
+    id requestError = nil;
+    @try {
+        requestError = [request valueForKey:@"error"];
+    } @catch (__unused NSException *exception) {}
+    if (requestError != nil && requestError != (id)[NSNull null]) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError([NSString stringWithFormat:@"embedding request failed: %@", requestError]);
+        }
+        return nil;
+    }
+
+    id result = request.embeddingResults.firstObject;
+    NSData *embeddingData = nil;
+    if ([result respondsToSelector:@selector(embeddingData)]) {
+        embeddingData = [result valueForKey:@"embeddingData"];
+    }
+    if (embeddingData == nil) {
+        if (errorMessage != NULL) {
+            *errorMessage = XCDocCopyError(@"embedding request produced no embedding");
+        }
+        return nil;
+    }
+    return XCDocFloat32DataFromEmbeddingData(embeddingData, errorMessage);
+}
+
+int XCDocSemanticSearchRuntimeAvailable(void) {
+    @autoreleasepool {
+        if (!XCDocLoadRequiredFrameworks(NULL)) {
+            return 0;
+        }
+        return NSClassFromString(@"MADTextEmbeddingRequest") != Nil
+            && NSClassFromString(@"MADTextInput") != Nil
+            && NSClassFromString(@"MADService") != Nil
+            && NSClassFromString(@"VSKConfig") != Nil
+            && NSClassFromString(@"VSKClient") != Nil;
+    }
+}
+
+char *XCDocSemanticSearchCopyResultJSON(
+    const char *databaseDirectoryPath,
+    const char *embeddingModelName,
+    const char *query,
+    int limit,
+    double timeoutSeconds,
+    char **errorMessage
+) {
+    @autoreleasepool {
+        if (errorMessage != NULL) {
+            *errorMessage = NULL;
+        }
+        NSString *databasePath = XCDocStringFromCString(databaseDirectoryPath);
+        NSString *queryString = XCDocStringFromCString(query);
+        NSString *modelName = XCDocStringFromCString(embeddingModelName) ?: @"md7v2";
+        if (databasePath.length == 0 || queryString.length == 0 || limit <= 0) {
+            if (errorMessage != NULL) {
+                *errorMessage = XCDocCopyError(@"invalid semantic search arguments");
+            }
+            return NULL;
+        }
+        if (!XCDocLoadRequiredFrameworks(errorMessage)) {
+            return NULL;
+        }
+
+        NSData *embedding = XCDocCopyQueryEmbedding(
+            queryString,
+            modelName,
+            timeoutSeconds,
+            errorMessage
+        );
+        if (embedding == nil) {
+            return NULL;
+        }
+
+        NSError *error = nil;
+        VSKClient *client = XCDocCachedVectorSearchClient(databasePath, errorMessage);
+        if (client == nil) {
+            return NULL;
+        }
+
+        NSArray *results = nil;
+        @synchronized (client) {
+            results = [client searchByVector:embedding
+                            attributeFilters:@[]
+                                       limit:limit
+                              includePayload:NO
+                              numberOfProbes:nil
+                                   batchSize:nil
+                        numConcurrentReaders:nil
+                                       error:&error];
+        }
+        if (results == nil) {
+            if (errorMessage != NULL) {
+                *errorMessage = XCDocCopyError([NSString stringWithFormat:@"VectorSearch query failed: %@", error]);
+            }
+            return NULL;
+        }
+
+        NSMutableArray *objects = [NSMutableArray arrayWithCapacity:results.count];
+        for (id result in results) {
+            NSString *identifier = [result valueForKey:@"stringIdentifier"];
+            NSNumber *score = [result valueForKey:@"value"];
+            if (identifier.length == 0 || score == nil) {
+                continue;
+            }
+            [objects addObject:@{
+                @"asset_id": identifier,
+                @"score": score,
+            }];
+        }
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:objects options:0 error:&error];
+        if (jsonData == nil) {
+            if (errorMessage != NULL) {
+                *errorMessage = XCDocCopyError([NSString stringWithFormat:@"semantic search JSON encoding failed: %@", error]);
+            }
+            return NULL;
+        }
+        NSString *json = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        return XCDocCopyCString(json);
+    }
+}
+
+void XCDocSemanticSearchFree(void *pointer) {
+    free(pointer);
+}

--- a/Sources/XcodeMCPDocumentationSearchPrivate/XcodeMCPDocumentationSearchPrivate.m
+++ b/Sources/XcodeMCPDocumentationSearchPrivate/XcodeMCPDocumentationSearchPrivate.m
@@ -5,6 +5,14 @@
 #import <objc/message.h>
 #import <stdint.h>
 
+#if __has_feature(objc_arc)
+#define XCDOC_AUTORELEASE(object) (object)
+#define XCDOC_RELEASE(object)
+#else
+#define XCDOC_AUTORELEASE(object) [(object) autorelease]
+#define XCDOC_RELEASE(object) [(object) release]
+#endif
+
 @interface MADTextInput : NSObject
 - (instancetype)initWithText:(NSString *)text;
 @end
@@ -104,8 +112,8 @@ static VSKClient *XCDocCachedVectorSearchClient(NSString *databasePath, char **e
     static NSMutableDictionary<NSString *, VSKClient *> *clientsByPath;
     static NSLock *lock;
     dispatch_once(&onceToken, ^{
-        clientsByPath = [NSMutableDictionary dictionary];
-        lock = [NSLock new];
+        clientsByPath = [[NSMutableDictionary alloc] init];
+        lock = [[NSLock alloc] init];
     });
 
     [lock lock];
@@ -116,11 +124,11 @@ static VSKClient *XCDocCachedVectorSearchClient(NSString *databasePath, char **e
     }
 
     NSError *error = nil;
-    VSKConfig *config = [[NSClassFromString(@"VSKConfig") alloc]
+    VSKConfig *config = XCDOC_AUTORELEASE([[NSClassFromString(@"VSKConfig") alloc]
         initWithBaseDirectory:[NSURL fileURLWithPath:databasePath isDirectory:YES]
                      readOnly:YES
       perConnectionPeakMemory:nil
-                        error:&error];
+                        error:&error]);
     if (config == nil) {
         if (errorMessage != NULL) {
             *errorMessage = XCDocCopyError([NSString stringWithFormat:@"VectorSearch config failed: %@", error]);
@@ -141,6 +149,7 @@ static VSKClient *XCDocCachedVectorSearchClient(NSString *databasePath, char **e
         clientsByPath[databasePath] = client;
         existingClient = client;
     }
+    XCDOC_RELEASE(client);
     [lock unlock];
     return existingClient;
 }
@@ -254,11 +263,11 @@ static NSData *XCDocCopyQueryEmbedding(
         return nil;
     }
 
-    MADTextEmbeddingRequest *request = [requestClass new];
+    MADTextEmbeddingRequest *request = XCDOC_AUTORELEASE([requestClass new]);
     request.version = version;
     request.extendedContextLength = YES;
     request.allowTruncation = YES;
-    MADTextInput *input = [[inputClass alloc] initWithText:query];
+    MADTextInput *input = XCDOC_AUTORELEASE([[inputClass alloc] initWithText:query]);
     MADService *service = [serviceClass service];
     if (service == nil || input == nil) {
         if (errorMessage != NULL) {

--- a/Sources/XcodeMCPDocumentationSearchPrivate/include/XcodeMCPDocumentationSearchPrivate.h
+++ b/Sources/XcodeMCPDocumentationSearchPrivate/include/XcodeMCPDocumentationSearchPrivate.h
@@ -1,0 +1,25 @@
+#ifndef XCODE_MCP_DOCUMENTATION_SEARCH_PRIVATE_H
+#define XCODE_MCP_DOCUMENTATION_SEARCH_PRIVATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int XCDocSemanticSearchRuntimeAvailable(void);
+
+char *XCDocSemanticSearchCopyResultJSON(
+    const char *databaseDirectoryPath,
+    const char *embeddingModelName,
+    const char *query,
+    int limit,
+    double timeoutSeconds,
+    char **errorMessage
+);
+
+void XCDocSemanticSearchFree(void *pointer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -2347,15 +2347,15 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
             return .unavailable
         }
         let deadline = Deadline.fromNow(requestTimeout, clock: clock)
-        let targets = orderedTargets(excluding: [])
-        guard targets.isEmpty == false else {
-            return .unavailable
-        }
         if preferLocalSearchProvider {
             let localUpdate = await installedDocumentationAssetToolListUpdate()
             if case .available = localUpdate {
                 return localUpdate
             }
+        }
+        let targets = orderedTargets(excluding: [])
+        guard targets.isEmpty == false else {
+            return .unavailable
         }
         for (index, target) in targets.enumerated() {
             guard !Task.isCancelled, !isShutdown else {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -1220,6 +1220,7 @@ private actor DocumentationAssetSQLiteMaterializer {
                  )
                 WHERE a.title IS NOT NULL
                   AND a.content IS NOT NULL
+                -- Preserve VectorSearch order to match mcpbridge DocumentationSearch ranking.
                 ORDER BY r.rank
                 """)
             defer { unsafe sqlite3_finalize(statement) }
@@ -2089,6 +2090,14 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         let descriptor: JSONValue
     }
 
+    private static let installedDocumentationAssetStandaloneTarget = XcodeProcessTarget(
+        processID: 0,
+        appPath: "installed-documentation-asset",
+        developerDir: "installed-documentation-asset",
+        mcpbridgePath: "installed-documentation-asset",
+        xcodeVersion: "installed-documentation-asset"
+    )
+
     private struct ProviderPreparationContext: Sendable {
         let transport: any DocumentationProviderRouting
         let initializeParams: [String: JSONValue]
@@ -2472,16 +2481,9 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
             }
             if preferLocalSearchProvider, attemptedPrimaryInstalledAsset == false {
                 attemptedPrimaryInstalledAsset = true
-                let fallbackCandidateCount = max(orderedTargets(excluding: []).count, 1)
-                let primaryDeadline = makeDeadline(
-                    fromTimeout: timeoutForCandidate(
-                        until: deadline,
-                        remainingCandidateCount: fallbackCandidateCount + 1
-                    )
-                )
-                switch try await lastResortInstalledDocumentationAssetFallback(
+                switch try await primaryInstalledDocumentationAssetFallback(
                     requestData: requestData,
-                    deadline: primaryDeadline
+                    deadline: deadline
                 ) {
                 case .success(let fallback):
                     return .handled(
@@ -2898,13 +2900,15 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
     private func attemptInstalledDocumentationAssetFallback(
         requestData: Data,
         target: XcodeProcessTarget,
-        deadline: Deadline?
+        deadline: Deadline?,
+        isPrimaryAttempt: Bool = false
     ) async throws -> InstalledDocumentationAssetFallbackAttempt {
         do {
             guard let fallback = try await callInstalledDocumentationAssetFallback(
                 requestData: requestData,
                 target: target,
-                deadline: deadline
+                deadline: deadline,
+                isPrimaryAttempt: isPrimaryAttempt
             ) else {
                 return .unavailable
             }
@@ -2927,37 +2931,26 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         }
     }
 
-    private func lastResortInstalledDocumentationAssetFallback(
+    private func primaryInstalledDocumentationAssetFallback(
         requestData: Data,
         deadline: Deadline?
     ) async throws -> InstalledDocumentationAssetFallbackAttempt {
-        var lastCandidateFailure: (any Error)?
-        for target in orderedTargetsForInstalledDocumentationAssetFallback() {
-            switch try await attemptInstalledDocumentationAssetFallback(
-                requestData: requestData,
-                target: target,
-                deadline: deadline
-            ) {
-            case .success(let fallback):
-                return .success(fallback)
-            case .unavailable:
-                continue
-            case .requestFailed(let error):
-                return .requestFailed(error)
-            case .candidateFailed(let error):
-                lastCandidateFailure = error
-                continue
-            }
-        }
-        if let lastCandidateFailure {
-            return .candidateFailed(lastCandidateFailure)
-        }
-        return .unavailable
+        try await attemptInstalledDocumentationAssetFallback(
+            requestData: requestData,
+            target: Self.installedDocumentationAssetStandaloneTarget,
+            deadline: deadline,
+            isPrimaryAttempt: true
+        )
     }
 
     private func installedDocumentationAssetToolListUpdate() async
         -> DocumentationProvider.ToolListUpdate
     {
+        if let descriptor = await localSearchProvider.descriptor(
+            for: Self.installedDocumentationAssetStandaloneTarget
+        ) {
+            return .available(descriptor)
+        }
         for target in orderedTargetsForInstalledDocumentationAssetFallback() {
             if let descriptor = await localSearchProvider.descriptor(for: target) {
                 return .available(descriptor)
@@ -3651,19 +3644,28 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
     private func callInstalledDocumentationAssetFallback(
         requestData: Data,
         target: XcodeProcessTarget,
-        deadline: Deadline?
+        deadline: Deadline?,
+        isPrimaryAttempt: Bool
     ) async throws -> InstalledDocumentationAssetFallback? {
         guard let descriptor = await localSearchProvider.descriptor(for: target) else {
             return nil
         }
-        logger.warning(
-            "Falling back to installed documentation asset for DocumentationSearch",
-            metadata: [
-                "pid": .string("\(target.processID)"),
-                "app_path": .string(target.appPath),
-                "xcode_version": .string(target.xcodeVersion),
-            ]
-        )
+        let metadata: Logger.Metadata = [
+            "pid": .string("\(target.processID)"),
+            "app_path": .string(target.appPath),
+            "xcode_version": .string(target.xcodeVersion),
+        ]
+        if isPrimaryAttempt {
+            logger.info(
+                "Using installed documentation asset as primary DocumentationSearch provider",
+                metadata: metadata
+            )
+        } else {
+            logger.warning(
+                "Falling back to installed documentation asset for DocumentationSearch",
+                metadata: metadata
+            )
+        }
         let responseData = try await localSearchProvider.callDocumentationSearch(
             requestData: requestData,
             for: target,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Logging
 import NIO
+import SQLite3
+import XcodeMCPDocumentationSearchPrivate
 import XcodeMCPKit
 
 enum DocumentationProvider {}
@@ -418,24 +420,30 @@ struct DocumentationSearchInstalledAsset: Sendable, Equatable {
     let assetURL: URL
     let configURL: URL
     let indexURL: URL
+    let databaseDirectoryURL: URL
     let xcodeVersion: String
     let osVersion: String
     let documentationRelease: Int?
+    let embeddingModelName: String
 
     init(
         assetURL: URL,
         configURL: URL,
         indexURL: URL,
+        databaseDirectoryURL: URL,
         xcodeVersion: String,
         osVersion: String,
-        documentationRelease: Int?
+        documentationRelease: Int?,
+        embeddingModelName: String
     ) {
         self.assetURL = assetURL
         self.configURL = configURL
         self.indexURL = indexURL
+        self.databaseDirectoryURL = databaseDirectoryURL
         self.xcodeVersion = xcodeVersion
         self.osVersion = osVersion
         self.documentationRelease = documentationRelease
+        self.embeddingModelName = embeddingModelName
     }
 }
 
@@ -521,6 +529,9 @@ enum DocumentationSearchAssetLocator {
         let configURL = assetURL
             .appendingPathComponent("AssetData", isDirectory: true)
             .appendingPathComponent("config.json", isDirectory: false)
+        let databaseDirectoryURL = assetURL
+            .appendingPathComponent("AssetData", isDirectory: true)
+            .appendingPathComponent("documentation-db", isDirectory: true)
         let indexURL = assetURL
             .appendingPathComponent("AssetData", isDirectory: true)
             .appendingPathComponent("documentation-db", isDirectory: true)
@@ -546,14 +557,18 @@ enum DocumentationSearchAssetLocator {
             return .rejected("info_plist_decode_failed")
         }
         let properties = plist.mobileAssetProperties
+        let config = (try? JSONDecoder().decode(AssetConfig.self, from: Data(contentsOf: configURL)))
+            ?? AssetConfig()
 
         return .asset(DocumentationSearchInstalledAsset(
             assetURL: assetURL,
             configURL: configURL,
             indexURL: indexURL,
+            databaseDirectoryURL: databaseDirectoryURL,
             xcodeVersion: properties.xcodeVersion,
             osVersion: properties.osVersion,
-            documentationRelease: properties.documentationRelease
+            documentationRelease: properties.documentationRelease,
+            embeddingModelName: config.embeddingModelName ?? "md7v2"
         ))
     }
 
@@ -744,6 +759,14 @@ enum DocumentationSearchAssetLocator {
             return nil
         }
     }
+
+    private struct AssetConfig: Decodable {
+        let embeddingModelName: String?
+
+        init(embeddingModelName: String? = nil) {
+            self.embeddingModelName = embeddingModelName
+        }
+    }
 }
 
 struct LiveDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairing {
@@ -833,90 +856,6 @@ struct LiveDocumentationSearchServiceRepairer: DocumentationSearchServiceRepairi
     }
 }
 
-private final class ProcessOutputTimeoutWaiter: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<ProcessOutput, Error>?
-    private var tasks: [Task<Void, Never>] = []
-    private var resolved = false
-
-    func wait(
-        for task: Task<ProcessOutput, Error>,
-        timeout: TimeAmount,
-        clock: ClockClient
-    ) async throws -> ProcessOutput {
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                setContinuation(continuation)
-                addTask(Task {
-                    do {
-                        let output = try await task.value
-                        self.resume(.success(output))
-                    } catch {
-                        self.resume(.failure(error))
-                    }
-                })
-                addTask(Task {
-                    await clock.sleep(.nanoseconds(timeout.nanoseconds))
-                    guard Task.isCancelled == false else {
-                        return
-                    }
-                    task.cancel()
-                    self.resume(.failure(TimeoutError()))
-                })
-            }
-        } onCancel: {
-            task.cancel()
-            resume(.failure(CancellationError()))
-        }
-    }
-
-    private func setContinuation(_ continuation: CheckedContinuation<ProcessOutput, Error>) {
-        lock.lock()
-        if resolved {
-            lock.unlock()
-            continuation.resume(throwing: CancellationError())
-            return
-        }
-        self.continuation = continuation
-        lock.unlock()
-    }
-
-    private func addTask(_ task: Task<Void, Never>) {
-        lock.lock()
-        if resolved {
-            lock.unlock()
-            task.cancel()
-            return
-        }
-        tasks.append(task)
-        lock.unlock()
-    }
-
-    private func resume(_ result: Result<ProcessOutput, Error>) {
-        lock.lock()
-        guard resolved == false else {
-            lock.unlock()
-            return
-        }
-        resolved = true
-        let continuation = continuation
-        self.continuation = nil
-        let tasks = tasks
-        self.tasks.removeAll()
-        lock.unlock()
-
-        for task in tasks {
-            task.cancel()
-        }
-        switch result {
-        case .success(let output):
-            continuation?.resume(returning: output)
-        case .failure(let error):
-            continuation?.resume(throwing: error)
-        }
-    }
-}
-
 private final class DocumentationSearchServiceRepairWaiter: @unchecked Sendable {
     struct Result: Sendable {
         let repairResult: DocumentationSearchServiceRepairResult?
@@ -997,6 +936,372 @@ private final class DocumentationSearchServiceRepairWaiter: @unchecked Sendable 
     }
 }
 
+struct DocumentationAssetSemanticSearchResult: Sendable, Decodable, Equatable {
+    let assetID: String
+    let score: Double
+
+    private enum CodingKeys: String, CodingKey {
+        case assetID = "asset_id"
+        case score
+    }
+}
+
+protocol DocumentationAssetSemanticSearching: Sendable {
+    func isAvailable() -> Bool
+    func search(
+        asset: DocumentationSearchInstalledAsset,
+        query: String,
+        limit: Int,
+        timeout: TimeAmount?
+    ) async throws -> [DocumentationAssetSemanticSearchResult]
+}
+
+struct LiveDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearching {
+    init() {}
+
+    func isAvailable() -> Bool {
+        XCDocSemanticSearchRuntimeAvailable() != 0
+    }
+
+    func search(
+        asset: DocumentationSearchInstalledAsset,
+        query: String,
+        limit: Int,
+        timeout: TimeAmount?
+    ) async throws -> [DocumentationAssetSemanticSearchResult] {
+        guard timeout?.nanoseconds != 0 else {
+            throw TimeoutError()
+        }
+        let timeoutSeconds: Double
+        if let timeout, timeout.nanoseconds > 0 {
+            timeoutSeconds = Double(timeout.nanoseconds) / 1_000_000_000.0
+        } else {
+            timeoutSeconds = 30
+        }
+        let databaseDirectoryPath = asset.databaseDirectoryURL.path
+        let embeddingModelName = asset.embeddingModelName
+        return try await Task.detached {
+            let json = try unsafe Self.copyResultJSON(
+                databaseDirectoryPath: databaseDirectoryPath,
+                embeddingModelName: embeddingModelName,
+                query: query,
+                limit: limit,
+                timeoutSeconds: timeoutSeconds
+            )
+            guard let data = json.data(using: .utf8) else {
+                return []
+            }
+            return try JSONDecoder().decode(
+                [DocumentationAssetSemanticSearchResult].self,
+                from: data
+            )
+        }.value
+    }
+
+    @unsafe private static func copyResultJSON(
+        databaseDirectoryPath: String,
+        embeddingModelName: String,
+        query: String,
+        limit: Int,
+        timeoutSeconds: Double
+    ) throws -> String {
+        var errorPointer: UnsafeMutablePointer<CChar>?
+        let resultPointer = unsafe databaseDirectoryPath.withCString { databasePathPointer in
+            unsafe embeddingModelName.withCString { embeddingModelNamePointer in
+                unsafe query.withCString { queryPointer in
+                    unsafe XCDocSemanticSearchCopyResultJSON(
+                        databasePathPointer,
+                        embeddingModelNamePointer,
+                        queryPointer,
+                        Int32(limit),
+                        timeoutSeconds,
+                        &errorPointer
+                    )
+                }
+            }
+        }
+        defer {
+            if let errorPointer = unsafe errorPointer {
+                unsafe XCDocSemanticSearchFree(errorPointer)
+            }
+            if let resultPointer = unsafe resultPointer {
+                unsafe XCDocSemanticSearchFree(resultPointer)
+            }
+        }
+        guard let resultPointer = unsafe resultPointer else {
+            let message: String
+            if let errorPointer = unsafe errorPointer {
+                message = unsafe String(cString: errorPointer)
+            } else {
+                message = "private semantic DocumentationSearch failed"
+            }
+            throw ControlPlane.Error.invalidResponse(message)
+        }
+        return unsafe String(cString: resultPointer)
+    }
+}
+
+private struct DocumentationAssetSearchRow: Sendable, Equatable {
+    let assetID: String?
+    let type: String?
+    let framework: String?
+    let title: String?
+    let content: String?
+    let score: Double?
+}
+
+private actor DocumentationAssetSelectionCache {
+    private struct RootSignature: Equatable {
+        let path: String
+        let modificationDate: Date?
+    }
+
+    private var cachedRootSignature: RootSignature?
+    private var cachedAsset: DocumentationSearchInstalledAsset?
+
+    func latestInstalledAsset(assetRoot: URL) -> DocumentationSearchInstalledAsset? {
+        let signature = Self.rootSignature(for: assetRoot)
+        if cachedRootSignature == signature, let cachedAsset {
+            return cachedAsset
+        }
+        guard let scan = try? DocumentationSearchAssetLocator.scanInstalledAssets(in: assetRoot)
+        else {
+            return nil
+        }
+        guard let asset = DocumentationSearchAssetLocator.latestAsset(from: scan.assets) else {
+            return nil
+        }
+        cachedRootSignature = signature
+        cachedAsset = asset
+        return asset
+    }
+
+    private static func rootSignature(for assetRoot: URL) -> RootSignature {
+        let modificationDate = (try? FileManager.default.attributesOfItem(
+            atPath: assetRoot.path
+        )[.modificationDate]) as? Date
+        return RootSignature(path: assetRoot.path, modificationDate: modificationDate)
+    }
+}
+
+private actor DocumentationAssetSQLiteMaterializer {
+    @safe private final class Connection {
+        let path: String
+        private var database: OpaquePointer?
+
+        @unsafe init(path: String) throws {
+            self.path = path
+            var openedDatabase: OpaquePointer?
+            let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX
+            guard unsafe sqlite3_open_v2(path, &openedDatabase, flags, nil) == SQLITE_OK else {
+                let message = unsafe Self.errorMessage(openedDatabase)
+                if let openedDatabase = unsafe openedDatabase {
+                    unsafe sqlite3_close_v2(openedDatabase)
+                }
+                throw ControlPlane.Error.invalidResponse(
+                    "local DocumentationSearch sqlite open failed: \(message)"
+                )
+            }
+            unsafe database = openedDatabase
+            try unsafe execute("PRAGMA temp_store = MEMORY")
+            try unsafe execute("""
+                CREATE TEMP TABLE IF NOT EXISTS xcode_mcp_ranked_doc_results (
+                    rank INTEGER PRIMARY KEY,
+                    asset_id TEXT NOT NULL,
+                    score REAL NOT NULL
+                )
+                """)
+        }
+
+        deinit {
+            if let database = unsafe database {
+                unsafe sqlite3_close_v2(database)
+            }
+        }
+
+        @unsafe func rows(
+            rankedResults: [DocumentationAssetSemanticSearchResult],
+            frameworks: [String],
+            limit: Int
+        ) throws -> [DocumentationAssetSearchRow] {
+            guard rankedResults.isEmpty == false else {
+                return []
+            }
+            try unsafe execute("DELETE FROM temp.xcode_mcp_ranked_doc_results")
+            try unsafe insertRankedResults(rankedResults)
+
+            let frameworkFilter = Set(frameworks.filter { $0.isEmpty == false })
+            var rows: [DocumentationAssetSearchRow] = []
+            let statement = try unsafe prepare("""
+                SELECT a.asset_id AS asset_id,
+                       a.type AS type,
+                       a.framework AS framework,
+                       a.title AS title,
+                       substr(a.content, 1, 4000) AS content,
+                       r.score AS score
+                FROM temp.xcode_mcp_ranked_doc_results r
+                JOIN attributes a
+                  ON a.asset_id = r.asset_id
+                 AND a.vector_id = (
+                   SELECT MIN(a2.vector_id)
+                   FROM attributes a2
+                   WHERE a2.asset_id = r.asset_id
+                     AND a2.title IS NOT NULL
+                     AND a2.content IS NOT NULL
+                 )
+                WHERE a.title IS NOT NULL
+                  AND a.content IS NOT NULL
+                ORDER BY r.rank
+                """)
+            defer { unsafe sqlite3_finalize(statement) }
+
+            var stepResult = unsafe sqlite3_step(statement)
+            while stepResult == SQLITE_ROW {
+                let framework = unsafe Self.stringColumn(statement, 2)
+                if frameworkFilter.isEmpty == false,
+                   framework.map({ frameworkFilter.contains($0) }) != true
+                {
+                    stepResult = unsafe sqlite3_step(statement)
+                    continue
+                }
+                let score: Double?
+                if unsafe sqlite3_column_type(statement, 5) == SQLITE_NULL {
+                    score = nil
+                } else {
+                    score = unsafe sqlite3_column_double(statement, 5)
+                }
+                rows.append(DocumentationAssetSearchRow(
+                    assetID: unsafe Self.stringColumn(statement, 0),
+                    type: unsafe Self.stringColumn(statement, 1),
+                    framework: framework,
+                    title: unsafe Self.stringColumn(statement, 3),
+                    content: unsafe Self.stringColumn(statement, 4),
+                    score: score
+                ))
+                if rows.count >= limit {
+                    break
+                }
+                stepResult = unsafe sqlite3_step(statement)
+            }
+            guard stepResult == SQLITE_DONE || rows.count >= limit
+            else {
+                throw ControlPlane.Error.invalidResponse(
+                    "local DocumentationSearch sqlite query failed: \(unsafe Self.errorMessage(database))"
+                )
+            }
+            return rows
+        }
+
+        @unsafe private func insertRankedResults(
+            _ rankedResults: [DocumentationAssetSemanticSearchResult]
+        ) throws {
+            let statement = try unsafe prepare("""
+                INSERT INTO temp.xcode_mcp_ranked_doc_results(rank, asset_id, score)
+                VALUES (?1, ?2, ?3)
+                """)
+            defer { unsafe sqlite3_finalize(statement) }
+
+            for (index, result) in rankedResults.enumerated() {
+                unsafe sqlite3_reset(statement)
+                unsafe sqlite3_clear_bindings(statement)
+                unsafe sqlite3_bind_int64(statement, 1, Int64(index))
+                try unsafe bind(result.assetID, to: statement, index: 2)
+                unsafe sqlite3_bind_double(statement, 3, result.score.isFinite ? result.score : 0)
+                guard unsafe sqlite3_step(statement) == SQLITE_DONE else {
+                    throw ControlPlane.Error.invalidResponse(
+                        "local DocumentationSearch sqlite insert failed: \(unsafe Self.errorMessage(database))"
+                    )
+                }
+            }
+        }
+
+        @unsafe private func execute(_ sql: String) throws {
+            var errorMessage: UnsafeMutablePointer<CChar>?
+            defer {
+                if let errorMessage = unsafe errorMessage {
+                    unsafe sqlite3_free(errorMessage)
+                }
+            }
+            guard unsafe sqlite3_exec(database, sql, nil, nil, &errorMessage) == SQLITE_OK else {
+                let message: String
+                if let errorMessage = unsafe errorMessage {
+                    message = unsafe String(cString: errorMessage)
+                } else {
+                    message = unsafe Self.errorMessage(database)
+                }
+                throw ControlPlane.Error.invalidResponse(
+                    "local DocumentationSearch sqlite exec failed: \(message)"
+                )
+            }
+        }
+
+        @unsafe private func prepare(_ sql: String) throws -> OpaquePointer? {
+            var statement: OpaquePointer?
+            guard unsafe sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+                throw ControlPlane.Error.invalidResponse(
+                    "local DocumentationSearch sqlite prepare failed: \(unsafe Self.errorMessage(database))"
+                )
+            }
+            return unsafe statement
+        }
+
+        @unsafe private func bind(_ value: String, to statement: OpaquePointer?, index: Int32) throws {
+            let transient = unsafe unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+            let result = unsafe value.withCString { valuePointer in
+                unsafe sqlite3_bind_text(statement, index, valuePointer, -1, transient)
+            }
+            guard result == SQLITE_OK else {
+                throw ControlPlane.Error.invalidResponse(
+                    "local DocumentationSearch sqlite bind failed: \(unsafe Self.errorMessage(database))"
+                )
+            }
+        }
+
+        @unsafe private static func stringColumn(
+            _ statement: OpaquePointer?,
+            _ index: Int32
+        ) -> String? {
+            guard let text = unsafe sqlite3_column_text(statement, index) else {
+                return nil
+            }
+            return unsafe String(cString: text)
+        }
+
+        @unsafe private static func errorMessage(_ database: OpaquePointer?) -> String {
+            guard let database = unsafe database,
+                  let message = unsafe sqlite3_errmsg(database)
+            else {
+                return "unknown sqlite error"
+            }
+            return unsafe String(cString: message)
+        }
+    }
+
+    private var connections: [String: Connection] = [:]
+
+    func rows(
+        asset: DocumentationSearchInstalledAsset,
+        rankedResults: [DocumentationAssetSemanticSearchResult],
+        frameworks: [String],
+        limit: Int
+    ) throws -> [DocumentationAssetSearchRow] {
+        let path = asset.indexURL.path
+        let connection: Connection
+        if let cached = connections[path] {
+            connection = cached
+        } else {
+            let opened = try unsafe Connection(path: path)
+            connections[path] = opened
+            connection = opened
+        }
+        return try unsafe connection.rows(
+            rankedResults: rankedResults,
+            frameworks: frameworks,
+            limit: limit
+        )
+    }
+}
+
 struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
     private struct SearchArguments {
         let requestID: JSONRPC.ID
@@ -1005,38 +1310,24 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
         let limit: Int
     }
 
-    private struct SearchRow: Decodable {
-        let assetID: String?
-        let type: String?
-        let framework: String?
-        let title: String?
-        let content: String?
-
-        private enum CodingKeys: String, CodingKey {
-            case assetID = "asset_id"
-            case type
-            case framework
-            case title
-            case content
-        }
-    }
-
     private let assetRoot: URL
-    private let processRunner: any ProcessRunning
-    private let clock: ClockClient
+    private let semanticSearcher: any DocumentationAssetSemanticSearching
+    private let assetCache: DocumentationAssetSelectionCache
+    private let sqliteMaterializer: DocumentationAssetSQLiteMaterializer
 
     init(
         assetRoot: URL = DocumentationSearchAssetLocator.defaultAssetRoot,
-        processRunner: any ProcessRunning = ProcessRunner(),
-        clock: ClockClient = .liveValue
+        semanticSearcher: any DocumentationAssetSemanticSearching =
+            LiveDocumentationAssetSemanticSearcher()
     ) {
         self.assetRoot = assetRoot
-        self.processRunner = processRunner
-        self.clock = clock
+        self.semanticSearcher = semanticSearcher
+        assetCache = DocumentationAssetSelectionCache()
+        sqliteMaterializer = DocumentationAssetSQLiteMaterializer()
     }
 
-    func descriptor(for target: XcodeProcessTarget) async -> JSONValue? {
-        guard installedAsset(for: target) != nil else {
+    func descriptor(for _: XcodeProcessTarget) async -> JSONValue? {
+        guard await latestInstalledAsset() != nil, semanticSearcher.isAvailable() else {
             return nil
         }
         return Self.descriptor
@@ -1051,10 +1342,24 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
             throw TimeoutError()
         }
         let arguments = try Self.searchArguments(from: requestData)
-        guard let asset = installedAsset(for: target) else {
+        guard let asset = await latestInstalledAsset() else {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
-        let rows = try await searchRows(arguments: arguments, asset: asset, timeout: timeout)
+        guard semanticSearcher.isAvailable() else {
+            throw UpstreamSlotScheduler.AcquisitionError.unavailable
+        }
+        let rankedResults = try await semanticSearcher.search(
+            asset: asset,
+            query: arguments.query,
+            limit: Self.semanticSearchLimit(for: arguments),
+            timeout: timeout
+        )
+        let rows = try await searchRows(
+            arguments: arguments,
+            asset: asset,
+            rankedResults: rankedResults,
+            timeout: timeout
+        )
         return try Self.makeResponse(
             requestID: arguments.requestID,
             query: arguments.query,
@@ -1063,65 +1368,25 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
         )
     }
 
-    private func installedAsset(
-        for target: XcodeProcessTarget
-    ) -> DocumentationSearchInstalledAsset? {
-        guard let scan = try? DocumentationSearchAssetLocator.scanInstalledAssets(in: assetRoot)
-        else {
-            return nil
-        }
-        return DocumentationSearchAssetLocator.latestAsset(from: scan.assets)
+    private func latestInstalledAsset() async -> DocumentationSearchInstalledAsset? {
+        await assetCache.latestInstalledAsset(assetRoot: assetRoot)
     }
 
     private func searchRows(
         arguments: SearchArguments,
         asset: DocumentationSearchInstalledAsset,
+        rankedResults: [DocumentationAssetSemanticSearchResult],
         timeout: TimeAmount?
-    ) async throws -> [SearchRow] {
-        let sql = Self.searchSQL(arguments: arguments)
-        let timeoutNanoseconds = timeout.flatMap { timeout in
-            timeout.nanoseconds > 0 ? timeout.nanoseconds : nil
+    ) async throws -> [DocumentationAssetSearchRow] {
+        guard rankedResults.isEmpty == false else {
+            return []
         }
-        let request = ProcessRequest(
-            label: "documentation-search-local",
-            executablePath: "/usr/bin/sqlite3",
-            arguments: [
-                "-readonly",
-                "-json",
-                asset.indexURL.path,
-                sql,
-            ],
-            input: nil,
-            timeoutNanoseconds: timeoutNanoseconds
+        return try await sqliteMaterializer.rows(
+            asset: asset,
+            rankedResults: rankedResults,
+            frameworks: arguments.frameworks,
+            limit: arguments.limit
         )
-        let output: ProcessOutput
-        do {
-            if let timeout, timeout.nanoseconds > 0 {
-                output = try await ProcessOutputTimeoutWaiter().wait(
-                    for: Task {
-                        try await processRunner.run(request)
-                    },
-                    timeout: timeout,
-                    clock: clock
-                )
-            } else {
-                output = try await processRunner.run(request)
-            }
-        } catch is ProcessTimeoutError {
-            throw TimeoutError()
-        }
-        guard output.terminationStatus == 0 else {
-            throw ControlPlane.Error.invalidResponse(
-                "local DocumentationSearch sqlite failed: \(output.stderr)"
-            )
-        }
-        guard let data = output.stdout.data(using: .utf8) else {
-            return []
-        }
-        guard output.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
-            return []
-        }
-        return try JSONDecoder().decode([SearchRow].self, from: data)
     }
 
     private static var descriptor: JSONValue {
@@ -1150,6 +1415,10 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
                 ]),
             ]),
         ])
+    }
+
+    private static func semanticSearchLimit(for arguments: SearchArguments) -> Int {
+        min(max(arguments.limit * 8, 40), 200)
     }
 
     private static func searchArguments(from data: Data) throws -> SearchArguments {
@@ -1188,65 +1457,11 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
         return array.compactMap { $0 as? String }.filter { $0.isEmpty == false }
     }
 
-    private static func searchSQL(arguments: SearchArguments) -> String {
-        let loweredQuery = arguments.query.lowercased()
-        let terms = loweredQuery
-            .split { character in
-                character.isWhitespace || character.isNewline
-            }
-            .prefix(6)
-            .map(String.init)
-        let termClauses = terms.isEmpty
-            ? [likeClause(for: loweredQuery)]
-            : terms.map(likeClause(for:))
-        var filters = termClauses
-        if arguments.frameworks.isEmpty == false {
-            let frameworks = arguments.frameworks
-                .map { sqliteStringLiteral($0) }
-                .joined(separator: ",")
-            filters.append("framework IN (\(frameworks))")
-        }
-        let whereClause = filters.joined(separator: " AND ")
-        let queryLiteral = sqliteStringLiteral(loweredQuery)
-        let prefixLiteral = sqliteStringLiteral("\(loweredQuery)%")
-        let containsLiteral = sqliteStringLiteral("%\(loweredQuery)%")
-        return """
-            SELECT asset_id,
-                   type,
-                   framework,
-                   title,
-                   substr(content, 1, 4000) AS content
-            FROM attributes
-            WHERE title IS NOT NULL
-              AND content IS NOT NULL
-              AND \(whereClause)
-            ORDER BY CASE
-                WHEN lower(title) = \(queryLiteral) OR lower(asset_id) = \(queryLiteral) THEN 0
-                WHEN lower(title) LIKE \(prefixLiteral) OR lower(asset_id) LIKE \(prefixLiteral) THEN 1
-                WHEN lower(title) LIKE \(containsLiteral) OR lower(asset_id) LIKE \(containsLiteral) THEN 2
-                WHEN lower(content) LIKE \(prefixLiteral) THEN 3
-                ELSE 4
-              END,
-              CASE type WHEN 'symbol' THEN 0 WHEN 'article' THEN 1 ELSE 2 END,
-              length(content)
-            LIMIT \(arguments.limit)
-            """
-    }
-
-    private static func likeClause(for term: String) -> String {
-        let pattern = sqliteStringLiteral("%\(term)%")
-        return "(lower(title) LIKE \(pattern) OR lower(asset_id) LIKE \(pattern) OR lower(content) LIKE \(pattern))"
-    }
-
-    private static func sqliteStringLiteral(_ value: String) -> String {
-        "'\(value.replacingOccurrences(of: "'", with: "''"))'"
-    }
-
     private static func makeResponse(
         requestID: JSONRPC.ID,
         query: String,
         asset: DocumentationSearchInstalledAsset,
-        rows: [SearchRow]
+        rows: [DocumentationAssetSearchRow]
     ) throws -> Data {
         let documents = rows.map { row -> [String: Any] in
             let type = row.type ?? ""
@@ -1265,6 +1480,9 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
             }
             if let framework = row.framework, framework.isEmpty == false {
                 document["framework"] = framework
+            }
+            if let score = row.score {
+                document["score"] = score
             }
             return document
         }
@@ -1785,11 +2003,6 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
             guard startupTimeout?.nanoseconds != 0 else {
                 throw TimeoutError()
             }
-            if preferLocalSearchProvider,
-               let localProfile = await installedDocumentationAssetPrimaryProfile(for: target)
-            {
-                return localProfile
-            }
             let route: DocumentationProviderRoute
             do {
                 route = try await transport.openRoute(
@@ -1800,7 +2013,7 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
-                if let localProfile = await installedDocumentationAssetFallbackProfile(for: target) {
+                if let localProfile = await installedDocumentationAssetPrimaryProfile(for: target) {
                     return localProfile
                 }
                 throw error
@@ -1838,29 +2051,6 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
             }
             logger.info(
                 "Using installed documentation asset as primary DocumentationSearch provider",
-                metadata: [
-                    "pid": .string("\(target.processID)"),
-                    "app_path": .string(target.appPath),
-                    "xcode_version": .string(target.xcodeVersion),
-                ]
-            )
-            return CandidateProfile(
-                id: UUID(),
-                target: target,
-                backend: .installedDocumentationAsset(descriptor: descriptor),
-                serverVersion: "installed-documentation-asset",
-                descriptorLookupCompleted: true
-            )
-        }
-
-        private func installedDocumentationAssetFallbackProfile(
-            for target: XcodeProcessTarget
-        ) async -> CandidateProfile? {
-            guard let descriptor = await localSearchProvider.descriptor(for: target) else {
-                return nil
-            }
-            logger.warning(
-                "Using installed documentation asset fallback for DocumentationSearch",
                 metadata: [
                     "pid": .string("\(target.processID)"),
                     "app_path": .string(target.appPath),
@@ -2036,6 +2226,12 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         guard targets.isEmpty == false else {
             return .unavailable
         }
+        if preferLocalSearchProvider {
+            let localUpdate = await installedDocumentationAssetToolListUpdate()
+            if case .available = localUpdate {
+                return localUpdate
+            }
+        }
         for (index, target) in targets.enumerated() {
             guard !Task.isCancelled, !isShutdown else {
                 return .unavailable
@@ -2072,6 +2268,8 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
                         "xcode_version": .string(target.xcodeVersion),
                     ]
                 )
+                permanentlyUnusableProcessIDs.insert(target.processID)
+                await discardPreparedProvider(profile)
                 continue
             } catch is CancellationError {
                 return .unavailable
@@ -2083,7 +2281,7 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
                 continue
             }
         }
-        return .unavailable
+        return await installedDocumentationAssetToolListUpdate()
     }
 
     func toolListUpdate(requestTimeout: TimeAmount?) async
@@ -2097,6 +2295,12 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         }
         guard !Task.isCancelled else {
             return .unavailable
+        }
+        if preferLocalSearchProvider {
+            let localUpdate = await installedDocumentationAssetToolListUpdate()
+            if case .available = localUpdate {
+                return localUpdate
+            }
         }
         let cached = toolListUpdateFromCachedState(requestTimeout: requestTimeout)
         if case .unchanged = cached {
@@ -2144,10 +2348,37 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         var rejectedProcessIDs: Set<pid_t> = []
         var invalidatedProvider = false
         var lastCandidateFailure: (any Error)?
+        var attemptedPrimaryInstalledAsset = false
 
         while !Task.isCancelled {
             if let deadline, deadline.hasExpired {
                 return .failed(TimeoutError(), invalidatedProvider: invalidatedProvider)
+            }
+            if preferLocalSearchProvider, attemptedPrimaryInstalledAsset == false {
+                attemptedPrimaryInstalledAsset = true
+                let fallbackCandidateCount = max(orderedTargets(excluding: []).count, 1)
+                let primaryDeadline = makeDeadline(
+                    fromTimeout: timeoutForCandidate(
+                        until: deadline,
+                        remainingCandidateCount: fallbackCandidateCount + 1
+                    )
+                )
+                switch try await lastResortInstalledDocumentationAssetFallback(
+                    requestData: requestData,
+                    deadline: primaryDeadline
+                ) {
+                case .success(let fallback):
+                    return .handled(
+                        fallback.responseData,
+                        invalidatedProvider: invalidatedProvider
+                    )
+                case .unavailable:
+                    break
+                case .requestFailed(let error):
+                    return .failed(error, invalidatedProvider: invalidatedProvider)
+                case .candidateFailed(let error):
+                    lastCandidateFailure = error
+                }
             }
             if let activeProvider,
                 rejectedProcessIDs.contains(activeProvider.profile.target.processID) == false,
@@ -2265,11 +2496,13 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
                                 "xcode_version": .string(target.xcodeVersion),
                             ]
                         )
-                        rejectedProcessIDs.insert(target.processID)
+                        rememberRejectedProvider(
+                            processID: target.processID,
+                            permanentlyUnusable: true,
+                            rejectedProcessIDs: &rejectedProcessIDs
+                        )
                         progressed = true
-                        if hasRemainingCandidate {
-                            await discardPreparedProvider(processID: target.processID)
-                        }
+                        await discardPreparedProvider(profile)
                         continue
                     }
                     let provider = ActiveProvider(profile: profile)
@@ -2578,6 +2811,45 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         }
     }
 
+    private func lastResortInstalledDocumentationAssetFallback(
+        requestData: Data,
+        deadline: Deadline?
+    ) async throws -> InstalledDocumentationAssetFallbackAttempt {
+        var lastCandidateFailure: (any Error)?
+        for target in orderedTargetsForInstalledDocumentationAssetFallback() {
+            switch try await attemptInstalledDocumentationAssetFallback(
+                requestData: requestData,
+                target: target,
+                deadline: deadline
+            ) {
+            case .success(let fallback):
+                return .success(fallback)
+            case .unavailable:
+                continue
+            case .requestFailed(let error):
+                return .requestFailed(error)
+            case .candidateFailed(let error):
+                lastCandidateFailure = error
+                continue
+            }
+        }
+        if let lastCandidateFailure {
+            return .candidateFailed(lastCandidateFailure)
+        }
+        return .unavailable
+    }
+
+    private func installedDocumentationAssetToolListUpdate() async
+        -> DocumentationProvider.ToolListUpdate
+    {
+        for target in orderedTargetsForInstalledDocumentationAssetFallback() {
+            if let descriptor = await localSearchProvider.descriptor(for: target) {
+                return .available(descriptor)
+            }
+        }
+        return .unavailable
+    }
+
     func invalidate(reason: String) async {
         await invalidate(reason: reason, awaitRouteTermination: false)
     }
@@ -2611,6 +2883,20 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         providerPreparations.removeValue(forKey: processID)?.task.cancel()
         guard let profile = preparedProviders.removeValue(forKey: processID) else {
             return
+        }
+        guard activeProvider?.profile.id != profile.id else {
+            return
+        }
+        await closeTransportRouteIfPresent(profile, awaitTermination: isShutdown)
+    }
+
+    private func discardPreparedProvider(_ profile: CandidateProfile) async {
+        providerPreparations.removeValue(forKey: profile.target.processID)?.task.cancel()
+        let cached = preparedProviders.removeValue(forKey: profile.target.processID)
+        if let cached, cached.id != profile.id,
+           activeProvider?.profile.id != cached.id
+        {
+            await closeTransportRouteIfPresent(cached, awaitTermination: isShutdown)
         }
         guard activeProvider?.profile.id != profile.id else {
             return
@@ -2915,9 +3201,21 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         let filtered = discovery.runningXcodeTargets().filter {
             excludedProcessIDs.contains($0.processID) == false
         }
+        return sortedDocumentationTargets(filtered)
+    }
+
+    private func orderedTargetsForInstalledDocumentationAssetFallback()
+        -> [XcodeProcessTarget]
+    {
+        sortedDocumentationTargets(discovery.runningXcodeTargets())
+    }
+
+    private func sortedDocumentationTargets(
+        _ targets: [XcodeProcessTarget]
+    ) -> [XcodeProcessTarget] {
         // DocumentationSearch owns provider selection separately from workspace/tab routing.
         // Discovery order is only target enumeration; version and stable identity choose priority.
-        return filtered.sorted { lhs, rhs in
+        targets.sorted { lhs, rhs in
             let versionComparison = Self.compareVersion(lhs.xcodeVersion, rhs.xcodeVersion)
             if versionComparison != .orderedSame {
                 return versionComparison == .orderedDescending
@@ -2950,16 +3248,21 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         guard startupTimeout?.nanoseconds != 0 else {
             throw TimeoutError()
         }
-        if preferLocalSearchProvider,
-           let localProfile = await installedDocumentationAssetPrimaryProfile(for: target)
-        {
-            return localProfile
+        let route: DocumentationProviderRoute
+        do {
+            route = try await transport.openRoute(
+                for: target,
+                requestTimeout: startupTimeout,
+                initializeParams: initializeParams
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if let localProfile = await installedDocumentationAssetPrimaryProfile(for: target) {
+                return localProfile
+            }
+            throw error
         }
-        let route = try await transport.openRoute(
-            for: target,
-            requestTimeout: startupTimeout,
-            initializeParams: initializeParams
-        )
         do {
             try Task.checkCancellation()
             guard !isShutdown else {
@@ -3177,26 +3480,6 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         }
     }
 
-    private func repairDocumentationSearch(
-        for target: XcodeProcessTarget,
-        timeout: TimeAmount?
-    ) async -> DocumentationSearchServiceRepairResult? {
-        guard timeout?.nanoseconds != 0 else {
-            return nil
-        }
-        guard let timeout, timeout.nanoseconds > 0 else {
-            return await serviceRepairer.repairDocumentationSearch(for: target)
-        }
-        let result = await DocumentationSearchServiceRepairWaiter().wait(
-            for: Task {
-                await serviceRepairer.repairDocumentationSearch(for: target)
-            },
-            timeout: timeout,
-            clock: clock
-        )
-        return result.repairResult
-    }
-
     private func profileByAddingInstalledDocumentationAssetFallback(
         _ profile: CandidateProfile
     ) async -> CandidateProfile {
@@ -3227,6 +3510,26 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
         updated.descriptorLookupCompleted = true
         await closeTransportRouteIfPresent(profile, awaitTermination: isShutdown)
         return updated
+    }
+
+    private func repairDocumentationSearch(
+        for target: XcodeProcessTarget,
+        timeout: TimeAmount?
+    ) async -> DocumentationSearchServiceRepairResult? {
+        guard timeout?.nanoseconds != 0 else {
+            return nil
+        }
+        guard let timeout, timeout.nanoseconds > 0 else {
+            return await serviceRepairer.repairDocumentationSearch(for: target)
+        }
+        let result = await DocumentationSearchServiceRepairWaiter().wait(
+            for: Task {
+                await serviceRepairer.repairDocumentationSearch(for: target)
+            },
+            timeout: timeout,
+            clock: clock
+        )
+        return result.repairResult
     }
 
     private func callInstalledDocumentationAssetFallback(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -2615,7 +2615,7 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
                         )
                         rememberRejectedProvider(
                             processID: target.processID,
-                            permanentlyUnusable: true,
+                            permanentlyUnusable: false,
                             rejectedProcessIDs: &rejectedProcessIDs
                         )
                         progressed = true

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -1039,26 +1039,22 @@ struct LiveDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearchi
         guard timeout?.nanoseconds != 0 else {
             throw TimeoutError()
         }
-        let operationTask = Task.detached {
-            try operation()
-        }
-        guard let timeout, timeout.nanoseconds > 0 else {
-            return try await operationTask.value
-        }
-
         let waiter = DocumentationSemanticSearchTimeoutWaiter<T>()
-        Task.detached {
+
+        DispatchQueue.global(qos: .userInitiated).async {
             do {
-                waiter.resume(.success(try await operationTask.value))
+                waiter.resume(.success(try operation()))
             } catch {
                 waiter.resume(.failure(error))
             }
         }
-        DispatchQueue.global().asyncAfter(
-            deadline: .now() + .nanoseconds(Int(clamping: timeout.nanoseconds))
-        ) {
-            waiter.resume(.failure(TimeoutError()))
-            operationTask.cancel()
+
+        if let timeout, timeout.nanoseconds > 0 {
+            DispatchQueue.global().asyncAfter(
+                deadline: .now() + .nanoseconds(Int(clamping: timeout.nanoseconds))
+            ) {
+                waiter.resume(.failure(TimeoutError()))
+            }
         }
 
         return try await withTaskCancellationHandler {
@@ -1067,7 +1063,6 @@ struct LiveDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearchi
             }
         } onCancel: {
             waiter.resume(.failure(CancellationError()))
-            operationTask.cancel()
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -946,6 +946,43 @@ struct DocumentationAssetSemanticSearchResult: Sendable, Decodable, Equatable {
     }
 }
 
+private final class DocumentationSemanticSearchTimeoutWaiter<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var result: Result<T, Error>?
+
+    func setContinuation(_ continuation: CheckedContinuation<T, Error>) {
+        let resultToResume: Result<T, Error>?
+        lock.lock()
+        if let result {
+            resultToResume = result
+        } else {
+            self.continuation = continuation
+            resultToResume = nil
+        }
+        lock.unlock()
+
+        if let resultToResume {
+            continuation.resume(with: resultToResume)
+        }
+    }
+
+    func resume(_ result: Result<T, Error>) {
+        let continuationToResume: CheckedContinuation<T, Error>?
+        lock.lock()
+        guard self.result == nil else {
+            lock.unlock()
+            return
+        }
+        self.result = result
+        continuationToResume = continuation
+        continuation = nil
+        lock.unlock()
+
+        continuationToResume?.resume(with: result)
+    }
+}
+
 protocol DocumentationAssetSemanticSearching: Sendable {
     func isAvailable() -> Bool
     func search(
@@ -969,9 +1006,6 @@ struct LiveDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearchi
         limit: Int,
         timeout: TimeAmount?
     ) async throws -> [DocumentationAssetSemanticSearchResult] {
-        guard timeout?.nanoseconds != 0 else {
-            throw TimeoutError()
-        }
         let timeoutSeconds: Double
         if let timeout, timeout.nanoseconds > 0 {
             timeoutSeconds = Double(timeout.nanoseconds) / 1_000_000_000.0
@@ -980,7 +1014,7 @@ struct LiveDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearchi
         }
         let databaseDirectoryPath = asset.databaseDirectoryURL.path
         let embeddingModelName = asset.embeddingModelName
-        return try await Task.detached {
+        return try await Self.runBlockingSearch(timeout: timeout) {
             let json = try unsafe Self.copyResultJSON(
                 databaseDirectoryPath: databaseDirectoryPath,
                 embeddingModelName: embeddingModelName,
@@ -995,7 +1029,46 @@ struct LiveDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearchi
                 [DocumentationAssetSemanticSearchResult].self,
                 from: data
             )
-        }.value
+        }
+    }
+
+    static func runBlockingSearch<T: Sendable>(
+        timeout: TimeAmount?,
+        operation: @escaping @Sendable () throws -> T
+    ) async throws -> T {
+        guard timeout?.nanoseconds != 0 else {
+            throw TimeoutError()
+        }
+        let operationTask = Task.detached {
+            try operation()
+        }
+        guard let timeout, timeout.nanoseconds > 0 else {
+            return try await operationTask.value
+        }
+
+        let waiter = DocumentationSemanticSearchTimeoutWaiter<T>()
+        Task.detached {
+            do {
+                waiter.resume(.success(try await operationTask.value))
+            } catch {
+                waiter.resume(.failure(error))
+            }
+        }
+        DispatchQueue.global().asyncAfter(
+            deadline: .now() + .nanoseconds(Int(clamping: timeout.nanoseconds))
+        ) {
+            waiter.resume(.failure(TimeoutError()))
+            operationTask.cancel()
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiter.setContinuation(continuation)
+            }
+        } onCancel: {
+            waiter.resume(.failure(CancellationError()))
+            operationTask.cancel()
+        }
     }
 
     @unsafe private static func copyResultJSON(
@@ -1127,6 +1200,7 @@ private actor DocumentationAssetSQLiteMaterializer {
             guard rankedResults.isEmpty == false else {
                 return []
             }
+            let rankedResults = Self.deduplicatedRankedResults(rankedResults)
             try unsafe execute("DELETE FROM temp.xcode_mcp_ranked_doc_results")
             try unsafe insertRankedResults(rankedResults)
 
@@ -1190,6 +1264,18 @@ private actor DocumentationAssetSQLiteMaterializer {
                 )
             }
             return rows
+        }
+
+        private static func deduplicatedRankedResults(
+            _ rankedResults: [DocumentationAssetSemanticSearchResult]
+        ) -> [DocumentationAssetSemanticSearchResult] {
+            var seenAssetIDs = Set<String>()
+            var deduplicated: [DocumentationAssetSemanticSearchResult] = []
+            deduplicated.reserveCapacity(rankedResults.count)
+            for result in rankedResults where seenAssetIDs.insert(result.assetID).inserted {
+                deduplicated.append(result)
+            }
+            return deduplicated
         }
 
         @unsafe private func insertRankedResults(
@@ -1348,17 +1434,11 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
         guard semanticSearcher.isAvailable() else {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
         }
-        let rankedResults = try await semanticSearcher.search(
-            asset: asset,
-            query: arguments.query,
-            limit: Self.semanticSearchLimit(for: arguments),
-            timeout: timeout
-        )
+        let deadline = Self.deadline(for: timeout)
         let rows = try await searchRows(
             arguments: arguments,
             asset: asset,
-            rankedResults: rankedResults,
-            timeout: timeout
+            deadline: deadline
         )
         return try Self.makeResponse(
             requestID: arguments.requestID,
@@ -1373,18 +1453,37 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
     private func searchRows(
         arguments: SearchArguments,
         asset: DocumentationSearchInstalledAsset,
-        rankedResults: [DocumentationAssetSemanticSearchResult],
-        timeout: TimeAmount?
+        deadline: UInt64?
     ) async throws -> [DocumentationAssetSearchRow] {
-        guard rankedResults.isEmpty == false else {
-            return []
+        var semanticLimit = Self.initialSemanticSearchLimit(for: arguments)
+        let maxSemanticLimit = Self.maxSemanticSearchLimit(for: arguments)
+        while true {
+            let rankedResults = try await semanticSearcher.search(
+                asset: asset,
+                query: arguments.query,
+                limit: semanticLimit,
+                timeout: try Self.remainingTimeout(until: deadline)
+            )
+            guard rankedResults.isEmpty == false else {
+                return []
+            }
+            let rows = try await sqliteMaterializer.rows(
+                asset: asset,
+                rankedResults: rankedResults,
+                frameworks: arguments.frameworks,
+                limit: arguments.limit
+            )
+            guard Self.shouldExpandSemanticSearch(
+                arguments: arguments,
+                rows: rows,
+                rankedResultCount: rankedResults.count,
+                semanticLimit: semanticLimit,
+                maxSemanticLimit: maxSemanticLimit
+            ) else {
+                return rows
+            }
+            semanticLimit = min(semanticLimit * 2, maxSemanticLimit)
         }
-        return try await sqliteMaterializer.rows(
-            asset: asset,
-            rankedResults: rankedResults,
-            frameworks: arguments.frameworks,
-            limit: arguments.limit
-        )
     }
 
     private static var descriptor: JSONValue {
@@ -1415,8 +1514,48 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
         ])
     }
 
-    private static func semanticSearchLimit(for arguments: SearchArguments) -> Int {
+    private static func initialSemanticSearchLimit(for arguments: SearchArguments) -> Int {
         min(max(arguments.limit * 8, 40), 200)
+    }
+
+    private static func maxSemanticSearchLimit(for arguments: SearchArguments) -> Int {
+        guard arguments.frameworks.contains(where: { $0.isEmpty == false }) else {
+            return initialSemanticSearchLimit(for: arguments)
+        }
+        return min(max(arguments.limit * 128, 1_000), 2_000)
+    }
+
+    private static func shouldExpandSemanticSearch(
+        arguments: SearchArguments,
+        rows: [DocumentationAssetSearchRow],
+        rankedResultCount: Int,
+        semanticLimit: Int,
+        maxSemanticLimit: Int
+    ) -> Bool {
+        arguments.frameworks.contains(where: { $0.isEmpty == false })
+            && rows.count < arguments.limit
+            && rankedResultCount >= semanticLimit
+            && semanticLimit < maxSemanticLimit
+    }
+
+    private static func deadline(for timeout: TimeAmount?) -> UInt64? {
+        guard let timeout, timeout.nanoseconds > 0 else {
+            return nil
+        }
+        let now = DispatchTime.now().uptimeNanoseconds
+        let (deadline, overflow) = now.addingReportingOverflow(UInt64(timeout.nanoseconds))
+        return overflow ? UInt64.max : deadline
+    }
+
+    private static func remainingTimeout(until deadline: UInt64?) throws -> TimeAmount? {
+        guard let deadline else {
+            return nil
+        }
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard deadline > now else {
+            throw TimeoutError()
+        }
+        return .nanoseconds(Int64(clamping: deadline - now))
     }
 
     private static func searchArguments(from data: Data) throws -> SearchArguments {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -1463,44 +1463,47 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
         asset: DocumentationSearchInstalledAsset,
         rows: [DocumentationAssetSearchRow]
     ) throws -> Data {
-        let documents = rows.map { row -> [String: Any] in
+        let documents = rows.map { row -> JSONValue in
             let type = row.type ?? ""
             let content = row.content ?? ""
-            var document: [String: Any] = [
-                "title": row.title ?? "",
-                "type": type,
-                "kind": type,
-                "content": content,
-                "contents": content,
+            var document: [String: JSONValue] = [
+                "title": .string(row.title ?? ""),
+                "type": .string(type),
+                "kind": .string(type),
+                "content": .string(content),
+                "contents": .string(content),
             ]
             if let assetID = row.assetID {
-                document["identifier"] = assetID
-                document["uri"] = assetID
-                document["url"] = "https://developer.apple.com\(assetID)"
+                document["identifier"] = .string(assetID)
+                document["uri"] = .string(assetID)
+                document["url"] = .string("https://developer.apple.com\(assetID)")
             }
             if let framework = row.framework, framework.isEmpty == false {
-                document["framework"] = framework
+                document["framework"] = .string(framework)
             }
             if let score = row.score {
-                document["score"] = score
+                document["score"] = .number(.double(score))
             }
-            return document
+            return .object(document)
         }
-        var assetPayload: [String: Any] = [
-            "path": asset.assetURL.path,
-            "xcodeVersion": asset.xcodeVersion,
-            "osVersion": asset.osVersion,
+        var assetPayload: [String: JSONValue] = [
+            "path": .string(asset.assetURL.path),
+            "xcodeVersion": .string(asset.xcodeVersion),
+            "osVersion": .string(asset.osVersion),
         ]
         if let documentationRelease = asset.documentationRelease {
-            assetPayload["documentationRelease"] = documentationRelease
+            assetPayload["documentationRelease"] = .number(.int(Int64(documentationRelease)))
         }
-        let payload: [String: Any] = [
-            "query": query,
-            "source": "installed-documentation-asset",
-            "asset": assetPayload,
-            "documents": documents,
-        ]
-        let payloadData = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        let structuredContent = JSONValue.object([
+            "query": .string(query),
+            "source": .string("installed-documentation-asset"),
+            "asset": .object(assetPayload),
+            "documents": .array(documents),
+        ])
+        let payloadData = try JSONSerialization.data(
+            withJSONObject: structuredContent.foundationObject,
+            options: [.sortedKeys]
+        )
         let payloadText = String(decoding: payloadData, as: UTF8.self)
         return try JSONRPC.Wire.resultResponseData(
             id: requestID,
@@ -1511,6 +1514,7 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
                         "text": .string(payloadText),
                     ])
                 ]),
+                "structuredContent": structuredContent,
                 "isError": .bool(false),
             ])
         )

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -1362,8 +1362,6 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
         )
         return try Self.makeResponse(
             requestID: arguments.requestID,
-            query: arguments.query,
-            asset: asset,
             rows: rows
         )
     }
@@ -1459,8 +1457,6 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
 
     private static func makeResponse(
         requestID: JSONRPC.ID,
-        query: String,
-        asset: DocumentationSearchInstalledAsset,
         rows: [DocumentationAssetSearchRow]
     ) throws -> Data {
         let documents = rows.map { row -> JSONValue in
@@ -1468,36 +1464,18 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
             let content = row.content ?? ""
             var document: [String: JSONValue] = [
                 "title": .string(row.title ?? ""),
-                "type": .string(type),
                 "kind": .string(type),
-                "content": .string(content),
                 "contents": .string(content),
             ]
             if let assetID = row.assetID {
-                document["identifier"] = .string(assetID)
                 document["uri"] = .string(assetID)
-                document["url"] = .string("https://developer.apple.com\(assetID)")
-            }
-            if let framework = row.framework, framework.isEmpty == false {
-                document["framework"] = .string(framework)
             }
             if let score = row.score {
                 document["score"] = .number(.double(score))
             }
             return .object(document)
         }
-        var assetPayload: [String: JSONValue] = [
-            "path": .string(asset.assetURL.path),
-            "xcodeVersion": .string(asset.xcodeVersion),
-            "osVersion": .string(asset.osVersion),
-        ]
-        if let documentationRelease = asset.documentationRelease {
-            assetPayload["documentationRelease"] = .number(.int(Int64(documentationRelease)))
-        }
         let structuredContent = JSONValue.object([
-            "query": .string(query),
-            "source": .string("installed-documentation-asset"),
-            "asset": .object(assetPayload),
             "documents": .array(documents),
         ])
         let payloadData = try JSONSerialization.data(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -2393,7 +2393,6 @@ actor DocumentationProviderManager: DocumentationProviderManaging {
                         "xcode_version": .string(target.xcodeVersion),
                     ]
                 )
-                permanentlyUnusableProcessIDs.insert(target.processID)
                 await discardPreparedProvider(profile)
                 continue
             } catch is CancellationError {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/DocumentationProvider.swift
@@ -1515,9 +1515,6 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
     }
 
     private static func maxSemanticSearchLimit(for arguments: SearchArguments) -> Int {
-        guard arguments.frameworks.contains(where: { $0.isEmpty == false }) else {
-            return initialSemanticSearchLimit(for: arguments)
-        }
         return min(max(arguments.limit * 128, 1_000), 2_000)
     }
 
@@ -1528,8 +1525,7 @@ struct LiveDocumentationAssetSearchProvider: DocumentationSearchProviding {
         semanticLimit: Int,
         maxSemanticLimit: Int
     ) -> Bool {
-        arguments.frameworks.contains(where: { $0.isEmpty == false })
-            && rows.count < arguments.limit
+        rows.count < arguments.limit
             && rankedResultCount >= semanticLimit
             && semanticLimit < maxSemanticLimit
     }

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -295,13 +295,83 @@ struct DocumentationProviderTests {
         #expect(invalidatedProvider == false)
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
         #expect(await factory.startedPIDs().isEmpty)
-        #expect(await localProvider.requestedDescriptorPIDs() == [target.processID])
-        #expect(await localProvider.requestedCallPIDs() == [target.processID])
+        #expect(await localProvider.requestedDescriptorPIDs() == [0])
+        #expect(await localProvider.requestedCallPIDs() == [0])
         #expect(await localProvider.requestedQueries() == ["SwiftUI"])
 
         let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
         let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
         #expect(documentationDescriptorDescription(in: result) == "docs-asset-primary")
+    }
+
+    @Test func documentationProviderUsesPrimaryInstalledAssetWithoutRunningXcodeWhenConfigured()
+        async throws
+    {
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-primary"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 119,
+                text: "{\"answer\":\"asset\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: []),
+            sessionFactory: ScriptedDocumentationSessionFactory(plansByPID: [:]),
+            localSearchProvider: localProvider,
+            preferLocalSearchProvider: true
+        )
+
+        let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+        #expect(documentationDescriptorDescription(in: result) == "docs-asset-primary")
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 119, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
+        #expect(await localProvider.requestedDescriptorPIDs() == [0, 0])
+        #expect(await localProvider.requestedCallPIDs() == [0])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI"])
+    }
+
+    @Test func documentationProviderGivesPrimaryInstalledAssetFullCallerTimeout()
+        async throws
+    {
+        let xcode26 = xcodeProcessTarget(processID: 126, xcodeVersion: "26.6")
+        let xcode27 = xcodeProcessTarget(processID: 127, xcodeVersion: "27.0")
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-primary"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 127,
+                text: "{\"answer\":\"asset\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [xcode26, xcode27]),
+            sessionFactory: ScriptedDocumentationSessionFactory(plansByPID: [:]),
+            localSearchProvider: localProvider,
+            preferLocalSearchProvider: true
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 127, query: "Observation"),
+            requestTimeoutOverride: .seconds(5)
+        )
+
+        guard case .handled(let responseData, _) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset\"}")
+        let timeout = try #require(await localProvider.requestedCallTimeouts().first)
+        #expect((timeout?.nanoseconds ?? 0) > 4_000_000_000)
     }
 
     @Test func documentationProviderFallsBackToMCPBridgeWhenPrimaryAssetSearchFails()
@@ -346,8 +416,8 @@ struct DocumentationProviderTests {
         }
         #expect(invalidatedProvider == false)
         #expect(try toolContentText(in: responseData) == "{\"answer\":\"xcode\"}")
-        #expect(await localProvider.requestedDescriptorPIDs() == [target.processID])
-        #expect(await localProvider.requestedCallPIDs() == [target.processID])
+        #expect(await localProvider.requestedDescriptorPIDs() == [0])
+        #expect(await localProvider.requestedCallPIDs() == [0])
         #expect(await localProvider.requestedQueries() == ["SwiftUI"])
         #expect(await factory.startedPIDs() == [target.processID])
         #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
@@ -3535,6 +3605,69 @@ struct DocumentationProviderTests {
         let documents = try #require(payload["documents"] as? [[String: Any]])
         #expect(documents.first?["title"] as? String == "UIView")
         #expect(await recorder.recordedValues() == [40, 80])
+    }
+
+    @Test func liveDocumentationAssetSearchProviderPreservesSemanticRankOrder()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        try addInstalledDocumentationAssetRows(
+            root: root,
+            name: "xcode-26-5",
+            rows: [
+                (
+                    vectorID: 2,
+                    assetID: "/documentation/UIKit/ZZLabel",
+                    type: "symbol",
+                    framework: "UIKit",
+                    title: "ZZLabel",
+                    content: "ZZLabel\nRelated UIKit label"
+                ),
+                (
+                    vectorID: 1,
+                    assetID: "/documentation/UIKit/UIView",
+                    type: "symbol",
+                    framework: "UIKit",
+                    title: "UIView",
+                    content: "UIView\nClass of UIKit"
+                ),
+            ]
+        )
+        let provider = LiveDocumentationAssetSearchProvider(
+            assetRoot: root,
+            semanticSearcher: StubDocumentationAssetSemanticSearcher(results: [
+                .init(assetID: "/documentation/UIKit/ZZLabel", score: 0.51),
+                .init(assetID: "/documentation/UIKit/UIView", score: 0.99),
+            ])
+        )
+        let target = xcodeProcessTarget(processID: 127, xcodeVersion: "26.6")
+
+        let response = try await provider.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequestWithArguments(
+                id: 127,
+                query: "UIView",
+                limit: 2
+            ),
+            for: target,
+            timeout: .seconds(1)
+        )
+
+        let text = try #require(try toolContentText(in: response))
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
+        )
+        let documents = try #require(payload["documents"] as? [[String: Any]])
+        #expect(documents.map { $0["title"] as? String } == ["ZZLabel", "UIView"])
     }
 
     @Test func liveDocumentationAssetSemanticSearcherEnforcesCallerTimeout()

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -3312,21 +3312,16 @@ struct DocumentationProviderTests {
         let structuredContent = try #require(result["structuredContent"] as? [String: Any])
         #expect(JSONValue(any: structuredContent) == JSONValue(any: payload))
 
-        #expect(payload["source"] as? String == "installed-documentation-asset")
+        #expect(Set(payload.keys) == ["documents"])
         let documents = try #require(payload["documents"] as? [[String: Any]])
         let firstDocument = try #require(documents.first)
         let firstTitle = firstDocument["title"] as? String
         #expect(firstTitle == "UIView")
-        #expect(firstDocument["type"] as? String == "symbol")
+        #expect(Set(firstDocument.keys) == ["contents", "kind", "score", "title", "uri"])
         #expect(firstDocument["kind"] as? String == "symbol")
-        #expect(firstDocument["content"] as? String == "UIView\nClass of UIKit")
         #expect(firstDocument["contents"] as? String == "UIView\nClass of UIKit")
-        #expect(firstDocument["identifier"] as? String == "/documentation/UIKit/UIView")
         #expect(firstDocument["uri"] as? String == "/documentation/UIKit/UIView")
         #expect(firstDocument["score"] as? Double == 0.92)
-        let asset = try #require(payload["asset"] as? [String: Any])
-        #expect(asset["xcodeVersion"] as? String == "26.5")
-        #expect((asset["path"] as? String)?.contains("xcode-26-5.asset") == true)
     }
 
     @Test func liveDocumentationAssetSearchProviderUsesLatestInstalledAsset()
@@ -3382,9 +3377,7 @@ struct DocumentationProviderTests {
         let payload = try #require(
             JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
         )
-        let asset = try #require(payload["asset"] as? [String: Any])
-        #expect(asset["xcodeVersion"] as? String == "27.0")
-        #expect((asset["path"] as? String)?.contains("xcode-27.asset") == true)
+        #expect(Set(payload.keys) == ["documents"])
         let documents = try #require(payload["documents"] as? [[String: Any]])
         #expect(documents.first?["title"] as? String == "TranscriptErrorHandlingPolicy")
     }
@@ -3437,8 +3430,8 @@ struct DocumentationProviderTests {
         let firstPayload = try #require(
             JSONSerialization.jsonObject(with: Data(firstText.utf8), options: []) as? [String: Any]
         )
-        let firstAsset = try #require(firstPayload["asset"] as? [String: Any])
-        #expect(firstAsset["xcodeVersion"] as? String == "26.5")
+        let firstDocuments = try #require(firstPayload["documents"] as? [[String: Any]])
+        #expect(firstDocuments.first?["title"] as? String == "OldAPI")
 
         try makeInstalledDocumentationAsset(
             root: root,
@@ -3475,8 +3468,6 @@ struct DocumentationProviderTests {
         let secondPayload = try #require(
             JSONSerialization.jsonObject(with: Data(secondText.utf8), options: []) as? [String: Any]
         )
-        let secondAsset = try #require(secondPayload["asset"] as? [String: Any])
-        #expect(secondAsset["xcodeVersion"] as? String == "27.0")
         let documents = try #require(secondPayload["documents"] as? [[String: Any]])
         #expect(documents.first?["title"] as? String == "NewAPI")
     }
@@ -3516,7 +3507,7 @@ struct DocumentationProviderTests {
         )
         let documents = try #require(payload["documents"] as? [[String: Any]])
         #expect(documents.isEmpty)
-        #expect(payload["source"] as? String == "installed-documentation-asset")
+        #expect(Set(payload.keys) == ["documents"])
     }
 
     @Test func liveDocumentationAssetSearchProviderHonorsSearchTimeout()

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -51,6 +51,66 @@ private struct AssetAwareStubDocumentationAssetSemanticSearcher: DocumentationAs
     }
 }
 
+private actor SearchLimitRecorder {
+    private var values: [Int] = []
+
+    func record(_ value: Int) {
+        values.append(value)
+    }
+
+    func recordedValues() -> [Int] {
+        values
+    }
+}
+
+private struct LimitAwareStubDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearching {
+    let recorder: SearchLimitRecorder
+    let results: @Sendable (Int) -> [DocumentationAssetSemanticSearchResult]
+
+    func isAvailable() -> Bool {
+        true
+    }
+
+    func search(
+        asset _: DocumentationSearchInstalledAsset,
+        query _: String,
+        limit: Int,
+        timeout _: TimeAmount?
+    ) async throws -> [DocumentationAssetSemanticSearchResult] {
+        await recorder.record(limit)
+        return results(limit)
+    }
+}
+
+private func makeDocumentationSearchRequestWithArguments(
+    id: Int64,
+    query: String,
+    frameworks: [String]? = nil,
+    limit: Int? = nil
+) throws -> Data {
+    var arguments: [String: Any] = [
+        "query": query,
+    ]
+    if let frameworks {
+        arguments["frameworks"] = frameworks
+    }
+    if let limit {
+        arguments["limit"] = limit
+    }
+    return try JSONSerialization.data(
+        withJSONObject: [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": [
+                "name": DocumentationProvider.ToolCatalog.toolName,
+                "arguments": arguments,
+            ],
+        ],
+        options: []
+    )
+}
+
 @Suite(.serialized)
 struct DocumentationProviderTests {
     @Test func documentationProviderConnectionCancelsEventReaderOnDeinit() async throws {
@@ -3322,6 +3382,174 @@ struct DocumentationProviderTests {
         #expect(firstDocument["contents"] as? String == "UIView\nClass of UIKit")
         #expect(firstDocument["uri"] as? String == "/documentation/UIKit/UIView")
         #expect(firstDocument["score"] as? Double == 0.92)
+    }
+
+    @Test func liveDocumentationAssetSearchProviderDeduplicatesSemanticAssetIDs()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        try addInstalledDocumentationAssetRows(
+            root: root,
+            name: "xcode-26-5",
+            rows: [
+                (
+                    vectorID: 1,
+                    assetID: "/documentation/UIKit/UIView",
+                    type: "symbol",
+                    framework: "UIKit",
+                    title: "UIView",
+                    content: "UIView\nClass of UIKit"
+                ),
+                (
+                    vectorID: 2,
+                    assetID: "/documentation/UIKit/UILabel",
+                    type: "symbol",
+                    framework: "UIKit",
+                    title: "UILabel",
+                    content: "UILabel\nClass of UIKit"
+                ),
+            ]
+        )
+        let provider = LiveDocumentationAssetSearchProvider(
+            assetRoot: root,
+            semanticSearcher: StubDocumentationAssetSemanticSearcher(results: [
+                .init(assetID: "/documentation/UIKit/UIView", score: 0.92),
+                .init(assetID: "/documentation/UIKit/UIView", score: 0.81),
+                .init(assetID: "/documentation/UIKit/UILabel", score: 0.72),
+            ])
+        )
+        let target = xcodeProcessTarget(processID: 124, xcodeVersion: "26.6")
+
+        let response = try await provider.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequestWithArguments(
+                id: 124,
+                query: "UIKit views",
+                limit: 2
+            ),
+            for: target,
+            timeout: .seconds(1)
+        )
+
+        let text = try #require(try toolContentText(in: response))
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
+        )
+        let documents = try #require(payload["documents"] as? [[String: Any]])
+        #expect(documents.map { $0["title"] as? String } == ["UIView", "UILabel"])
+    }
+
+    @Test func liveDocumentationAssetSearchProviderExpandsSemanticSearchForFrameworkFilters()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        let swiftRows: [(
+            vectorID: Int64,
+            assetID: String,
+            type: String,
+            framework: String?,
+            title: String,
+            content: String
+        )] = (0..<40).map { index in
+            (
+                vectorID: Int64(index + 1),
+                assetID: "/documentation/Swift/Only\(index)",
+                type: "symbol",
+                framework: "Swift",
+                title: "SwiftOnly\(index)",
+                content: "SwiftOnly\(index)"
+            )
+        }
+        try addInstalledDocumentationAssetRows(
+            root: root,
+            name: "xcode-26-5",
+            rows: swiftRows + [
+                (
+                    vectorID: 41,
+                    assetID: "/documentation/UIKit/UIView",
+                    type: "symbol",
+                    framework: "UIKit",
+                    title: "UIView",
+                    content: "UIView\nClass of UIKit"
+                ),
+            ]
+        )
+        let recorder = SearchLimitRecorder()
+        let provider = LiveDocumentationAssetSearchProvider(
+            assetRoot: root,
+            semanticSearcher: LimitAwareStubDocumentationAssetSemanticSearcher(
+                recorder: recorder,
+                results: { limit in
+                    var results = (0..<min(limit, 40)).map { index in
+                        DocumentationAssetSemanticSearchResult(
+                            assetID: "/documentation/Swift/Only\(index)",
+                            score: 1.0 - (Double(index) * 0.001)
+                        )
+                    }
+                    if limit > 40 {
+                        results.append(.init(
+                            assetID: "/documentation/UIKit/UIView",
+                            score: 0.5
+                        ))
+                    }
+                    return results
+                }
+            )
+        )
+        let target = xcodeProcessTarget(processID: 126, xcodeVersion: "26.6")
+
+        let response = try await provider.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequestWithArguments(
+                id: 126,
+                query: "UIView",
+                frameworks: ["UIKit"],
+                limit: 1
+            ),
+            for: target,
+            timeout: .seconds(1)
+        )
+
+        let text = try #require(try toolContentText(in: response))
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
+        )
+        let documents = try #require(payload["documents"] as? [[String: Any]])
+        #expect(documents.first?["title"] as? String == "UIView")
+        #expect(await recorder.recordedValues() == [40, 80])
+    }
+
+    @Test func liveDocumentationAssetSemanticSearcherEnforcesCallerTimeout()
+        async throws
+    {
+        let startedAt = Date()
+        await #expect(throws: TimeoutError.self) {
+            try await LiveDocumentationAssetSemanticSearcher.runBlockingSearch(
+                timeout: .milliseconds(10)
+            ) {
+                Thread.sleep(forTimeInterval: 0.2)
+                return [DocumentationAssetSemanticSearchResult]()
+            }
+        }
+        #expect(Date().timeIntervalSince(startedAt) < 0.15)
     }
 
     @Test func liveDocumentationAssetSearchProviderUsesLatestInstalledAsset()

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -3305,6 +3305,13 @@ struct DocumentationProviderTests {
         let payload = try #require(
             JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
         )
+        let responseObject = try #require(
+            JSONSerialization.jsonObject(with: response, options: []) as? [String: Any]
+        )
+        let result = try #require(responseObject["result"] as? [String: Any])
+        let structuredContent = try #require(result["structuredContent"] as? [String: Any])
+        #expect(JSONValue(any: structuredContent) == JSONValue(any: payload))
+
         #expect(payload["source"] as? String == "installed-documentation-asset")
         let documents = try #require(payload["documents"] as? [[String: Any]])
         let firstDocument = try #require(documents.first)

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -8,6 +8,49 @@ import XcodeMCPKit
 import XcodeMCPProxyTestSupport
 @testable import XcodeMCPProxyInternalTestSupport
 
+private struct StubDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearching {
+    let available: Bool
+    let results: [DocumentationAssetSemanticSearchResult]
+
+    init(
+        available: Bool = true,
+        results: [DocumentationAssetSemanticSearchResult]
+    ) {
+        self.available = available
+        self.results = results
+    }
+
+    func isAvailable() -> Bool {
+        available
+    }
+
+    func search(
+        asset _: DocumentationSearchInstalledAsset,
+        query _: String,
+        limit _: Int,
+        timeout _: TimeAmount?
+    ) async throws -> [DocumentationAssetSemanticSearchResult] {
+        results
+    }
+}
+
+private struct AssetAwareStubDocumentationAssetSemanticSearcher: DocumentationAssetSemanticSearching {
+    let results: @Sendable (DocumentationSearchInstalledAsset) -> [DocumentationAssetSemanticSearchResult]
+
+    func isAvailable() -> Bool {
+        true
+    }
+
+    func search(
+        asset: DocumentationSearchInstalledAsset,
+        query _: String,
+        limit _: Int,
+        timeout _: TimeAmount?
+    ) async throws -> [DocumentationAssetSemanticSearchResult] {
+        results(asset)
+    }
+}
+
 @Suite(.serialized)
 struct DocumentationProviderTests {
     @Test func documentationProviderConnectionCancelsEventReaderOnDeinit() async throws {
@@ -199,6 +242,55 @@ struct DocumentationProviderTests {
         let update = await manager.toolListUpdate(requestTimeout: .seconds(1))
         let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
         #expect(documentationDescriptorDescription(in: result) == "docs-asset-primary")
+    }
+
+    @Test func documentationProviderFallsBackToMCPBridgeWhenPrimaryAssetSearchFails()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 118, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"xcode\"}")
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-primary"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 118,
+                text: "{\"answer\":\"asset\"}"
+            ),
+            failsCalls: true
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider,
+            preferLocalSearchProvider: true
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 118, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider == false)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"xcode\"}")
+        #expect(await localProvider.requestedDescriptorPIDs() == [target.processID])
+        #expect(await localProvider.requestedCallPIDs() == [target.processID])
+        #expect(await localProvider.requestedQueries() == ["SwiftUI"])
+        #expect(await factory.startedPIDs() == [target.processID])
+        #expect(await factory.documentationQueries(for: target.processID) == ["SwiftUI"])
     }
 
     @Test func xcodeVersionKeyDistinguishesDeveloperDirAndMCPBridgePath() {
@@ -1498,6 +1590,62 @@ struct DocumentationProviderTests {
         #expect(await localProvider.requestedQueries() == ["SwiftData"])
     }
 
+    @Test func documentationProviderUsesNewestAssetFallbackBeforeOlderCandidateWhenTransportThrows()
+        async throws
+    {
+        let older = xcodeProcessTarget(processID: 760, xcodeVersion: "26.6")
+        let newest = xcodeProcessTarget(processID: 761, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                older.processID: [
+                    .init(
+                        serverVersion: "26.6",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"older\"}")
+                    ),
+                ],
+                newest.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .exit
+                    ),
+                ],
+            ]
+        )
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-newest"),
+            responseData: try makeDocumentationSearchResponse(
+                id: 98,
+                text: "{\"answer\":\"asset-newest\"}"
+            )
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [older, newest]),
+            sessionFactory: factory,
+            localSearchProvider: localProvider
+        )
+
+        let outcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 98, query: "ModelActor"),
+            requestTimeoutOverride: .seconds(1)
+        )
+
+        guard case .handled(let responseData, let invalidatedProvider) = outcome else {
+            Issue.record("expected handled outcome, got \(outcome)")
+            return
+        }
+        #expect(invalidatedProvider)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"asset-newest\"}")
+        #expect(await factory.startedPIDs() == [newest.processID])
+        #expect(await factory.documentationQueries(for: newest.processID) == ["ModelActor"])
+        #expect(await factory.documentationQueries(for: older.processID).isEmpty)
+        #expect(await localProvider.requestedCallPIDs() == [newest.processID])
+        #expect(await localProvider.requestedQueries() == ["ModelActor"])
+    }
+
     @Test func documentationProviderUsesNewestAssetFallbackBeforeOlderCandidateWhenDescriptorMissing()
         async throws
     {
@@ -2589,9 +2737,9 @@ struct DocumentationProviderTests {
         #expect(await repairer.repairedPIDs() == [target.processID])
         #expect(await factory.startedPIDs() == [target.processID, target.processID])
         try await waitWithTimeout("waiting for rejected documentation provider stop") {
-            try await factory.waitForStopCount(1)
+            try await factory.waitForStopCount(2)
         }
-        #expect(await factory.stoppedPIDs() == [target.processID])
+        #expect(await factory.stoppedPIDs() == [target.processID, target.processID])
         #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
         #expect(await factory.documentationQueries(for: target.processID).isEmpty)
@@ -3123,16 +3271,25 @@ struct DocumentationProviderTests {
             osVersion: "26.2",
             documentationRelease: 900339
         )
-        let runner = StubProcessRunner(output: ProcessOutput(
-            terminationStatus: 0,
-            stdout: """
-                [{"asset_id":"/documentation/UIKit/UIView","type":"symbol","framework":"UIKit","title":"UIView","content":"UIView\\nClass of UIKit"}]
-                """,
-            stderr: ""
-        ))
+        try addInstalledDocumentationAssetRows(
+            root: root,
+            name: "xcode-26-5",
+            rows: [
+                (
+                    vectorID: 1,
+                    assetID: "/documentation/UIKit/UIView",
+                    type: "symbol",
+                    framework: "UIKit",
+                    title: "UIView",
+                    content: "UIView\nClass of UIKit"
+                ),
+            ]
+        )
         let provider = LiveDocumentationAssetSearchProvider(
             assetRoot: root,
-            processRunner: runner
+            semanticSearcher: StubDocumentationAssetSemanticSearcher(results: [
+                .init(assetID: "/documentation/UIKit/UIView", score: 0.92),
+            ])
         )
         let target = xcodeProcessTarget(processID: 123, xcodeVersion: "26.6")
 
@@ -3159,13 +3316,10 @@ struct DocumentationProviderTests {
         #expect(firstDocument["contents"] as? String == "UIView\nClass of UIKit")
         #expect(firstDocument["identifier"] as? String == "/documentation/UIKit/UIView")
         #expect(firstDocument["uri"] as? String == "/documentation/UIKit/UIView")
-        let requests = await runner.recordedRequests()
-        #expect(requests.count == 1)
-        #expect(requests.first?.arguments.prefix(2) == ["-readonly", "-json"])
-        #expect(requests.first?.arguments.joined(separator: " ").contains(
-            "xcode-26-5.asset/AssetData/documentation-db/index.sql"
-        ) == true)
-        #expect(requests.first?.arguments.joined(separator: " ").contains("lower(asset_id)") == true)
+        #expect(firstDocument["score"] as? Double == 0.92)
+        let asset = try #require(payload["asset"] as? [String: Any])
+        #expect(asset["xcodeVersion"] as? String == "26.5")
+        #expect((asset["path"] as? String)?.contains("xcode-26-5.asset") == true)
     }
 
     @Test func liveDocumentationAssetSearchProviderUsesLatestInstalledAsset()
@@ -3189,28 +3343,135 @@ struct DocumentationProviderTests {
             osVersion: "27.0",
             documentationRelease: 950001
         )
-        let runner = StubProcessRunner(output: ProcessOutput(
-            terminationStatus: 0,
-            stdout: "[]",
-            stderr: ""
-        ))
+        try addInstalledDocumentationAssetRows(
+            root: root,
+            name: "xcode-27",
+            rows: [
+                (
+                    vectorID: 1,
+                    assetID: "/documentation/Swift/TranscriptErrorHandlingPolicy",
+                    type: "symbol",
+                    framework: "Swift",
+                    title: "TranscriptErrorHandlingPolicy",
+                    content: "TranscriptErrorHandlingPolicy"
+                ),
+            ]
+        )
         let provider = LiveDocumentationAssetSearchProvider(
             assetRoot: root,
-            processRunner: runner
+            semanticSearcher: StubDocumentationAssetSemanticSearcher(results: [
+                .init(assetID: "/documentation/Swift/TranscriptErrorHandlingPolicy", score: 0.75),
+            ])
         )
         let target = xcodeProcessTarget(processID: 128, xcodeVersion: "26.6")
 
-        _ = try await provider.callDocumentationSearch(
+        let response = try await provider.callDocumentationSearch(
             requestData: makeDocumentationSearchRequest(id: 128, query: "TranscriptErrorHandlingPolicy"),
             for: target,
             timeout: .seconds(1)
         )
 
-        let requests = await runner.recordedRequests()
-        #expect(requests.count == 1)
-        #expect(requests.first?.arguments.joined(separator: " ").contains(
-            "xcode-27.asset/AssetData/documentation-db/index.sql"
-        ) == true)
+        let text = try #require(try toolContentText(in: response))
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
+        )
+        let asset = try #require(payload["asset"] as? [String: Any])
+        #expect(asset["xcodeVersion"] as? String == "27.0")
+        #expect((asset["path"] as? String)?.contains("xcode-27.asset") == true)
+        let documents = try #require(payload["documents"] as? [[String: Any]])
+        #expect(documents.first?["title"] as? String == "TranscriptErrorHandlingPolicy")
+    }
+
+    @Test func liveDocumentationAssetSearchProviderRefreshesLatestAssetWhenAssetRootChanges()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        try addInstalledDocumentationAssetRows(
+            root: root,
+            name: "xcode-26-5",
+            rows: [
+                (
+                    vectorID: 1,
+                    assetID: "/documentation/Old/API",
+                    type: "symbol",
+                    framework: "OldFramework",
+                    title: "OldAPI",
+                    content: "OldAPI"
+                ),
+            ]
+        )
+        let provider = LiveDocumentationAssetSearchProvider(
+            assetRoot: root,
+            semanticSearcher: AssetAwareStubDocumentationAssetSemanticSearcher { asset in
+                if asset.xcodeVersion == "27.0" {
+                    return [.init(assetID: "/documentation/New/API", score: 0.91)]
+                }
+                return [.init(assetID: "/documentation/Old/API", score: 0.81)]
+            }
+        )
+        let target = xcodeProcessTarget(processID: 132, xcodeVersion: "26.6")
+
+        let firstResponse = try await provider.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 132, query: "API"),
+            for: target,
+            timeout: .seconds(1)
+        )
+        let firstText = try #require(try toolContentText(in: firstResponse))
+        let firstPayload = try #require(
+            JSONSerialization.jsonObject(with: Data(firstText.utf8), options: []) as? [String: Any]
+        )
+        let firstAsset = try #require(firstPayload["asset"] as? [String: Any])
+        #expect(firstAsset["xcodeVersion"] as? String == "26.5")
+
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-27",
+            xcodeVersion: "27.0",
+            osVersion: "27.0",
+            documentationRelease: 950001
+        )
+        try addInstalledDocumentationAssetRows(
+            root: root,
+            name: "xcode-27",
+            rows: [
+                (
+                    vectorID: 1,
+                    assetID: "/documentation/New/API",
+                    type: "symbol",
+                    framework: "NewFramework",
+                    title: "NewAPI",
+                    content: "NewAPI"
+                ),
+            ]
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(10)],
+            ofItemAtPath: root.path
+        )
+
+        let secondResponse = try await provider.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 133, query: "API"),
+            for: target,
+            timeout: .seconds(1)
+        )
+        let secondText = try #require(try toolContentText(in: secondResponse))
+        let secondPayload = try #require(
+            JSONSerialization.jsonObject(with: Data(secondText.utf8), options: []) as? [String: Any]
+        )
+        let secondAsset = try #require(secondPayload["asset"] as? [String: Any])
+        #expect(secondAsset["xcodeVersion"] as? String == "27.0")
+        let documents = try #require(secondPayload["documents"] as? [[String: Any]])
+        #expect(documents.first?["title"] as? String == "NewAPI")
     }
 
     @Test func liveDocumentationAssetSearchProviderTreatsEmptySQLiteOutputAsNoResults()
@@ -3227,14 +3488,11 @@ struct DocumentationProviderTests {
             osVersion: "26.2",
             documentationRelease: 900339
         )
-        let runner = StubProcessRunner(output: ProcessOutput(
-            terminationStatus: 0,
-            stdout: "",
-            stderr: ""
-        ))
         let provider = LiveDocumentationAssetSearchProvider(
             assetRoot: root,
-            processRunner: runner
+            semanticSearcher: StubDocumentationAssetSemanticSearcher(results: [
+                .init(assetID: "/documentation/NoMatch", score: 0.1),
+            ])
         )
         let target = xcodeProcessTarget(processID: 127, xcodeVersion: "26.6")
 
@@ -3268,49 +3526,21 @@ struct DocumentationProviderTests {
             osVersion: "26.2",
             documentationRelease: 900339
         )
-        let runGate = OperationGate<Int>()
-        let (clock, timeoutClock, uptimeClock) = makeRuntimeCoordinatorDeterministicClocks()
-        let runner = StubProcessRunner(
-            output: ProcessOutput(terminationStatus: 0, stdout: "[]", stderr: ""),
-            gate: runGate
-        )
         let provider = LiveDocumentationAssetSearchProvider(
             assetRoot: root,
-            processRunner: runner,
-            clock: clock
+            semanticSearcher: StubDocumentationAssetSemanticSearcher(results: [
+                .init(assetID: "/documentation/UIKit/UIView", score: 0.92),
+            ])
         )
         let target = xcodeProcessTarget(processID: 125, xcodeVersion: "26.6")
 
-        let searchTask = Task {
+        await #expect(throws: TimeoutError.self) {
             try await provider.callDocumentationSearch(
                 requestData: makeDocumentationSearchRequest(id: 125, query: "UIView"),
                 for: target,
-                timeout: .milliseconds(20)
+                timeout: .nanoseconds(0)
             )
         }
-        try await waitWithTimeout("waiting for local DocumentationSearch process to suspend") {
-            try await runGate.waitUntilWaiting(for: 1, count: 1)
-        }
-        try await advanceRuntimeCoordinatorTimeout(
-            timeoutClock: timeoutClock,
-            uptimeClock: uptimeClock,
-            by: .milliseconds(20)
-        )
-        await #expect(throws: TimeoutError.self) {
-            _ = try await waitWithTimeout(
-                "local DocumentationSearch should honor the caller timeout",
-                timeout: .milliseconds(500)
-            ) {
-                try await searchTask.value
-            }
-        }
-        let requests = await runner.recordedRequests()
-        #expect(requests.count == 1)
-        #expect(requests.first?.timeoutNanoseconds == 20_000_000)
-        _ = try await waitWithTimeout("waiting for local search process cancellation") {
-            try await runner.nextCancelledRunCount(at: 0)
-        }
-        #expect(await runner.cancelledRunCount() == 1)
     }
 
     @Test func documentationProviderBackgroundDiscoveryRemovesStaleDescriptorWhenAbsent()

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -3959,6 +3959,55 @@ struct DocumentationProviderTests {
         #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
     }
 
+    @Test func documentationProviderBackgroundDiscoveryRetriesDescriptorMissOnLaterPoll()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 115, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 46,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .success
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let firstUpdate = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let firstResult = DocumentationProvider.ToolCatalog.applying(
+            firstUpdate,
+            to: try jsonValue([
+                "tools": [
+                    documentationDescriptor(version: "stale").foundationObject,
+                ],
+            ])
+        )
+        let secondUpdate = await manager.startBackgroundDiscovery(requestTimeout: .seconds(1))
+        let secondResult = DocumentationProvider.ToolCatalog.applying(
+            secondUpdate,
+            to: try jsonValue(["tools": []])
+        )
+
+        #expect(DocumentationProvider.ToolCatalog.descriptor(in: firstResult) == nil)
+        #expect(documentationDescriptorDescription(in: secondResult) == "docs-27.0")
+        #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/call") == 0)
+    }
+
     @Test func documentationSearchDoesNotCallCandidateWhileDescriptorFetchIsHanging() async throws {
         let target = xcodeProcessTarget(processID: 114, xcodeVersion: "27.0")
         let clocks = makeRuntimeCoordinatorDeterministicClocks()

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -3628,6 +3628,85 @@ struct DocumentationProviderTests {
         #expect(await recorder.recordedValues() == [40, 80])
     }
 
+    @Test func liveDocumentationAssetSearchProviderExpandsWhenDuplicatesShrinkUnfilteredResults()
+        async throws
+    {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xcode-doc-assets-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try makeInstalledDocumentationAsset(
+            root: root,
+            name: "xcode-26-5",
+            xcodeVersion: "26.5",
+            osVersion: "26.2",
+            documentationRelease: 900339
+        )
+        try addInstalledDocumentationAssetRows(
+            root: root,
+            name: "xcode-26-5",
+            rows: [
+                (
+                    vectorID: 1,
+                    assetID: "/documentation/UIKit/UIView",
+                    type: "symbol",
+                    framework: "UIKit",
+                    title: "UIView",
+                    content: "UIView\nClass of UIKit"
+                ),
+                (
+                    vectorID: 41,
+                    assetID: "/documentation/UIKit/UILabel",
+                    type: "symbol",
+                    framework: "UIKit",
+                    title: "UILabel",
+                    content: "UILabel\nClass of UIKit"
+                ),
+            ]
+        )
+        let recorder = SearchLimitRecorder()
+        let provider = LiveDocumentationAssetSearchProvider(
+            assetRoot: root,
+            semanticSearcher: LimitAwareStubDocumentationAssetSemanticSearcher(
+                recorder: recorder,
+                results: { limit in
+                    var results = (0..<min(limit, 40)).map { index in
+                        DocumentationAssetSemanticSearchResult(
+                            assetID: "/documentation/UIKit/UIView",
+                            score: 1.0 - (Double(index) * 0.001)
+                        )
+                    }
+                    if limit > 40 {
+                        results.append(.init(
+                            assetID: "/documentation/UIKit/UILabel",
+                            score: 0.5
+                        ))
+                    }
+                    return results
+                }
+            )
+        )
+        let target = xcodeProcessTarget(processID: 129, xcodeVersion: "26.6")
+
+        let response = try await provider.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequestWithArguments(
+                id: 129,
+                query: "UIKit views",
+                limit: 2
+            ),
+            for: target,
+            timeout: .seconds(1)
+        )
+
+        let text = try #require(try toolContentText(in: response))
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(text.utf8), options: []) as? [String: Any]
+        )
+        let documents = try #require(payload["documents"] as? [[String: Any]])
+        #expect(documents.map { $0["title"] as? String } == ["UIView", "UILabel"])
+        #expect(await recorder.recordedValues() == [40, 80])
+    }
+
     @Test func liveDocumentationAssetSearchProviderPreservesSemanticRankOrder()
         async throws
     {

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -341,6 +341,27 @@ struct DocumentationProviderTests {
         #expect(await localProvider.requestedQueries() == ["SwiftUI"])
     }
 
+    @Test func documentationProviderBackgroundDiscoveryUsesPrimaryInstalledAssetWithoutRunningXcodeWhenConfigured()
+        async throws
+    {
+        let localProvider = StubDocumentationSearchProvider(
+            descriptor: documentationDescriptor(version: "asset-primary"),
+            responseData: Data()
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: []),
+            sessionFactory: ScriptedDocumentationSessionFactory(plansByPID: [:]),
+            localSearchProvider: localProvider,
+            preferLocalSearchProvider: true
+        )
+
+        let update = await manager.startBackgroundDiscovery(requestTimeout: TimeAmount.seconds(1))
+        let result = DocumentationProvider.ToolCatalog.applying(update, to: try jsonValue(["tools": []]))
+
+        #expect(documentationDescriptorDescription(in: result) == "docs-asset-primary")
+        #expect(await localProvider.requestedDescriptorPIDs() == [0])
+    }
+
     @Test func documentationProviderGivesPrimaryInstalledAssetFullCallerTimeout()
         async throws
     {

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -4481,6 +4481,56 @@ struct DocumentationProviderTests {
         #expect(await factory.documentationQueries(for: xcode26.processID) == ["SwiftUI"])
     }
 
+    @Test func documentationProviderManagerRetriesDescriptorMissOnLaterCall() async throws {
+        let target = xcodeProcessTarget(processID: 612, xcodeVersion: "27.0")
+        let factory = ScriptedDocumentationSessionFactory(
+            plansByPID: [
+                target.processID: [
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 46,
+                        includesDocumentationSearch: false,
+                        firstDocumentationResponse: .success
+                    ),
+                    .init(
+                        serverVersion: "27.0",
+                        toolCount: 47,
+                        includesDocumentationSearch: true,
+                        firstDocumentationResponse: .successText("{\"answer\":\"recovered\"}")
+                    ),
+                ],
+            ]
+        )
+        let manager = DocumentationProviderManager(
+            discovery: StubXcodeTargetDiscovery(targets: [target]),
+            sessionFactory: factory
+        )
+
+        let firstOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 85, query: "SwiftUI"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .unavailable(let reason) = firstOutcome else {
+            Issue.record("expected unavailable outcome, got \(firstOutcome)")
+            return
+        }
+
+        let secondOutcome = try await manager.callDocumentationSearch(
+            requestData: makeDocumentationSearchRequest(id: 86, query: "Observation"),
+            requestTimeoutOverride: .seconds(1)
+        )
+        guard case .handled(let responseData, _) = secondOutcome else {
+            Issue.record("expected handled outcome, got \(secondOutcome)")
+            return
+        }
+
+        #expect(reason.message == DocumentationProvider.UnavailableReason.userFacingMessage)
+        #expect(try toolContentText(in: responseData) == "{\"answer\":\"recovered\"}")
+        #expect(await factory.startedPIDs() == [target.processID, target.processID])
+        #expect(await factory.requestCount(processID: target.processID, method: "tools/list") == 2)
+        #expect(await factory.documentationQueries(for: target.processID) == ["Observation"])
+    }
+
     @Test func documentationProviderManagerRetriesActualRequestWhenNewestIsNotEnabled() async throws {
         let xcode26 = xcodeProcessTarget(processID: 420, xcodeVersion: "26.6")
         let xcode27 = xcodeProcessTarget(processID: 421, xcodeVersion: "27.0")

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -695,6 +695,7 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
     private let timeoutOnceAfterSuccessfulCallCount: Int?
     private var descriptorPIDs: [pid_t] = []
     private var callPIDs: [pid_t] = []
+    private var callTimeoutValues: [TimeAmount?] = []
     private var queries: [String] = []
     private var successfulCallCount = 0
     private var didThrowTimeout = false
@@ -721,9 +722,10 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
     func callDocumentationSearch(
         requestData: Data,
         for target: XcodeProcessTarget,
-        timeout _: TimeAmount?
+        timeout: TimeAmount?
     ) async throws -> Data {
         callPIDs.append(target.processID)
+        callTimeoutValues.append(timeout)
         if let query = try documentationSearchQuery(in: requestData) {
             queries.append(query)
         }
@@ -752,6 +754,10 @@ actor StubDocumentationSearchProvider: DocumentationSearchProviding {
 
     func requestedCallPIDs() -> [pid_t] {
         callPIDs
+    }
+
+    func requestedCallTimeouts() -> [TimeAmount?] {
+        callTimeoutValues
     }
 
     func requestedQueries() -> [String] {

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -3,6 +3,7 @@ import Foundation
 import NIO
 import NIOConcurrencyHelpers
 import NIOEmbedded
+import SQLite3
 import Testing
 import XcodeMCPKit
 @testable import XcodeMCPProxyKit
@@ -218,9 +219,153 @@ func makeInstalledDocumentationAsset(
     try Data("{}".utf8).write(
         to: assetDataURL.appendingPathComponent("config.json", isDirectory: false)
     )
-    try Data("-- sqlite index placeholder".utf8).write(
-        to: databaseURL.appendingPathComponent("index.sql", isDirectory: false)
+    try createInstalledDocumentationIndex(
+        at: databaseURL.appendingPathComponent("index.sql", isDirectory: false)
     )
+}
+
+func addInstalledDocumentationAssetRows(
+    root: URL,
+    name: String,
+    rows: [(
+        vectorID: Int64,
+        assetID: String,
+        type: String,
+        framework: String?,
+        title: String,
+        content: String
+    )]
+) throws {
+    let indexURL = root
+        .appendingPathComponent("\(name).asset", isDirectory: true)
+        .appendingPathComponent("AssetData", isDirectory: true)
+        .appendingPathComponent("documentation-db", isDirectory: true)
+        .appendingPathComponent("index.sql", isDirectory: false)
+    try withDocumentationIndexDatabase(at: indexURL) { database in
+        let insert = try prepareStatement(
+            database,
+            """
+            INSERT INTO attributes(vector_id, asset_id, type, framework, title, content)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            """
+        )
+        defer { sqlite3_finalize(insert) }
+        for row in rows {
+            sqlite3_reset(insert)
+            sqlite3_clear_bindings(insert)
+            sqlite3_bind_int64(insert, 1, row.vectorID)
+            try bind(row.assetID, to: insert, index: 2, database: database)
+            try bind(row.type, to: insert, index: 3, database: database)
+            if let framework = row.framework {
+                try bind(framework, to: insert, index: 4, database: database)
+            } else {
+                sqlite3_bind_null(insert, 4)
+            }
+            try bind(row.title, to: insert, index: 5, database: database)
+            try bind(row.content, to: insert, index: 6, database: database)
+            guard sqlite3_step(insert) == SQLITE_DONE else {
+                throw sqliteError(database, message: "insert documentation asset row failed")
+            }
+        }
+    }
+}
+
+private func createInstalledDocumentationIndex(at url: URL) throws {
+    try withDocumentationIndexDatabase(at: url) { database in
+        try executeSQL(
+            database,
+            """
+            CREATE TABLE attributes(
+                vector_id INTEGER NOT NULL,
+                asset_id TEXT NOT NULL,
+                type TEXT,
+                framework TEXT,
+                title TEXT,
+                content TEXT
+            );
+            CREATE INDEX attributes_asset_id_index ON attributes(asset_id);
+            """
+        )
+    }
+}
+
+private func withDocumentationIndexDatabase(
+    at url: URL,
+    _ body: (OpaquePointer?) throws -> Void
+) throws {
+    var database: OpaquePointer?
+    guard sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nil) == SQLITE_OK else {
+        let message = database.map { sqliteErrorMessage($0) } ?? "unknown sqlite error"
+        if let database {
+            sqlite3_close_v2(database)
+        }
+        throw NSError(
+            domain: "XcodeMCPKitTests.SQLite",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+    defer {
+        sqlite3_close_v2(database)
+    }
+    try body(database)
+}
+
+private func executeSQL(_ database: OpaquePointer?, _ sql: String) throws {
+    var errorMessage: UnsafeMutablePointer<CChar>?
+    defer {
+        if let errorMessage {
+            sqlite3_free(errorMessage)
+        }
+    }
+    guard sqlite3_exec(database, sql, nil, nil, &errorMessage) == SQLITE_OK else {
+        throw NSError(
+            domain: "XcodeMCPKitTests.SQLite",
+            code: 2,
+            userInfo: [
+                NSLocalizedDescriptionKey: errorMessage.map { String(cString: $0) }
+                    ?? sqliteErrorMessage(database),
+            ]
+        )
+    }
+}
+
+private func prepareStatement(_ database: OpaquePointer?, _ sql: String) throws -> OpaquePointer? {
+    var statement: OpaquePointer?
+    guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
+        throw sqliteError(database, message: "prepare failed")
+    }
+    return statement
+}
+
+private func bind(
+    _ value: String,
+    to statement: OpaquePointer?,
+    index: Int32,
+    database: OpaquePointer?
+) throws {
+    let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    let result = value.withCString { valuePointer in
+        sqlite3_bind_text(statement, index, valuePointer, -1, transient)
+    }
+    guard result == SQLITE_OK else {
+        throw sqliteError(database, message: "bind failed")
+    }
+}
+
+private func sqliteError(_ database: OpaquePointer?, message: String) -> NSError {
+    NSError(
+        domain: "XcodeMCPKitTests.SQLite",
+        code: Int(sqlite3_errcode(database)),
+        userInfo: [NSLocalizedDescriptionKey: "\(message): \(sqliteErrorMessage(database))"]
+    )
+}
+
+private func sqliteErrorMessage(_ database: OpaquePointer?) -> String {
+    guard let database, let message = sqlite3_errmsg(database) else {
+        return "unknown sqlite error"
+    }
+    return String(cString: message)
 }
 
 func makeDocumentationSearchRequest(id: Int64, query: String) throws -> Data {


### PR DESCRIPTION
## Purpose
- Make DocumentationSearch independent from mcpbridge/Xcode process stale documentation asset state.

## Changes
- Add a private documentation search bridge using MediaAnalysisServices and VectorSearch to query installed documentation assets directly.
- Prefer the latest installed Apple Developer Documentation asset as the primary DocumentationSearch provider, with mcpbridge kept as fallback.
- Replace sqlite3 CLI lookups with cached read-only SQLite connections and add fixture coverage for asset refresh and fallback behavior.

## Testing
- scripts/check.sh
- Live private search probe returned /documentation/Observation/withContinuousObservation(options:apply:) as the top result.
