### PR TITLE
Reconcile Xcode process routes dynamically

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/HTTPGateway/HTTP/HTTPControlService.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/HTTPGateway/HTTP/HTTPControlService.swift
@@ -10,6 +10,7 @@ final class HTTPControlService: Sendable {
         let warmupInFlight: Bool
         let controlPlane: ControlPlane.DebugSnapshot?
         let upstreams: [ProxyDebug.UpstreamSnapshot]
+        let processRoutes: [ProxyDebug.ProcessRouteSnapshot]
         let processToolCatalogs: [ProcessToolCatalogRegistry.DebugSnapshot]
         let recentTraffic: [ProxyDebug.TrafficEvent]
         let sessions: [SessionRequestPipeline.DebugSnapshot]
@@ -27,6 +28,7 @@ final class HTTPControlService: Sendable {
             self.warmupInFlight = base.warmupInFlight
             self.controlPlane = base.controlPlane
             self.upstreams = base.upstreams
+            self.processRoutes = base.processRoutes
             self.processToolCatalogs = base.processToolCatalogs
             self.recentTraffic = base.recentTraffic
             self.sessions = base.sessions

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Bridge/UpstreamHealthManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Bridge/UpstreamHealthManager.swift
@@ -142,6 +142,13 @@ final class UpstreamHealthManager: Sendable {
         ))
     }
 
+    func appendUpstreams(count: Int) {
+        guard count > 0 else { return }
+        state.withLockedValue { state in
+            state.upstreamStates.append(contentsOf: Array(repeating: UpstreamState(), count: count))
+        }
+    }
+
     func statesSnapshot() -> [UpstreamState] {
         state.withLockedValue { $0.upstreamStates }
     }

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
@@ -32,9 +32,7 @@ enum MCPBridgeRuntime {
         xcodeTargets: [XcodeProcessTarget]
     ) -> MCPBridgeUpstreamPlan {
         let orderedXcodeTargets = orderedXcodeTargets(xcodeTargets)
-        let canUseProcessBoundXcodeUpstreams =
-            orderedXcodeTargets.isEmpty == false
-            && supportsProcessBoundRouting(config: config)
+        let canUseProcessBoundXcodeUpstreams = supportsProcessBoundRouting(config: config)
         var upstreams: [ManagedUpstreamSlot] = []
         var xcodeProcessBindings: [XcodeProcessBinding] = []
         let upstreamCount = config.upstreamProcessCount
@@ -84,6 +82,22 @@ enum MCPBridgeRuntime {
             xcodeProcessRoutes: topology.xcodeProcessRoutes(),
             topology: topology
         )
+    }
+
+    static func makeProcessBoundUpstreamSlots(
+        config: Configuration,
+        xcodeTarget: XcodeProcessTarget
+    ) -> [ManagedUpstreamSlot] {
+        (0..<config.upstreamProcessCount).map { _ in
+            ManagedUpstreamSlot(
+                factory: UpstreamProcess(
+                    configuration: makeDefaultUpstreamConfig(
+                        config: config,
+                        xcodeTarget: xcodeTarget
+                    )
+                )
+            )
+        }
     }
 
     static func supportsProcessBoundRouting(config: Configuration) -> Bool {
@@ -156,7 +170,7 @@ enum MCPBridgeRuntime {
         return max(minimum, multiplied.partialValue)
     }
 
-    private static func orderedXcodeTargets(
+    static func orderedXcodeTargets(
         _ targets: [XcodeProcessTarget]
     ) -> [XcodeProcessTarget] {
         targets.sorted { lhs, rhs in

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
@@ -34,7 +34,8 @@ enum MCPBridgeRuntime {
     ) -> MCPBridgeUpstreamPlan {
         let orderedXcodeTargets = orderedXcodeTargets(xcodeTargets)
         let canUseProcessBoundXcodeUpstreams =
-            processBoundRoutingEnabled ?? supportsProcessBoundRouting(config: config)
+            processBoundRoutingEnabled
+            ?? (supportsProcessBoundRouting(config: config) && orderedXcodeTargets.isEmpty == false)
         var upstreams: [ManagedUpstreamSlot] = []
         var xcodeProcessBindings: [XcodeProcessBinding] = []
         let upstreamCount = config.upstreamProcessCount

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
@@ -29,10 +29,12 @@ enum MCPBridgeRuntime {
 
     static func makeUpstreamPlan(
         config: Configuration,
-        xcodeTargets: [XcodeProcessTarget]
+        xcodeTargets: [XcodeProcessTarget],
+        processBoundRoutingEnabled: Bool? = nil
     ) -> MCPBridgeUpstreamPlan {
         let orderedXcodeTargets = orderedXcodeTargets(xcodeTargets)
-        let canUseProcessBoundXcodeUpstreams = supportsProcessBoundRouting(config: config)
+        let canUseProcessBoundXcodeUpstreams =
+            processBoundRoutingEnabled ?? supportsProcessBoundRouting(config: config)
         var upstreams: [ManagedUpstreamSlot] = []
         var xcodeProcessBindings: [XcodeProcessBinding] = []
         let upstreamCount = config.upstreamProcessCount

--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Broker/UpstreamRouter.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Broker/UpstreamRouter.swift
@@ -25,6 +25,19 @@ final class UpstreamRouter: Sendable {
         }
     }
 
+    func appendUpstreams(count: Int) {
+        guard count > 0 else { return }
+        state.withLockedValue { state in
+            state.mappingsByUpstream.append(contentsOf: Array(repeating: [:], count: count))
+            state.upstreamIDByRequestKeyByUpstream.append(
+                contentsOf: Array(repeating: [:], count: count)
+            )
+            state.recentlyReleasedResponseIDsByUpstream.append(
+                contentsOf: Array(repeating: [], count: count)
+            )
+        }
+    }
+
     func assign(upstreamIndex: Int, sessionID: String, originalID: JSONRPC.ID, isInitialize: Bool)
         -> Int64
     {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -122,6 +122,17 @@ final class InitializeManager: Sendable {
         }
     }
 
+    func removePendingInitializes(sessionID: String) -> [PendingInitialize] {
+        state.withLockedValue { state in
+            let removed = state.initPending.filter { $0.sessionID == sessionID }
+            guard removed.isEmpty == false else {
+                return []
+            }
+            state.initPending.removeAll { $0.sessionID == sessionID }
+            return removed
+        }
+    }
+
     func isInitialized() -> Bool {
         brokerState.initializeResult() != nil
     }
@@ -186,6 +197,7 @@ final class InitializeManager: Sendable {
                 )
             }
 
+            let hadPendingInitialize = state.initPending.isEmpty == false
             let promise = eventLoop.makePromise(of: ByteBuffer.self)
             state.initPending.append(
                 PendingInitialize(
@@ -212,7 +224,7 @@ final class InitializeManager: Sendable {
                     promise: promise,
                     cachedResult: nil,
                     shouldSendRequest: false,
-                    shouldScheduleTimeout: true,
+                    shouldScheduleTimeout: !hadPendingInitialize,
                     isShuttingDown: false
                 )
             }
@@ -222,7 +234,7 @@ final class InitializeManager: Sendable {
                 promise: promise,
                 cachedResult: nil,
                 shouldSendRequest: true,
-                shouldScheduleTimeout: true,
+                shouldScheduleTimeout: !hadPendingInitialize,
                 isShuttingDown: false
             )
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -162,7 +162,7 @@ final class InitializeManager: Sendable {
         sessionID: String,
         sessionGeneration: UInt64,
         originalID: JSONRPC.ID,
-        primaryUpstreamIndex: Int,
+        primaryUpstreamIndex: Int?,
         on eventLoop: EventLoop
     ) -> RegisterDecision {
         state.withLockedValue { state in
@@ -203,6 +203,16 @@ final class InitializeManager: Sendable {
                     cachedResult: nil,
                     shouldSendRequest: false,
                     shouldScheduleTimeout: false,
+                    isShuttingDown: false
+                )
+            }
+
+            guard let primaryUpstreamIndex else {
+                return RegisterDecision(
+                    promise: promise,
+                    cachedResult: nil,
+                    shouldSendRequest: false,
+                    shouldScheduleTimeout: true,
                     isShuttingDown: false
                 )
             }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -82,6 +82,11 @@ final class InitializeManager: Sendable {
         let primaryInitUpstreamID: Int64?
     }
 
+    struct PendingRemovalResult: Sendable {
+        let pending: [PendingInitialize]
+        let timeout: RuntimeScheduledTimeout?
+    }
+
     struct Snapshot: Sendable {
         let hasInitResult: Bool
         let initInFlight: Bool
@@ -122,14 +127,21 @@ final class InitializeManager: Sendable {
         }
     }
 
-    func removePendingInitializes(sessionID: String) -> [PendingInitialize] {
+    func removePendingInitializes(sessionID: String) -> PendingRemovalResult {
         state.withLockedValue { state in
             let removed = state.initPending.filter { $0.sessionID == sessionID }
             guard removed.isEmpty == false else {
-                return []
+                return PendingRemovalResult(pending: [], timeout: nil)
             }
             state.initPending.removeAll { $0.sessionID == sessionID }
-            return removed
+            let timeout: RuntimeScheduledTimeout?
+            if state.initPending.isEmpty, state.primaryInitializePhase.isInFlight == false {
+                timeout = state.initTimeout
+                state.initTimeout = nil
+            } else {
+                timeout = nil
+            }
+            return PendingRemovalResult(pending: removed, timeout: timeout)
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -161,7 +161,7 @@ final class InitializeManager: Sendable {
                 return (false, false)
             }
             state.primaryInitializePhase = .pendingSend(upstreamIndex: upstreamIndex)
-            return (true, true)
+            return (true, state.initTimeout == nil)
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -451,19 +451,25 @@ extension RuntimeCoordinator {
                 throw TimeoutError()
             }
             do {
-                return try await loadCanonicalToolsCatalogFromRoute(
-                    .pinnedUpstream(upstreamIndex),
-                    requestTimeout: routeTimeout,
-                    rpcHandle: rpcHandle,
-                    startedAt: startedAt,
-                    purpose: "tools-\(upstreamIndex)",
-                    failureRouteMetadata: [
-                        "pid": .string("\(route.target.processID)"),
-                        "app_path": .string(route.target.appPath),
-                        "xcode_version": .string(route.target.xcodeVersion),
-                        "upstream": .string("\(upstreamIndex)"),
-                    ]
-                )
+                // First-success catalog loads cancel sibling routes; the route-level
+                // handle must release queued or in-flight fallback RPCs.
+                return try await withTaskCancellationHandler {
+                    try await loadCanonicalToolsCatalogFromRoute(
+                        .pinnedUpstream(upstreamIndex),
+                        requestTimeout: routeTimeout,
+                        rpcHandle: rpcHandle,
+                        startedAt: startedAt,
+                        purpose: "tools-\(upstreamIndex)",
+                        failureRouteMetadata: [
+                            "pid": .string("\(route.target.processID)"),
+                            "app_path": .string(route.target.appPath),
+                            "xcode_version": .string(route.target.xcodeVersion),
+                            "upstream": .string("\(upstreamIndex)"),
+                        ]
+                    )
+                } onCancel: {
+                    rpcHandle.cancel()
+                }
             } catch is CancellationError {
                 throw CancellationError()
             } catch {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -75,7 +75,7 @@ extension RuntimeCoordinator {
                 defaultSeconds: config.requestTimeout
             )
         let requestDeadlineUptimeNs = deadlineUptimeNanoseconds(for: effectiveRequestTimeout)
-        if xcodeProcessRoutes.isEmpty == false {
+        if processRoutingEnabled {
             return try await loadAvailableToolsCatalogSurfaceAcrossProcessRoutes(
                 requestTimeout: effectiveRequestTimeout,
                 deadlineUptimeNs: requestDeadlineUptimeNs,
@@ -279,6 +279,8 @@ extension RuntimeCoordinator {
         guard let sourceUpstream = result.sourceUpstream else {
             return result
         }
+        let hadProcessCatalog =
+            processToolCatalogRegistry.catalog(forProcessID: target.processID) != nil
         processToolCatalogRegistry.record(
             target: target,
             upstreamIndex: sourceUpstream,
@@ -287,6 +289,9 @@ extension RuntimeCoordinator {
             }?.upstreamIndices ?? [],
             rawResult: result.rawResult
         )
+        if hadProcessCatalog == false {
+            publishToolsListChangedNotification()
+        }
         let surface = processToolCatalogRegistry.availableToolCatalogSurface(
             processIDs: exposedProcessIDs
         )

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -103,7 +103,7 @@ extension RuntimeCoordinator {
             guard unavailable.contains(route.target.processID) == false else {
                 return nil
             }
-            let upstreamIndices = usableInitializedUpstreamIndices(in: route)
+            let upstreamIndices = recoveryAwareUsableInitializedUpstreamIndices(in: route)
             guard upstreamIndices.isEmpty == false else {
                 return nil
             }
@@ -274,7 +274,7 @@ extension RuntimeCoordinator {
             guard unavailable.contains(route.target.processID) == false else {
                 return nil
             }
-            let upstreamIndices = usableInitializedUpstreamIndices(in: route)
+            let upstreamIndices = recoveryAwareUsableInitializedUpstreamIndices(in: route)
             guard upstreamIndices.isEmpty == false else {
                 return nil
             }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -62,6 +62,7 @@ extension RuntimeCoordinator {
     private enum AvailableToolsCatalogOutcome: Sendable {
         case success(route: AvailableToolsCatalogRoute, result: CanonicalToolsCatalogLoadResult)
         case failure(route: AvailableToolsCatalogRoute, upstreamIndex: Int, error: any Error)
+        case stale
     }
 
     func loadCanonicalToolsCatalog(
@@ -192,14 +193,21 @@ extension RuntimeCoordinator {
                             deadlineUptimeNs: deadlineUptimeNs,
                             startedAt: startedAt
                         )
+                        if let sourceUpstream = result.sourceUpstream,
+                           let hook = self.testHooks.processToolsCatalogLoadedBeforeRecord {
+                            await hook(route.target, sourceUpstream)
+                        }
+                        guard let recordedResult = self.recordAvailableToolsCatalog(
+                            target: route.target,
+                            result: result,
+                            startedAt: startedAt,
+                            exposedProcessIDs: exposedProcessIDs
+                        ) else {
+                            return .stale
+                        }
                         return .success(
                             route: route,
-                            result: self.recordAvailableToolsCatalog(
-                                target: route.target,
-                                result: result,
-                                startedAt: startedAt,
-                                exposedProcessIDs: exposedProcessIDs
-                            )
+                            result: recordedResult
                         )
                     } catch is CancellationError {
                         throw CancellationError()
@@ -232,6 +240,8 @@ extension RuntimeCoordinator {
                     }
                 case .failure(let route, let upstreamIndex, let error):
                     failures.append((target: route.target, upstreamIndex: upstreamIndex, error: error))
+                case .stale:
+                    continue
                 }
             }
             if let firstSuccess {
@@ -323,18 +333,30 @@ extension RuntimeCoordinator {
         result: CanonicalToolsCatalogLoadResult,
         startedAt: UInt64,
         exposedProcessIDs: Set<pid_t>
-    ) -> CanonicalToolsCatalogLoadResult {
+    ) -> CanonicalToolsCatalogLoadResult? {
         guard let sourceUpstream = result.sourceUpstream else {
             return result
+        }
+        guard let activeRoute = xcodeProcessRoutes.first(where: {
+            $0.target == target && $0.upstreamIndices.contains(sourceUpstream)
+        }) else {
+            logger.debug(
+                "Dropping stale process tools/list catalog",
+                metadata: [
+                    "pid": .string("\(target.processID)"),
+                    "app_path": .string(target.appPath),
+                    "xcode_version": .string(target.xcodeVersion),
+                    "upstream": .string("\(sourceUpstream)"),
+                ]
+            )
+            return nil
         }
         let hadProcessCatalog =
             processToolCatalogRegistry.catalog(forProcessID: target.processID) != nil
         processToolCatalogRegistry.record(
             target: target,
             upstreamIndex: sourceUpstream,
-            associatedUpstreamIndices: xcodeProcessRoutes.first {
-                $0.target.processID == target.processID
-            }?.upstreamIndices ?? [],
+            associatedUpstreamIndices: activeRoute.upstreamIndices,
             rawResult: result.rawResult
         )
         _ = pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -252,6 +252,54 @@ extension RuntimeCoordinator {
         }
     }
 
+    func refreshMissingProcessToolsCatalogsIfNeeded(
+        reason: String,
+        processIDs requestedProcessIDs: Set<pid_t>? = nil
+    ) {
+        guard processRoutingEnabled, isInitialized() else {
+            return
+        }
+        let unavailable = unavailableXcodeProcessIDs()
+        let routes = xcodeProcessRoutes.compactMap { route -> AvailableToolsCatalogRoute? in
+            guard unavailable.contains(route.target.processID) == false else {
+                return nil
+            }
+            let upstreamIndices = usableInitializedUpstreamIndices(in: route)
+            guard upstreamIndices.isEmpty == false else {
+                return nil
+            }
+            return AvailableToolsCatalogRoute(target: route.target, upstreamIndices: upstreamIndices)
+        }
+        let missingRoutes = routes.filter {
+            if let requestedProcessIDs,
+               requestedProcessIDs.contains($0.target.processID) == false {
+                return false
+            }
+            return processToolCatalogRegistry.catalog(forProcessID: $0.target.processID) == nil
+        }
+        guard missingRoutes.isEmpty == false else {
+            return
+        }
+        logger.debug(
+            "Refreshing missing process tools/list catalogs",
+            metadata: [
+                "reason": .string(reason),
+                "process_ids": .string(
+                    missingRoutes
+                        .map { "\($0.target.processID)" }
+                        .joined(separator: ",")
+                ),
+            ]
+        )
+        scheduleAvailableToolsCatalogCompletion(
+            missingRoutes,
+            requestTimeout: MCP.MethodDispatcher.timeoutForControlPlane(
+                defaultSeconds: config.requestTimeout
+            ),
+            exposedProcessIDs: Set(routes.map { $0.target.processID })
+        )
+    }
+
     private func availableToolsCatalogSurfaceResult(
         startedAt: UInt64,
         exposedProcessIDs: Set<pid_t>,
@@ -289,6 +337,9 @@ extension RuntimeCoordinator {
             }?.upstreamIndices ?? [],
             rawResult: result.rawResult
         )
+        _ = pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
+            $0.remove(target.processID)
+        }
         if hadProcessCatalog == false {
             publishToolsListChangedNotification()
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -123,6 +123,10 @@ extension RuntimeCoordinator {
         )
         if success {
             upstreamSlotScheduler.wake()
+            refreshPendingProcessToolsCatalogForReadyUpstream(
+                upstreamIndex: upstreamIndex,
+                reason: "health_probe_\(upstreamIndex)"
+            )
         } else {
             failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
         }
@@ -170,6 +174,21 @@ extension RuntimeCoordinator {
             return true
         }
         return false
+    }
+
+    func recoveryAwareUsableInitializedUpstreamIndices(in route: XcodeProcessRoute) -> [Int] {
+        let nowUptimeNs = nowUptimeNanoseconds()
+        var effects: [UpstreamHealthManager.Effect] = []
+        let upstreamIndices = route.upstreamIndices.filter { upstreamIndex in
+            let evaluation = upstreamHealthManager.evaluateUsableInitialized(
+                index: upstreamIndex,
+                nowUptimeNs: nowUptimeNs
+            )
+            effects.append(contentsOf: evaluation.effects)
+            return evaluation.isUsable
+        }
+        applyHealthEffects(effects)
+        return upstreamIndices
     }
 
     func startUpstreamWarmInitialize(upstreamIndex: Int, applyBackoff: Bool = false) {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -173,6 +173,7 @@ extension RuntimeCoordinator {
     }
 
     func startUpstreamWarmInitialize(upstreamIndex: Int, applyBackoff: Bool = false) {
+        guard isActiveProcessBoundUpstream(upstreamIndex) else { return }
         runWhenUpstreamReady(
             reason: "warm_initialize_\(upstreamIndex)",
             applyBackoff: applyBackoff
@@ -182,6 +183,7 @@ extension RuntimeCoordinator {
     }
 
     private func startUpstreamWarmInitializeWhenReady(upstreamIndex: Int) {
+        guard isActiveProcessBoundUpstream(upstreamIndex) else { return }
         guard upstreamHealthManager.beginWarmInitialize(upstreamIndex: upstreamIndex) else { return }
 
         let upstreamID = upstreamRouter.assignInitialize(upstreamIndex: upstreamIndex)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -5,17 +5,46 @@ import XcodeMCPKit
 extension RuntimeCoordinator {
     func startEagerInitializePrimary(applyBackoff: Bool = false) {
         guard let upstreamIndex = primaryInitializeUpstreamIndex() else {
+            if startXcodeProcessDiscoveryWhenReadyForPrimaryInitialize(
+                applyBackoff: applyBackoff
+            ) {
+                return
+            }
             failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
             return
         }
         runWhenUpstreamReady(
             reason: "primary_initialize",
             applyBackoff: applyBackoff
-        ) { [weak self, upstreamIndex] in
+        ) { [weak self, upstreamIndex, applyBackoff] in
             guard let self else { return }
+            guard self.isActiveProcessBoundUpstream(upstreamIndex) else {
+                self.startEagerInitializePrimary(applyBackoff: applyBackoff)
+                return
+            }
             self.startUpstreamSlot(upstreamIndex)
             self.startEagerInitializePrimaryWhenReady(upstreamIndex: upstreamIndex)
         }
+    }
+
+    @discardableResult
+    private func startXcodeProcessDiscoveryWhenReadyForPrimaryInitialize(
+        applyBackoff: Bool
+    ) -> Bool {
+        guard processRoutingEnabled,
+              xcodeTargetDiscovery != nil,
+              xcodeProcessRoutes.isEmpty,
+              upstreamReadinessGate.isEnabled
+        else {
+            return false
+        }
+        runWhenUpstreamReady(
+            reason: "primary_initialize_process_discovery",
+            applyBackoff: applyBackoff
+        ) { [weak self] in
+            self?.triggerXcodeProcessReconcile(reason: "primary_initialize_readiness")
+        }
+        return true
     }
 
     private func startEagerInitializePrimaryWhenReady(upstreamIndex: Int) {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -77,7 +77,7 @@ extension RuntimeCoordinator {
     }
 
     func primaryInitializeUpstreamIndex(excluding excludedUpstreamIndices: Set<Int> = []) -> Int? {
-        guard xcodeProcessRoutes.isEmpty == false else {
+        guard processRoutingEnabled else {
             return excludedUpstreamIndices.contains(0) ? nil : 0
         }
 
@@ -150,7 +150,7 @@ extension RuntimeCoordinator {
         failedUpstreamID: Int64?,
         reason: String
     ) -> Bool {
-        guard xcodeProcessRoutes.isEmpty == false else {
+        guard processRoutingEnabled else {
             return false
         }
         guard let retryUpstreamIndex = primaryInitializeRetryUpstreamIndex(
@@ -192,7 +192,7 @@ extension RuntimeCoordinator {
         )
         let handlesPrimaryInitialize = isPrimaryInitialize
             || (
-                xcodeProcessRoutes.isEmpty
+                !processRoutingEnabled
                     && isCurrentPrimaryInitializeUpstream(upstreamIndex)
                     && initializeManager.activePrimaryInitializeUpstreamIndex() == nil
             )
@@ -404,7 +404,7 @@ extension RuntimeCoordinator {
         let activePrimaryUpstreamIndex = initializeManager.activePrimaryInitializeUpstreamIndex()
         let handlesPrimaryInitialize = activePrimaryUpstreamIndex == upstreamIndex
             || (
-                xcodeProcessRoutes.isEmpty
+                !processRoutingEnabled
                     && isCurrentPrimaryInitializeUpstream(upstreamIndex)
                     && activePrimaryUpstreamIndex == nil
             )

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -700,17 +700,15 @@ extension RuntimeCoordinator {
     }
 
     func warmUpSecondaryUpstreams(excluding primaryUpstreamIndex: Int? = nil) {
-        guard upstreams.count > 1 else { return }
         let resolvedPrimaryUpstreamIndex = primaryUpstreamIndex ?? currentPrimaryInitializeUpstreamIndex()
-        for upstreamIndex in upstreams.indices where upstreamIndex != resolvedPrimaryUpstreamIndex {
+        for upstreamIndex in secondaryUpstreamIndices(excluding: resolvedPrimaryUpstreamIndex) {
             startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
         }
     }
 
     func resetSecondaryUpstreamsForPrimaryRetry(excluding primaryUpstreamIndex: Int? = nil) {
-        guard upstreams.count > 1 else { return }
         let resolvedPrimaryUpstreamIndex = primaryUpstreamIndex ?? currentPrimaryInitializeUpstreamIndex()
-        for upstreamIndex in upstreams.indices where upstreamIndex != resolvedPrimaryUpstreamIndex {
+        for upstreamIndex in secondaryUpstreamIndices(excluding: resolvedPrimaryUpstreamIndex) {
             clearUpstreamState(upstreamIndex: upstreamIndex)
         }
     }
@@ -730,8 +728,10 @@ extension RuntimeCoordinator {
 
     func hasUsableInitializedSecondaryUpstreams(excluding primaryUpstreamIndex: Int? = nil) -> Bool {
         let resolvedPrimaryUpstreamIndex = primaryUpstreamIndex ?? currentPrimaryInitializeUpstreamIndex()
-        return upstreamHealthManager.statesSnapshot().enumerated().contains { upstreamIndex, upstream in
-            guard upstreamIndex != resolvedPrimaryUpstreamIndex else { return false }
+        let states = upstreamHealthManager.statesSnapshot()
+        return secondaryUpstreamIndices(excluding: resolvedPrimaryUpstreamIndex).contains { upstreamIndex in
+            guard upstreamIndex >= 0, upstreamIndex < states.count else { return false }
+            let upstream = states[upstreamIndex]
             guard upstream.isInitialized else { return false }
             switch upstream.healthState {
             case .healthy, .degraded:

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -256,6 +256,9 @@ extension RuntimeCoordinator {
                     return
                 }
                 self.upstreamSlotScheduler.wake()
+                self.refreshPendingProcessToolsCatalogAfterWarmInitialize(
+                    upstreamIndex: upstreamIndex
+                )
             } onRejected: { [weak self] in
                 self?.handleInitializedNotificationSendOverload(
                     upstreamIndex: upstreamIndex,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -190,11 +190,19 @@ extension RuntimeCoordinator {
             upstreamIndex: upstreamIndex,
             upstreamID: upstreamID
         )
+        let activePrimaryInitializeUpstreamIndex =
+            initializeManager.activePrimaryInitializeUpstreamIndex()
+        let canPromoteWarmInitializeToPrimary =
+            processRoutingEnabled
+            && isPrimaryInitialize == false
+            && activePrimaryInitializeUpstreamIndex == nil
+            && canonicalBrokerState.initializeResult() == nil
         let handlesPrimaryInitialize = isPrimaryInitialize
+            || canPromoteWarmInitializeToPrimary
             || (
                 !processRoutingEnabled
                     && isCurrentPrimaryInitializeUpstream(upstreamIndex)
-                    && initializeManager.activePrimaryInitializeUpstreamIndex() == nil
+                    && activePrimaryInitializeUpstreamIndex == nil
             )
 
         guard let resultValue = object["result"], let result = JSONValue(any: resultValue) else {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -5,11 +5,11 @@ import XcodeMCPKit
 
 extension RuntimeCoordinator {
     func failQueuedRequestsIfNoHealthyOrRecoveringUpstream() {
-        guard upstreamHealthManager.initializedHealthyishCount() == 0 else { return }
-        guard upstreamHealthManager.anyRecoveryInFlight() == false else { return }
+        guard activeInitializedHealthyishCount() == 0 else { return }
+        guard anyActiveRecoveryInFlight() == false else { return }
         if initializeManager.consumeWarmInitRecoveryIntent(policy: .regardlessOfCachedInitialize) {
             startPrimaryEagerRetry()
-            if upstreamHealthManager.anyRecoveryInFlight() {
+            if anyActiveRecoveryInFlight() {
                 return
             }
         }
@@ -255,7 +255,7 @@ extension RuntimeCoordinator {
     /// upstream can still vouch for an equivalent catalog.
     func toolsCatalogLostItsSource(_ upstreamIndex: Int) -> Bool {
         canonicalBrokerState.toolsSourceUpstream() == upstreamIndex
-            && !upstreamHealthManager.anyInitialized()
+            && !anyActiveInitializedUpstream()
     }
 
     func handleUpstreamExit(_ status: Int32, upstreamIndex: Int) {
@@ -305,7 +305,7 @@ extension RuntimeCoordinator {
 
         let shouldResetGlobalInit: Bool
         if globalInit.hadGlobalInit {
-            shouldResetGlobalInit = !upstreamHealthManager.anyInitialized()
+            shouldResetGlobalInit = !anyActiveInitializedUpstream()
         } else {
             shouldResetGlobalInit = false
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -543,25 +543,47 @@ extension RuntimeCoordinator {
             allSessionIDs: sessionRegistry.sessionIDs()
         )
         let schedulerSnapshot = upstreamSlotScheduler.debugSnapshot()
+        let processToolCatalogs = processToolCatalogRegistry.debugSnapshots(
+            exposedCatalog: brokerSnapshot.toolsCatalogRaw,
+            canonicalSourceUpstream: brokerSnapshot.toolsSourceUpstream,
+            tabOwnerCountsByProcessID: ownerCountsByProcessID(
+                tabOwnerProcessIDs.withLockedValue { $0 }
+            ),
+            workspaceOwnerCountsByProcessID: ownerCountsByProcessID(
+                workspaceOwnerProcessIDs.withLockedValue { $0 }
+            )
+        )
+        let processIDsWithToolCatalog = Set(processToolCatalogs.map(\.processID))
+        let pendingToolCatalogProcessIDs =
+            pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue { $0 }
+        let unavailableProcessIDs = unavailableXcodeProcessIDs()
 
         return debugRecorder.snapshot(
             proxyInitialized: initSnapshot.hasInitResult && !initSnapshot.isShuttingDown,
             cachedToolsListAvailable: brokerSnapshot.toolsCatalogRaw != nil,
             controlPlane: controlPlaneSnapshot,
-            processRoutes: xcodeProcessRegistry.debugSnapshots { [weak self] route in
-                guard let self else { return 0 }
-                return self.usableInitializedUpstreamIndices(in: route).count
-            },
-            processToolCatalogs: processToolCatalogRegistry.debugSnapshots(
-                exposedCatalog: brokerSnapshot.toolsCatalogRaw,
-                canonicalSourceUpstream: brokerSnapshot.toolsSourceUpstream,
-                tabOwnerCountsByProcessID: ownerCountsByProcessID(
-                    tabOwnerProcessIDs.withLockedValue { $0 }
-                ),
-                workspaceOwnerCountsByProcessID: ownerCountsByProcessID(
-                    workspaceOwnerProcessIDs.withLockedValue { $0 }
-                )
+            processRoutes: xcodeProcessRegistry.debugSnapshots(
+                usableSlotCount: { [weak self] route in
+                    guard let self else { return 0 }
+                    return self.usableInitializedUpstreamIndices(in: route).count
+                },
+                toolsCatalogState: { route, routeState in
+                    guard routeState == "active" else {
+                        return "retired"
+                    }
+                    if processIDsWithToolCatalog.contains(route.target.processID) {
+                        return "available"
+                    }
+                    if unavailableProcessIDs.contains(route.target.processID) {
+                        return "unavailable"
+                    }
+                    if pendingToolCatalogProcessIDs.contains(route.target.processID) {
+                        return "pending"
+                    }
+                    return "missing"
+                }
             ),
+            processToolCatalogs: processToolCatalogs,
             upstreamStates: upstreamStates,
             sessionSnapshots: sessionSnapshots,
             leaseSnapshots: leaseSnapshots,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -548,6 +548,10 @@ extension RuntimeCoordinator {
             proxyInitialized: initSnapshot.hasInitResult && !initSnapshot.isShuttingDown,
             cachedToolsListAvailable: brokerSnapshot.toolsCatalogRaw != nil,
             controlPlane: controlPlaneSnapshot,
+            processRoutes: xcodeProcessRegistry.debugSnapshots { [weak self] route in
+                guard let self else { return 0 }
+                return self.usableInitializedUpstreamIndices(in: route).count
+            },
             processToolCatalogs: processToolCatalogRegistry.debugSnapshots(
                 exposedCatalog: brokerSnapshot.toolsCatalogRaw,
                 canonicalSourceUpstream: brokerSnapshot.toolsSourceUpstream,
@@ -1106,7 +1110,7 @@ extension RuntimeCoordinator {
         )
     }
 
-    private func releaseLeases(_ actions: [LeaseManager.ReleaseAction]) {
+    func releaseLeases(_ actions: [LeaseManager.ReleaseAction]) {
         for action in actions {
             if let upstreamIndex = action.upstreamIndex {
                 upstreamSlotScheduler.releaseUpstreamSlot(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -210,7 +210,10 @@ extension RuntimeCoordinator {
             initializeManager.resetWarmSecondaryForRetry()
         }
 
-        if globalInit?.wasInFlight == true,
+        let retiredPrimaryInitialize =
+            globalInit?.wasInFlight == true
+            && globalInit?.primaryInitUpstreamIndex == upstreamIndex
+        if retiredPrimaryInitialize,
            retryPrimaryInitializeOnAlternativeUpstream(
                failedUpstreamIndex: upstreamIndex,
                failedUpstreamID: nil,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -23,9 +23,14 @@ extension RuntimeCoordinator {
         addRuntimeTask { [weak self, xcodeTargetDiscovery] in
             guard let self else { return }
             while !Task.isCancelled {
+                let hasPendingProcessToolsCatalogRefresh =
+                    self.pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
+                        $0.isEmpty == false
+                    }
                 let isRecovering =
                     self.upstreamHealthManager.initializedHealthyishCount() == 0
                     || self.upstreamHealthManager.anyRecoveryInFlight()
+                    || hasPendingProcessToolsCatalogRefresh
                 let interval: Duration = self.xcodeProcessRoutes.isEmpty
                     || isRecovering
                     ? .seconds(2)
@@ -53,13 +58,21 @@ extension RuntimeCoordinator {
                 self.appendProcessBoundRoute(for: target)
             }
         )
-        guard result.didChange else { return }
+        guard result.didChange else {
+            retryPendingProcessRouteReadiness(reason: reason)
+            return
+        }
 
         for route in result.retiredRoutes {
             retireProcessBoundRoute(route, reason: reason)
         }
 
         if result.addedRoutes.isEmpty == false {
+            pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue { processIDs in
+                for route in result.addedRoutes {
+                    processIDs.insert(route.target.processID)
+                }
+            }
             unavailableXcodeProcessRoutes.withLockedValue { unavailable in
                 for route in result.addedRoutes {
                     unavailable.removeValue(forKey: route.target.processID)
@@ -76,6 +89,7 @@ extension RuntimeCoordinator {
             startInitializationForAddedProcessRoutes(result.addedRoutes)
         }
 
+        retryPendingProcessRouteReadiness(reason: reason)
         publishToolsListChangedNotification()
     }
 
@@ -127,6 +141,9 @@ extension RuntimeCoordinator {
             state.removeValue(forKey: route.target.processID)
         }
         xcodeProcessEventMonitor.removeExitObserver(processID: route.target.processID)
+        _ = pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
+            $0.remove(route.target.processID)
+        }
         processToolCatalogRegistry.removeCatalog(forProcessID: route.target.processID)
         removeXcodeWindowOwners(forProcessID: route.target.processID)
 
@@ -213,10 +230,51 @@ extension RuntimeCoordinator {
                     startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
                 }
             }
-            refreshToolsListIfNeeded()
             return
         }
         startEagerInitializePrimary()
+    }
+
+    private func retryPendingProcessRouteReadiness(reason: String) {
+        let activeRoutes = xcodeProcessRoutes
+        let activeProcessIDs = Set(activeRoutes.map(\.target.processID))
+        let pendingProcessIDs = pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
+            processIDs -> Set<pid_t> in
+            processIDs = processIDs.filter { processID in
+                activeProcessIDs.contains(processID)
+                && processToolCatalogRegistry.catalog(forProcessID: processID) == nil
+            }
+            return processIDs
+        }
+        guard pendingProcessIDs.isEmpty == false else {
+            return
+        }
+
+        for route in activeRoutes where pendingProcessIDs.contains(route.target.processID) {
+            for upstreamIndex in route.upstreamIndices {
+                startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+            }
+        }
+        refreshMissingProcessToolsCatalogsIfNeeded(
+            reason: "pending_process_route_\(reason)",
+            processIDs: pendingProcessIDs
+        )
+    }
+
+    func refreshPendingProcessToolsCatalogAfterWarmInitialize(upstreamIndex: Int) {
+        guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) else {
+            return
+        }
+        let shouldRefresh = pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
+            $0.contains(route.target.processID)
+        }
+        guard shouldRefresh else {
+            return
+        }
+        refreshMissingProcessToolsCatalogsIfNeeded(
+            reason: "warm_initialize_\(upstreamIndex)",
+            processIDs: [route.target.processID]
+        )
     }
 
     func publishToolsListChangedNotification() {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -277,6 +277,9 @@ extension RuntimeCoordinator {
             clearInitialize: resetInitialize,
             clearToolsCatalog: true
         )
+        if resetInitialize {
+            restartPrimaryInitializeAfterRetiringCachedProcessRoute()
+        }
         failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
         logger.info(
             "Retired Xcode process route",
@@ -332,6 +335,35 @@ extension RuntimeCoordinator {
                reason: "xcode_process_removed_\(reason)"
            ) {
             return
+        }
+    }
+
+    private func restartPrimaryInitializeAfterRetiringCachedProcessRoute() {
+        guard processRoutingEnabled, isInitialized() == false else {
+            return
+        }
+        guard initializeManager.snapshot().initInFlight == false else {
+            return
+        }
+
+        clearActiveWarmInitializesBeforePrimaryRestart()
+        startEagerInitializePrimary(applyBackoff: true)
+    }
+
+    private func clearActiveWarmInitializesBeforePrimaryRestart() {
+        let activePrimaryUpstreamIndex = initializeManager.activePrimaryInitializeUpstreamIndex()
+        let states = upstreamHealthManager.statesSnapshot()
+        for upstreamIndex in activeProcessBoundUpstreamIndices().sorted() {
+            guard upstreamIndex != activePrimaryUpstreamIndex,
+                  upstreamIndex >= 0,
+                  upstreamIndex < states.count else {
+                continue
+            }
+            let state = states[upstreamIndex]
+            guard state.initInFlight, state.isInitialized == false else {
+                continue
+            }
+            clearUpstreamState(upstreamIndex: upstreamIndex)
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -41,25 +41,78 @@ extension RuntimeCoordinator {
         guard processRoutingEnabled, xcodeTargetDiscovery != nil else {
             return
         }
-        addRuntimeTask { [weak self] in
-            guard let self else { return }
-            while !Task.isCancelled {
-                let hasPendingProcessToolsCatalogRefresh =
-                    self.pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
-                        $0.isEmpty == false
-                    }
-                let isRecovering =
-                    self.activeInitializedHealthyishCount() == 0
-                    || self.anyActiveRecoveryInFlight()
-                    || hasPendingProcessToolsCatalogRefresh
-                let interval: Duration = self.xcodeProcessRoutes.isEmpty
-                    || isRecovering
-                    ? .seconds(2)
-                    : .seconds(30)
-                await self.clock.sleep(interval)
-                guard !Task.isCancelled else { return }
-                self.triggerXcodeProcessReconcile(reason: "periodic_scan")
+        let generation = xcodeProcessReconciliationLoopState.withLockedValue { state -> UInt64? in
+            guard state.isRunning == false else {
+                return nil
             }
+            state.generation &+= 1
+            state.isRunning = true
+            return state.generation
+        }
+        guard let generation else { return }
+        let accepted = addRuntimeTask { [weak self, generation] in
+            guard let self else { return }
+            await self.runXcodeProcessReconciliationLoop(generation: generation)
+        }
+        if accepted == false {
+            finishXcodeProcessReconciliationLoop(generation: generation)
+        }
+    }
+
+    func restartXcodeProcessReconciliationLoopAfterRuntimeTaskReset() {
+        guard processRoutingEnabled else {
+            return
+        }
+        invalidateXcodeProcessReconciliationLoop()
+        startXcodeProcessReconciliationLoop()
+    }
+
+    private func runXcodeProcessReconciliationLoop(generation: UInt64) async {
+        defer {
+            finishXcodeProcessReconciliationLoop(generation: generation)
+        }
+        while !Task.isCancelled, isCurrentXcodeProcessReconciliationLoop(generation: generation) {
+            let hasPendingProcessToolsCatalogRefresh =
+                pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
+                    $0.isEmpty == false
+                }
+            let isRecovering =
+                activeInitializedHealthyishCount() == 0
+                || anyActiveRecoveryInFlight()
+                || hasPendingProcessToolsCatalogRefresh
+            let interval: Duration = xcodeProcessRoutes.isEmpty
+                || isRecovering
+                ? .seconds(2)
+                : .seconds(30)
+            await clock.sleep(interval)
+            guard !Task.isCancelled,
+                  isCurrentXcodeProcessReconciliationLoop(generation: generation)
+            else {
+                return
+            }
+            triggerXcodeProcessReconcile(reason: "periodic_scan")
+        }
+    }
+
+    private func invalidateXcodeProcessReconciliationLoop() {
+        xcodeProcessReconciliationLoopState.withLockedValue { state in
+            state.generation &+= 1
+            state.isRunning = false
+        }
+    }
+
+    private func isCurrentXcodeProcessReconciliationLoop(generation: UInt64) -> Bool {
+        xcodeProcessReconciliationLoopState.withLockedValue { state in
+            state.isRunning && state.generation == generation
+        }
+    }
+
+    private func finishXcodeProcessReconciliationLoop(generation: UInt64) {
+        xcodeProcessReconciliationLoopState.withLockedValue { state in
+            guard state.generation == generation else {
+                return
+            }
+            state.isRunning = false
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -1,0 +1,243 @@
+import Foundation
+import NIO
+import XcodeMCPKit
+
+extension RuntimeCoordinator {
+    func triggerXcodeProcessReconcile(reason: String) {
+        guard processRoutingEnabled, let xcodeTargetDiscovery else {
+            return
+        }
+        addRuntimeTask { [weak self, xcodeTargetDiscovery] in
+            guard let self else { return }
+            self.reconcileXcodeProcessTargets(
+                xcodeTargetDiscovery.runningXcodeTargets(),
+                reason: reason
+            )
+        }
+    }
+
+    func startXcodeProcessReconciliationLoop() {
+        guard processRoutingEnabled, let xcodeTargetDiscovery else {
+            return
+        }
+        addRuntimeTask { [weak self, xcodeTargetDiscovery] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                let isRecovering =
+                    self.upstreamHealthManager.initializedHealthyishCount() == 0
+                    || self.upstreamHealthManager.anyRecoveryInFlight()
+                let interval: Duration = self.xcodeProcessRoutes.isEmpty
+                    || isRecovering
+                    ? .seconds(2)
+                    : .seconds(30)
+                await self.clock.sleep(interval)
+                guard !Task.isCancelled else { return }
+                self.reconcileXcodeProcessTargets(
+                    xcodeTargetDiscovery.runningXcodeTargets(),
+                    reason: "periodic_scan"
+                )
+            }
+        }
+    }
+
+    func reconcileXcodeProcessTargets(
+        _ targets: [XcodeProcessTarget],
+        reason: String
+    ) {
+        guard processRoutingEnabled else { return }
+        let result = xcodeProcessRegistry.reconcile(
+            targets: targets,
+            reason: reason,
+            nowUptimeNs: nowUptimeNanoseconds(),
+            makeRoute: { target in
+                self.appendProcessBoundRoute(for: target)
+            }
+        )
+        guard result.didChange else { return }
+
+        for route in result.retiredRoutes {
+            retireProcessBoundRoute(route, reason: reason)
+        }
+
+        if result.addedRoutes.isEmpty == false {
+            unavailableXcodeProcessRoutes.withLockedValue { unavailable in
+                for route in result.addedRoutes {
+                    unavailable.removeValue(forKey: route.target.processID)
+                }
+            }
+            for route in result.addedRoutes {
+                observeXcodeProcessExit(route.target.processID)
+            }
+            invalidateControlPlane(
+                reason: "xcode_process_added",
+                clearInitialize: false,
+                clearToolsCatalog: true
+            )
+            startInitializationForAddedProcessRoutes(result.addedRoutes)
+        }
+
+        publishToolsListChangedNotification()
+    }
+
+    private func appendProcessBoundRoute(
+        for target: XcodeProcessTarget
+    ) -> XcodeProcessRoute {
+        let slots = dynamicUpstreamFactory?(target) ?? []
+        let startIndex = upstreamsBox.withLockedValue { upstreams -> Int in
+            let startIndex = upstreams.count
+            upstreams.append(contentsOf: slots)
+            return startIndex
+        }
+        guard slots.isEmpty == false else {
+            logger.warning(
+                "Discovered Xcode process without a dynamic upstream factory",
+                metadata: [
+                    "pid": .string("\(target.processID)"),
+                    "app_path": .string(target.appPath),
+                ]
+            )
+            return XcodeProcessRoute(target: target, upstreamIndices: [])
+        }
+
+        upstreamRouter.appendUpstreams(count: slots.count)
+        upstreamHealthManager.appendUpstreams(count: slots.count)
+        debugRecorder.appendUpstreams(count: slots.count)
+
+        let upstreamIndices = Array(startIndex..<(startIndex + slots.count))
+        for (offset, upstream) in slots.enumerated() {
+            observeUpstreamEvents(upstream, upstreamIndex: startIndex + offset)
+        }
+        logger.info(
+            "Added Xcode process route",
+            metadata: [
+                "pid": .string("\(target.processID)"),
+                "app_path": .string(target.appPath),
+                "xcode_version": .string(target.xcodeVersion),
+                "upstreams": .string(upstreamIndices.map(String.init).joined(separator: ",")),
+            ]
+        )
+        return XcodeProcessRoute(target: target, upstreamIndices: upstreamIndices)
+    }
+
+    private func retireProcessBoundRoute(
+        _ route: XcodeProcessRoute,
+        reason: String
+    ) {
+        _ = unavailableXcodeProcessRoutes.withLockedValue { state in
+            state.removeValue(forKey: route.target.processID)
+        }
+        xcodeProcessEventMonitor.removeExitObserver(processID: route.target.processID)
+        processToolCatalogRegistry.removeCatalog(forProcessID: route.target.processID)
+        removeXcodeWindowOwners(forProcessID: route.target.processID)
+
+        var resetInitialize = false
+        for upstreamIndex in route.upstreamIndices {
+            retireProcessBoundUpstream(
+                upstreamIndex: upstreamIndex,
+                reason: reason,
+                resetInitialize: &resetInitialize
+            )
+        }
+
+        resyncProcessToolsCatalogSurfaceAfterRemoving(
+            upstreamIndex: route.primaryUpstreamIndex ?? -1,
+            processID: route.target.processID
+        )
+        invalidateControlPlane(
+            reason: "xcode_process_removed",
+            clearInitialize: resetInitialize,
+            clearToolsCatalog: true
+        )
+        failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+        logger.info(
+            "Retired Xcode process route",
+            metadata: [
+                "pid": .string("\(route.target.processID)"),
+                "app_path": .string(route.target.appPath),
+                "xcode_version": .string(route.target.xcodeVersion),
+                "reason": .string(reason),
+            ]
+        )
+    }
+
+    private func retireProcessBoundUpstream(
+        upstreamIndex: Int,
+        reason: String,
+        resetInitialize: inout Bool
+    ) {
+        let globalInit = initializeManager.handleUpstreamExit(upstreamIndex: upstreamIndex)
+        if globalInit?.primaryInitUpstreamIndex == upstreamIndex,
+           let upstreamID = globalInit?.primaryInitUpstreamID {
+            upstreamRouter.remove(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
+        }
+
+        clearUpstreamState(upstreamIndex: upstreamIndex)
+        upstreamRouter.reset(upstreamIndex: upstreamIndex)
+        releaseLeases(
+            leaseManager.abandonActiveLeases(
+                upstreamIndex: upstreamIndex,
+                reason: .upstreamExit
+            )
+        )
+
+        if globalInit?.hadGlobalInit == true, upstreamHealthManager.anyInitialized() == false {
+            resetInitialize = true
+            initializeManager.resetWarmSecondaryForRetry()
+        }
+
+        if globalInit?.wasInFlight == true,
+           retryPrimaryInitializeOnAlternativeUpstream(
+               failedUpstreamIndex: upstreamIndex,
+               failedUpstreamID: nil,
+               reason: "xcode_process_removed_\(reason)"
+           ) {
+            return
+        }
+
+        if let upstream = upstreamsBox.withLockedValue({ upstreams in
+            upstreamIndex >= 0 && upstreamIndex < upstreams.count ? upstreams[upstreamIndex] : nil
+        }) {
+            addRuntimeTask {
+                await upstream.stop()
+            }
+        }
+    }
+
+    private func startInitializationForAddedProcessRoutes(_ routes: [XcodeProcessRoute]) {
+        guard routes.contains(where: { $0.upstreamIndices.isEmpty == false }) else {
+            return
+        }
+        if isInitialized() {
+            for route in routes {
+                for upstreamIndex in route.upstreamIndices {
+                    startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+                }
+            }
+            refreshToolsListIfNeeded()
+            return
+        }
+        startEagerInitializePrimary()
+    }
+
+    func publishToolsListChangedNotification() {
+        let notification = JSONRPC.Wire.notificationObject(
+            method: "notifications/tools/list_changed"
+        )
+        guard let data = try? JSONRPC.Wire.data(from: notification) else {
+            return
+        }
+
+        var deliveredSessionIDs = Set<String>()
+        let targets = sessionRegistry.activeNotificationTargets()
+            + sessionRegistry.pendingNotificationClientTargets()
+        for target in targets where deliveredSessionIDs.insert(target.id).inserted {
+            target.router.handleIncoming(data)
+        }
+    }
+
+    private func observeXcodeProcessExit(_ processID: pid_t) {
+        xcodeProcessEventMonitor.observeExit(processID: processID) { [weak self] reason in
+            self?.triggerXcodeProcessReconcile(reason: reason)
+        }
+    }
+}

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -385,10 +385,21 @@ extension RuntimeCoordinator {
     private func retryPendingProcessRouteReadiness(reason: String) {
         let activeRoutes = xcodeProcessRoutes
         let activeProcessIDs = Set(activeRoutes.map(\.target.processID))
+        let unavailableProcessIDs = unavailableXcodeProcessIDs()
+        let missingCatalogProcessIDs = Set(activeRoutes.compactMap { route -> pid_t? in
+            guard unavailableProcessIDs.contains(route.target.processID) == false,
+                  processToolCatalogRegistry.catalog(forProcessID: route.target.processID) == nil
+            else {
+                return nil
+            }
+            return route.target.processID
+        })
         let pendingProcessIDs = pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
             processIDs -> Set<pid_t> in
+            processIDs.formUnion(missingCatalogProcessIDs)
             processIDs = processIDs.filter { processID in
                 activeProcessIDs.contains(processID)
+                && unavailableProcessIDs.contains(processID) == false
                 && processToolCatalogRegistry.catalog(forProcessID: processID) == nil
             }
             return processIDs

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -409,6 +409,13 @@ extension RuntimeCoordinator {
     }
 
     func refreshPendingProcessToolsCatalogAfterWarmInitialize(upstreamIndex: Int) {
+        refreshPendingProcessToolsCatalogForReadyUpstream(
+            upstreamIndex: upstreamIndex,
+            reason: "warm_initialize_\(upstreamIndex)"
+        )
+    }
+
+    func refreshPendingProcessToolsCatalogForReadyUpstream(upstreamIndex: Int, reason: String) {
         guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) else {
             return
         }
@@ -419,7 +426,7 @@ extension RuntimeCoordinator {
             return
         }
         refreshMissingProcessToolsCatalogsIfNeeded(
-            reason: "warm_initialize_\(upstreamIndex)",
+            reason: reason,
             processIDs: [route.target.processID]
         )
     }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -7,20 +7,41 @@ extension RuntimeCoordinator {
         guard processRoutingEnabled, let xcodeTargetDiscovery else {
             return
         }
-        addRuntimeTask { [weak self, xcodeTargetDiscovery] in
+        xcodeProcessReconcileScheduleState.withLockedValue { state in
+            state.pendingReasons.append(reason)
+        }
+        startScheduledXcodeProcessReconcileWorkerIfNeeded(discovery: xcodeTargetDiscovery)
+    }
+
+    private func startScheduledXcodeProcessReconcileWorkerIfNeeded(
+        discovery: any XcodeTargetDiscovering
+    ) {
+        let shouldStartWorker = xcodeProcessReconcileScheduleState.withLockedValue { state in
+            guard state.workerRunning == false, state.pendingReasons.isEmpty == false else {
+                return false
+            }
+            state.workerRunning = true
+            return true
+        }
+        guard shouldStartWorker else { return }
+        let accepted = addRuntimeTask { [weak self, discovery] in
             guard let self else { return }
-            self.reconcileXcodeProcessTargets(
-                xcodeTargetDiscovery.runningXcodeTargets(),
-                reason: reason
-            )
+            self.runScheduledXcodeProcessReconciles(discovery: discovery)
+        }
+        guard accepted == false else {
+            return
+        }
+        xcodeProcessReconcileScheduleState.withLockedValue { state in
+            state.workerRunning = false
+            state.pendingReasons.removeAll()
         }
     }
 
     func startXcodeProcessReconciliationLoop() {
-        guard processRoutingEnabled, let xcodeTargetDiscovery else {
+        guard processRoutingEnabled, xcodeTargetDiscovery != nil else {
             return
         }
-        addRuntimeTask { [weak self, xcodeTargetDiscovery] in
+        addRuntimeTask { [weak self] in
             guard let self else { return }
             while !Task.isCancelled {
                 let hasPendingProcessToolsCatalogRefresh =
@@ -37,12 +58,50 @@ extension RuntimeCoordinator {
                     : .seconds(30)
                 await self.clock.sleep(interval)
                 guard !Task.isCancelled else { return }
-                self.reconcileXcodeProcessTargets(
-                    xcodeTargetDiscovery.runningXcodeTargets(),
-                    reason: "periodic_scan"
-                )
+                self.triggerXcodeProcessReconcile(reason: "periodic_scan")
             }
         }
+    }
+
+    private func runScheduledXcodeProcessReconciles(
+        discovery: any XcodeTargetDiscovering
+    ) {
+        defer {
+            finishScheduledXcodeProcessReconcileWorker(discovery: discovery)
+        }
+        while !Task.isCancelled {
+            guard let reason = dequeueScheduledXcodeProcessReconcileReason() else {
+                return
+            }
+            let targets = discovery.runningXcodeTargets()
+            guard !Task.isCancelled else {
+                return
+            }
+            reconcileXcodeProcessTargets(
+                targets,
+                reason: reason
+            )
+        }
+    }
+
+    private func dequeueScheduledXcodeProcessReconcileReason() -> String? {
+        xcodeProcessReconcileScheduleState.withLockedValue { state in
+            guard state.pendingReasons.isEmpty == false else {
+                return nil
+            }
+            let reasons = state.pendingReasons
+            state.pendingReasons.removeAll()
+            return reasons.joined(separator: ",")
+        }
+    }
+
+    private func finishScheduledXcodeProcessReconcileWorker(
+        discovery: any XcodeTargetDiscovering
+    ) {
+        xcodeProcessReconcileScheduleState.withLockedValue { state in
+            state.workerRunning = false
+        }
+        startScheduledXcodeProcessReconcileWorkerIfNeeded(discovery: discovery)
     }
 
     func reconcileXcodeProcessTargets(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -28,8 +28,8 @@ extension RuntimeCoordinator {
                         $0.isEmpty == false
                     }
                 let isRecovering =
-                    self.upstreamHealthManager.initializedHealthyishCount() == 0
-                    || self.upstreamHealthManager.anyRecoveryInFlight()
+                    self.activeInitializedHealthyishCount() == 0
+                    || self.anyActiveRecoveryInFlight()
                     || hasPendingProcessToolsCatalogRefresh
                 let interval: Duration = self.xcodeProcessRoutes.isEmpty
                     || isRecovering
@@ -196,8 +196,16 @@ extension RuntimeCoordinator {
                 reason: .upstreamExit
             )
         )
+        let upstreamToStop = upstreamsBox.withLockedValue { upstreams in
+            upstreamIndex >= 0 && upstreamIndex < upstreams.count ? upstreams[upstreamIndex] : nil
+        }
+        if let upstreamToStop {
+            addRuntimeTask {
+                await upstreamToStop.stop()
+            }
+        }
 
-        if globalInit?.hadGlobalInit == true, upstreamHealthManager.anyInitialized() == false {
+        if globalInit?.hadGlobalInit == true, anyActiveInitializedUpstream() == false {
             resetInitialize = true
             initializeManager.resetWarmSecondaryForRetry()
         }
@@ -209,14 +217,6 @@ extension RuntimeCoordinator {
                reason: "xcode_process_removed_\(reason)"
            ) {
             return
-        }
-
-        if let upstream = upstreamsBox.withLockedValue({ upstreams in
-            upstreamIndex >= 0 && upstreamIndex < upstreams.count ? upstreams[upstreamIndex] : nil
-        }) {
-            addRuntimeTask {
-                await upstream.stop()
-            }
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -397,6 +397,12 @@ extension RuntimeCoordinator {
             return
         }
 
+        guard isInitialized() else {
+            clearActiveWarmInitializesBeforePrimaryRestart()
+            startEagerInitializePrimary(applyBackoff: true)
+            return
+        }
+
         for route in activeRoutes where pendingProcessIDs.contains(route.target.processID) {
             for upstreamIndex in route.upstreamIndices {
                 startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -780,6 +780,71 @@ extension RuntimeCoordinator {
         xcodeProcessRoutes.first { $0.upstreamIndices.contains(upstreamIndex) }
     }
 
+    func isActiveProcessBoundUpstream(_ upstreamIndex: Int) -> Bool {
+        guard processRoutingEnabled else { return true }
+        return xcodeProcessRoute(forUpstreamIndex: upstreamIndex) != nil
+    }
+
+    func activeProcessBoundUpstreamIndices() -> Set<Int> {
+        guard processRoutingEnabled else {
+            return Set(upstreams.indices)
+        }
+        return Set(xcodeProcessRoutes.flatMap(\.upstreamIndices))
+    }
+
+    func inactiveProcessBoundUpstreamIndices() -> Set<Int> {
+        guard processRoutingEnabled else { return [] }
+        return Set(upstreams.indices).subtracting(activeProcessBoundUpstreamIndices())
+    }
+
+    func secondaryUpstreamIndices(excluding upstreamIndex: Int) -> [Int] {
+        let candidates = processRoutingEnabled
+            ? xcodeProcessRoutes.flatMap(\.upstreamIndices)
+            : Array(upstreams.indices)
+        return candidates.filter { $0 != upstreamIndex }
+    }
+
+    func activeInitializedHealthyishCount() -> Int {
+        guard processRoutingEnabled else {
+            return upstreamHealthManager.initializedHealthyishCount()
+        }
+        let states = upstreamHealthManager.statesSnapshot()
+        return activeProcessBoundUpstreamIndices().reduce(into: 0) { count, upstreamIndex in
+            guard upstreamIndex >= 0, upstreamIndex < states.count else { return }
+            let upstream = states[upstreamIndex]
+            guard upstream.isInitialized else { return }
+            switch upstream.healthState {
+            case .healthy, .degraded:
+                count += 1
+            case .quarantined:
+                break
+            }
+        }
+    }
+
+    func anyActiveInitializedUpstream() -> Bool {
+        guard processRoutingEnabled else {
+            return upstreamHealthManager.anyInitialized()
+        }
+        let states = upstreamHealthManager.statesSnapshot()
+        return activeProcessBoundUpstreamIndices().contains { upstreamIndex in
+            guard upstreamIndex >= 0, upstreamIndex < states.count else { return false }
+            return states[upstreamIndex].isInitialized
+        }
+    }
+
+    func anyActiveRecoveryInFlight() -> Bool {
+        guard processRoutingEnabled else {
+            return upstreamHealthManager.anyRecoveryInFlight()
+        }
+        let states = upstreamHealthManager.statesSnapshot()
+        return activeProcessBoundUpstreamIndices().contains { upstreamIndex in
+            guard upstreamIndex >= 0, upstreamIndex < states.count else { return false }
+            let upstream = states[upstreamIndex]
+            return upstream.initInFlight || upstream.healthProbeInFlight
+        }
+    }
+
     private func processID(forUpstreamIndex upstreamIndex: Int) -> pid_t? {
         xcodeProcessRoute(forUpstreamIndex: upstreamIndex)?.target.processID
     }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -220,7 +220,7 @@ extension RuntimeCoordinator {
     }
 
     func documentationCandidateProcessIDs() -> Set<pid_t>? {
-        guard xcodeProcessRoutes.isEmpty == false else {
+        guard processRoutingEnabled else {
             return nil
         }
         let unavailable = unavailableXcodeProcessIDs()
@@ -340,7 +340,7 @@ extension RuntimeCoordinator {
     }
 
     func preferredUpstreamIndex(for requestJSON: Any) -> Int? {
-        guard xcodeProcessRoutes.isEmpty == false else {
+        guard processRoutingEnabled else {
             return nil
         }
         let indices = preferredUpstreamIndices(in: requestJSON)
@@ -364,7 +364,7 @@ extension RuntimeCoordinator {
     }
 
     func immediateToolRoutingDecision(for requestJSON: Any) -> ToolRoutingDecision? {
-        guard xcodeProcessRoutes.isEmpty == false else {
+        guard processRoutingEnabled else {
             return .forward(preferredUpstreamIndex: nil)
         }
         let requests = toolRoutingRequests(in: requestJSON)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -75,6 +75,11 @@ struct RuntimeCoordinatorTestHooks: Sendable {
     }
 }
 
+struct XcodeProcessReconcileScheduleState: Sendable {
+    var workerRunning = false
+    var pendingReasons: [String] = []
+}
+
 typealias XcodeProcessUpstreamFactory =
     @Sendable (_ target: XcodeProcessTarget) -> [any UpstreamSlotControlling]
 
@@ -393,6 +398,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let documentationProviderManager: (any DocumentationProviderManaging)?
     let processRoutingEnabled: Bool
     let xcodeProcessRegistry: XcodeProcessRegistry
+    let xcodeProcessReconcileScheduleState =
+        NIOLockedValueBox(XcodeProcessReconcileScheduleState())
     let xcodeProcessEventMonitor = XcodeProcessEventMonitor()
     let xcodeTargetDiscovery: (any XcodeTargetDiscovering)?
     let dynamicUpstreamFactory: XcodeProcessUpstreamFactory?

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -762,6 +762,12 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     func removeSession(id: String) {
         let context = sessionRegistry.removeSession(id: id)
         context?.notificationHub.closeAll()
+        let pendingInitializes = initializeManager.removePendingInitializes(sessionID: id)
+        for pending in pendingInitializes {
+            pending.eventLoop.execute {
+                pending.promise.fail(CancellationError())
+            }
+        }
     }
 
     func debugReset() {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -397,6 +397,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let tabOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
     let workspaceOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
     let availableToolsCatalogRefreshKeys = NIOLockedValueBox<Set<String>>([])
+    let pendingProcessToolsCatalogRefreshProcessIDs = NIOLockedValueBox<Set<pid_t>>([])
     let unavailableXcodeProcessRoutes =
         NIOLockedValueBox<[pid_t: UInt64]>([:])
     let prewarmDocumentationProviderOnStartup: Bool

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -777,7 +777,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         let context = sessionRegistry.removeSession(id: id)
         context?.notificationHub.closeAll()
         let pendingInitializes = initializeManager.removePendingInitializes(sessionID: id)
-        for pending in pendingInitializes {
+        pendingInitializes.timeout?.cancel()
+        for pending in pendingInitializes.pending {
             pending.eventLoop.execute {
                 pending.promise.fail(CancellationError())
             }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -1034,7 +1034,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         return chosen
     }
 
-    private func applyHealthEffects(_ effects: [UpstreamHealthManager.Effect]) {
+    func applyHealthEffects(_ effects: [UpstreamHealthManager.Effect]) {
         for effect in effects {
             switch effect {
             case .cancelInitTimeout(let timeout):

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -70,6 +70,9 @@ struct RuntimeCoordinatorTestHooks: Sendable {
     }
 }
 
+typealias XcodeProcessUpstreamFactory =
+    @Sendable (_ target: XcodeProcessTarget) -> [any UpstreamSlotControlling]
+
 /// The single routing decision for a DocumentationSearch tools/call:
 /// either the provider produced the response, or proxy-managed
 /// DocumentationSearch is unavailable.
@@ -363,7 +366,10 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let upstreamRouter: UpstreamRouter
     let config: ProxyConfig
     let logger: Logger = ProxyLogging.make("session")
-    let upstreams: [any UpstreamSlotControlling]
+    let upstreamsBox: NIOLockedValueBox<[any UpstreamSlotControlling]>
+    var upstreams: [any UpstreamSlotControlling] {
+        upstreamsBox.withLockedValue { $0 }
+    }
     let initializeParamsOverride: ProxyConfig.File.InitializeHandshakeOverride?
     let canonicalBrokerState: CanonicalBrokerState
     let controlPlaneDebugMirror = ControlPlane.DebugMirror()
@@ -380,7 +386,14 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             RuntimeScheduledTimeout
     let controlPlaneCoordinator: ControlPlaneCoordinator
     let documentationProviderManager: (any DocumentationProviderManaging)?
-    let xcodeProcessRoutes: [XcodeProcessRoute]
+    let processRoutingEnabled: Bool
+    let xcodeProcessRegistry: XcodeProcessRegistry
+    let xcodeProcessEventMonitor = XcodeProcessEventMonitor()
+    let xcodeTargetDiscovery: (any XcodeTargetDiscovering)?
+    let dynamicUpstreamFactory: XcodeProcessUpstreamFactory?
+    var xcodeProcessRoutes: [XcodeProcessRoute] {
+        xcodeProcessRegistry.activeRoutes()
+    }
     let tabOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
     let workspaceOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
     let availableToolsCatalogRefreshKeys = NIOLockedValueBox<Set<String>>([])
@@ -448,6 +461,14 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             clock: clock,
             upstreamReadinessGate: upstreamReadinessGate,
             xcodeProcessRoutes: upstreamPlan.xcodeProcessRoutes,
+            processRoutingEnabled: xcodeProcessRoutingEnabled,
+            xcodeTargetDiscovery: xcodeTargetDiscovery,
+            dynamicUpstreamFactory: { target in
+                MCPBridgeRuntime.makeProcessBoundUpstreamSlots(
+                    config: bridgeRuntimeConfig,
+                    xcodeTarget: target
+                )
+            },
             documentationProviderManager: documentationProviderManager,
             prewarmDocumentationProviderOnStartup: documentationProviderManager != nil,
             startImmediately: startImmediately,
@@ -496,13 +517,21 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 RuntimeScheduledTimeout
         )? = nil,
         xcodeProcessRoutes: [XcodeProcessRoute] = [],
+        processRoutingEnabled: Bool? = nil,
+        xcodeTargetDiscovery: (any XcodeTargetDiscovering)? = nil,
+        dynamicUpstreamFactory: XcodeProcessUpstreamFactory? = nil,
         documentationProviderManager: (any DocumentationProviderManaging)? = nil,
         prewarmDocumentationProviderOnStartup: Bool = false,
         testHooks: RuntimeCoordinatorTestHooks = RuntimeCoordinatorTestHooks(),
         startImmediately: Bool = true,
         runtimeBox providedRuntimeBox: WeakRuntimeCoordinatorBox? = nil
     ) {
-        precondition(!upstreams.isEmpty, "upstreams must not be empty")
+        let resolvedProcessRoutingEnabled =
+            processRoutingEnabled ?? (xcodeProcessRoutes.isEmpty == false)
+        precondition(
+            !upstreams.isEmpty || resolvedProcessRoutingEnabled,
+            "upstreams must not be empty outside process-bound routing mode"
+        )
         let runtimeBox = providedRuntimeBox ?? WeakRuntimeCoordinatorBox()
         let uptimeProvider = nowUptimeNanoseconds ?? clock.uptimeNanoseconds
         let runtimeClock = ClockClient(
@@ -522,7 +551,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             }
         self.config = config
         self.eventLoop = eventLoop
-        self.upstreams = upstreams
+        self.upstreamsBox = NIOLockedValueBox(upstreams)
         self.clock = runtimeClock
         let brokerState = CanonicalBrokerState()
         self.canonicalBrokerState = brokerState
@@ -535,7 +564,14 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.nowUptimeNanoseconds = uptimeProvider
         self.scheduleRuntimeTimeout = timeoutScheduler
         self.documentationProviderManager = documentationProviderManager
-        self.xcodeProcessRoutes = xcodeProcessRoutes
+        self.processRoutingEnabled = resolvedProcessRoutingEnabled
+        self.xcodeProcessRegistry = XcodeProcessRegistry(
+            initialRoutes: xcodeProcessRoutes,
+            nowUptimeNs: uptimeProvider(),
+            reason: "startup"
+        )
+        self.xcodeTargetDiscovery = xcodeTargetDiscovery
+        self.dynamicUpstreamFactory = dynamicUpstreamFactory
         self.prewarmDocumentationProviderOnStartup = prewarmDocumentationProviderOnStartup
         self.testHooks = testHooks
         let resolvedReadinessGate =
@@ -622,27 +658,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         runtimeBox.value = self
 
         for (upstreamIndex, upstream) in upstreams.enumerated() {
-            upstreamEventTasks.run { [weak self, upstream] in
-                guard let self else { return }
-                for await event in upstream.events {
-                    switch event {
-                    case .message(let data):
-                        self.routeUpstreamMessage(data, upstreamIndex: upstreamIndex)
-                    case .stderr(let message):
-                        self.handleUpstreamStderr(message, upstreamIndex: upstreamIndex)
-                    case .stdoutProtocolViolation(let protocolViolation):
-                        self.handleUpstreamProtocolViolation(
-                            protocolViolation,
-                            upstreamIndex: upstreamIndex
-                        )
-                    case .stdoutBufferSize(let size):
-                        self.handleBufferedStdoutBytes(size, upstreamIndex: upstreamIndex)
-                    case .exit(let status):
-                        self.handleUpstreamExit(status, upstreamIndex: upstreamIndex)
-                    }
-                    self.testHooks.upstreamEventHandled?(upstreamIndex)
-                }
-            }
+            observeUpstreamEvents(upstream, upstreamIndex: upstreamIndex)
         }
 
         if startImmediately {
@@ -657,9 +673,52 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             return true
         }
         guard shouldStart else { return }
+        if processRoutingEnabled {
+            xcodeProcessEventMonitor.startWorkspaceNotifications { [weak self] reason in
+                self?.triggerXcodeProcessReconcile(reason: reason)
+            }
+            for route in xcodeProcessRoutes {
+                xcodeProcessEventMonitor.observeExit(processID: route.target.processID) {
+                    [weak self] reason in
+                    self?.triggerXcodeProcessReconcile(reason: reason)
+                }
+            }
+            triggerXcodeProcessReconcile(reason: "startup")
+            startXcodeProcessReconciliationLoop()
+        }
         startEagerInitializePrimary()
         if prewarmDocumentationProviderOnStartup {
             prewarmDocumentationProvider()
+        }
+    }
+
+    func observeUpstreamEvents(
+        _ upstream: any UpstreamSlotControlling,
+        upstreamIndex: Int
+    ) {
+        upstreamEventTasks.run { [weak self, upstream] in
+            guard let self else { return }
+            for await event in upstream.events {
+                switch event {
+                case .message(let data):
+                    self.routeUpstreamMessage(data, upstreamIndex: upstreamIndex)
+                case .stderr(let message):
+                    self.handleUpstreamStderr(message, upstreamIndex: upstreamIndex)
+                case .stdoutProtocolViolation(let protocolViolation):
+                    self.handleUpstreamProtocolViolation(
+                        protocolViolation,
+                        upstreamIndex: upstreamIndex
+                    )
+                case .stdoutBufferSize(let size):
+                    self.handleBufferedStdoutBytes(size, upstreamIndex: upstreamIndex)
+                case .exit(let status):
+                    self.handleUpstreamExit(status, upstreamIndex: upstreamIndex)
+                    if self.processRoutingEnabled {
+                        self.triggerXcodeProcessReconcile(reason: "upstream_exit_\(status)")
+                    }
+                }
+                self.testHooks.upstreamEventHandled?(upstreamIndex)
+            }
         }
     }
 
@@ -746,6 +805,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
         documentationPrewarmTask?.cancel()
         upstreamReadinessCoordinator.shutdown()
+        xcodeProcessEventMonitor.stop()
 
         let runtimeDrain = runtimeTasks.beginShutdown()
         canonicalBrokerState.reset()
@@ -803,7 +863,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         upstreamIndex removedUpstreamIndex: Int,
         processID removedProcessID: pid_t? = nil
     ) {
-        guard xcodeProcessRoutes.isEmpty == false,
+        guard processRoutingEnabled,
               canonicalBrokerState.toolsCatalogRaw() != nil else {
             return
         }
@@ -1041,7 +1101,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         let sessionGeneration = sessionRegistry.generation(of: sessionID) ?? 0
         let primaryUpstreamIndex = initializeManager.activePrimaryInitializeUpstreamIndex()
             ?? primaryInitializeUpstreamIndex()
-        guard primaryUpstreamIndex != nil || initializeManager.isInitialized() else {
+        guard primaryUpstreamIndex != nil || initializeManager.isInitialized() || processRoutingEnabled else {
             return eventLoop.makeFailedFuture(UpstreamSlotScheduler.AcquisitionError.unavailable)
         }
 
@@ -1049,7 +1109,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             sessionID: sessionID,
             sessionGeneration: sessionGeneration,
             originalID: originalID,
-            primaryUpstreamIndex: primaryUpstreamIndex ?? 0,
+            primaryUpstreamIndex: primaryUpstreamIndex,
             on: eventLoop
         )
         let cachedResult = decision.cachedResult
@@ -1164,7 +1224,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             )
         let deadline = timeoutDeadline(for: timeout)
         switch route {
-        case .anyHealthy where xcodeProcessRoutes.isEmpty == false:
+        case .anyHealthy where processRoutingEnabled:
             return try await liveXcodeListWindowsAcrossProcessRoutes(
                 deadlineUptimeNs: deadline,
                 routeScope: .catalogSurface
@@ -1235,9 +1295,9 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         let summary = ToolCatalogStartupLogFormatter.summary(
             from: result,
             process: toolCatalogSourceProcess(),
-            exposurePolicy: xcodeProcessRoutes.isEmpty
-                ? nil
-                : "available_route_catalog_surface"
+            exposurePolicy: processRoutingEnabled
+                ? "available_route_catalog_surface"
+                : nil
         )
         logger.info("\(summary)")
     }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -39,6 +39,8 @@ struct RuntimeCoordinatorTestHooks: Sendable {
     var initializedNotificationStaleIgnored: (@Sendable (_ upstreamIndex: Int) -> Void)?
     var upstreamEventHandled: (@Sendable (_ upstreamIndex: Int) -> Void)?
     var toolsListRefreshCompleted: (@Sendable (_ upstreamIndex: Int, _ succeeded: Bool) -> Void)?
+    var processToolsCatalogLoadedBeforeRecord:
+        (@Sendable (_ target: XcodeProcessTarget, _ upstreamIndex: Int) async -> Void)?
     var upstreamInitialized: (@Sendable (_ upstreamIndex: Int) -> Void)?
     var upstreamRequestQueued:
         (@Sendable (
@@ -52,6 +54,8 @@ struct RuntimeCoordinatorTestHooks: Sendable {
         initializedNotificationStaleIgnored: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil,
         upstreamEventHandled: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil,
         toolsListRefreshCompleted: (@Sendable (_ upstreamIndex: Int, _ succeeded: Bool) -> Void)? = nil,
+        processToolsCatalogLoadedBeforeRecord:
+            (@Sendable (_ target: XcodeProcessTarget, _ upstreamIndex: Int) async -> Void)? = nil,
         upstreamInitialized: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil,
         upstreamRequestQueued:
             (@Sendable (
@@ -64,6 +68,7 @@ struct RuntimeCoordinatorTestHooks: Sendable {
         self.initializedNotificationStaleIgnored = initializedNotificationStaleIgnored
         self.upstreamEventHandled = upstreamEventHandled
         self.toolsListRefreshCompleted = toolsListRefreshCompleted
+        self.processToolsCatalogLoadedBeforeRecord = processToolsCatalogLoadedBeforeRecord
         self.upstreamInitialized = upstreamInitialized
         self.upstreamRequestQueued = upstreamRequestQueued
         self.primaryInitializeFailureCleanupCompleted = primaryInitializeFailureCleanupCompleted
@@ -415,9 +420,10 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         startImmediately: Bool = true
     ) {
         let bridgeRuntimeConfig = config.mcpBridgeRuntimeConfiguration
-        let xcodeProcessRoutingEnabled = MCPBridgeRuntime.supportsProcessBoundRouting(
+        let xcodeProcessRoutingSupported = MCPBridgeRuntime.supportsProcessBoundRouting(
             config: bridgeRuntimeConfig
         )
+        let xcodeProcessRoutingEnabled = xcodeProcessRoutingSupported && xcodeTargetDiscovery != nil
         let documentationServiceEnabled = Self.documentationProviderServiceIsConfigured(
             config: config
         )
@@ -427,7 +433,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             : []
         let upstreamPlan = MCPBridgeRuntime.makeUpstreamPlan(
             config: bridgeRuntimeConfig,
-            xcodeTargets: xcodeTargets
+            xcodeTargets: xcodeTargets,
+            processBoundRoutingEnabled: xcodeProcessRoutingEnabled
         )
         let clock = ClockClient.liveValue
         let runtimeBox = WeakRuntimeCoordinatorBox()

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -552,7 +552,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             }
         self.config = config
         self.eventLoop = eventLoop
-        self.upstreamsBox = NIOLockedValueBox(upstreams)
+        let upstreamStore = NIOLockedValueBox(upstreams)
+        self.upstreamsBox = upstreamStore
         self.clock = runtimeClock
         let brokerState = CanonicalBrokerState()
         self.canonicalBrokerState = brokerState
@@ -561,16 +562,18 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.debugRecorder = ProxyDebugRecorder(upstreamCount: upstreams.count)
         self.leaseManager = LeaseManager()
         self.upstreamRouter = UpstreamRouter(upstreamCount: upstreams.count)
-        self.upstreamHealthManager = UpstreamHealthManager(upstreamCount: upstreams.count)
+        let upstreamHealthManager = UpstreamHealthManager(upstreamCount: upstreams.count)
+        self.upstreamHealthManager = upstreamHealthManager
         self.nowUptimeNanoseconds = uptimeProvider
         self.scheduleRuntimeTimeout = timeoutScheduler
         self.documentationProviderManager = documentationProviderManager
         self.processRoutingEnabled = resolvedProcessRoutingEnabled
-        self.xcodeProcessRegistry = XcodeProcessRegistry(
+        let xcodeProcessRegistry = XcodeProcessRegistry(
             initialRoutes: xcodeProcessRoutes,
             nowUptimeNs: uptimeProvider(),
             reason: "startup"
         )
+        self.xcodeProcessRegistry = xcodeProcessRegistry
         self.xcodeTargetDiscovery = xcodeTargetDiscovery
         self.dynamicUpstreamFactory = dynamicUpstreamFactory
         self.prewarmDocumentationProviderOnStartup = prewarmDocumentationProviderOnStartup
@@ -583,11 +586,25 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             gate: resolvedReadinessGate,
             logger: ProxyLogging.make("upstream.readiness")
         )
+        let activeProcessBoundUpstreamIndices: @Sendable () -> Set<Int> = {
+            guard resolvedProcessRoutingEnabled else { return [] }
+            return Set(xcodeProcessRegistry.activeRoutes().flatMap(\.upstreamIndices))
+        }
+        let inactiveProcessBoundUpstreamIndices: @Sendable () -> Set<Int> = {
+            guard resolvedProcessRoutingEnabled else { return [] }
+            let active = activeProcessBoundUpstreamIndices()
+            let upstreamCount = upstreamStore.withLockedValue { $0.count }
+            return Set(0..<upstreamCount).subtracting(active)
+        }
         self.upstreamSlotScheduler = UpstreamSlotScheduler(
             canUseUpstream: {
-                [weak upstreamHealthManager = self.upstreamHealthManager] upstreamIndex in
+                [weak upstreamHealthManager] upstreamIndex in
                 let nowUptimeNs = uptimeProvider()
                 guard let upstreamHealthManager else {
+                    return UpstreamHealthManager.UseEvaluation(isUsable: false, effects: [])
+                }
+                if resolvedProcessRoutingEnabled,
+                   activeProcessBoundUpstreamIndices().contains(upstreamIndex) == false {
                     return UpstreamHealthManager.UseEvaluation(isUsable: false, effects: [])
                 }
                 return upstreamHealthManager.evaluateUsableInitialized(
@@ -595,11 +612,11 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                     nowUptimeNs: nowUptimeNs
                 )
             },
-            selectUpstream: { [weak upstreamHealthManager = self.upstreamHealthManager] occupied in
+            selectUpstream: { [weak upstreamHealthManager] occupied in
                 let nowUptimeNs = uptimeProvider()
                 return upstreamHealthManager?.chooseBestInitializedUpstream(
                     nowUptimeNs: nowUptimeNs,
-                    occupiedUpstreams: occupied
+                    occupiedUpstreams: occupied.union(inactiveProcessBoundUpstreamIndices())
                 ) ?? UpstreamHealthManager.SelectionResult(upstreamIndex: nil, effects: [])
             },
             applyHealthEffects: { [runtimeBox] effects in
@@ -972,6 +989,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     func chooseUpstreamIndex() -> Int? {
         let nowUptimeNs = nowUptimeNanoseconds()
         let occupiedUpstreams = upstreamSlotScheduler.occupiedUpstreamIndices()
+            .union(inactiveProcessBoundUpstreamIndices())
 
         let chooseResult = upstreamHealthManager.chooseBestInitializedUpstream(
             nowUptimeNs: nowUptimeNs,
@@ -1037,13 +1055,13 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         preferredUpstreamIndices: [Int]?,
         starter: @escaping @Sendable (Int) -> EventLoopFuture<Output>
     ) -> EventLoopFuture<Output> {
-        let hasHealthyUpstream = upstreamHealthManager.initializedHealthyishCount() > 0
-        var recoveryInFlight = upstreamHealthManager.anyRecoveryInFlight()
+        let hasHealthyUpstream = activeInitializedHealthyishCount() > 0
+        var recoveryInFlight = anyActiveRecoveryInFlight()
         if hasHealthyUpstream == false, recoveryInFlight == false,
             initializeManager.consumeWarmInitRecoveryIntent(policy: .regardlessOfCachedInitialize)
         {
             startPrimaryEagerRetry()
-            recoveryInFlight = upstreamHealthManager.anyRecoveryInFlight()
+            recoveryInFlight = anyActiveRecoveryInFlight()
         }
         guard hasHealthyUpstream || recoveryInFlight else {
             _ = chooseUpstreamIndex()

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -80,6 +80,11 @@ struct XcodeProcessReconcileScheduleState: Sendable {
     var pendingReasons: [String] = []
 }
 
+struct XcodeProcessReconciliationLoopState: Sendable {
+    var generation: UInt64 = 0
+    var isRunning = false
+}
+
 typealias XcodeProcessUpstreamFactory =
     @Sendable (_ target: XcodeProcessTarget) -> [any UpstreamSlotControlling]
 
@@ -364,6 +369,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let initializeManager: InitializeManager
     let upstreamEventTasks = AsyncTaskSupervisor()
     let runtimeTasks = AsyncTaskSupervisor()
+    let xcodeProcessReconciliationLoopState =
+        NIOLockedValueBox(XcodeProcessReconciliationLoopState())
     let upstreamStderrLogLimiter = UpstreamStderrLogLimiter()
     let primaryInitializeReadinessTokenBox =
         NIOLockedValueBox<UpstreamReadinessWaiterToken?>(nil)
@@ -821,6 +828,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         )
         canonicalBrokerState.reset()
         processToolCatalogRegistry.reset()
+        restartXcodeProcessReconciliationLoopAfterRuntimeTaskReset()
     }
 
     func shutdown() async {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessEventMonitor.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessEventMonitor.swift
@@ -67,6 +67,7 @@ final class XcodeProcessEventMonitor: @unchecked Sendable {
             queue: DispatchQueue.global()
         )
         exitSources[processID] = source
+        let sourceIdentity = ObjectIdentifier(source as AnyObject)
         lock.unlock()
 
         source.setEventHandler {
@@ -75,7 +76,10 @@ final class XcodeProcessEventMonitor: @unchecked Sendable {
         source.setCancelHandler { [weak self] in
             guard let self else { return }
             self.lock.lock()
-            self.exitSources.removeValue(forKey: processID)
+            if let currentSource = self.exitSources[processID],
+               ObjectIdentifier(currentSource as AnyObject) == sourceIdentity {
+                self.exitSources.removeValue(forKey: processID)
+            }
             self.lock.unlock()
         }
         source.resume()

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessEventMonitor.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessEventMonitor.swift
@@ -1,0 +1,118 @@
+import Dispatch
+import Foundation
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+final class XcodeProcessEventMonitor: @unchecked Sendable {
+    private let lock = NSLock()
+    private var notificationTokens: [NSObjectProtocol] = []
+    private var exitSources: [pid_t: DispatchSourceProcess] = [:]
+    private var didStartWorkspaceNotifications = false
+
+    deinit {
+        stop()
+    }
+
+    func startWorkspaceNotifications(
+        trigger: @escaping @Sendable (_ reason: String) -> Void
+    ) {
+        #if canImport(AppKit)
+        lock.lock()
+        guard didStartWorkspaceNotifications == false else {
+            lock.unlock()
+            return
+        }
+        didStartWorkspaceNotifications = true
+        lock.unlock()
+
+        let center = NSWorkspace.shared.notificationCenter
+        let launchToken = center.addObserver(
+            forName: NSWorkspace.didLaunchApplicationNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(250)) {
+                trigger("workspace_launch")
+            }
+        }
+        let terminateToken = center.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            trigger("workspace_terminate")
+        }
+
+        lock.lock()
+        notificationTokens.append(launchToken)
+        notificationTokens.append(terminateToken)
+        lock.unlock()
+        #endif
+    }
+
+    func observeExit(
+        processID: pid_t,
+        trigger: @escaping @Sendable (_ reason: String) -> Void
+    ) {
+        lock.lock()
+        if exitSources[processID] != nil {
+            lock.unlock()
+            return
+        }
+        let source = DispatchSource.makeProcessSource(
+            identifier: processID,
+            eventMask: .exit,
+            queue: DispatchQueue.global()
+        )
+        exitSources[processID] = source
+        lock.unlock()
+
+        source.setEventHandler {
+            trigger("process_exit_\(processID)")
+        }
+        source.setCancelHandler { [weak self] in
+            guard let self else { return }
+            self.lock.lock()
+            self.exitSources.removeValue(forKey: processID)
+            self.lock.unlock()
+        }
+        source.resume()
+    }
+
+    func removeExitObserver(processID: pid_t) {
+        lock.lock()
+        let source = exitSources.removeValue(forKey: processID)
+        lock.unlock()
+        source?.cancel()
+    }
+
+    func stop() {
+        #if canImport(AppKit)
+        lock.lock()
+        let tokens = notificationTokens
+        notificationTokens.removeAll()
+        didStartWorkspaceNotifications = false
+        let sources = Array(exitSources.values)
+        exitSources.removeAll()
+        lock.unlock()
+
+        let center = NSWorkspace.shared.notificationCenter
+        for token in tokens {
+            center.removeObserver(token)
+        }
+        for source in sources {
+            source.cancel()
+        }
+        #else
+        lock.lock()
+        let sources = Array(exitSources.values)
+        exitSources.removeAll()
+        lock.unlock()
+        for source in sources {
+            source.cancel()
+        }
+        #endif
+    }
+}

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRegistry.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRegistry.swift
@@ -1,0 +1,192 @@
+import Foundation
+import NIOConcurrencyHelpers
+import XcodeMCPKit
+
+final class XcodeProcessRegistry: Sendable {
+    struct ReconcileResult: Sendable {
+        let addedRoutes: [XcodeProcessRoute]
+        let retiredRoutes: [XcodeProcessRoute]
+        let activeRoutes: [XcodeProcessRoute]
+
+        var didChange: Bool {
+            addedRoutes.isEmpty == false || retiredRoutes.isEmpty == false
+        }
+    }
+
+    private enum RouteState: String, Sendable {
+        case active
+        case retired
+    }
+
+    private struct InstanceKey: Hashable, Sendable {
+        let processID: pid_t
+        let appPath: String
+        let developerDir: String
+        let mcpbridgePath: String
+        let xcodeVersion: String
+
+        init(target: XcodeProcessTarget) {
+            self.processID = target.processID
+            self.appPath = target.appPath
+            self.developerDir = target.developerDir
+            self.mcpbridgePath = target.mcpbridgePath
+            self.xcodeVersion = target.xcodeVersion
+        }
+    }
+
+    private struct Record: Sendable {
+        let key: InstanceKey
+        var route: XcodeProcessRoute
+        var state: RouteState
+        var firstSeenGeneration: UInt64
+        var lastSeenGeneration: UInt64
+        var lastSeenUptimeNs: UInt64?
+        var missingSinceUptimeNs: UInt64?
+        var lastReconcileReason: String
+    }
+
+    private struct State: Sendable {
+        var recordsByKey: [InstanceKey: Record] = [:]
+        var order: [InstanceKey] = []
+        var generation: UInt64 = 0
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    init(
+        initialRoutes: [XcodeProcessRoute] = [],
+        nowUptimeNs: UInt64 = 0,
+        reason: String = "startup"
+    ) {
+        guard initialRoutes.isEmpty == false else { return }
+        state.withLockedValue { state in
+            for route in initialRoutes {
+                let key = InstanceKey(target: route.target)
+                guard state.recordsByKey[key] == nil else { continue }
+                state.generation &+= 1
+                let record = Record(
+                    key: key,
+                    route: route,
+                    state: .active,
+                    firstSeenGeneration: state.generation,
+                    lastSeenGeneration: state.generation,
+                    lastSeenUptimeNs: nowUptimeNs,
+                    missingSinceUptimeNs: nil,
+                    lastReconcileReason: reason
+                )
+                state.recordsByKey[key] = record
+                state.order.append(key)
+            }
+        }
+    }
+
+    func activeRoutes() -> [XcodeProcessRoute] {
+        state.withLockedValue { state in
+            state.order.compactMap { key in
+                guard let record = state.recordsByKey[key], record.state == .active else {
+                    return nil
+                }
+                return record.route
+            }
+        }
+    }
+
+    func reconcile(
+        targets: [XcodeProcessTarget],
+        reason: String,
+        nowUptimeNs: UInt64,
+        makeRoute: (XcodeProcessTarget) -> XcodeProcessRoute
+    ) -> ReconcileResult {
+        let orderedTargets = MCPBridgeRuntime.orderedXcodeTargets(targets)
+        return state.withLockedValue { state in
+            var addedRoutes: [XcodeProcessRoute] = []
+            var retiredRoutes: [XcodeProcessRoute] = []
+            let liveKeys = Set(orderedTargets.map(InstanceKey.init(target:)))
+
+            for target in orderedTargets {
+                let key = InstanceKey(target: target)
+                if var record = state.recordsByKey[key], record.state == .active {
+                    state.generation &+= 1
+                    record.route = XcodeProcessRoute(
+                        target: target,
+                        upstreamIndices: record.route.upstreamIndices
+                    )
+                    record.lastSeenGeneration = state.generation
+                    record.lastSeenUptimeNs = nowUptimeNs
+                    record.missingSinceUptimeNs = nil
+                    record.lastReconcileReason = reason
+                    state.recordsByKey[key] = record
+                    continue
+                }
+
+                let route = makeRoute(target)
+                state.generation &+= 1
+                let record = Record(
+                    key: key,
+                    route: route,
+                    state: .active,
+                    firstSeenGeneration: state.generation,
+                    lastSeenGeneration: state.generation,
+                    lastSeenUptimeNs: nowUptimeNs,
+                    missingSinceUptimeNs: nil,
+                    lastReconcileReason: reason
+                )
+                state.recordsByKey[key] = record
+                state.order.append(key)
+                addedRoutes.append(route)
+            }
+
+            for key in state.order {
+                guard liveKeys.contains(key) == false,
+                      var record = state.recordsByKey[key],
+                      record.state == .active else {
+                    continue
+                }
+                state.generation &+= 1
+                record.state = .retired
+                record.lastSeenGeneration = state.generation
+                record.missingSinceUptimeNs = nowUptimeNs
+                record.lastReconcileReason = reason
+                state.recordsByKey[key] = record
+                retiredRoutes.append(record.route)
+            }
+
+            let activeRoutes: [XcodeProcessRoute] = state.order.compactMap { key in
+                guard let record = state.recordsByKey[key], record.state == .active else {
+                    return nil
+                }
+                return record.route
+            }
+            return ReconcileResult(
+                addedRoutes: addedRoutes,
+                retiredRoutes: retiredRoutes,
+                activeRoutes: activeRoutes
+            )
+        }
+    }
+
+    func debugSnapshots(
+        usableSlotCount: @Sendable (XcodeProcessRoute) -> Int
+    ) -> [ProxyDebug.ProcessRouteSnapshot] {
+        state.withLockedValue { state in
+            state.order.compactMap { key in
+                guard let record = state.recordsByKey[key] else { return nil }
+                return ProxyDebug.ProcessRouteSnapshot(
+                    state: record.state.rawValue,
+                    processID: record.route.target.processID,
+                    appPath: record.route.target.appPath,
+                    developerDir: record.route.target.developerDir,
+                    mcpbridgePath: record.route.target.mcpbridgePath,
+                    xcodeVersion: record.route.target.xcodeVersion,
+                    upstreamIndices: record.route.upstreamIndices,
+                    usableSlotCount: usableSlotCount(record.route),
+                    firstSeenGeneration: record.firstSeenGeneration,
+                    lastSeenGeneration: record.lastSeenGeneration,
+                    lastSeenUptimeNs: record.lastSeenUptimeNs,
+                    missingSinceUptimeNs: record.missingSinceUptimeNs,
+                    lastReconcileReason: record.lastReconcileReason
+                )
+            }
+        }
+    }
+}

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRegistry.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRegistry.swift
@@ -166,13 +166,15 @@ final class XcodeProcessRegistry: Sendable {
     }
 
     func debugSnapshots(
-        usableSlotCount: @Sendable (XcodeProcessRoute) -> Int
+        usableSlotCount: @Sendable (XcodeProcessRoute) -> Int,
+        toolsCatalogState: @Sendable (XcodeProcessRoute, String) -> String
     ) -> [ProxyDebug.ProcessRouteSnapshot] {
         state.withLockedValue { state in
             state.order.compactMap { key in
                 guard let record = state.recordsByKey[key] else { return nil }
+                let routeState = record.state.rawValue
                 return ProxyDebug.ProcessRouteSnapshot(
-                    state: record.state.rawValue,
+                    state: routeState,
                     processID: record.route.target.processID,
                     appPath: record.route.target.appPath,
                     developerDir: record.route.target.developerDir,
@@ -180,6 +182,7 @@ final class XcodeProcessRegistry: Sendable {
                     xcodeVersion: record.route.target.xcodeVersion,
                     upstreamIndices: record.route.upstreamIndices,
                     usableSlotCount: usableSlotCount(record.route),
+                    toolsCatalogState: toolsCatalogState(record.route, routeState),
                     firstSeenGeneration: record.firstSeenGeneration,
                     lastSeenGeneration: record.lastSeenGeneration,
                     lastSeenUptimeNs: record.lastSeenUptimeNs,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRegistry.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRegistry.swift
@@ -132,7 +132,9 @@ final class XcodeProcessRegistry: Sendable {
                     lastReconcileReason: reason
                 )
                 state.recordsByKey[key] = record
-                state.order.append(key)
+                if state.order.contains(key) == false {
+                    state.order.append(key)
+                }
                 addedRoutes.append(route)
             }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRegistry.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRegistry.swift
@@ -101,7 +101,8 @@ final class XcodeProcessRegistry: Sendable {
         return state.withLockedValue { state in
             var addedRoutes: [XcodeProcessRoute] = []
             var retiredRoutes: [XcodeProcessRoute] = []
-            let liveKeys = Set(orderedTargets.map(InstanceKey.init(target:)))
+            let orderedKeys = orderedTargets.map(InstanceKey.init(target:))
+            let liveKeys = Set(orderedKeys)
 
             for target in orderedTargets {
                 let key = InstanceKey(target: target)
@@ -153,6 +154,7 @@ final class XcodeProcessRegistry: Sendable {
                 retiredRoutes.append(record.route)
             }
 
+            reorderActiveKeys(orderedKeys, in: &state)
             let activeRoutes: [XcodeProcessRoute] = state.order.compactMap { key in
                 guard let record = state.recordsByKey[key], record.state == .active else {
                     return nil
@@ -165,6 +167,21 @@ final class XcodeProcessRegistry: Sendable {
                 activeRoutes: activeRoutes
             )
         }
+    }
+
+    private func reorderActiveKeys(_ orderedKeys: [InstanceKey], in state: inout State) {
+        var activeKeys: [InstanceKey] = []
+        var activeKeySet = Set<InstanceKey>()
+        for key in orderedKeys {
+            guard let record = state.recordsByKey[key],
+                  record.state == .active,
+                  activeKeySet.insert(key).inserted else {
+                continue
+            }
+            activeKeys.append(key)
+        }
+        let historicalKeys = state.order.filter { activeKeySet.contains($0) == false }
+        state.order = activeKeys + historicalKeys
     }
 
     func debugSnapshots(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Session/ProxyDebugRecorder.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Session/ProxyDebugRecorder.swift
@@ -41,6 +41,13 @@ final class ProxyDebugRecorder: Sendable {
         }
     }
 
+    func appendUpstreams(count: Int) {
+        guard count > 0 else { return }
+        state.withLockedValue { state in
+            state.upstreams.append(contentsOf: Array(repeating: DebugUpstreamState(), count: count))
+        }
+    }
+
     func resetUpstream(_ upstreamIndex: Int) {
         state.withLockedValue { state in
             guard upstreamIndex >= 0, upstreamIndex < state.upstreams.count else { return }
@@ -138,6 +145,7 @@ final class ProxyDebugRecorder: Sendable {
         proxyInitialized: Bool,
         cachedToolsListAvailable: Bool,
         controlPlane: ControlPlane.DebugSnapshot?,
+        processRoutes: [ProxyDebug.ProcessRouteSnapshot],
         processToolCatalogs: [ProcessToolCatalogRegistry.DebugSnapshot],
         upstreamStates: [UpstreamHealthManager.UpstreamState],
         sessionSnapshots: [SessionRequestPipeline.DebugSnapshot],
@@ -206,6 +214,7 @@ final class ProxyDebugRecorder: Sendable {
             warmupInFlight: controlPlane?.phase == "loading_tools_catalog",
             controlPlane: controlPlane,
             upstreams: upstreamSnapshots,
+            processRoutes: processRoutes,
             processToolCatalogs: processToolCatalogs,
             recentTraffic: recordedState.recentTraffic.map {
                 ProxyDebug.TrafficEvent(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Session/ProxyDebugSnapshot.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Session/ProxyDebugSnapshot.swift
@@ -117,6 +117,24 @@ extension ProxyDebug {
 }
 
 extension ProxyDebug {
+    struct ProcessRouteSnapshot: Codable, Sendable {
+        let state: String
+        let processID: pid_t
+        let appPath: String
+        let developerDir: String
+        let mcpbridgePath: String
+        let xcodeVersion: String
+        let upstreamIndices: [Int]
+        let usableSlotCount: Int
+        let firstSeenGeneration: UInt64
+        let lastSeenGeneration: UInt64
+        let lastSeenUptimeNs: UInt64?
+        let missingSinceUptimeNs: UInt64?
+        let lastReconcileReason: String
+    }
+}
+
+extension ProxyDebug {
     struct Snapshot: Codable, Sendable {
         let generatedAt: Date
         let proxyInitialized: Bool
@@ -124,6 +142,7 @@ extension ProxyDebug {
         let warmupInFlight: Bool
         let controlPlane: ControlPlane.DebugSnapshot?
         let upstreams: [ProxyDebug.UpstreamSnapshot]
+        let processRoutes: [ProxyDebug.ProcessRouteSnapshot]
         let processToolCatalogs: [ProcessToolCatalogRegistry.DebugSnapshot]
         let recentTraffic: [ProxyDebug.TrafficEvent]
         let sessions: [SessionRequestPipeline.DebugSnapshot]
@@ -137,6 +156,7 @@ extension ProxyDebug {
             warmupInFlight: Bool,
             controlPlane: ControlPlane.DebugSnapshot? = nil,
             upstreams: [ProxyDebug.UpstreamSnapshot],
+            processRoutes: [ProxyDebug.ProcessRouteSnapshot] = [],
             processToolCatalogs: [ProcessToolCatalogRegistry.DebugSnapshot] = [],
             recentTraffic: [ProxyDebug.TrafficEvent],
             sessions: [SessionRequestPipeline.DebugSnapshot],
@@ -149,6 +169,7 @@ extension ProxyDebug {
             self.warmupInFlight = warmupInFlight
             self.controlPlane = controlPlane
             self.upstreams = upstreams
+            self.processRoutes = processRoutes
             self.processToolCatalogs = processToolCatalogs
             self.recentTraffic = recentTraffic
             self.sessions = sessions

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Session/ProxyDebugSnapshot.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Session/ProxyDebugSnapshot.swift
@@ -126,6 +126,7 @@ extension ProxyDebug {
         let xcodeVersion: String
         let upstreamIndices: [Int]
         let usableSlotCount: Int
+        let toolsCatalogState: String
         let firstSeenGeneration: UInt64
         let lastSeenGeneration: UInt64
         let lastSeenUptimeNs: UInt64?

--- a/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
+++ b/Tests/ProxyDocumentationProviderTests/DocumentationProviderTests.swift
@@ -3288,28 +3288,19 @@ struct DocumentationProviderTests {
                 timeout: .milliseconds(20)
             )
         }
-        try await waitWithTimeout("waiting for local DocumentationSearch process to suspend") {
-            try await runGate.waitUntilWaiting(for: 1, count: 1)
-        }
+        try await runGate.waitUntilWaiting(for: 1, count: 1)
         try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: timeoutClock,
             uptimeClock: uptimeClock,
             by: .milliseconds(20)
         )
         await #expect(throws: TimeoutError.self) {
-            _ = try await waitWithTimeout(
-                "local DocumentationSearch should honor the caller timeout",
-                timeout: .milliseconds(500)
-            ) {
-                try await searchTask.value
-            }
+            try await searchTask.value
         }
         let requests = await runner.recordedRequests()
         #expect(requests.count == 1)
         #expect(requests.first?.timeoutNanoseconds == 20_000_000)
-        _ = try await waitWithTimeout("waiting for local search process cancellation") {
-            try await runner.nextCancelledRunCount(at: 0)
-        }
+        _ = try await runner.nextCancelledRunCount(at: 0)
         #expect(await runner.cancelledRunCount() == 1)
     }
 

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -2565,7 +2565,7 @@ extension HTTPHandlerTests {
     }
 
     @Test func httpRefreshCodeIssuesRequeuesLeaseAcrossRetryAttempts() async throws {
-        var config = makeConfig(requestTimeout: 10)
+        var config = makeConfig(requestTimeout: 0)
         config.refreshCodeIssuesMode = .upstream
         let attempts = NIOLockedValueBox(0)
         let sessionManager = TestRuntimeCoordinator(
@@ -2616,6 +2616,7 @@ extension HTTPHandlerTests {
             let inFlightLease = try #require(sessionManager.leaseDebugSnapshots().first)
             #expect(inFlightLease.state == .active)
             #expect(inFlightLease.releaseReason == nil)
+            #expect(inFlightLease.timeoutAt == nil)
 
             sessionManager.deliverNextPendingResponse()
 

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -2565,7 +2565,7 @@ extension HTTPHandlerTests {
     }
 
     @Test func httpRefreshCodeIssuesRequeuesLeaseAcrossRetryAttempts() async throws {
-        var config = makeConfig(requestTimeout: 2)
+        var config = makeConfig(requestTimeout: 10)
         config.refreshCodeIssuesMode = .upstream
         let attempts = NIOLockedValueBox(0)
         let sessionManager = TestRuntimeCoordinator(

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -780,6 +780,127 @@ struct RuntimeCoordinatorTests {
         #expect(manager.debugSnapshot().processRoutes.map(\.state) == ["active", "retired"])
     }
 
+    @Test func processRoutingRetiringCachedInitializeSourceRestartsPrimaryOnIdleActiveRoute()
+        async throws
+    {
+        let cachedUpstream = TestUpstreamClient()
+        let activeUpstream = TestUpstreamClient()
+        let cachedTarget = xcodeProcessTarget(processID: 27025, xcodeVersion: "27.0")
+        let activeTarget = xcodeProcessTarget(processID: 26625, xcodeVersion: "26.6")
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [cachedUpstream, activeUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: cachedTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: activeTarget, upstreamIndices: [1]),
+            ],
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        let cachedHandshake = try jsonValue([
+            "protocolVersion": MCP.ProtocolVersion.current,
+            "capabilities": [String: Any](),
+            "serverInfo": ["name": "cached-source"],
+        ])
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.canonicalBrokerState.syncCanonicalInitialize(
+            cachedHandshake,
+            sourceUpstream: 0
+        )
+
+        manager.reconcileXcodeProcessTargets(
+            [activeTarget],
+            reason: "test_remove_cached_initialize_source"
+        )
+        _ = try await cachedUpstream.nextStopCount()
+
+        #expect(manager.testStateSnapshot().hasInitResult == false)
+        let restartedInitialize = try await activeUpstream.nextSent(at: 0)
+        #expect(methodName(from: restartedInitialize) == "initialize")
+        await activeUpstream.yield(
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: restartedInitialize),
+                    serverName: "active-primary"
+                )
+            )
+        )
+        let initializedNotification = try await activeUpstream.nextSent(at: 1)
+        #expect(methodName(from: initializedNotification) == "notifications/initialized")
+        await manager.drainRuntimeTasksForTesting()
+
+        #expect(manager.testStateSnapshot().hasInitResult)
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized)
+        #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 1)
+    }
+
+    @Test func processRoutingRetiringCachedInitializeSourceRestartsPrimaryOverWarmRoute()
+        async throws
+    {
+        let cachedUpstream = TestUpstreamClient()
+        let activeUpstream = TestUpstreamClient()
+        let cachedTarget = xcodeProcessTarget(processID: 27026, xcodeVersion: "27.0")
+        let activeTarget = xcodeProcessTarget(processID: 26626, xcodeVersion: "26.6")
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [cachedUpstream, activeUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: cachedTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: activeTarget, upstreamIndices: [1]),
+            ],
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        let cachedHandshake = try jsonValue([
+            "protocolVersion": MCP.ProtocolVersion.current,
+            "capabilities": [String: Any](),
+            "serverInfo": ["name": "cached-source"],
+        ])
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.canonicalBrokerState.syncCanonicalInitialize(
+            cachedHandshake,
+            sourceUpstream: 0
+        )
+        manager.startUpstreamWarmInitialize(upstreamIndex: 1)
+        let warmInitialize = try await activeUpstream.nextSent(at: 0)
+        let warmUpstreamID = try extractUpstreamID(from: warmInitialize)
+        #expect(manager.testStateSnapshot().upstreams[1].initInFlight)
+
+        manager.reconcileXcodeProcessTargets(
+            [activeTarget],
+            reason: "test_remove_cached_initialize_source_during_warm_init"
+        )
+        _ = try await cachedUpstream.nextStopCount()
+
+        let restartedInitialize = try await activeUpstream.nextSent(at: 1)
+        let restartedUpstreamID = try extractUpstreamID(from: restartedInitialize)
+        #expect(methodName(from: restartedInitialize) == "initialize")
+        await activeUpstream.yield(
+            .message(try makeInitializeResponse(id: warmUpstreamID, serverName: "stale-warm"))
+        )
+        await manager.drainRuntimeTasksForTesting()
+        #expect(manager.testStateSnapshot().hasInitResult == false)
+        #expect(manager.canonicalBrokerState.initializeSourceUpstream() == nil)
+
+        await activeUpstream.yield(
+            .message(
+                try makeInitializeResponse(
+                    id: restartedUpstreamID,
+                    serverName: "active-primary"
+                )
+            )
+        )
+        let initializedNotification = try await activeUpstream.nextSent(at: 2)
+        #expect(methodName(from: initializedNotification) == "notifications/initialized")
+        await manager.drainRuntimeTasksForTesting()
+
+        #expect(manager.testStateSnapshot().hasInitResult)
+        #expect(manager.testStateSnapshot().upstreams[1].isInitialized)
+        #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 1)
+    }
+
     @Test func processRoutingRetiringNonPrimaryRouteDoesNotStealPrimaryInitialize()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -37,6 +37,39 @@ struct RuntimeCoordinatorTests {
         #expect(plan.xcodeProcessRoutes.isEmpty)
     }
 
+    @Test func processRoutingWithoutInitialTargetsRunsReadinessAutoLaunch() async throws {
+        let readiness = ReadinessFlag(isReady: false)
+        let sleepRecorder = ControlledReadinessSleep()
+        let launchRecorder = XcodeLaunchRecorder()
+        let discovery = RecordingXcodeTargetDiscovery(targets: [])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                sleepRecorder: sleepRecorder,
+                recordPollSleeps: true,
+                launchRecorder: launchRecorder
+            ),
+            processRoutingEnabled: true,
+            xcodeTargetDiscovery: discovery
+        )
+        defer { fixture.shutdownAndWait() }
+
+        _ = try await waitWithTimeout("waiting for no-target Xcode launch", timeout: .seconds(2)) {
+            try await launchRecorder.nextLaunch(at: 0)
+        }
+        let sleep = try await waitWithTimeout(
+            "waiting for no-target readiness poll",
+            timeout: .seconds(2)
+        ) {
+            try await sleepRecorder.nextSleep(at: 0)
+        }
+
+        #expect(sleep == 1_000_000)
+        #expect(fixture.manager.debugSnapshot().upstreams.isEmpty)
+        #expect(fixture.manager.debugSnapshot().processRoutes.isEmpty)
+    }
+
     @Test func defaultCoordinatorWithoutDiscoveryUsesStaticFallbackUpstream() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -348,6 +381,43 @@ struct RuntimeCoordinatorTests {
         }
         await #expect(throws: TimeoutError.self) {
             try await secondFuture.get()
+        }
+    }
+
+    @Test func processRoutingLateXcodeKeepsOriginalInitializeTimeout()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27008, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let future = fixture.registerInitialize(
+            requestID: 1,
+            sessionID: "session-late-xcode-timeout"
+        )
+        #expect(timeoutScheduler.scheduledCount() == 1)
+
+        manager.reconcileXcodeProcessTargets([target], reason: "test_late_xcode_timeout")
+        let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        _ = try await upstream.nextSent(at: 0)
+
+        #expect(timeoutScheduler.scheduledCount() == 1)
+        timeoutScheduler.fire(at: 0)
+        await #expect(throws: TimeoutError.self) {
+            try await future.get()
         }
     }
 
@@ -886,6 +956,49 @@ struct RuntimeCoordinatorTests {
         #expect(response["result"] != nil)
         #expect(await oldUpstream.stopCount() == 1)
         #expect(manager.debugSnapshot().processRoutes.map(\.state) == ["active", "retired"])
+    }
+
+    @Test func processRoutingReadinessGateSkipsRetiredPrimaryRoute()
+        async throws
+    {
+        let oldUpstream = TestUpstreamClient()
+        let oldTarget = xcodeProcessTarget(processID: 27027, xcodeVersion: "27.0")
+        let readiness = ReadinessFlag(isReady: false)
+        let sleepRecorder = ControlledReadinessSleep()
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [oldUpstream],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                sleepRecorder: sleepRecorder,
+                recordPollSleeps: true
+            ),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: oldTarget, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        _ = try await readiness.nextCheck(at: 0)
+        _ = try await waitWithTimeout(
+            "waiting for primary readiness poll",
+            timeout: .seconds(2)
+        ) {
+            try await sleepRecorder.nextSleep(at: 0)
+        }
+
+        manager.reconcileXcodeProcessTargets([], reason: "test_retire_waiting_primary")
+        _ = try await oldUpstream.nextStopCount()
+
+        await readiness.setReady(true)
+        await sleepRecorder.resumeNext()
+        _ = try await readiness.nextCheck(at: 1)
+        await Task.yield()
+        await manager.drainRuntimeTasksForTesting()
+
+        #expect(await oldUpstream.startCount() == 0)
+        #expect(await oldUpstream.sentCount() == 0)
     }
 
     @Test func processRoutingRetiringCachedInitializeSourceRestartsPrimaryOnIdleActiveRoute()

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -16,6 +16,21 @@ struct RuntimeCoordinatorTests {
         #expect(environment["MCP_XCODE_PID"] == nil)
     }
 
+    @Test func defaultCoordinatorWithoutDiscoveryUsesStaticFallbackUpstream() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 0),
+            eventLoop: group.next(),
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+
+        #expect(manager.processRoutingEnabled == false)
+        #expect(manager.debugSnapshot().upstreams.count == 1)
+        #expect(manager.debugSnapshot().processRoutes.isEmpty)
+    }
+
     @Test func defaultUpstreamsPassThroughInheritedMCPXcodePIDEnvironment() async throws {
         let environment = try withEnvironmentVariables(
             [
@@ -3359,6 +3374,59 @@ struct RuntimeCoordinatorTests {
         }
         #expect(await upstream0.sentCount() == 1)
         #expect(await upstream1.sentCount() == 1)
+    }
+
+    @Test func sessionManagerDropsProcessToolsCatalogLoadedAfterRouteRetires()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let target = xcodeProcessTarget(processID: 80437, xcodeVersion: "27.0")
+        let upstream = AutoToolsListUpstreamClient(toolNames: ["RetiredOnlyTool"])
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let routeRetiredBeforeRecord = LockedRecordedValues<pid_t>()
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 0),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            testHooks: RuntimeCoordinatorTestHooks(
+                processToolsCatalogLoadedBeforeRecord: { loadedTarget, sourceUpstream in
+                    guard loadedTarget == target, sourceUpstream == 0 else {
+                        return
+                    }
+                    _ = runtimeBox.value?.xcodeProcessRegistry.reconcile(
+                        targets: [],
+                        reason: "test_route_retired_before_catalog_record",
+                        nowUptimeNs: 0,
+                        makeRoute: { XcodeProcessRoute(target: $0, upstreamIndices: []) }
+                    )
+                    routeRetiredBeforeRecord.append(loadedTarget.processID)
+                }
+            ),
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        do {
+            _ = try await manager.sharedToolsList(
+                sessionID: "session-process-catalog-stale-after-retire",
+                requestTimeoutOverride: nil
+            )
+            Issue.record("retired route tools/list catalog should not be returned")
+        } catch {
+            #expect(error is UpstreamSlotScheduler.AcquisitionError)
+        }
+        #expect(routeRetiredBeforeRecord.count() == 1)
+        #expect(await upstream.sentCount() == 1)
+        #expect(manager.cachedToolsListResult() == nil)
+        #expect(manager.debugSnapshot().processToolCatalogs.isEmpty)
+        #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == nil)
     }
 
     @Test func sessionManagerToolsListClearsSiblingCanonicalCatalogWhenProcessRouteUnavailable()
@@ -9892,4 +9960,45 @@ struct RuntimeCoordinatorTests {
         #expect(scheduler.debugSnapshot().queuedRequestCount == 0)
     }
 
+}
+
+private actor AutoToolsListUpstreamClient: UpstreamSlotControlling {
+    nonisolated let events: AsyncStream<Upstream.Event>
+    private let continuation: AsyncStream<Upstream.Event>.Continuation
+    private let sentMessages = RecordedValues<Data>()
+    private let toolNames: [String]
+
+    init(toolNames: [String]) {
+        self.toolNames = toolNames
+        var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
+        self.events = AsyncStream { continuation in
+            streamContinuation = continuation
+        }
+        self.continuation = streamContinuation
+    }
+
+    func start() async {}
+
+    func stop() async {
+        continuation.finish()
+    }
+
+    func send(_ data: Data) async -> Upstream.SendResult {
+        await sentMessages.append(data)
+        guard methodName(from: data) == "tools/list",
+              let upstreamID = try? extractUpstreamID(from: data),
+              let response = try? makeDocumentationToolsListResponse(
+                  id: upstreamID,
+                  tools: toolNames.map { toolDescriptor(name: $0) }
+              )
+        else {
+            return .accepted
+        }
+        continuation.yield(.message(response))
+        return .accepted
+    }
+
+    func sentCount() async -> Int {
+        await sentMessages.count()
+    }
 }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -388,6 +388,42 @@ struct RuntimeCoordinatorTests {
         }
     }
 
+    @Test func processRoutingDebugResetRestartsPeriodicReconcileLoop() async throws {
+        let clocks = makeRuntimeCoordinatorDeterministicClocks()
+        let discovery = RecordingXcodeTargetDiscovery(targets: [])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            clock: clocks.clock,
+            processRoutingEnabled: true,
+            xcodeTargetDiscovery: discovery,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        manager.start()
+        #expect(
+            try await waitForRecordedValue(
+                discovery.calls,
+                at: 0,
+                description: "waiting for startup process reconcile"
+            ) == 1
+        )
+        try await clocks.timeoutClock.sleep(untilSuspendedBy: 1)
+
+        manager.debugReset()
+        try await clocks.timeoutClock.sleep(untilSuspendedBy: 1)
+        clocks.timeoutClock.advance(by: .seconds(2))
+
+        #expect(
+            try await waitForRecordedValue(
+                discovery.calls,
+                at: 1,
+                description: "waiting for periodic process reconcile after debug reset"
+            ) == 2
+        )
+    }
+
     @Test func processRegistryReactivatesRetiredRouteWithoutDuplicatingOrder() {
         let target = xcodeProcessTarget(processID: 27003, xcodeVersion: "27.0")
         let registry = XcodeProcessRegistry()
@@ -10167,5 +10203,26 @@ private final class BlockingSequencedXcodeTargetDiscovery:
             callCountValue += 1
             return callCountValue
         }
+    }
+}
+
+private final class RecordingXcodeTargetDiscovery: XcodeTargetDiscovering, @unchecked Sendable {
+    let calls = LockedRecordedValues<Int>()
+
+    private let lock = NSLock()
+    private let targets: [XcodeProcessTarget]
+    private var callCountValue = 0
+
+    init(targets: [XcodeProcessTarget]) {
+        self.targets = targets
+    }
+
+    func runningXcodeTargets() -> [XcodeProcessTarget] {
+        let call = lock.withLock {
+            callCountValue += 1
+            return callCountValue
+        }
+        calls.append(call)
+        return targets
     }
 }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -198,6 +198,49 @@ struct RuntimeCoordinatorTests {
         #expect(snapshot.processRoutes.map(\.state) == ["active"])
     }
 
+    @Test func processRegistryReactivatesRetiredRouteWithoutDuplicatingOrder() {
+        let target = xcodeProcessTarget(processID: 27003, xcodeVersion: "27.0")
+        let registry = XcodeProcessRegistry()
+        var nextUpstreamIndex = 0
+        let makeRoute: (XcodeProcessTarget) -> XcodeProcessRoute = { target in
+            defer { nextUpstreamIndex += 1 }
+            return XcodeProcessRoute(target: target, upstreamIndices: [nextUpstreamIndex])
+        }
+
+        var result = registry.reconcile(
+            targets: [target],
+            reason: "initial_seen",
+            nowUptimeNs: 1,
+            makeRoute: makeRoute
+        )
+        #expect(result.addedRoutes.map(\.upstreamIndices) == [[0]])
+        #expect(registry.activeRoutes().map(\.upstreamIndices) == [[0]])
+
+        result = registry.reconcile(
+            targets: [],
+            reason: "transient_missing",
+            nowUptimeNs: 2,
+            makeRoute: makeRoute
+        )
+        #expect(result.retiredRoutes.map(\.upstreamIndices) == [[0]])
+        #expect(registry.activeRoutes().isEmpty)
+
+        result = registry.reconcile(
+            targets: [target],
+            reason: "seen_again",
+            nowUptimeNs: 3,
+            makeRoute: makeRoute
+        )
+        #expect(result.addedRoutes.map(\.upstreamIndices) == [[1]])
+        #expect(registry.activeRoutes().map(\.upstreamIndices) == [[1]])
+        let snapshots = registry.debugSnapshots(
+            usableSlotCount: { $0.upstreamIndices.count },
+            toolsCatalogState: { _, state in state }
+        )
+        #expect(snapshots.map(\.processID) == [target.processID])
+        #expect(snapshots.map(\.state) == ["active"])
+    }
+
     @Test func processRoutingAddsLateXcodeProcessWithoutRestart() async throws {
         let olderUpstream = TestUpstreamClient()
         let olderTarget = xcodeProcessTarget(processID: 26610, xcodeVersion: "26.6")

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -220,6 +220,12 @@ struct RuntimeCoordinatorTests {
         let manager = fixture.manager
 
         _ = try await fixture.initializePrimary(on: olderUpstream)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (olderTarget, 0, [toolDescriptor(name: "Only26")]),
+            ]
+        )
         manager.reconcileXcodeProcessTargets(
             [olderTarget, newerTarget],
             reason: "test_add_late_xcode"
@@ -229,10 +235,38 @@ struct RuntimeCoordinatorTests {
         let warmInitialize = try await sentValue(from: newerUpstream, at: 0, timeout: .seconds(2))
         let warmUpstreamID = try extractUpstreamID(from: warmInitialize)
         await newerUpstream.yield(.message(try makeInitializeResponse(id: warmUpstreamID)))
-        _ = try await sentValue(from: newerUpstream, at: 1, timeout: .seconds(2))
+        let initializedNotification = try await sentValue(
+            from: newerUpstream,
+            at: 1,
+            timeout: .seconds(2)
+        )
+        #expect(methodName(from: initializedNotification) == "notifications/initialized")
+        let toolsRequest = try await sentValue(
+            from: newerUpstream,
+            startingAt: 2,
+            matching: { methodName(from: $0) == "tools/list" },
+            timeout: .seconds(2),
+            description: "waiting for late-added process tools/list"
+        )
+        await newerUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: toolsRequest),
+                    tools: [
+                        toolDescriptor(name: "Only27"),
+                    ]
+                )
+            )
+        )
+        _ = try await waitWithTimeout("waiting for late process catalog sync") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 1
+            }
+        }
 
         let snapshot = manager.debugSnapshot()
         #expect(snapshot.processRoutes.map(\.state) == ["active", "active"])
+        #expect(snapshot.processRoutes.map(\.toolsCatalogState) == ["available", "available"])
         #expect(snapshot.processRoutes.map(\.processID) == [
             olderTarget.processID,
             newerTarget.processID,
@@ -240,6 +274,111 @@ struct RuntimeCoordinatorTests {
         #expect(manager.documentationCandidateProcessIDs() == Set([
             olderTarget.processID,
             newerTarget.processID,
+        ]))
+        #expect(Set(snapshot.processToolCatalogs.map(\.processID)) == Set([
+            olderTarget.processID,
+            newerTarget.processID,
+        ]))
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set([
+            "Only26",
+            "Only27",
+        ]))
+    }
+
+    @Test func processRoutingRetriesLateXcodeUntilMCPBridgeCanConnect() async throws {
+        let olderUpstream = TestUpstreamClient()
+        let olderTarget = xcodeProcessTarget(processID: 26611, xcodeVersion: "26.6")
+        let newerTarget = xcodeProcessTarget(processID: 27011, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [olderUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        _ = try await fixture.initializePrimary(on: olderUpstream)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (olderTarget, 0, [toolDescriptor(name: "Only26")]),
+            ]
+        )
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_add_late_xcode_before_workspace"
+        )
+
+        let newerUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        let firstInitialize = try await sentValue(
+            from: newerUpstream,
+            at: 0,
+            timeout: .seconds(2)
+        )
+        manager.handleUpstreamInitTimeout(
+            upstreamIndex: 1,
+            upstreamID: try extractUpstreamID(from: firstInitialize)
+        )
+        let pendingSnapshot = manager.debugSnapshot()
+        #expect(pendingSnapshot.processRoutes.map(\.toolsCatalogState) == [
+            "available",
+            "pending",
+        ])
+
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_workspace_opened"
+        )
+        let retriedInitialize = try await sentValue(
+            from: newerUpstream,
+            at: 1,
+            timeout: .seconds(2)
+        )
+        await newerUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retriedInitialize)))
+        )
+        _ = try await sentValue(from: newerUpstream, at: 2, timeout: .seconds(2))
+        let toolsRequest = try await sentValue(
+            from: newerUpstream,
+            startingAt: 3,
+            matching: { methodName(from: $0) == "tools/list" },
+            timeout: .seconds(2),
+            description: "waiting for retried late process tools/list"
+        )
+        await newerUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: toolsRequest),
+                    tools: [
+                        toolDescriptor(name: "Only27"),
+                    ]
+                )
+            )
+        )
+        _ = try await waitWithTimeout("waiting for retried process catalog sync") {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 1
+            }
+        }
+
+        let snapshot = manager.debugSnapshot()
+        #expect(snapshot.processRoutes.map(\.toolsCatalogState) == ["available", "available"])
+        #expect(Set(snapshot.processToolCatalogs.map(\.processID)) == Set([
+            olderTarget.processID,
+            newerTarget.processID,
+        ]))
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set([
+            "Only26",
+            "Only27",
         ]))
     }
 

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -16,6 +16,27 @@ struct RuntimeCoordinatorTests {
         #expect(environment["MCP_XCODE_PID"] == nil)
     }
 
+    @Test func upstreamPlanDefaultsToStaticFallbackWhenNoTargetsAreProvided() {
+        let plan = MCPBridgeRuntime.makeUpstreamPlan(
+            config: makeBridgeRuntimeConfig(makeConfig(requestTimeout: 0)),
+            xcodeTargets: []
+        )
+
+        #expect(plan.upstreams.count == 1)
+        #expect(plan.xcodeProcessRoutes.isEmpty)
+    }
+
+    @Test func upstreamPlanExplicitProcessRoutingCanStartWithoutInitialTargets() {
+        let plan = MCPBridgeRuntime.makeUpstreamPlan(
+            config: makeBridgeRuntimeConfig(makeConfig(requestTimeout: 0)),
+            xcodeTargets: [],
+            processBoundRoutingEnabled: true
+        )
+
+        #expect(plan.upstreams.isEmpty)
+        #expect(plan.xcodeProcessRoutes.isEmpty)
+    }
+
     @Test func defaultCoordinatorWithoutDiscoveryUsesStaticFallbackUpstream() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -262,7 +262,12 @@ struct RuntimeCoordinatorTests {
         defer { fixture.shutdownAndWait() }
         let manager = fixture.manager
 
-        _ = try await fixture.initializePrimary(on: olderUpstream)
+        let olderInitializeFuture = fixture.registerInitialize(requestID: 1)
+        let olderInitialize = try await olderUpstream.nextSent(at: 0)
+        await olderUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: olderInitialize)))
+        )
+        _ = try await olderInitializeFuture.get()
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
@@ -340,7 +345,12 @@ struct RuntimeCoordinatorTests {
         defer { fixture.shutdownAndWait() }
         let manager = fixture.manager
 
-        _ = try await fixture.initializePrimary(on: olderUpstream)
+        let olderInitializeFuture = fixture.registerInitialize(requestID: 1)
+        let olderInitialize = try await olderUpstream.nextSent(at: 0)
+        await olderUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: olderInitialize)))
+        )
+        _ = try await olderInitializeFuture.get()
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
@@ -424,7 +434,12 @@ struct RuntimeCoordinatorTests {
         defer { fixture.shutdownAndWait() }
         let manager = fixture.manager
 
-        _ = try await fixture.initializePrimary(on: oldUpstream)
+        let oldInitializeFuture = fixture.registerInitialize(requestID: 1)
+        let oldInitialize = try await oldUpstream.nextSent(at: 0)
+        await oldUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: oldInitialize)))
+        )
+        _ = try await oldInitializeFuture.get()
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
@@ -444,7 +459,7 @@ struct RuntimeCoordinatorTests {
             [relaunchedTarget],
             reason: "test_relaunch"
         )
-        manager.drainRuntimeTasksAndWaitForTesting()
+        _ = try await oldUpstream.nextStopCount()
 
         let relaunchedUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
         let initialize = try await relaunchedUpstream.nextSent(at: 0)
@@ -461,6 +476,94 @@ struct RuntimeCoordinatorTests {
         #expect(snapshot.processToolCatalogs.isEmpty)
         #expect(await oldUpstream.stopCount() == 1)
         #expect(manager.documentationCandidateProcessIDs() == Set([relaunchedTarget.processID]))
+
+        let oldSentCountAfterRetire = await oldUpstream.sentCount()
+        manager.warmUpSecondaryUpstreams(excluding: 1)
+        #expect(await oldUpstream.sentCount() == oldSentCountAfterRetire)
+    }
+
+    @Test func processRoutingRetiresInFlightPrimaryStopsOldSlotAndRetriesActiveRoute()
+        async throws
+    {
+        let oldUpstream = TestUpstreamClient()
+        let activeUpstream = TestUpstreamClient()
+        let oldTarget = xcodeProcessTarget(processID: 27022, xcodeVersion: "27.0")
+        let activeTarget = xcodeProcessTarget(processID: 26622, xcodeVersion: "26.6")
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [oldUpstream, activeUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: oldTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: activeTarget, upstreamIndices: [1]),
+            ],
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let initializeFuture = fixture.registerInitialize(requestID: 1)
+        _ = try await oldUpstream.nextSent(at: 0)
+
+        manager.reconcileXcodeProcessTargets([activeTarget], reason: "test_remove_inflight")
+        _ = try await oldUpstream.nextStopCount()
+
+        let retriedInitialize = try await activeUpstream.nextSent(at: 0)
+        await activeUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retriedInitialize)))
+        )
+
+        let response = try decodeJSON(from: try await initializeFuture.get())
+        #expect(response["result"] != nil)
+        #expect(await oldUpstream.stopCount() == 1)
+        #expect(manager.debugSnapshot().processRoutes.map(\.state) == ["retired", "active"])
+    }
+
+    @Test func processRoutingDoesNotSelectRetiredSlotEvenIfHealthLooksInitialized()
+        async throws
+    {
+        let retiredUpstream = TestUpstreamClient()
+        let activeUpstream = TestUpstreamClient()
+        let retiredTarget = xcodeProcessTarget(processID: 27023, xcodeVersion: "27.0")
+        let activeTarget = xcodeProcessTarget(processID: 26623, xcodeVersion: "26.6")
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [retiredUpstream, activeUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: retiredTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: activeTarget, upstreamIndices: [1]),
+            ],
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        manager.reconcileXcodeProcessTargets([activeTarget], reason: "test_retire_slot")
+        _ = try await retiredUpstream.nextStopCount()
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let descriptor = SessionRequestPipeline.Descriptor(
+            sessionID: "session-retired-slot",
+            label: "tools/call:GenericTool",
+            isBatch: false,
+            expectsResponse: true,
+            isTopLevelClientRequest: true
+        )
+        let leaseID = manager.createRequestLease(descriptor: descriptor)
+        let selectedUpstream = NIOLockedValueBox<Int?>(nil)
+        let future: EventLoopFuture<Void> = manager.enqueueOnUpstreamSlot(
+            leaseID: leaseID,
+            descriptor: descriptor,
+            on: fixture.eventLoop
+        ) { upstreamIndex in
+            selectedUpstream.withLockedValue { $0 = upstreamIndex }
+            return fixture.eventLoop.makeSucceededFuture(())
+        }
+
+        _ = try await future.get()
+        #expect(selectedUpstream.withLockedValue { $0 } == 1)
+        manager.completeRequestLease(leaseID)
     }
 
     @Test func sessionManagerRetriesProcessPrimaryInitializeOnNextXcodeProcessAfterError()

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -234,6 +234,90 @@ struct RuntimeCoordinatorTests {
         #expect(snapshot.processRoutes.map(\.state) == ["active"])
     }
 
+    @Test func processRoutingSerializesTriggeredReconciles() async throws {
+        let olderTarget = xcodeProcessTarget(processID: 27004, xcodeVersion: "26.6")
+        let newerTarget = xcodeProcessTarget(processID: 27005, xcodeVersion: "27.0")
+        let discovery = BlockingSequencedXcodeTargetDiscovery(
+            firstTargets: [olderTarget],
+            secondTargets: [newerTarget]
+        )
+        let routeCreations = LockedRecordedValues<pid_t>()
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            processRoutingEnabled: true,
+            xcodeTargetDiscovery: discovery,
+            dynamicUpstreamFactory: { target in
+                routeCreations.append(target.processID)
+                return [TestUpstreamClient()]
+            },
+            startImmediately: false
+        )
+        defer {
+            discovery.releaseFirst()
+            fixture.shutdownAndWait()
+        }
+        let manager = fixture.manager
+
+        manager.triggerXcodeProcessReconcile(reason: "first_snapshot")
+        try await discovery.firstStarted.waitUntilSignaled()
+        manager.triggerXcodeProcessReconcile(reason: "second_snapshot")
+
+        #expect(discovery.callCount() == 1)
+        discovery.releaseFirst()
+
+        try await discovery.secondStarted.waitUntilSignaled()
+        #expect(try await nextRecordedValue(routeCreations, at: 1) == newerTarget.processID)
+        #expect(discovery.callCount() == 2)
+        #expect(manager.xcodeProcessRoutes.map(\.target.processID) == [newerTarget.processID])
+        let processRoutes = manager.debugSnapshot().processRoutes
+        #expect(processRoutes.map(\.processID) == [
+            olderTarget.processID,
+            newerTarget.processID,
+        ])
+        #expect(processRoutes.map(\.state) == ["retired", "active"])
+    }
+
+    @Test func processRoutingReschedulesQueuedReconcileAfterWorkerCancellation() async throws {
+        let canceledTarget = xcodeProcessTarget(processID: 27006, xcodeVersion: "26.6")
+        let recoveredTarget = xcodeProcessTarget(processID: 27007, xcodeVersion: "27.0")
+        let discovery = BlockingSequencedXcodeTargetDiscovery(
+            firstTargets: [canceledTarget],
+            secondTargets: [recoveredTarget]
+        )
+        let routeCreations = LockedRecordedValues<pid_t>()
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            processRoutingEnabled: true,
+            xcodeTargetDiscovery: discovery,
+            dynamicUpstreamFactory: { target in
+                routeCreations.append(target.processID)
+                return [TestUpstreamClient()]
+            },
+            startImmediately: false
+        )
+        defer {
+            discovery.releaseFirst()
+            fixture.shutdownAndWait()
+        }
+        let manager = fixture.manager
+
+        manager.triggerXcodeProcessReconcile(reason: "cancelled_snapshot")
+        try await discovery.firstStarted.waitUntilSignaled()
+        manager.debugReset()
+        manager.triggerXcodeProcessReconcile(reason: "queued_after_cancel")
+
+        #expect(discovery.callCount() == 1)
+        discovery.releaseFirst()
+
+        try await discovery.secondStarted.waitUntilSignaled()
+        #expect(try await nextRecordedValue(routeCreations, at: 0) == recoveredTarget.processID)
+        #expect(discovery.callCount() == 2)
+        #expect(manager.xcodeProcessRoutes.map(\.target.processID) == [recoveredTarget.processID])
+        let processRoutes = manager.debugSnapshot().processRoutes
+        #expect(processRoutes.map(\.processID) == [recoveredTarget.processID])
+        #expect(processRoutes.map(\.state) == ["active"])
+    }
+
     @Test func processRoutingNoXcodeInitializeWaitDoesNotRescheduleTimeoutForJoinedClient()
         async throws
     {
@@ -10021,5 +10105,65 @@ private actor AutoToolsListUpstreamClient: UpstreamSlotControlling {
 
     func sentCount() async -> Int {
         await sentMessages.count()
+    }
+}
+
+private final class BlockingSequencedXcodeTargetDiscovery:
+    XcodeTargetDiscovering,
+    @unchecked Sendable
+{
+    let firstStarted = TestSignal()
+    let secondStarted = TestSignal()
+
+    private let lock = NSLock()
+    private let firstTargets: [XcodeProcessTarget]
+    private let secondTargets: [XcodeProcessTarget]
+    private let releaseFirstSemaphore = DispatchSemaphore(value: 0)
+    private var callCountValue = 0
+    private var firstReleased = false
+
+    init(
+        firstTargets: [XcodeProcessTarget],
+        secondTargets: [XcodeProcessTarget]
+    ) {
+        self.firstTargets = firstTargets
+        self.secondTargets = secondTargets
+    }
+
+    func runningXcodeTargets() -> [XcodeProcessTarget] {
+        let call = nextCallCount()
+        if call == 1 {
+            firstStarted.signal()
+            releaseFirstSemaphore.wait()
+            return firstTargets
+        }
+        if call == 2 {
+            secondStarted.signal()
+        }
+        return secondTargets
+    }
+
+    func releaseFirst() {
+        let shouldRelease = lock.withLock { () -> Bool in
+            guard firstReleased == false else {
+                return false
+            }
+            firstReleased = true
+            return true
+        }
+        if shouldRelease {
+            releaseFirstSemaphore.signal()
+        }
+    }
+
+    func callCount() -> Int {
+        lock.withLock { callCountValue }
+    }
+
+    private func nextCallCount() -> Int {
+        lock.withLock {
+            callCountValue += 1
+            return callCountValue
+        }
     }
 }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -187,7 +187,7 @@ struct RuntimeCoordinatorTests {
         manager.reconcileXcodeProcessTargets([target], reason: "test_late_xcode")
 
         let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
-        let initializeRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let initializeRequest = try await upstream.nextSent(at: 0)
         let upstreamID = try extractUpstreamID(from: initializeRequest)
         await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
 
@@ -275,21 +275,14 @@ struct RuntimeCoordinatorTests {
         )
 
         let newerUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
-        let warmInitialize = try await sentValue(from: newerUpstream, at: 0, timeout: .seconds(2))
+        let warmInitialize = try await newerUpstream.nextSent(at: 0)
         let warmUpstreamID = try extractUpstreamID(from: warmInitialize)
         await newerUpstream.yield(.message(try makeInitializeResponse(id: warmUpstreamID)))
-        let initializedNotification = try await sentValue(
-            from: newerUpstream,
-            at: 1,
-            timeout: .seconds(2)
-        )
+        let initializedNotification = try await newerUpstream.nextSent(at: 1)
         #expect(methodName(from: initializedNotification) == "notifications/initialized")
-        let toolsRequest = try await sentValue(
-            from: newerUpstream,
+        let toolsRequest = try await newerUpstream.nextSent(
             startingAt: 2,
-            matching: { methodName(from: $0) == "tools/list" },
-            timeout: .seconds(2),
-            description: "waiting for late-added process tools/list"
+            matching: { methodName(from: $0) == "tools/list" }
         )
         await newerUpstream.yield(
             .message(
@@ -301,10 +294,8 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
-        _ = try await waitWithTimeout("waiting for late process catalog sync") {
-            try await manager.controlPlaneDebugMirror.waitForSnapshot {
-                $0.canonicalToolsSourceUpstream == 1
-            }
+        _ = try await manager.controlPlaneDebugMirror.waitForSnapshot {
+            $0.canonicalToolsSourceUpstream == 1
         }
 
         let snapshot = manager.debugSnapshot()
@@ -362,11 +353,7 @@ struct RuntimeCoordinatorTests {
         )
 
         let newerUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
-        let firstInitialize = try await sentValue(
-            from: newerUpstream,
-            at: 0,
-            timeout: .seconds(2)
-        )
+        let firstInitialize = try await newerUpstream.nextSent(at: 0)
         manager.handleUpstreamInitTimeout(
             upstreamIndex: 1,
             upstreamID: try extractUpstreamID(from: firstInitialize)
@@ -381,21 +368,14 @@ struct RuntimeCoordinatorTests {
             [olderTarget, newerTarget],
             reason: "test_workspace_opened"
         )
-        let retriedInitialize = try await sentValue(
-            from: newerUpstream,
-            at: 1,
-            timeout: .seconds(2)
-        )
+        let retriedInitialize = try await newerUpstream.nextSent(at: 1)
         await newerUpstream.yield(
             .message(try makeInitializeResponse(id: try extractUpstreamID(from: retriedInitialize)))
         )
-        _ = try await sentValue(from: newerUpstream, at: 2, timeout: .seconds(2))
-        let toolsRequest = try await sentValue(
-            from: newerUpstream,
+        _ = try await newerUpstream.nextSent(at: 2)
+        let toolsRequest = try await newerUpstream.nextSent(
             startingAt: 3,
-            matching: { methodName(from: $0) == "tools/list" },
-            timeout: .seconds(2),
-            description: "waiting for retried late process tools/list"
+            matching: { methodName(from: $0) == "tools/list" }
         )
         await newerUpstream.yield(
             .message(
@@ -407,10 +387,8 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
-        _ = try await waitWithTimeout("waiting for retried process catalog sync") {
-            try await manager.controlPlaneDebugMirror.waitForSnapshot {
-                $0.canonicalToolsSourceUpstream == 1
-            }
+        _ = try await manager.controlPlaneDebugMirror.waitForSnapshot {
+            $0.canonicalToolsSourceUpstream == 1
         }
 
         let snapshot = manager.debugSnapshot()
@@ -469,14 +447,10 @@ struct RuntimeCoordinatorTests {
         manager.drainRuntimeTasksAndWaitForTesting()
 
         let relaunchedUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
-        let initialize = try await sentValue(
-            from: relaunchedUpstream,
-            at: 0,
-            timeout: .seconds(2)
-        )
+        let initialize = try await relaunchedUpstream.nextSent(at: 0)
         let upstreamID = try extractUpstreamID(from: initialize)
         await relaunchedUpstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
-        _ = try await sentValue(from: relaunchedUpstream, at: 1, timeout: .seconds(2))
+        _ = try await relaunchedUpstream.nextSent(at: 1)
 
         let snapshot = manager.debugSnapshot()
         #expect(snapshot.processRoutes.map(\.state) == ["retired", "active"])

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -163,6 +163,150 @@ struct RuntimeCoordinatorTests {
         #expect(response["result"] != nil)
     }
 
+    @Test func processRoutingWaitsForLateXcodeBeforeCompletingInitialize()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27002, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let future = fixture.registerInitialize(requestID: 1)
+        #expect(manager.testStateSnapshot().initInFlight == false)
+
+        manager.reconcileXcodeProcessTargets([target], reason: "test_late_xcode")
+
+        let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        let initializeRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let upstreamID = try extractUpstreamID(from: initializeRequest)
+        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
+
+        let response = try decodeJSON(from: try await future.get())
+        #expect(response["result"] != nil)
+        let snapshot = manager.debugSnapshot()
+        #expect(snapshot.processRoutes.map(\.processID) == [target.processID])
+        #expect(snapshot.processRoutes.map(\.state) == ["active"])
+    }
+
+    @Test func processRoutingAddsLateXcodeProcessWithoutRestart() async throws {
+        let olderUpstream = TestUpstreamClient()
+        let olderTarget = xcodeProcessTarget(processID: 26610, xcodeVersion: "26.6")
+        let newerTarget = xcodeProcessTarget(processID: 27010, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [olderUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        _ = try await fixture.initializePrimary(on: olderUpstream)
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_add_late_xcode"
+        )
+
+        let newerUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        let warmInitialize = try await sentValue(from: newerUpstream, at: 0, timeout: .seconds(2))
+        let warmUpstreamID = try extractUpstreamID(from: warmInitialize)
+        await newerUpstream.yield(.message(try makeInitializeResponse(id: warmUpstreamID)))
+        _ = try await sentValue(from: newerUpstream, at: 1, timeout: .seconds(2))
+
+        let snapshot = manager.debugSnapshot()
+        #expect(snapshot.processRoutes.map(\.state) == ["active", "active"])
+        #expect(snapshot.processRoutes.map(\.processID) == [
+            olderTarget.processID,
+            newerTarget.processID,
+        ])
+        #expect(manager.documentationCandidateProcessIDs() == Set([
+            olderTarget.processID,
+            newerTarget.processID,
+        ]))
+    }
+
+    @Test func processRoutingRetiresCrashedPIDAndAddsRelaunchedPID() async throws {
+        let oldUpstream = TestUpstreamClient()
+        let oldTarget = xcodeProcessTarget(processID: 27020, xcodeVersion: "27.0")
+        let relaunchedTarget = xcodeProcessTarget(processID: 27021, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [oldUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: oldTarget, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        _ = try await fixture.initializePrimary(on: oldUpstream)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (oldTarget, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
+        #expect(manager.recordXcodeWindowOwners(
+            from: try jsonValue([
+                "structuredContent": [
+                    "message": "* tabIdentifier: old-tab, workspacePath: /Old/App.xcworkspace",
+                ],
+            ]),
+            upstreamIndex: 0
+        ))
+
+        manager.reconcileXcodeProcessTargets(
+            [relaunchedTarget],
+            reason: "test_relaunch"
+        )
+        manager.drainRuntimeTasksAndWaitForTesting()
+
+        let relaunchedUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        let initialize = try await sentValue(
+            from: relaunchedUpstream,
+            at: 0,
+            timeout: .seconds(2)
+        )
+        let upstreamID = try extractUpstreamID(from: initialize)
+        await relaunchedUpstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
+        _ = try await sentValue(from: relaunchedUpstream, at: 1, timeout: .seconds(2))
+
+        let snapshot = manager.debugSnapshot()
+        #expect(snapshot.processRoutes.map(\.state) == ["retired", "active"])
+        #expect(snapshot.processRoutes.map(\.processID) == [
+            oldTarget.processID,
+            relaunchedTarget.processID,
+        ])
+        #expect(snapshot.processToolCatalogs.isEmpty)
+        #expect(await oldUpstream.stopCount() == 1)
+        #expect(manager.documentationCandidateProcessIDs() == Set([relaunchedTarget.processID]))
+    }
+
     @Test func sessionManagerRetriesProcessPrimaryInitializeOnNextXcodeProcessAfterError()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -3298,6 +3298,7 @@ struct RuntimeCoordinatorTests {
         let latestUpstream = TestUpstreamClient()
         let olderTarget = xcodeProcessTarget(processID: 66341, xcodeVersion: "26.6")
         let latestTarget = xcodeProcessTarget(processID: 80428, xcodeVersion: "27.0")
+        let toolsListRefreshes = NIOLockedValueBox<[String]>([])
         let manager = RuntimeCoordinator(
             config: makeConfig(requestTimeout: 5),
             eventLoop: eventLoop,
@@ -3306,6 +3307,13 @@ struct RuntimeCoordinatorTests {
                 XcodeProcessRoute(target: latestTarget, upstreamIndices: [1]),
                 XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
             ],
+            testHooks: RuntimeCoordinatorTestHooks(
+                toolsListRefreshCompleted: { upstreamIndex, succeeded in
+                    toolsListRefreshes.withLockedValue {
+                        $0.append("\(upstreamIndex):\(succeeded)")
+                    }
+                }
+            ),
             startImmediately: false
         )
         defer { manager.shutdownAndWait() }
@@ -3339,6 +3347,19 @@ struct RuntimeCoordinatorTests {
         #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [
             olderTarget.processID,
         ])
+
+        await latestUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: latestRequest),
+                    tools: [
+                        toolDescriptor(name: "LatestRouteOnly"),
+                    ]
+                )
+            )
+        )
+        await manager.drainRuntimeTasksForTesting()
+        #expect(toolsListRefreshes.withLockedValue { $0 } == ["1:true"])
     }
 
     @Test func sessionManagerToolsListSkipsUnavailableProcessRouteCatalog() async throws {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -518,6 +518,47 @@ struct RuntimeCoordinatorTests {
         #expect(manager.debugSnapshot().processRoutes.map(\.state) == ["retired", "active"])
     }
 
+    @Test func processRoutingRetiringNonPrimaryRouteDoesNotStealPrimaryInitialize()
+        async throws
+    {
+        let primaryUpstream = TestUpstreamClient()
+        let retiringUpstream = TestUpstreamClient()
+        let alternateUpstream = TestUpstreamClient()
+        let primaryTarget = xcodeProcessTarget(processID: 27024, xcodeVersion: "27.0")
+        let retiringTarget = xcodeProcessTarget(processID: 26624, xcodeVersion: "26.6")
+        let alternateTarget = xcodeProcessTarget(processID: 26524, xcodeVersion: "26.5")
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [primaryUpstream, retiringUpstream, alternateUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: primaryTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: retiringTarget, upstreamIndices: [1]),
+                XcodeProcessRoute(target: alternateTarget, upstreamIndices: [2]),
+            ],
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let initializeFuture = fixture.registerInitialize(requestID: 1)
+        let primaryInitialize = try await primaryUpstream.nextSent(at: 0)
+
+        manager.reconcileXcodeProcessTargets(
+            [primaryTarget, alternateTarget],
+            reason: "test_remove_non_primary_during_initialize"
+        )
+        _ = try await retiringUpstream.nextStopCount()
+        await manager.drainRuntimeTasksForTesting()
+        #expect(await alternateUpstream.sentCount() == 0)
+
+        await primaryUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: primaryInitialize)))
+        )
+        let response = try decodeJSON(from: try await initializeFuture.get())
+        #expect(response["result"] != nil)
+        #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 0)
+    }
+
     @Test func processRoutingDoesNotSelectRetiredSlotEvenIfHealthLooksInitialized()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -198,6 +198,74 @@ struct RuntimeCoordinatorTests {
         #expect(snapshot.processRoutes.map(\.state) == ["active"])
     }
 
+    @Test func processRoutingNoXcodeInitializeWaitDoesNotRescheduleTimeoutForJoinedClient()
+        async throws
+    {
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+
+        let firstFuture = fixture.registerInitialize(
+            requestID: 1,
+            sessionID: "session-no-xcode-timeout-1"
+        )
+        #expect(timeoutScheduler.scheduledCount() == 1)
+
+        let secondFuture = fixture.registerInitialize(
+            requestID: 2,
+            sessionID: "session-no-xcode-timeout-2"
+        )
+        #expect(timeoutScheduler.scheduledCount() == 1)
+
+        timeoutScheduler.fire(at: 0)
+        await #expect(throws: TimeoutError.self) {
+            try await firstFuture.get()
+        }
+        await #expect(throws: TimeoutError.self) {
+            try await secondFuture.get()
+        }
+    }
+
+    @Test func processRoutingNoXcodeRemovedInitializeDoesNotSuppressNextTimeout()
+        async throws
+    {
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+
+        let removedFuture = fixture.registerInitialize(
+            requestID: 1,
+            sessionID: "session-no-xcode-removed"
+        )
+        #expect(timeoutScheduler.scheduledCount() == 1)
+
+        fixture.manager.removeSession(id: "session-no-xcode-removed")
+        await #expect(throws: CancellationError.self) {
+            try await removedFuture.get()
+        }
+
+        let nextFuture = fixture.registerInitialize(
+            requestID: 2,
+            sessionID: "session-no-xcode-next"
+        )
+        #expect(timeoutScheduler.scheduledCount() == 2)
+
+        timeoutScheduler.fire(at: 1)
+        await #expect(throws: TimeoutError.self) {
+            try await nextFuture.get()
+        }
+    }
+
     @Test func processRegistryReactivatesRetiredRouteWithoutDuplicatingOrder() {
         let target = xcodeProcessTarget(processID: 27003, xcodeVersion: "27.0")
         let registry = XcodeProcessRegistry()
@@ -1595,8 +1663,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         let sessionID = "session-removed"
@@ -1610,12 +1686,16 @@ struct RuntimeCoordinatorTests {
 
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
         manager.removeSession(id: sessionID)
+        await #expect(throws: CancellationError.self) {
+            try await future.get()
+        }
 
         let sent = await upstream.sent()
         let initID = try extractUpstreamID(from: sent[0])
+        let responseEventIndex = upstreamEvents.count()
         await upstream.yield(.message(try makeInitializeResponse(id: initID)))
+        _ = try await nextRecordedValue(upstreamEvents, at: responseEventIndex)
 
-        _ = try await future.get()
         #expect(manager.hasSession(id: sessionID) == false)
     }
 
@@ -1624,8 +1704,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         let sessionID = "session-recreated"
@@ -1644,7 +1732,9 @@ struct RuntimeCoordinatorTests {
 
         let sent = await upstream.sent()
         let initID = try extractUpstreamID(from: sent[0])
+        let responseEventIndex = upstreamEvents.count()
         await upstream.yield(.message(try makeInitializeResponse(id: initID)))
+        _ = try await nextRecordedValue(upstreamEvents, at: responseEventIndex)
 
         let notification = try JSONSerialization.data(
             withJSONObject: [
@@ -1654,7 +1744,9 @@ struct RuntimeCoordinatorTests {
             ],
             options: []
         )
-        _ = try await future.get()
+        await #expect(throws: CancellationError.self) {
+            try await future.get()
+        }
         manager.routeUpstreamMessage(notification, upstreamIndex: 0)
         #expect(replacement.router.drainBufferedNotifications().isEmpty)
     }
@@ -1748,13 +1840,13 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let timeoutClock = TestClock()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
         let config = makeConfig(requestTimeout: 1)
         let manager = RuntimeCoordinator(
             config: config,
             eventLoop: eventLoop,
             upstreams: [upstream],
-            scheduleRuntimeTimeout: makeDeterministicRuntimeTimeoutScheduler(clock: timeoutClock)
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler()
         )
         defer { manager.shutdownAndWait() }
 
@@ -1772,8 +1864,8 @@ struct RuntimeCoordinatorTests {
         )
         #expect((await upstream.sent()).count == 1)
 
-        try await timeoutClock.sleep(untilSuspendedBy: 1)
-        timeoutClock.advance(by: .seconds(1))
+        #expect(timeoutScheduler.scheduledCount() == 1)
+        timeoutScheduler.fire(at: 0)
         await #expect(throws: TimeoutError.self) {
             try await future.get()
         }
@@ -1822,13 +1914,13 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
-        let timeoutClock = TestClock()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
         let config = makeConfig(requestTimeout: 1)
         let manager = RuntimeCoordinator(
             config: config,
             eventLoop: eventLoop,
             upstreams: [upstream],
-            scheduleRuntimeTimeout: makeDeterministicRuntimeTimeoutScheduler(clock: timeoutClock)
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler()
         )
         defer { manager.shutdownAndWait() }
 
@@ -1842,26 +1934,16 @@ struct RuntimeCoordinatorTests {
         )
 
         try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
-        try await waitWithTimeout(
-            "waiting for initialize timeout sleeper",
-            timeout: .seconds(2)
-        ) {
-            try await timeoutClock.sleep(untilSuspendedBy: 1)
-        }
+        #expect(timeoutScheduler.scheduledCount() == 1)
 
         manager.removeSession(id: sessionID)
         _ = manager.session(id: sessionID)
         let replacementSnapshotBeforeTimeout = try #require(manager.testSessionSnapshot(id: sessionID))
-        timeoutClock.advance(by: .seconds(1))
-
-        try await waitWithTimeout(
-            "waiting for deterministic initialize timeout",
-            timeout: .seconds(2)
-        ) {
-            await #expect(throws: TimeoutError.self) {
-                try await future.get()
-            }
+        await #expect(throws: CancellationError.self) {
+            try await future.get()
         }
+
+        timeoutScheduler.fire(at: 0)
 
         let replacementSnapshotAfterTimeout = try #require(manager.testSessionSnapshot(id: sessionID))
         #expect(replacementSnapshotAfterTimeout.generation == replacementSnapshotBeforeTimeout.generation)
@@ -1874,8 +1956,16 @@ struct RuntimeCoordinatorTests {
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
         let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            )
+        )
         defer { manager.shutdownAndWait() }
 
         let sessionID = "session-error-recreated"
@@ -1895,6 +1985,7 @@ struct RuntimeCoordinatorTests {
         _ = manager.session(id: sessionID)
         let replacementSnapshotBeforeError = try #require(manager.testSessionSnapshot(id: sessionID))
 
+        let errorEventIndex = upstreamEvents.count()
         await upstream.yield(
             .message(
                 try JSONSerialization.data(
@@ -1910,10 +2001,11 @@ struct RuntimeCoordinatorTests {
                 )
             )
         )
+        _ = try await nextRecordedValue(upstreamEvents, at: errorEventIndex)
 
-        let response = try decodeJSON(from: try await future.get())
-        let errorObject = try #require(response["error"] as? [String: Any])
-        #expect(errorObject["message"] as? String == "boom")
+        await #expect(throws: CancellationError.self) {
+            try await future.get()
+        }
 
         let replacementSnapshotAfterError = try #require(manager.testSessionSnapshot(id: sessionID))
         #expect(replacementSnapshotAfterError.generation == replacementSnapshotBeforeError.generation)
@@ -8598,26 +8690,25 @@ struct RuntimeCoordinatorTests {
         )
         defer { manager.shutdownAndWait() }
 
-        let init0 = try await sentValue(from: upstream0, at: 0, timeout: .seconds(2))
+        let init0 = try await upstream0.nextSent(at: 0)
         let init0ID = try extractUpstreamID(from: init0)
         await upstream0.yield(.message(try makeInitializeResponse(id: init0ID)))
 
-        let init1 = try await sentValue(from: upstream1, at: 0, timeout: .seconds(2))
+        let init1 = try await upstream1.nextSent(at: 0)
         let init1ID = try extractUpstreamID(from: init1)
         await upstream1.yield(.message(try makeInitializeResponse(id: init1ID)))
 
-        _ = try await sentValue(from: upstream0, at: 1, timeout: .seconds(2))
-        _ = try await sentValue(from: upstream1, at: 1, timeout: .seconds(2))
+        _ = try await upstream0.nextSent(at: 1)
+        _ = try await upstream1.nextSent(at: 1)
 
         await upstream0.yield(.exit(1))
-        let firstWarmRetry = try await sentValue(from: upstream0, at: 2, timeout: .seconds(2))
+        let firstWarmRetry = try await upstream0.nextSent(at: 2)
         let firstWarmRetryID = try extractUpstreamID(from: firstWarmRetry)
 
         await upstream0.overloadNextInitializedNotificationSend()
         await upstream0.yield(.message(try makeInitializeResponse(id: firstWarmRetryID)))
 
-        try await waitForSentCount(upstream0, count: 5, timeoutSeconds: 2)
-        let secondWarmRetry = try await sentValue(from: upstream0, at: 4, timeout: .seconds(2))
+        let secondWarmRetry = try await upstream0.nextSent(at: 4)
         let secondWarmRetryID = try extractUpstreamID(from: secondWarmRetry)
 
         let errorResponse: [String: Any] = [
@@ -8632,16 +8723,7 @@ struct RuntimeCoordinatorTests {
         await upstream0.yield(
             .message(try JSONSerialization.data(withJSONObject: errorResponse, options: []))
         )
-        _ = try await waitForRecordedValue(
-            upstreamEvents,
-            at: errorEventIndex,
-            description: "waiting for warm init failure"
-        )
-
-        let snapshot = manager.testStateSnapshot()
-        #expect(snapshot.shouldRetryEagerInitializePrimaryAfterWarmInitFailure)
-        #expect(snapshot.upstreams[0].isInitialized == false)
-        #expect(snapshot.upstreams[0].initInFlight == false)
+        _ = try await nextRecordedValue(upstreamEvents, at: errorEventIndex)
 
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
         _ = manager.upstreamHealthManager.markRequestTimedOut(upstreamIndex: 1, nowUptimeNs: 0)
@@ -8672,8 +8754,7 @@ struct RuntimeCoordinatorTests {
         }
         _ = future
 
-        try await waitForSentCount(upstream0, count: 6, timeoutSeconds: 5)
-        let eagerRetry = try await sentValue(from: upstream0, at: 5, timeout: .seconds(2))
+        let eagerRetry = try await upstream0.nextSent(at: 5)
         #expect(methodName(from: eagerRetry) == "initialize")
 
         manager.abandonRequestLease(

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -723,6 +723,66 @@ struct RuntimeCoordinatorTests {
         #expect(response["result"] != nil)
     }
 
+    @Test func processRoutingRetriesUnchangedRouteAfterUnavailableCooldown()
+        async throws
+    {
+        let uptimeClock = TestUptimeClock()
+        let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
+        let target = xcodeProcessTarget(processID: 27013, xcodeVersion: "27.0")
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [upstream],
+            nowUptimeNanoseconds: uptimeClock.now,
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            ),
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        _ = try await fixture.initializePrimary(on: upstream)
+        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target, 0, [toolDescriptor(name: "RecoveredProcessTool")]),
+            ]
+        )
+
+        let exitEventIndex = upstreamEvents.count()
+        await upstream.yield(.exit(1))
+        _ = try await waitForRecordedValue(
+            upstreamEvents,
+            at: exitEventIndex,
+            description: "waiting for process route upstream exit"
+        )
+        let sentCountAfterExit = await upstream.sentCount()
+        #expect(manager.testStateSnapshot().hasInitResult == false)
+        #expect(manager.debugSnapshot().processToolCatalogs.isEmpty)
+
+        manager.reconcileXcodeProcessTargets([target], reason: "test_before_cooldown")
+        #expect(await upstream.sentCount() == sentCountAfterExit)
+
+        uptimeClock.advance(by: .seconds(3))
+        manager.reconcileXcodeProcessTargets([target], reason: "test_after_cooldown")
+        let restartedInitialize = try await upstream.nextSent(at: sentCountAfterExit)
+        #expect(methodName(from: restartedInitialize) == "initialize")
+
+        await upstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: restartedInitialize)))
+        )
+        let initializedNotification = try await upstream.nextSent(at: sentCountAfterExit + 1)
+        #expect(methodName(from: initializedNotification) == "notifications/initialized")
+        await manager.drainRuntimeTasksForTesting()
+
+        #expect(manager.testStateSnapshot().hasInitResult)
+        #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 0)
+    }
+
     @Test func processRoutingRetiresCrashedPIDAndAddsRelaunchedPID() async throws {
         let oldUpstream = TestUpstreamClient()
         let oldTarget = xcodeProcessTarget(processID: 27020, xcodeVersion: "27.0")

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -271,10 +271,10 @@ struct RuntimeCoordinatorTests {
         #expect(manager.xcodeProcessRoutes.map(\.target.processID) == [newerTarget.processID])
         let processRoutes = manager.debugSnapshot().processRoutes
         #expect(processRoutes.map(\.processID) == [
-            olderTarget.processID,
             newerTarget.processID,
+            olderTarget.processID,
         ])
-        #expect(processRoutes.map(\.state) == ["retired", "active"])
+        #expect(processRoutes.map(\.state) == ["active", "retired"])
     }
 
     @Test func processRoutingReschedulesQueuedReconcileAfterWorkerCancellation() async throws {
@@ -467,6 +467,42 @@ struct RuntimeCoordinatorTests {
         #expect(snapshots.map(\.state) == ["active"])
     }
 
+    @Test func processRegistryKeepsActiveRoutesInSortedXcodeOrderAfterLateAdd() {
+        let olderTarget = xcodeProcessTarget(processID: 26640, xcodeVersion: "26.6")
+        let newerTarget = xcodeProcessTarget(processID: 27040, xcodeVersion: "27.0")
+        let registry = XcodeProcessRegistry()
+        var nextUpstreamIndex = 0
+        let makeRoute: (XcodeProcessTarget) -> XcodeProcessRoute = { target in
+            defer { nextUpstreamIndex += 1 }
+            return XcodeProcessRoute(target: target, upstreamIndices: [nextUpstreamIndex])
+        }
+
+        _ = registry.reconcile(
+            targets: [olderTarget],
+            reason: "initial_older",
+            nowUptimeNs: 1,
+            makeRoute: makeRoute
+        )
+
+        let result = registry.reconcile(
+            targets: [olderTarget, newerTarget],
+            reason: "late_newer",
+            nowUptimeNs: 2,
+            makeRoute: makeRoute
+        )
+
+        #expect(result.addedRoutes.map(\.target.processID) == [newerTarget.processID])
+        #expect(result.activeRoutes.map(\.target.processID) == [
+            newerTarget.processID,
+            olderTarget.processID,
+        ])
+        #expect(registry.activeRoutes().map(\.target.processID) == [
+            newerTarget.processID,
+            olderTarget.processID,
+        ])
+        #expect(registry.activeRoutes().map(\.upstreamIndices) == [[1], [0]])
+    }
+
     @Test func processRoutingAddsLateXcodeProcessWithoutRestart() async throws {
         let olderUpstream = TestUpstreamClient()
         let olderTarget = xcodeProcessTarget(processID: 26610, xcodeVersion: "26.6")
@@ -533,8 +569,8 @@ struct RuntimeCoordinatorTests {
         #expect(snapshot.processRoutes.map(\.state) == ["active", "active"])
         #expect(snapshot.processRoutes.map(\.toolsCatalogState) == ["available", "available"])
         #expect(snapshot.processRoutes.map(\.processID) == [
-            olderTarget.processID,
             newerTarget.processID,
+            olderTarget.processID,
         ])
         #expect(manager.documentationCandidateProcessIDs() == Set([
             olderTarget.processID,
@@ -596,8 +632,8 @@ struct RuntimeCoordinatorTests {
         )
         let pendingSnapshot = manager.debugSnapshot()
         #expect(pendingSnapshot.processRoutes.map(\.toolsCatalogState) == [
-            "available",
             "pending",
+            "available",
         ])
 
         manager.reconcileXcodeProcessTargets(
@@ -694,10 +730,10 @@ struct RuntimeCoordinatorTests {
         _ = try await relaunchedUpstream.nextSent(at: 1)
 
         let snapshot = manager.debugSnapshot()
-        #expect(snapshot.processRoutes.map(\.state) == ["retired", "active"])
+        #expect(snapshot.processRoutes.map(\.state) == ["active", "retired"])
         #expect(snapshot.processRoutes.map(\.processID) == [
-            oldTarget.processID,
             relaunchedTarget.processID,
+            oldTarget.processID,
         ])
         #expect(snapshot.processToolCatalogs.isEmpty)
         #expect(await oldUpstream.stopCount() == 1)
@@ -741,7 +777,7 @@ struct RuntimeCoordinatorTests {
         let response = try decodeJSON(from: try await initializeFuture.get())
         #expect(response["result"] != nil)
         #expect(await oldUpstream.stopCount() == 1)
-        #expect(manager.debugSnapshot().processRoutes.map(\.state) == ["retired", "active"])
+        #expect(manager.debugSnapshot().processRoutes.map(\.state) == ["active", "retired"])
     }
 
     @Test func processRoutingRetiringNonPrimaryRouteDoesNotStealPrimaryInitialize()

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -3409,6 +3409,102 @@ struct RuntimeCoordinatorTests {
         ])
     }
 
+    @Test func sessionManagerRetriesPendingProcessCatalogAfterQuarantinedRouteRecovers()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = xcodeProcessTarget(processID: 80429, xcodeVersion: "27.0")
+        let uptimeClock = TestUptimeClock()
+        let toolsListRefreshes = LockedRecordedValues<(Int, Bool)>()
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            nowUptimeNanoseconds: uptimeClock.now,
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            testHooks: RuntimeCoordinatorTestHooks(
+                toolsListRefreshCompleted: { upstreamIndex, succeeded in
+                    toolsListRefreshes.append((upstreamIndex, succeeded))
+                }
+            ),
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.canonicalBrokerState.syncCanonicalInitialize(
+            try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+                "serverInfo": ["name": "cached-source"],
+            ]),
+            sourceUpstream: 0
+        )
+        _ = manager.pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
+            $0.insert(target.processID)
+        }
+
+        manager.markToolsListRefreshFailed(
+            upstreamIndex: 0,
+            nowUptimeNs: uptimeClock.now(),
+            reason: "test_catalog_failure"
+        )
+        manager.refreshMissingProcessToolsCatalogsIfNeeded(
+            reason: "test_before_quarantine_expired",
+            processIDs: [target.processID]
+        )
+        #expect(await upstream.sentCount() == 0)
+
+        uptimeClock.advance(by: .seconds(31))
+        manager.refreshMissingProcessToolsCatalogsIfNeeded(
+            reason: "test_after_quarantine_expired",
+            processIDs: [target.processID]
+        )
+        let probeRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        #expect(methodName(from: probeRequest) == "tools/list")
+        await upstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: probeRequest),
+                    tools: []
+                )
+            )
+        )
+
+        let catalogRequest = try await sentValue(
+            from: upstream,
+            startingAt: 1,
+            matching: { methodName(from: $0) == "tools/list" },
+            timeout: .seconds(2),
+            description: "waiting for pending process catalog refresh after health probe"
+        )
+        await upstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: catalogRequest),
+                    tools: [
+                        toolDescriptor(name: "RecoveredRouteOnly"),
+                    ]
+                )
+            )
+        )
+        await manager.drainRuntimeTasksForTesting()
+
+        let failedRefresh = try await nextRecordedValue(toolsListRefreshes, at: 0)
+        #expect(failedRefresh.0 == 0)
+        #expect(failedRefresh.1 == false)
+        let recoveredRefresh = try await nextRecordedValue(toolsListRefreshes, at: 1)
+        #expect(recoveredRefresh.0 == 0)
+        #expect(recoveredRefresh.1 == true)
+        #expect(manager.pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue { $0.isEmpty })
+        #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [target.processID])
+        #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["RecoveredRouteOnly"])
+    }
+
     @Test func sessionManagerToolsListReturnsCachedProcessCatalogWhileFreshRouteRefreshIsPending()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -675,6 +675,54 @@ struct RuntimeCoordinatorTests {
         ]))
     }
 
+    @Test func processRoutingRetriesPendingRouteAsPrimaryUntilInitializeCompletes()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27012, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let failedFuture = fixture.registerInitialize(requestID: 1)
+        manager.reconcileXcodeProcessTargets([target], reason: "test_initial_route")
+        let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        _ = try await upstream.nextSent(at: 0)
+
+        manager.failInitPending(error: TimeoutError())
+        await #expect(throws: TimeoutError.self) {
+            try await failedFuture.get()
+        }
+        #expect(manager.testStateSnapshot().hasInitResult == false)
+
+        manager.reconcileXcodeProcessTargets([target], reason: "test_retry_pending_route")
+        let retriedInitialize = try await upstream.nextSent(at: 1)
+        #expect(methodName(from: retriedInitialize) == "initialize")
+        #expect(manager.testStateSnapshot().initInFlight)
+
+        await upstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retriedInitialize)))
+        )
+        let initializedNotification = try await upstream.nextSent(at: 2)
+        #expect(methodName(from: initializedNotification) == "notifications/initialized")
+        await manager.drainRuntimeTasksForTesting()
+
+        #expect(manager.testStateSnapshot().hasInitResult)
+        #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 0)
+        let cachedFuture = fixture.registerInitialize(requestID: 2)
+        let response = try decodeJSON(from: try await cachedFuture.get())
+        #expect(response["result"] != nil)
+    }
+
     @Test func processRoutingRetiresCrashedPIDAndAddsRelaunchedPID() async throws {
         let oldUpstream = TestUpstreamClient()
         let oldTarget = xcodeProcessTarget(processID: 27020, xcodeVersion: "27.0")

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -373,6 +373,7 @@ struct RuntimeCoordinatorTests {
         await #expect(throws: CancellationError.self) {
             try await removedFuture.get()
         }
+        #expect(timeoutScheduler.isCancelled(at: 0))
 
         let nextFuture = fixture.registerInitialize(
             requestID: 2,
@@ -380,6 +381,7 @@ struct RuntimeCoordinatorTests {
         )
         #expect(timeoutScheduler.scheduledCount() == 2)
 
+        #expect(timeoutScheduler.fire(at: 0) == false)
         timeoutScheduler.fire(at: 1)
         await #expect(throws: TimeoutError.self) {
             try await nextFuture.get()

--- a/Tests/ProxyToolSurfaceTests/RefreshCodeIssuesCoordinatorTests.swift
+++ b/Tests/ProxyToolSurfaceTests/RefreshCodeIssuesCoordinatorTests.swift
@@ -406,6 +406,7 @@ struct RefreshCodeIssuesCoordinatorTests {
                         await acquisitions.append("first-cancelling")
                         activeCancellationObserved.signal()
                         await allowActiveExit.waitIgnoringCancellation()
+                        await acquisitions.append("first-exiting")
                         throw CancellationError()
                     }
                 }
@@ -446,12 +447,16 @@ struct RefreshCodeIssuesCoordinatorTests {
 
         _ = await secondTask.value
         _ = await activeTask.value
-        #expect(await acquisitions.snapshot() == [
+        let acquisitionEvents = await acquisitions.snapshot()
+        #expect(Array(acquisitionEvents.prefix(3)) == [
             "first",
             "first-cancelling",
-            "first-cancelled",
-            "second",
+            "first-exiting",
         ])
+        #expect(acquisitionEvents.contains("first-cancelled"))
+        let firstExitedIndex = try #require(acquisitionEvents.firstIndex(of: "first-exiting"))
+        let secondIndex = try #require(acquisitionEvents.firstIndex(of: "second"))
+        #expect(firstExitedIndex < secondIndex)
     }
 }
 

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -2340,14 +2340,26 @@ func makeDeterministicRuntimeTimeoutScheduler(
 }
 
 final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
-    private let operations = NIOLockedValueBox<[@Sendable () -> Void]>([])
+    private struct Operation {
+        let operation: @Sendable () -> Void
+        var isCancelled = false
+    }
+
+    private let operations = NIOLockedValueBox<[Operation]>([])
 
     func scheduler() -> @Sendable (TimeAmount, @escaping @Sendable () -> Void) -> RuntimeScheduledTimeout {
         { _, operation in
-            self.operations.withLockedValue {
-                $0.append(operation)
+            let index = self.operations.withLockedValue { operations in
+                let index = operations.count
+                operations.append(Operation(operation: operation))
+                return index
             }
-            return RuntimeScheduledTimeout {}
+            return RuntimeScheduledTimeout {
+                self.operations.withLockedValue { operations in
+                    guard operations.indices.contains(index) else { return }
+                    operations[index].isCancelled = true
+                }
+            }
         }
     }
 
@@ -2355,11 +2367,26 @@ final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
         operations.withLockedValue(\.count)
     }
 
-    func fire(at index: Int) {
-        let operation = operations.withLockedValue { operations in
-            operations[index]
+    func isCancelled(at index: Int) -> Bool {
+        operations.withLockedValue { operations in
+            guard operations.indices.contains(index) else { return false }
+            return operations[index].isCancelled
+        }
+    }
+
+    @discardableResult
+    func fire(at index: Int) -> Bool {
+        let operation: (@Sendable () -> Void)? = operations.withLockedValue { operations in
+            guard operations.indices.contains(index), operations[index].isCancelled == false else {
+                return nil
+            }
+            return operations[index].operation
+        }
+        guard let operation else {
+            return false
         }
         operation()
+        return true
     }
 }
 

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -1342,8 +1342,16 @@ actor StubDocumentationProviderManager: DocumentationProviderManaging {
 func defaultUpstreamEnvironment(sharedSessionID: String?) throws -> [String: String] {
     var config = makeConfig(requestTimeout: 5)
     config.upstreamSessionID = sharedSessionID
+    let bridgeConfig = MCPBridgeRuntime.Configuration(
+        upstreamCommand: config.upstreamCommand,
+        upstreamArgs: config.upstreamArgs,
+        upstreamProcessCount: config.upstreamProcessCount,
+        sharedSessionID: config.upstreamSessionID,
+        maxBodyBytes: config.maxBodyBytes,
+        processBoundRoutingSupported: false
+    )
     let upstreams = MCPBridgeRuntime.makeUpstreamPlan(
-        config: makeBridgeRuntimeConfig(config),
+        config: bridgeConfig,
         xcodeTargets: []
     ).upstreams
     let upstream = try #require(upstreams.first)
@@ -1990,6 +1998,9 @@ struct RuntimeCoordinatorFixture {
                 RuntimeScheduledTimeout
         )? = nil,
         xcodeProcessRoutes: [XcodeProcessRoute] = [],
+        processRoutingEnabled: Bool? = nil,
+        xcodeTargetDiscovery: (any XcodeTargetDiscovering)? = nil,
+        dynamicUpstreamFactory: XcodeProcessUpstreamFactory? = nil,
         documentationProviderManager: (any DocumentationProviderManaging)? = nil,
         prewarmDocumentationProviderOnStartup: Bool = false,
         testHooks: RuntimeCoordinatorTestHooks = RuntimeCoordinatorTestHooks(),
@@ -2009,6 +2020,9 @@ struct RuntimeCoordinatorFixture {
             nowUptimeNanoseconds: nowUptimeNanoseconds,
             scheduleRuntimeTimeout: scheduleRuntimeTimeout,
             xcodeProcessRoutes: xcodeProcessRoutes,
+            processRoutingEnabled: processRoutingEnabled,
+            xcodeTargetDiscovery: xcodeTargetDiscovery,
+            dynamicUpstreamFactory: dynamicUpstreamFactory,
             documentationProviderManager: documentationProviderManager,
             prewarmDocumentationProviderOnStartup: prewarmDocumentationProviderOnStartup,
             testHooks: testHooks,

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -35,6 +35,10 @@ extension RuntimeCoordinator {
             description: "timed out waiting for RuntimeCoordinator runtime task drain"
         )
     }
+
+    func drainRuntimeTasksForTesting() async {
+        await runtimeTasks.drainCurrentTasks().wait()
+    }
 }
 
 func makeTestUpstreamSlotScheduler(upstreamCount: Int) -> UpstreamSlotScheduler {

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -2188,6 +2188,30 @@ func makeDeterministicRuntimeTimeoutScheduler(
     }
 }
 
+final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
+    private let operations = NIOLockedValueBox<[@Sendable () -> Void]>([])
+
+    func scheduler() -> @Sendable (TimeAmount, @escaping @Sendable () -> Void) -> RuntimeScheduledTimeout {
+        { _, operation in
+            self.operations.withLockedValue {
+                $0.append(operation)
+            }
+            return RuntimeScheduledTimeout {}
+        }
+    }
+
+    func scheduledCount() -> Int {
+        operations.withLockedValue(\.count)
+    }
+
+    func fire(at index: Int) {
+        let operation = operations.withLockedValue { operations in
+            operations[index]
+        }
+        operation()
+    }
+}
+
 func makeDeterministicClockClient(
     timeoutClock: TestClock,
     uptimeClock: TestUptimeClock
@@ -2266,6 +2290,13 @@ func waitForRecordedValue<Value: Sendable>(
     try await waitWithTimeout(description, timeout: timeout) {
         try await values.nextValue(at: index)
     }
+}
+
+func nextRecordedValue<Value: Sendable>(
+    _ values: LockedRecordedValues<Value>,
+    at index: Int
+) async throws -> Value {
+    try await values.nextValue(at: index)
 }
 
 func methodName(from data: Data) -> String? {

--- a/Tests/XcodeMCPProxyInternalTestSupport/TestUpstreamClient.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/TestUpstreamClient.swift
@@ -8,6 +8,7 @@ actor TestUpstreamClient: UpstreamSlotControlling {
     nonisolated let events: AsyncStream<Upstream.Event>
     private let continuation: AsyncStream<Upstream.Event>.Continuation
     private let sentMessages = RecordedValues<Data>()
+    private let stopEvents = RecordedValues<Int>()
     private var startCountValue = 0
     private var stopCountValue = 0
 
@@ -25,6 +26,7 @@ actor TestUpstreamClient: UpstreamSlotControlling {
 
     func stop() async {
         stopCountValue += 1
+        await stopEvents.append(stopCountValue)
         continuation.finish()
     }
 
@@ -72,6 +74,10 @@ actor TestUpstreamClient: UpstreamSlotControlling {
 
     func stopCount() async -> Int {
         stopCountValue
+    }
+
+    func nextStopCount(at index: Int = 0) async throws -> Int {
+        try await stopEvents.nextValue(at: index)
     }
 }
 

--- a/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
@@ -480,6 +480,30 @@ package final class TestSignal: @unchecked Sendable {
         }
     }
 
+    package func waitUntilSignaled() async throws {
+        if state.withLockedValue({ $0.signaled }) {
+            return
+        }
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                let shouldResume = self.state.withLockedValue { state in
+                    if state.signaled {
+                        return true
+                    }
+                    state.waiters.append(Waiter(id: waiterID, continuation: continuation))
+                    return false
+                }
+                if shouldResume {
+                    continuation.resume(returning: ())
+                }
+            }
+        } onCancel: {
+            self.cancelWaiter(id: waiterID)
+        }
+    }
+
     package func signal() {
         let waiters = state.withLockedValue { state -> [Waiter] in
             guard state.signaled == false else {


### PR DESCRIPTION
## Purpose

Keep `xcode-mcp-proxy-server` running across Xcode process lifecycle changes without requiring a proxy restart. This covers startup with no Xcode process, late Xcode launches, process removal, and crash/relaunch with a new PID.

## Changes

- Add an `XcodeProcessRegistry` and reconciliation loop that treat `LiveXcodeTargetDiscovery.runningXcodeTargets()` snapshots as the source of truth.
- Allow default `mcpbridge` routing to enter dynamic process-bound mode even when no Xcode process exists at startup, while preserving static custom upstream behavior.
- Append process-bound upstream slots dynamically and expand router, health, and debug state for newly discovered Xcode processes.
- Retire removed process routes without compacting `upstreamIndex`, clearing PID-scoped tool catalogs, window owners, leases, router mappings, and health state.
- Recover still-running process routes after upstream exit/cooldown by re-registering missing process catalogs and retrying primary initialization until the canonical initialize exists.
- Publish `notifications/tools/list_changed` after process route/catalog changes and expose process route state in debug snapshots.
- Add runtime coordinator coverage for late Xcode startup, adding another Xcode process, crash/relaunch cleanup, pending primary initialize recovery, and unchanged-route recovery after cooldown.

## Testing

- `swift test --filter RuntimeCoordinatorTests/processRoutingRetries -Xswiftc -strict-concurrency=minimal`
- `swift test --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test -Xswiftc -strict-concurrency=minimal`
- `XCODE_MCP_RUN_PROCESS_TESTS=1 swift test --no-parallel --filter XcodeMCPProcessRuntimeTests -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`

Manual live check with real Xcode process launch/crash/relaunch was not run in this worktree.
