### PR TITLE
Retry Xcode process route catalog activation

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -359,6 +359,10 @@ extension RuntimeCoordinator {
             associatedUpstreamIndices: activeRoute.upstreamIndices,
             rawResult: result.rawResult
         )
+        markProcessRouteActivationCataloged(
+            target: target,
+            upstreamIndex: sourceUpstream
+        )
         _ = pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
             $0.remove(target.processID)
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -164,8 +164,7 @@ extension RuntimeCoordinator {
                 requestTimeout: requestTimeout,
                 deadlineUptimeNs: deadlineUptimeNs,
                 startedAt: startedAt,
-                exposedProcessIDs: exposedProcessIDs,
-                registerActivationCatalogRPCs: true
+                exposedProcessIDs: exposedProcessIDs
             )
         } catch is CancellationError {
             guard Task.isCancelled == false,
@@ -223,8 +222,7 @@ extension RuntimeCoordinator {
         deadlineUptimeNs: UInt64?,
         startedAt: UInt64,
         exposedProcessIDs: Set<pid_t>,
-        returnAfterFirstSuccess: Bool = true,
-        registerActivationCatalogRPCs: Bool = false
+        returnAfterFirstSuccess: Bool = true
     ) async throws -> CanonicalToolsCatalogLoadResult {
         try await withThrowingTaskGroup(
             of: AvailableToolsCatalogOutcome.self,
@@ -238,8 +236,7 @@ extension RuntimeCoordinator {
                             route,
                             requestTimeout: requestTimeout,
                             deadlineUptimeNs: deadlineUptimeNs,
-                            startedAt: startedAt,
-                            registerActivationCatalogRPCs: registerActivationCatalogRPCs
+                            startedAt: startedAt
                         )
                         if let sourceUpstream = result.sourceUpstream,
                            let hook = self.testHooks.processToolsCatalogLoadedBeforeRecord {
@@ -529,8 +526,7 @@ extension RuntimeCoordinator {
                     deadlineUptimeNs: self.deadlineUptimeNanoseconds(for: requestTimeout),
                     startedAt: startedAt,
                     exposedProcessIDs: exposedProcessIDs,
-                    returnAfterFirstSuccess: false,
-                    registerActivationCatalogRPCs: true
+                    returnAfterFirstSuccess: false
                 )
                 guard result.cacheableAsCanonical,
                       let sourceUpstream = result.sourceUpstream,
@@ -572,18 +568,19 @@ extension RuntimeCoordinator {
         _ route: AvailableToolsCatalogRoute,
         requestTimeout: TimeAmount?,
         deadlineUptimeNs: UInt64?,
-        startedAt: UInt64,
-        registerActivationCatalogRPCs: Bool
+        startedAt: UInt64
     ) async throws -> CanonicalToolsCatalogLoadResult {
         var lastFailure: (upstreamIndex: Int, error: any Error)?
         for upstreamIndex in route.upstreamIndices {
             let rpcHandle = ControlPlane.RPCHandle()
-            if registerActivationCatalogRPCs,
-               route.activationUpstreamIndex == upstreamIndex,
+            // Fallback-upstream RPCs are registered on the activation attempt
+            // too; otherwise they outlive the catalog-phase timeout and their
+            // late failure would drop a catalog recorded by a newer attempt.
+            if let activationUpstreamIndex = route.activationUpstreamIndex,
                let activationAttempt = route.activationAttempt {
                 xcodeProcessRouteActivationTracker.storeCatalogRPCHandle(
                     processID: route.target.processID,
-                    upstreamIndex: upstreamIndex,
+                    upstreamIndex: activationUpstreamIndex,
                     attempt: activationAttempt,
                     rpcHandle: rpcHandle
                 )

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -395,17 +395,29 @@ extension RuntimeCoordinator {
                activationUpstreamIndex: resolvedActivation.upstreamIndex,
                attempt: resolvedActivation.attempt
            ) == false {
-            logger.debug(
-                "Dropping stale process tools/list catalog",
-                metadata: [
-                    "pid": .string("\(target.processID)"),
-                    "app_path": .string(target.appPath),
-                    "xcode_version": .string(target.xcodeVersion),
-                    "upstream": .string("\(sourceUpstream)"),
-                    "activation_attempt": .string("\(resolvedActivation.attempt)"),
-                ]
-            )
-            return nil
+            if hadProcessCatalog {
+                return availableToolsCatalogSurfaceResult(
+                    startedAt: startedAt,
+                    exposedProcessIDs: exposedProcessIDs,
+                    fallback: result
+                )
+            }
+            guard xcodeProcessRouteActivationTracker.isCataloged(
+                processID: target.processID,
+                attempt: resolvedActivation.attempt
+            ) else {
+                logger.debug(
+                    "Dropping stale process tools/list catalog",
+                    metadata: [
+                        "pid": .string("\(target.processID)"),
+                        "app_path": .string(target.appPath),
+                        "xcode_version": .string(target.xcodeVersion),
+                        "upstream": .string("\(sourceUpstream)"),
+                        "activation_attempt": .string("\(resolvedActivation.attempt)"),
+                    ]
+                )
+                return nil
+            }
         }
         processToolCatalogRegistry.record(
             target: target,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -57,6 +57,8 @@ extension RuntimeCoordinator {
     private struct AvailableToolsCatalogRoute: Sendable {
         let target: XcodeProcessTarget
         let upstreamIndices: [Int]
+        let activationUpstreamIndex: Int?
+        let activationAttempt: Int?
     }
 
     private enum AvailableToolsCatalogOutcome: Sendable {
@@ -107,7 +109,16 @@ extension RuntimeCoordinator {
             guard upstreamIndices.isEmpty == false else {
                 return nil
             }
-            return AvailableToolsCatalogRoute(target: route.target, upstreamIndices: upstreamIndices)
+            let activation = availableToolsCatalogActivation(
+                route: route,
+                upstreamIndices: upstreamIndices
+            )
+            return AvailableToolsCatalogRoute(
+                target: route.target,
+                upstreamIndices: upstreamIndices,
+                activationUpstreamIndex: activation?.upstreamIndex,
+                activationAttempt: activation?.attempt
+            )
         }
         guard routes.isEmpty == false else {
             throw UpstreamSlotScheduler.AcquisitionError.unavailable
@@ -177,7 +188,8 @@ extension RuntimeCoordinator {
         deadlineUptimeNs: UInt64?,
         startedAt: UInt64,
         exposedProcessIDs: Set<pid_t>,
-        returnAfterFirstSuccess: Bool = true
+        returnAfterFirstSuccess: Bool = true,
+        registerActivationCatalogRPCs: Bool = false
     ) async throws -> CanonicalToolsCatalogLoadResult {
         try await withThrowingTaskGroup(
             of: AvailableToolsCatalogOutcome.self,
@@ -191,7 +203,8 @@ extension RuntimeCoordinator {
                             route,
                             requestTimeout: requestTimeout,
                             deadlineUptimeNs: deadlineUptimeNs,
-                            startedAt: startedAt
+                            startedAt: startedAt,
+                            registerActivationCatalogRPCs: registerActivationCatalogRPCs
                         )
                         if let sourceUpstream = result.sourceUpstream,
                            let hook = self.testHooks.processToolsCatalogLoadedBeforeRecord {
@@ -199,6 +212,8 @@ extension RuntimeCoordinator {
                         }
                         guard let recordedResult = self.recordAvailableToolsCatalog(
                             target: route.target,
+                            activationUpstreamIndex: route.activationUpstreamIndex,
+                            activationAttempt: route.activationAttempt,
                             result: result,
                             startedAt: startedAt,
                             exposedProcessIDs: exposedProcessIDs
@@ -278,7 +293,16 @@ extension RuntimeCoordinator {
             guard upstreamIndices.isEmpty == false else {
                 return nil
             }
-            return AvailableToolsCatalogRoute(target: route.target, upstreamIndices: upstreamIndices)
+            let activation = availableToolsCatalogActivation(
+                route: route,
+                upstreamIndices: upstreamIndices
+            )
+            return AvailableToolsCatalogRoute(
+                target: route.target,
+                upstreamIndices: upstreamIndices,
+                activationUpstreamIndex: activation?.upstreamIndex,
+                activationAttempt: activation?.attempt
+            )
         }
         let missingRoutes = routes.filter {
             if let requestedProcessIDs,
@@ -330,6 +354,8 @@ extension RuntimeCoordinator {
 
     private func recordAvailableToolsCatalog(
         target: XcodeProcessTarget,
+        activationUpstreamIndex: Int?,
+        activationAttempt: Int?,
         result: CanonicalToolsCatalogLoadResult,
         startedAt: UInt64,
         exposedProcessIDs: Set<pid_t>
@@ -353,16 +379,46 @@ extension RuntimeCoordinator {
         }
         let hadProcessCatalog =
             processToolCatalogRegistry.catalog(forProcessID: target.processID) != nil
+        let resolvedActivation: (upstreamIndex: Int, attempt: Int)?
+        if let activationUpstreamIndex, let activationAttempt {
+            resolvedActivation = (activationUpstreamIndex, activationAttempt)
+        } else {
+            resolvedActivation = availableToolsCatalogActivation(
+                route: activeRoute,
+                upstreamIndices: activeRoute.upstreamIndices
+            )
+        }
+        if let resolvedActivation,
+           markProcessRouteActivationCataloged(
+               target: target,
+               upstreamIndex: sourceUpstream,
+               activationUpstreamIndex: resolvedActivation.upstreamIndex,
+               attempt: resolvedActivation.attempt
+           ) == false {
+            logger.debug(
+                "Dropping stale process tools/list catalog",
+                metadata: [
+                    "pid": .string("\(target.processID)"),
+                    "app_path": .string(target.appPath),
+                    "xcode_version": .string(target.xcodeVersion),
+                    "upstream": .string("\(sourceUpstream)"),
+                    "activation_attempt": .string("\(resolvedActivation.attempt)"),
+                ]
+            )
+            return nil
+        }
         processToolCatalogRegistry.record(
             target: target,
             upstreamIndex: sourceUpstream,
             associatedUpstreamIndices: activeRoute.upstreamIndices,
             rawResult: result.rawResult
         )
-        markProcessRouteActivationCataloged(
-            target: target,
-            upstreamIndex: sourceUpstream
-        )
+        if resolvedActivation == nil {
+            _ = markProcessRouteActivationCataloged(
+                target: target,
+                upstreamIndex: sourceUpstream
+            )
+        }
         _ = pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
             $0.remove(target.processID)
         }
@@ -378,6 +434,24 @@ extension RuntimeCoordinator {
             durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt),
             cacheableAsCanonical: surface?.processIDs == exposedProcessIDs
         )
+    }
+
+    private func availableToolsCatalogActivation(
+        route: XcodeProcessRoute,
+        upstreamIndices: [Int]
+    ) -> (upstreamIndex: Int, attempt: Int)? {
+        guard processToolCatalogRegistry.catalog(forProcessID: route.target.processID) == nil,
+              let primaryUpstreamIndex = route.primaryUpstreamIndex
+        else {
+            return nil
+        }
+        guard let attempt = processRouteActivationCatalogAttempt(
+            processID: route.target.processID,
+            upstreamIndex: primaryUpstreamIndex
+        ) else {
+            return nil
+        }
+        return (primaryUpstreamIndex, attempt)
     }
 
     private func scheduleAvailableToolsCatalogCompletion(
@@ -408,7 +482,8 @@ extension RuntimeCoordinator {
                     deadlineUptimeNs: self.deadlineUptimeNanoseconds(for: requestTimeout),
                     startedAt: startedAt,
                     exposedProcessIDs: exposedProcessIDs,
-                    returnAfterFirstSuccess: false
+                    returnAfterFirstSuccess: false,
+                    registerActivationCatalogRPCs: true
                 )
                 guard result.cacheableAsCanonical,
                       let sourceUpstream = result.sourceUpstream,
@@ -436,7 +511,12 @@ extension RuntimeCoordinator {
         for routes: [AvailableToolsCatalogRoute]
     ) -> String {
         routes
-            .map { "\($0.target.processID)" }
+            .map { route in
+                if let activationAttempt = route.activationAttempt {
+                    return "\(route.target.processID):\(activationAttempt)"
+                }
+                return "\(route.target.processID)"
+            }
             .sorted()
             .joined(separator: ",")
     }
@@ -445,11 +525,22 @@ extension RuntimeCoordinator {
         _ route: AvailableToolsCatalogRoute,
         requestTimeout: TimeAmount?,
         deadlineUptimeNs: UInt64?,
-        startedAt: UInt64
+        startedAt: UInt64,
+        registerActivationCatalogRPCs: Bool
     ) async throws -> CanonicalToolsCatalogLoadResult {
         var lastFailure: (upstreamIndex: Int, error: any Error)?
         for upstreamIndex in route.upstreamIndices {
             let rpcHandle = ControlPlane.RPCHandle()
+            if registerActivationCatalogRPCs,
+               route.activationUpstreamIndex == upstreamIndex,
+               let activationAttempt = route.activationAttempt {
+                xcodeProcessRouteActivationTracker.storeCatalogRPCHandle(
+                    processID: route.target.processID,
+                    upstreamIndex: upstreamIndex,
+                    attempt: activationAttempt,
+                    rpcHandle: rpcHandle
+                )
+            }
             let routeTimeout = timeAmount(until: deadlineUptimeNs) ?? requestTimeout
             if routeTimeout?.nanoseconds == 0 {
                 throw TimeoutError()

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -164,10 +164,24 @@ extension RuntimeCoordinator {
                 requestTimeout: requestTimeout,
                 deadlineUptimeNs: deadlineUptimeNs,
                 startedAt: startedAt,
-                exposedProcessIDs: exposedProcessIDs
+                exposedProcessIDs: exposedProcessIDs,
+                registerActivationCatalogRPCs: true
             )
         } catch is CancellationError {
-            throw CancellationError()
+            guard Task.isCancelled == false,
+                  let surface = try await waitForAvailableToolsCatalogSurface(
+                      exposedProcessIDs: exposedProcessIDs,
+                      deadlineUptimeNs: deadlineUptimeNs
+                  ),
+                  let sourceUpstream = surface.sourceUpstream else {
+                throw CancellationError()
+            }
+            return CanonicalToolsCatalogLoadResult(
+                rawResult: surface.rawResult,
+                sourceUpstream: sourceUpstream,
+                durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt),
+                cacheableAsCanonical: surface.processIDs == exposedProcessIDs
+            )
         } catch {
             guard let surface = currentSurface,
                   let sourceUpstream = surface.sourceUpstream else {
@@ -179,6 +193,27 @@ extension RuntimeCoordinator {
                 durationMilliseconds: elapsedMilliseconds(sinceUptimeNanoseconds: startedAt),
                 cacheableAsCanonical: surface.processIDs == exposedProcessIDs
             )
+        }
+    }
+
+    private func waitForAvailableToolsCatalogSurface(
+        exposedProcessIDs: Set<pid_t>,
+        deadlineUptimeNs: UInt64?
+    ) async throws -> ProcessToolCatalogRegistry.AvailableToolCatalog? {
+        while true {
+            if let surface = processToolCatalogRegistry.availableToolCatalogSurface(
+                processIDs: exposedProcessIDs
+            ),
+                surface.processIDs == exposedProcessIDs
+            {
+                return surface
+            }
+            try Task.checkCancellation()
+            if let deadlineUptimeNs,
+               nowUptimeNanoseconds() >= deadlineUptimeNs {
+                return nil
+            }
+            try await Task.sleep(for: .milliseconds(25))
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -4,6 +4,11 @@ import NIOFoundationCompat
 import XcodeMCPKit
 
 extension RuntimeCoordinator {
+    enum WarmInitializeMode: Sendable, Equatable {
+        case regular
+        case processRouteActivation(processID: pid_t)
+    }
+
     func markRequestSucceeded(upstreamIndex: Int) {
         upstreamHealthManager.markRequestSucceeded(upstreamIndex: upstreamIndex)
     }
@@ -191,23 +196,47 @@ extension RuntimeCoordinator {
         return upstreamIndices
     }
 
-    func startUpstreamWarmInitialize(upstreamIndex: Int, applyBackoff: Bool = false) {
+    func startUpstreamWarmInitialize(
+        upstreamIndex: Int,
+        applyBackoff: Bool = false,
+        mode: WarmInitializeMode = .regular
+    ) {
         guard isActiveProcessBoundUpstream(upstreamIndex) else { return }
         runWhenUpstreamReady(
             reason: "warm_initialize_\(upstreamIndex)",
             applyBackoff: applyBackoff
-        ) { [weak self] in
-            self?.startUpstreamWarmInitializeWhenReady(upstreamIndex: upstreamIndex)
+        ) { [weak self, mode] in
+            self?.startUpstreamWarmInitializeWhenReady(
+                upstreamIndex: upstreamIndex,
+                mode: mode
+            )
         }
     }
 
-    private func startUpstreamWarmInitializeWhenReady(upstreamIndex: Int) {
+    private func startUpstreamWarmInitializeWhenReady(
+        upstreamIndex: Int,
+        mode: WarmInitializeMode
+    ) {
         guard isActiveProcessBoundUpstream(upstreamIndex) else { return }
         guard upstreamHealthManager.beginWarmInitialize(upstreamIndex: upstreamIndex) else { return }
 
         let upstreamID = upstreamRouter.assignInitialize(upstreamIndex: upstreamIndex)
         upstreamHealthManager.setWarmInitializeUpstreamID(upstreamID, for: upstreamIndex)
-        scheduleUpstreamInitTimeout(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
+        let activationStart = beginProcessRouteActivationIfNeeded(
+            mode: mode,
+            upstreamIndex: upstreamIndex
+        )
+        if case .processRouteActivation = mode, activationStart == nil {
+            upstreamRouter.remove(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
+            clearUpstreamState(upstreamIndex: upstreamIndex, expectedUpstreamID: upstreamID)
+            return
+        }
+        scheduleUpstreamInitTimeout(
+            upstreamIndex: upstreamIndex,
+            upstreamID: upstreamID,
+            mode: mode,
+            activationAttempt: activationStart?.attempt
+        )
 
         let request = makeInternalInitializeRequest(id: upstreamID)
         if let data = try? JSONRPC.Wire.data(from: request) {
@@ -217,19 +246,48 @@ extension RuntimeCoordinator {
         }
     }
 
-    func scheduleUpstreamInitTimeout(upstreamIndex: Int, upstreamID: Int64) {
+    func scheduleUpstreamInitTimeout(
+        upstreamIndex: Int,
+        upstreamID: Int64,
+        mode: WarmInitializeMode = .regular,
+        activationAttempt: Int? = nil
+    ) {
         guard
-            let timeoutAmount = MCP.MethodDispatcher.timeoutForInitialize(
-                defaultSeconds: config.requestTimeout)
+            let timeoutAmount = upstreamInitTimeoutAmount(for: mode)
         else {
             return
         }
-        let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
+        let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self, mode] in
             guard let self else { return }
-            self.handleUpstreamInitTimeout(upstreamIndex: upstreamIndex, upstreamID: upstreamID)
+            switch mode {
+            case .regular:
+                self.handleUpstreamInitTimeout(
+                    upstreamIndex: upstreamIndex,
+                    upstreamID: upstreamID
+                )
+            case .processRouteActivation(let processID):
+                self.handleProcessRouteActivationTimeout(
+                    processID: processID,
+                    upstreamIndex: upstreamIndex,
+                    upstreamID: upstreamID,
+                    attempt: activationAttempt
+                )
+            }
         }
         let previous = upstreamHealthManager.replaceInitTimeout(timeout, upstreamIndex: upstreamIndex)
         previous?.cancel()
+    }
+
+    func upstreamInitTimeoutAmount(for mode: WarmInitializeMode) -> TimeAmount? {
+        switch mode {
+        case .regular:
+            return MCP.MethodDispatcher.timeoutForInitialize(defaultSeconds: config.requestTimeout)
+        case .processRouteActivation:
+            guard config.autoApproveXcodeDialog else {
+                return MCP.MethodDispatcher.timeoutForInitialize(defaultSeconds: config.requestTimeout)
+            }
+            return .seconds(3)
+        }
     }
 
     func handleUpstreamInitTimeout(upstreamIndex: Int, upstreamID: Int64) {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -265,7 +265,11 @@ extension RuntimeCoordinator {
         guard let negotiatedProtocolVersion = Self.supportedProtocolVersion(
             fromInitializeResult: result
         ) else {
-            handleUnsupportedInitializeProtocolVersion(result, upstreamIndex: upstreamIndex)
+            handleUnsupportedInitializeProtocolVersion(
+                result,
+                upstreamIndex: upstreamIndex,
+                upstreamID: upstreamID
+            )
             return
         }
 
@@ -431,7 +435,11 @@ extension RuntimeCoordinator {
         return version
     }
 
-    func handleUnsupportedInitializeProtocolVersion(_ result: JSONValue, upstreamIndex: Int) {
+    func handleUnsupportedInitializeProtocolVersion(
+        _ result: JSONValue,
+        upstreamIndex: Int,
+        upstreamID: Int64
+    ) {
         let version = Self.protocolVersion(fromInitializeResult: result)
         let errorObject: [String: Any] = [
             "code": -32000,
@@ -442,13 +450,22 @@ extension RuntimeCoordinator {
             ],
         ]
         let activePrimaryUpstreamIndex = initializeManager.activePrimaryInitializeUpstreamIndex()
+        let canPromoteWarmInitializeToPrimary =
+            processRoutingEnabled
+            && activePrimaryUpstreamIndex == nil
+            && canonicalBrokerState.initializeResult() == nil
+            && processRouteActivationOwnsPrimaryInitialize(upstreamIndex: upstreamIndex)
         let handlesPrimaryInitialize = activePrimaryUpstreamIndex == upstreamIndex
+            || canPromoteWarmInitializeToPrimary
             || (
                 !processRoutingEnabled
                     && isCurrentPrimaryInitializeUpstream(upstreamIndex)
                     && activePrimaryUpstreamIndex == nil
             )
         if handlesPrimaryInitialize {
+            if canPromoteWarmInitializeToPrimary {
+                clearUpstreamState(upstreamIndex: upstreamIndex, expectedUpstreamID: upstreamID)
+            }
             let didRetry = retryPrimaryInitializeOnAlternativeUpstream(
                 failedUpstreamIndex: upstreamIndex,
                 failedUpstreamID: nil,
@@ -690,6 +707,7 @@ extension RuntimeCoordinator {
                 upstreamID: initUpstreamID
             )
         }
+        resetProcessRouteActivationIfClearingPreCatalogUpstream(upstreamIndex: upstreamIndex)
         debugRecorder.resetUpstream(upstreamIndex)
         if let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
            let replacementUpstreamIndex = firstUsableInitializedUpstreamIndex(in: route)
@@ -721,6 +739,7 @@ extension RuntimeCoordinator {
         }
         result.timeout?.cancel()
         markXcodeProcessRouteAvailable(upstreamIndex: upstreamIndex)
+        markProcessRouteActivationInitialized(upstreamIndex: upstreamIndex)
         testHooks.upstreamInitialized?(upstreamIndex)
         noteUpstreamInitializationSucceeded()
         return true
@@ -732,6 +751,7 @@ extension RuntimeCoordinator {
         }
         result.timeout?.cancel()
         markXcodeProcessRouteAvailable(upstreamIndex: upstreamIndex)
+        markProcessRouteActivationInitialized(upstreamIndex: upstreamIndex)
         testHooks.upstreamInitialized?(upstreamIndex)
         noteUpstreamInitializationSucceeded()
     }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -258,6 +258,10 @@ extension RuntimeCoordinator {
         }
         processToolCatalogRegistry.removeCatalog(forProcessID: route.target.processID)
         removeXcodeWindowOwners(forProcessID: route.target.processID)
+        resetProcessRouteActivation(
+            processID: route.target.processID,
+            reason: "route_retired_\(reason)"
+        )
 
         var resetInitialize = false
         for upstreamIndex in route.upstreamIndices {
@@ -368,18 +372,17 @@ extension RuntimeCoordinator {
     }
 
     private func startInitializationForAddedProcessRoutes(_ routes: [XcodeProcessRoute]) {
-        guard routes.contains(where: { $0.upstreamIndices.isEmpty == false }) else {
+        let routesWithUpstreams = routes.filter { $0.upstreamIndices.isEmpty == false }
+        guard routesWithUpstreams.isEmpty == false else {
             return
         }
-        if isInitialized() {
-            for route in routes {
-                for upstreamIndex in route.upstreamIndices {
-                    startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
-                }
-            }
+        guard isInitialized() else {
+            startProcessRouteActivation(for: routesWithUpstreams[0])
             return
         }
-        startEagerInitializePrimary()
+        for route in routesWithUpstreams {
+            startProcessRouteActivation(for: route)
+        }
     }
 
     private func retryPendingProcessRouteReadiness(reason: String) {
@@ -409,15 +412,19 @@ extension RuntimeCoordinator {
         }
 
         guard isInitialized() else {
-            clearActiveWarmInitializesBeforePrimaryRestart()
-            startEagerInitializePrimary(applyBackoff: true)
+            guard initializeManager.snapshot().initInFlight == false else {
+                return
+            }
+            if let route = activeRoutes.first(where: {
+                pendingProcessIDs.contains($0.target.processID)
+            }) {
+                startProcessRouteActivation(for: route)
+            }
             return
         }
 
         for route in activeRoutes where pendingProcessIDs.contains(route.target.processID) {
-            for upstreamIndex in route.upstreamIndices {
-                startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
-            }
+            startProcessRouteActivation(for: route)
         }
         refreshMissingProcessToolsCatalogsIfNeeded(
             reason: "pending_process_route_\(reason)",

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -1,0 +1,319 @@
+import Foundation
+import Logging
+import NIO
+import XcodeMCPKit
+
+extension RuntimeCoordinator {
+    func startProcessRouteActivation(for route: XcodeProcessRoute) {
+        guard let upstreamIndex = route.primaryUpstreamIndex else {
+            abandonProcessRouteActivation(
+                processID: route.target.processID,
+                reason: "missing_upstream"
+            )
+            return
+        }
+        xcodeProcessRouteActivationTracker.prepare(processID: route.target.processID)
+        startUpstreamWarmInitialize(
+            upstreamIndex: upstreamIndex,
+            mode: .processRouteActivation(processID: route.target.processID)
+        )
+        guard isInitialized() else {
+            return
+        }
+        for secondaryUpstreamIndex in route.upstreamIndices where secondaryUpstreamIndex != upstreamIndex {
+            startUpstreamWarmInitialize(upstreamIndex: secondaryUpstreamIndex)
+        }
+    }
+
+    func processRouteActivationOwnsPrimaryInitialize(upstreamIndex: Int) -> Bool {
+        guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
+              route.primaryUpstreamIndex == upstreamIndex
+        else {
+            return false
+        }
+        switch xcodeProcessRouteActivationTracker.phase(processID: route.target.processID) {
+        case .pending, .attaching, .initialized:
+            return true
+        case .cataloged, .abandoned, nil:
+            return false
+        }
+    }
+
+    func beginProcessRouteActivationIfNeeded(
+        mode: WarmInitializeMode,
+        upstreamIndex: Int
+    ) -> XcodeProcessRouteActivationTracker.Start? {
+        guard case .processRouteActivation(let processID) = mode else {
+            return nil
+        }
+        let now = nowUptimeNanoseconds()
+        guard let start = xcodeProcessRouteActivationTracker.beginAttaching(
+            processID: processID,
+            upstreamIndex: upstreamIndex,
+            nowUptimeNs: now
+        ) else {
+            return nil
+        }
+        let timeoutMs = upstreamInitTimeoutAmount(for: mode).map {
+            $0.nanoseconds / 1_000_000
+        }
+        logger.info(
+            "route_activation_started",
+            metadata: [
+                "pid": .string("\(processID)"),
+                "upstream": .string("\(upstreamIndex)"),
+                "attempt": .string("\(start.attempt)"),
+                "timeout_ms": .string(timeoutMs.map(String.init) ?? "disabled"),
+            ]
+        )
+        testHooks.processRouteActivationEvent?(processID, upstreamIndex, "started")
+        return start
+    }
+
+    func handleProcessRouteActivationTimeout(
+        processID: pid_t,
+        upstreamIndex: Int,
+        upstreamID: Int64,
+        attempt: Int?
+    ) {
+        guard let attempt,
+              let retry = xcodeProcessRouteActivationTracker.handleTimeout(
+                  processID: processID,
+                  upstreamIndex: upstreamIndex,
+                  attempt: attempt
+              )
+        else {
+            return
+        }
+
+        logger.info(
+            "route_activation_timeout",
+            metadata: [
+                "pid": .string("\(processID)"),
+                "upstream": .string("\(upstreamIndex)"),
+                "attempt": .string("\(attempt)"),
+            ]
+        )
+        testHooks.processRouteActivationEvent?(processID, upstreamIndex, "timeout")
+
+        guard clearUpstreamState(upstreamIndex: upstreamIndex, expectedUpstreamID: upstreamID) else {
+            resetProcessRouteActivation(
+                processID: processID,
+                reason: "stale_activation_timeout"
+            )
+            return
+        }
+        guard replaceProcessBoundUpstreamSlot(processID: processID, upstreamIndex: upstreamIndex) else {
+            return
+        }
+        scheduleProcessRouteActivationRetry(
+            processID: processID,
+            retry: retry,
+            reason: "timeout"
+        )
+    }
+
+    func markProcessRouteActivationInitialized(upstreamIndex: Int) {
+        guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) else {
+            return
+        }
+        let processID = route.target.processID
+        guard xcodeProcessRouteActivationTracker.markInitialized(
+            processID: processID,
+            upstreamIndex: upstreamIndex,
+            nowUptimeNs: nowUptimeNanoseconds()
+        ) else {
+            return
+        }
+        logger.info(
+            "route_activation_initialized",
+            metadata: [
+                "pid": .string("\(processID)"),
+                "upstream": .string("\(upstreamIndex)"),
+            ]
+        )
+        testHooks.processRouteActivationEvent?(processID, upstreamIndex, "initialized")
+    }
+
+    func markProcessRouteActivationCataloged(
+        target: XcodeProcessTarget,
+        upstreamIndex: Int
+    ) {
+        let now = nowUptimeNanoseconds()
+        guard let cataloged = xcodeProcessRouteActivationTracker.markCataloged(
+            processID: target.processID,
+            upstreamIndex: upstreamIndex,
+            nowUptimeNs: now
+        ) else {
+            return
+        }
+        logger.info(
+            "route_activation_cataloged",
+            metadata: [
+                "pid": .string("\(target.processID)"),
+                "upstream": .string("\(upstreamIndex)"),
+                "duration_ms": .string(
+                    "\(cataloged / 1_000_000)"
+                ),
+            ]
+        )
+        testHooks.processRouteActivationEvent?(target.processID, upstreamIndex, "cataloged")
+    }
+
+    func abandonProcessRouteActivation(processID: pid_t, reason: String) {
+        xcodeProcessRouteActivationTracker.abandon(processID: processID, reason: reason)
+        logger.info(
+            "route_activation_abandoned",
+            metadata: [
+                "pid": .string("\(processID)"),
+                "reason": .string(reason),
+            ]
+        )
+        testHooks.processRouteActivationEvent?(processID, nil, "abandoned")
+    }
+
+    func resetProcessRouteActivation(processID: pid_t, reason: String) {
+        guard xcodeProcessRouteActivationTracker.reset(processID: processID) else {
+            return
+        }
+        logger.info(
+            "route_activation_abandoned",
+            metadata: [
+                "pid": .string("\(processID)"),
+                "reason": .string(reason),
+            ]
+        )
+        testHooks.processRouteActivationEvent?(processID, nil, "abandoned")
+    }
+
+    func resetProcessRouteActivationIfClearingPreCatalogUpstream(upstreamIndex: Int) {
+        guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
+              processToolCatalogRegistry.catalog(forProcessID: route.target.processID) == nil
+        else {
+            return
+        }
+        switch xcodeProcessRouteActivationTracker.phase(processID: route.target.processID) {
+        case .attaching(let activationUpstreamIndex, _, _)
+            where activationUpstreamIndex == upstreamIndex:
+            resetProcessRouteActivation(
+                processID: route.target.processID,
+                reason: "upstream_cleared_before_catalog"
+            )
+        case .initialized(let activationUpstreamIndex, _, _)
+            where activationUpstreamIndex == upstreamIndex:
+            resetProcessRouteActivation(
+                processID: route.target.processID,
+                reason: "upstream_cleared_before_catalog"
+            )
+        case .pending, .cataloged, .abandoned, .attaching, .initialized, nil:
+            return
+        }
+    }
+
+    func resetAllProcessRouteActivations(reason: String) {
+        for processID in xcodeProcessRouteActivationTracker.resetAll() {
+            logger.info(
+                "route_activation_abandoned",
+                metadata: [
+                    "pid": .string("\(processID)"),
+                    "reason": .string(reason),
+                ]
+            )
+            testHooks.processRouteActivationEvent?(processID, nil, "abandoned")
+        }
+    }
+
+    private func scheduleProcessRouteActivationRetry(
+        processID: pid_t,
+        retry: XcodeProcessRouteActivationTracker.Retry,
+        reason: String
+    ) {
+        logger.info(
+            "route_activation_retry_scheduled",
+            metadata: [
+                "pid": .string("\(processID)"),
+                "delay_ms": .string("\(retry.delayMilliseconds)"),
+                "attempt": .string("\(retry.attempt)"),
+                "reason": .string(reason),
+            ]
+        )
+        testHooks.processRouteActivationEvent?(processID, nil, "retry_scheduled")
+        let timeout = scheduleRuntimeTimeout(retry.delay) { [weak self] in
+            guard let self else { return }
+            guard self.xcodeProcessRouteActivationTracker.handleRetryFired(
+                processID: processID
+            ) else {
+                return
+            }
+            guard let route = self.xcodeProcessRoutes.first(where: {
+                $0.target.processID == processID
+            }) else {
+                self.abandonProcessRouteActivation(
+                    processID: processID,
+                    reason: "retry_route_missing"
+                )
+                return
+            }
+            self.startProcessRouteActivation(for: route)
+        }
+        xcodeProcessRouteActivationTracker.storeRetry(
+            processID: processID,
+            timeout: timeout
+        )
+    }
+
+    @discardableResult
+    private func replaceProcessBoundUpstreamSlot(
+        processID: pid_t,
+        upstreamIndex: Int
+    ) -> Bool {
+        guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
+              route.target.processID == processID
+        else {
+            abandonProcessRouteActivation(
+                processID: processID,
+                reason: "replacement_route_unavailable"
+            )
+            return false
+        }
+        let replacements = dynamicUpstreamFactory?(route.target) ?? []
+        guard let replacement = replacements.first else {
+            abandonProcessRouteActivation(
+                processID: processID,
+                reason: "replacement_unavailable"
+            )
+            return false
+        }
+
+        let previous = upstreamsBox.withLockedValue { upstreams -> (any UpstreamSlotControlling)? in
+            guard upstreamIndex >= 0, upstreamIndex < upstreams.count else {
+                return nil
+            }
+            let previous = upstreams[upstreamIndex]
+            upstreams[upstreamIndex] = replacement
+            return previous
+        }
+        guard let previous else {
+            for unusedReplacement in replacements {
+                addRuntimeTask {
+                    await unusedReplacement.stop()
+                }
+            }
+            abandonProcessRouteActivation(
+                processID: processID,
+                reason: "replacement_slot_unavailable"
+            )
+            return false
+        }
+        observeUpstreamEvents(replacement, upstreamIndex: upstreamIndex)
+        addRuntimeTask {
+            await previous.stop()
+        }
+        for unusedReplacement in replacements.dropFirst() {
+            addRuntimeTask {
+                await unusedReplacement.stop()
+            }
+        }
+        return true
+    }
+}

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -118,7 +118,7 @@ extension RuntimeCoordinator {
             return
         }
         let processID = route.target.processID
-        guard xcodeProcessRouteActivationTracker.markInitialized(
+        guard let initialized = xcodeProcessRouteActivationTracker.markInitialized(
             processID: processID,
             upstreamIndex: upstreamIndex,
             nowUptimeNs: nowUptimeNanoseconds()
@@ -133,19 +133,37 @@ extension RuntimeCoordinator {
             ]
         )
         testHooks.processRouteActivationEvent?(processID, upstreamIndex, "initialized")
+        if let existingCatalog = processToolCatalogRegistry.catalog(forProcessID: processID),
+           markProcessRouteActivationCataloged(
+               target: route.target,
+               upstreamIndex: existingCatalog.upstreamIndex,
+               activationUpstreamIndex: upstreamIndex,
+               attempt: initialized.attempt
+           ) {
+            return
+        }
+        scheduleProcessRouteActivationCatalogTimeout(
+            processID: processID,
+            upstreamIndex: upstreamIndex,
+            attempt: initialized.attempt
+        )
     }
 
     func markProcessRouteActivationCataloged(
         target: XcodeProcessTarget,
-        upstreamIndex: Int
-    ) {
+        upstreamIndex: Int,
+        activationUpstreamIndex: Int? = nil,
+        attempt: Int? = nil
+    ) -> Bool {
         let now = nowUptimeNanoseconds()
         guard let cataloged = xcodeProcessRouteActivationTracker.markCataloged(
             processID: target.processID,
-            upstreamIndex: upstreamIndex,
+            upstreamIndex: activationUpstreamIndex ?? upstreamIndex,
+            catalogedUpstreamIndex: upstreamIndex,
+            attempt: attempt,
             nowUptimeNs: now
         ) else {
-            return
+            return false
         }
         logger.info(
             "route_activation_cataloged",
@@ -158,6 +176,17 @@ extension RuntimeCoordinator {
             ]
         )
         testHooks.processRouteActivationEvent?(target.processID, upstreamIndex, "cataloged")
+        return true
+    }
+
+    func processRouteActivationCatalogAttempt(
+        processID: pid_t,
+        upstreamIndex: Int
+    ) -> Int? {
+        xcodeProcessRouteActivationTracker.catalogAttempt(
+            processID: processID,
+            upstreamIndex: upstreamIndex
+        )
     }
 
     func abandonProcessRouteActivation(processID: pid_t, reason: String) {
@@ -259,6 +288,66 @@ extension RuntimeCoordinator {
         xcodeProcessRouteActivationTracker.storeRetry(
             processID: processID,
             timeout: timeout
+        )
+    }
+
+    private func scheduleProcessRouteActivationCatalogTimeout(
+        processID: pid_t,
+        upstreamIndex: Int,
+        attempt: Int
+    ) {
+        let mode = WarmInitializeMode.processRouteActivation(processID: processID)
+        guard let timeoutAmount = upstreamInitTimeoutAmount(for: mode) else {
+            return
+        }
+        let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
+            self?.handleProcessRouteActivationCatalogTimeout(
+                processID: processID,
+                upstreamIndex: upstreamIndex,
+                attempt: attempt
+            )
+        }
+        xcodeProcessRouteActivationTracker.storeCatalogTimeout(
+            processID: processID,
+            upstreamIndex: upstreamIndex,
+            attempt: attempt,
+            timeout: timeout
+        )
+    }
+
+    private func handleProcessRouteActivationCatalogTimeout(
+        processID: pid_t,
+        upstreamIndex: Int,
+        attempt: Int
+    ) {
+        guard let timeout = xcodeProcessRouteActivationTracker.handleCatalogTimeout(
+            processID: processID,
+            upstreamIndex: upstreamIndex,
+            attempt: attempt
+        ) else {
+            return
+        }
+        timeout.rpcHandle?.cancel()
+
+        logger.info(
+            "route_activation_timeout",
+            metadata: [
+                "pid": .string("\(processID)"),
+                "upstream": .string("\(upstreamIndex)"),
+                "attempt": .string("\(attempt)"),
+                "phase": .string("catalog"),
+            ]
+        )
+        testHooks.processRouteActivationEvent?(processID, upstreamIndex, "timeout")
+
+        clearUpstreamState(upstreamIndex: upstreamIndex)
+        guard replaceProcessBoundUpstreamSlot(processID: processID, upstreamIndex: upstreamIndex) else {
+            return
+        }
+        scheduleProcessRouteActivationRetry(
+            processID: processID,
+            retry: timeout.retry,
+            reason: "catalog_timeout"
         )
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -327,7 +327,7 @@ extension RuntimeCoordinator {
         ) else {
             return
         }
-        timeout.rpcHandle?.cancel()
+        timeout.rpcHandles.forEach { $0.cancel() }
 
         logger.info(
             "route_activation_timeout",

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -49,6 +49,8 @@ struct RuntimeCoordinatorTestHooks: Sendable {
             _ queuedRequestCount: Int
         ) -> Void)?
     var primaryInitializeFailureCleanupCompleted: (@Sendable (_ upstreamIndex: Int?) -> Void)?
+    var processRouteActivationEvent:
+        (@Sendable (_ processID: pid_t, _ upstreamIndex: Int?, _ event: String) -> Void)?
 
     init(
         initializedNotificationStaleIgnored: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil,
@@ -63,7 +65,9 @@ struct RuntimeCoordinatorTestHooks: Sendable {
                 _ descriptor: SessionRequestPipeline.Descriptor,
                 _ queuedRequestCount: Int
             ) -> Void)? = nil,
-        primaryInitializeFailureCleanupCompleted: (@Sendable (_ upstreamIndex: Int?) -> Void)? = nil
+        primaryInitializeFailureCleanupCompleted: (@Sendable (_ upstreamIndex: Int?) -> Void)? = nil,
+        processRouteActivationEvent:
+            (@Sendable (_ processID: pid_t, _ upstreamIndex: Int?, _ event: String) -> Void)? = nil
     ) {
         self.initializedNotificationStaleIgnored = initializedNotificationStaleIgnored
         self.upstreamEventHandled = upstreamEventHandled
@@ -72,6 +76,7 @@ struct RuntimeCoordinatorTestHooks: Sendable {
         self.upstreamInitialized = upstreamInitialized
         self.upstreamRequestQueued = upstreamRequestQueued
         self.primaryInitializeFailureCleanupCompleted = primaryInitializeFailureCleanupCompleted
+        self.processRouteActivationEvent = processRouteActivationEvent
     }
 }
 
@@ -417,6 +422,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let workspaceOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
     let availableToolsCatalogRefreshKeys = NIOLockedValueBox<Set<String>>([])
     let pendingProcessToolsCatalogRefreshProcessIDs = NIOLockedValueBox<Set<pid_t>>([])
+    let xcodeProcessRouteActivationTracker = XcodeProcessRouteActivationTracker()
     let unavailableXcodeProcessRoutes =
         NIOLockedValueBox<[pid_t: UInt64]>([:])
     let prewarmDocumentationProviderOnStartup: Bool
@@ -819,6 +825,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         cancelPrimaryInitializeReadinessWaiter()
         debugRecorder.resetAll()
         upstreamStderrLogLimiter.reset()
+        resetAllProcessRouteActivations(reason: "debug_reset")
         unavailableXcodeProcessRoutes.withLockedValue { $0.removeAll() }
         clearXcodeWindowOwners()
         invalidateControlPlane(
@@ -852,6 +859,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
         documentationPrewarmTask?.cancel()
         upstreamReadinessCoordinator.shutdown()
+        resetAllProcessRouteActivations(reason: "shutdown")
         xcodeProcessEventMonitor.stop()
 
         let runtimeDrain = runtimeTasks.beginShutdown()
@@ -1147,8 +1155,17 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     ) -> EventLoopFuture<ByteBuffer> {
         _ = session(id: sessionID)
         let sessionGeneration = sessionRegistry.generation(of: sessionID) ?? 0
-        let primaryUpstreamIndex = initializeManager.activePrimaryInitializeUpstreamIndex()
-            ?? primaryInitializeUpstreamIndex()
+        let activePrimaryUpstreamIndex = initializeManager.activePrimaryInitializeUpstreamIndex()
+        let candidatePrimaryUpstreamIndex = activePrimaryUpstreamIndex ?? primaryInitializeUpstreamIndex()
+        let primaryUpstreamIndex: Int?
+        if activePrimaryUpstreamIndex == nil,
+           let candidatePrimaryUpstreamIndex,
+           processRouteActivationOwnsPrimaryInitialize(upstreamIndex: candidatePrimaryUpstreamIndex)
+        {
+            primaryUpstreamIndex = nil
+        } else {
+            primaryUpstreamIndex = candidatePrimaryUpstreamIndex
+        }
         guard primaryUpstreamIndex != nil || initializeManager.isInitialized() || processRoutingEnabled else {
             return eventLoop.makeFailedFuture(UpstreamSlotScheduler.AcquisitionError.unavailable)
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
@@ -17,21 +17,47 @@ final class XcodeProcessRouteActivationTracker: Sendable {
         let startedAtUptimeNs: UInt64
     }
 
+    struct Initialized: Sendable {
+        let attempt: Int
+        let startedAtUptimeNs: UInt64
+    }
+
     struct Retry: Sendable {
         let attempt: Int
         let delay: TimeAmount
         let delayMilliseconds: Int64
     }
 
+    struct CatalogTimeout: Sendable {
+        let retry: Retry
+        let rpcHandle: ControlPlane.RPCHandle?
+    }
+
     private struct Record: Sendable {
         var phase: Phase
         var attempt: Int
         var retryTimeout: RuntimeScheduledTimeout?
+        var catalogTimeout: RuntimeScheduledTimeout?
+        var catalogRPCHandle: ControlPlane.RPCHandle?
 
-        init(phase: Phase, attempt: Int = 0, retryTimeout: RuntimeScheduledTimeout? = nil) {
+        init(
+            phase: Phase,
+            attempt: Int = 0,
+            retryTimeout: RuntimeScheduledTimeout? = nil,
+            catalogTimeout: RuntimeScheduledTimeout? = nil,
+            catalogRPCHandle: ControlPlane.RPCHandle? = nil
+        ) {
             self.phase = phase
             self.attempt = attempt
             self.retryTimeout = retryTimeout
+            self.catalogTimeout = catalogTimeout
+            self.catalogRPCHandle = catalogRPCHandle
+        }
+
+        func cancelTimeouts() {
+            retryTimeout?.cancel()
+            catalogTimeout?.cancel()
+            catalogRPCHandle?.cancel()
         }
     }
 
@@ -75,6 +101,10 @@ final class XcodeProcessRouteActivationTracker: Sendable {
 
             record.retryTimeout?.cancel()
             record.retryTimeout = nil
+            record.catalogTimeout?.cancel()
+            record.catalogTimeout = nil
+            record.catalogRPCHandle?.cancel()
+            record.catalogRPCHandle = nil
             record.attempt += 1
             record.phase = .attaching(
                 upstreamIndex: upstreamIndex,
@@ -90,13 +120,13 @@ final class XcodeProcessRouteActivationTracker: Sendable {
         processID: pid_t,
         upstreamIndex: Int,
         nowUptimeNs _: UInt64
-    ) -> Bool {
-        state.withLockedValue { records -> Bool in
-            guard var record = records[processID] else { return false }
+    ) -> Initialized? {
+        state.withLockedValue { records -> Initialized? in
+            guard var record = records[processID] else { return nil }
             guard case .attaching(let currentUpstreamIndex, let attempt, let startedAt) = record.phase,
                   currentUpstreamIndex == upstreamIndex
             else {
-                return false
+                return nil
             }
             record.phase = .initialized(
                 upstreamIndex: upstreamIndex,
@@ -104,24 +134,32 @@ final class XcodeProcessRouteActivationTracker: Sendable {
                 startedAtUptimeNs: startedAt
             )
             records[processID] = record
-            return true
+            return Initialized(attempt: attempt, startedAtUptimeNs: startedAt)
         }
     }
 
     func markCataloged(
         processID: pid_t,
         upstreamIndex: Int,
+        catalogedUpstreamIndex: Int? = nil,
+        attempt expectedAttempt: Int? = nil,
         nowUptimeNs: UInt64
     ) -> UInt64? {
         state.withLockedValue { records -> UInt64? in
             guard var record = records[processID] else { return nil }
             let duration: UInt64
             switch record.phase {
-            case .initialized(let currentUpstreamIndex, _, let startedAt)
+            case .initialized(let currentUpstreamIndex, let attempt, let startedAt)
                 where currentUpstreamIndex == upstreamIndex:
+                if let expectedAttempt, expectedAttempt != attempt {
+                    return nil
+                }
                 duration = nowUptimeNs &- startedAt
-            case .attaching(let currentUpstreamIndex, _, let startedAt)
+            case .attaching(let currentUpstreamIndex, let attempt, let startedAt)
                 where currentUpstreamIndex == upstreamIndex:
+                if let expectedAttempt, expectedAttempt != attempt {
+                    return nil
+                }
                 duration = nowUptimeNs &- startedAt
             case .cataloged(let currentUpstreamIndex) where currentUpstreamIndex == upstreamIndex:
                 return nil
@@ -130,7 +168,10 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             }
             record.retryTimeout?.cancel()
             record.retryTimeout = nil
-            record.phase = .cataloged(upstreamIndex: upstreamIndex)
+            record.catalogTimeout?.cancel()
+            record.catalogTimeout = nil
+            record.catalogRPCHandle = nil
+            record.phase = .cataloged(upstreamIndex: catalogedUpstreamIndex ?? upstreamIndex)
             records[processID] = record
             return duration
         }
@@ -152,6 +193,31 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             record.phase = .pending
             records[processID] = record
             return Self.retry(forAttempt: currentAttempt)
+        }
+    }
+
+    func handleCatalogTimeout(
+        processID: pid_t,
+        upstreamIndex: Int,
+        attempt: Int
+    ) -> CatalogTimeout? {
+        state.withLockedValue { records in
+            guard var record = records[processID] else { return nil }
+            guard case .initialized(let currentUpstreamIndex, let currentAttempt, _) = record.phase,
+                  currentUpstreamIndex == upstreamIndex,
+                  currentAttempt == attempt
+            else {
+                return nil
+            }
+            let rpcHandle = record.catalogRPCHandle
+            record.catalogRPCHandle = nil
+            record.catalogTimeout = nil
+            record.phase = .pending
+            records[processID] = record
+            return CatalogTimeout(
+                retry: Self.retry(forAttempt: currentAttempt),
+                rpcHandle: rpcHandle
+            )
         }
     }
 
@@ -182,11 +248,61 @@ final class XcodeProcessRouteActivationTracker: Sendable {
         }
     }
 
+    func storeCatalogTimeout(
+        processID: pid_t,
+        upstreamIndex: Int,
+        attempt: Int,
+        timeout: RuntimeScheduledTimeout
+    ) {
+        let shouldCancelTimeout = state.withLockedValue { records -> Bool in
+            guard var record = records[processID],
+                  case .initialized(let currentUpstreamIndex, let currentAttempt, _) = record.phase,
+                  currentUpstreamIndex == upstreamIndex,
+                  currentAttempt == attempt
+            else {
+                return true
+            }
+            record.catalogTimeout?.cancel()
+            record.catalogTimeout = timeout
+            records[processID] = record
+            return false
+        }
+        if shouldCancelTimeout {
+            timeout.cancel()
+        }
+    }
+
+    func storeCatalogRPCHandle(
+        processID: pid_t,
+        upstreamIndex: Int,
+        attempt: Int,
+        rpcHandle: ControlPlane.RPCHandle
+    ) {
+        let shouldCancelHandle = state.withLockedValue { records -> Bool in
+            guard var record = records[processID],
+                  case .initialized(let currentUpstreamIndex, let currentAttempt, _) = record.phase,
+                  currentUpstreamIndex == upstreamIndex,
+                  currentAttempt == attempt
+            else {
+                return true
+            }
+            record.catalogRPCHandle?.cancel()
+            record.catalogRPCHandle = rpcHandle
+            records[processID] = record
+            return false
+        }
+        if shouldCancelHandle {
+            rpcHandle.cancel()
+        }
+    }
+
     func abandon(processID: pid_t, reason: String) {
         state.withLockedValue { records in
             var record = records[processID] ?? Record(phase: .pending)
-            record.retryTimeout?.cancel()
+            record.cancelTimeouts()
             record.retryTimeout = nil
+            record.catalogTimeout = nil
+            record.catalogRPCHandle = nil
             record.phase = .abandoned(reason: reason)
             records[processID] = record
         }
@@ -198,7 +314,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             guard let record = records.removeValue(forKey: processID) else {
                 return false
             }
-            record.retryTimeout?.cancel()
+            record.cancelTimeouts()
             return true
         }
     }
@@ -207,7 +323,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
         state.withLockedValue { records in
             let processIDs = Array(records.keys)
             for record in records.values {
-                record.retryTimeout?.cancel()
+                record.cancelTimeouts()
             }
             records.removeAll()
             return processIDs
@@ -216,6 +332,21 @@ final class XcodeProcessRouteActivationTracker: Sendable {
 
     func phase(processID: pid_t) -> Phase? {
         state.withLockedValue { $0[processID]?.phase }
+    }
+
+    func catalogAttempt(processID: pid_t, upstreamIndex: Int) -> Int? {
+        state.withLockedValue { records in
+            guard let record = records[processID] else {
+                return nil
+            }
+            switch record.phase {
+            case .initialized(let currentUpstreamIndex, let attempt, _)
+                where currentUpstreamIndex == upstreamIndex:
+                return attempt
+            case .pending, .attaching, .initialized, .cataloged, .abandoned:
+                return nil
+            }
+        }
     }
 
     private static func retry(forAttempt attempt: Int) -> Retry {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
@@ -170,6 +170,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             record.retryTimeout = nil
             record.catalogTimeout?.cancel()
             record.catalogTimeout = nil
+            record.catalogRPCHandle?.cancel()
             record.catalogRPCHandle = nil
             record.phase = .cataloged(upstreamIndex: catalogedUpstreamIndex ?? upstreamIndex)
             records[processID] = record

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
@@ -30,7 +30,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
 
     struct CatalogTimeout: Sendable {
         let retry: Retry
-        let rpcHandle: ControlPlane.RPCHandle?
+        let rpcHandles: [ControlPlane.RPCHandle]
     }
 
     private struct Record: Sendable {
@@ -38,26 +38,26 @@ final class XcodeProcessRouteActivationTracker: Sendable {
         var attempt: Int
         var retryTimeout: RuntimeScheduledTimeout?
         var catalogTimeout: RuntimeScheduledTimeout?
-        var catalogRPCHandle: ControlPlane.RPCHandle?
+        var catalogRPCHandles: [ControlPlane.RPCHandle]
 
         init(
             phase: Phase,
             attempt: Int = 0,
             retryTimeout: RuntimeScheduledTimeout? = nil,
             catalogTimeout: RuntimeScheduledTimeout? = nil,
-            catalogRPCHandle: ControlPlane.RPCHandle? = nil
+            catalogRPCHandles: [ControlPlane.RPCHandle] = []
         ) {
             self.phase = phase
             self.attempt = attempt
             self.retryTimeout = retryTimeout
             self.catalogTimeout = catalogTimeout
-            self.catalogRPCHandle = catalogRPCHandle
+            self.catalogRPCHandles = catalogRPCHandles
         }
 
         func cancelTimeouts() {
             retryTimeout?.cancel()
             catalogTimeout?.cancel()
-            catalogRPCHandle?.cancel()
+            catalogRPCHandles.forEach { $0.cancel() }
         }
     }
 
@@ -103,8 +103,8 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             record.retryTimeout = nil
             record.catalogTimeout?.cancel()
             record.catalogTimeout = nil
-            record.catalogRPCHandle?.cancel()
-            record.catalogRPCHandle = nil
+            record.catalogRPCHandles.forEach { $0.cancel() }
+            record.catalogRPCHandles.removeAll()
             record.attempt += 1
             record.phase = .attaching(
                 upstreamIndex: upstreamIndex,
@@ -173,8 +173,8 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             record.retryTimeout = nil
             record.catalogTimeout?.cancel()
             record.catalogTimeout = nil
-            record.catalogRPCHandle?.cancel()
-            record.catalogRPCHandle = nil
+            record.catalogRPCHandles.forEach { $0.cancel() }
+            record.catalogRPCHandles.removeAll()
             record.phase = .cataloged(
                 upstreamIndex: catalogedUpstreamIndex ?? upstreamIndex,
                 attempt: catalogedAttempt
@@ -228,14 +228,14 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             else {
                 return nil
             }
-            let rpcHandle = record.catalogRPCHandle
-            record.catalogRPCHandle = nil
+            let rpcHandles = record.catalogRPCHandles
+            record.catalogRPCHandles.removeAll()
             record.catalogTimeout = nil
             record.phase = .pending
             records[processID] = record
             return CatalogTimeout(
                 retry: Self.retry(forAttempt: currentAttempt),
-                rpcHandle: rpcHandle
+                rpcHandles: rpcHandles
             )
         }
     }
@@ -305,8 +305,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             else {
                 return true
             }
-            record.catalogRPCHandle?.cancel()
-            record.catalogRPCHandle = rpcHandle
+            record.catalogRPCHandles.append(rpcHandle)
             records[processID] = record
             return false
         }
@@ -321,7 +320,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             record.cancelTimeouts()
             record.retryTimeout = nil
             record.catalogTimeout = nil
-            record.catalogRPCHandle = nil
+            record.catalogRPCHandles.removeAll()
             record.phase = .abandoned(reason: reason)
             records[processID] = record
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
@@ -8,7 +8,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
         case pending
         case attaching(upstreamIndex: Int, attempt: Int, startedAtUptimeNs: UInt64)
         case initialized(upstreamIndex: Int, attempt: Int, startedAtUptimeNs: UInt64)
-        case cataloged(upstreamIndex: Int)
+        case cataloged(upstreamIndex: Int, attempt: Int)
         case abandoned(reason: String)
     }
 
@@ -148,6 +148,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
         state.withLockedValue { records -> UInt64? in
             guard var record = records[processID] else { return nil }
             let duration: UInt64
+            let catalogedAttempt: Int
             switch record.phase {
             case .initialized(let currentUpstreamIndex, let attempt, let startedAt)
                 where currentUpstreamIndex == upstreamIndex:
@@ -155,13 +156,15 @@ final class XcodeProcessRouteActivationTracker: Sendable {
                     return nil
                 }
                 duration = nowUptimeNs &- startedAt
+                catalogedAttempt = attempt
             case .attaching(let currentUpstreamIndex, let attempt, let startedAt)
                 where currentUpstreamIndex == upstreamIndex:
                 if let expectedAttempt, expectedAttempt != attempt {
                     return nil
                 }
                 duration = nowUptimeNs &- startedAt
-            case .cataloged(let currentUpstreamIndex) where currentUpstreamIndex == upstreamIndex:
+                catalogedAttempt = attempt
+            case .cataloged(let currentUpstreamIndex, _) where currentUpstreamIndex == upstreamIndex:
                 return nil
             case .pending, .abandoned, .attaching, .initialized, .cataloged:
                 return nil
@@ -172,9 +175,24 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             record.catalogTimeout = nil
             record.catalogRPCHandle?.cancel()
             record.catalogRPCHandle = nil
-            record.phase = .cataloged(upstreamIndex: catalogedUpstreamIndex ?? upstreamIndex)
+            record.phase = .cataloged(
+                upstreamIndex: catalogedUpstreamIndex ?? upstreamIndex,
+                attempt: catalogedAttempt
+            )
             records[processID] = record
             return duration
+        }
+    }
+
+    func isCataloged(processID: pid_t, attempt expectedAttempt: Int? = nil) -> Bool {
+        state.withLockedValue { records in
+            guard case .cataloged(_, let attempt)? = records[processID]?.phase else {
+                return false
+            }
+            if let expectedAttempt {
+                return attempt == expectedAttempt
+            }
+            return true
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
@@ -1,0 +1,239 @@
+import Foundation
+import NIO
+import NIOConcurrencyHelpers
+import XcodeMCPKit
+
+final class XcodeProcessRouteActivationTracker: Sendable {
+    enum Phase: Sendable, Equatable {
+        case pending
+        case attaching(upstreamIndex: Int, attempt: Int, startedAtUptimeNs: UInt64)
+        case initialized(upstreamIndex: Int, attempt: Int, startedAtUptimeNs: UInt64)
+        case cataloged(upstreamIndex: Int)
+        case abandoned(reason: String)
+    }
+
+    struct Start: Sendable {
+        let attempt: Int
+        let startedAtUptimeNs: UInt64
+    }
+
+    struct Retry: Sendable {
+        let attempt: Int
+        let delay: TimeAmount
+        let delayMilliseconds: Int64
+    }
+
+    private struct Record: Sendable {
+        var phase: Phase
+        var attempt: Int
+        var retryTimeout: RuntimeScheduledTimeout?
+
+        init(phase: Phase, attempt: Int = 0, retryTimeout: RuntimeScheduledTimeout? = nil) {
+            self.phase = phase
+            self.attempt = attempt
+            self.retryTimeout = retryTimeout
+        }
+    }
+
+    private let state = NIOLockedValueBox<[pid_t: Record]>([:])
+
+    func prepare(processID: pid_t) {
+        state.withLockedValue { records in
+            if let record = records[processID] {
+                switch record.phase {
+                case .cataloged:
+                    records[processID] = Record(phase: .pending, attempt: record.attempt)
+                case .abandoned:
+                    records[processID] = Record(phase: .pending, attempt: 0)
+                case .pending, .attaching, .initialized:
+                    break
+                }
+            } else {
+                records[processID] = Record(phase: .pending)
+            }
+        }
+    }
+
+    func beginAttaching(
+        processID: pid_t,
+        upstreamIndex: Int,
+        nowUptimeNs: UInt64
+    ) -> Start? {
+        state.withLockedValue { records in
+            var record = records[processID] ?? Record(phase: .pending)
+            switch record.phase {
+            case .pending:
+                guard record.retryTimeout == nil else {
+                    records[processID] = record
+                    return nil
+                }
+            case .abandoned:
+                break
+            case .attaching, .initialized, .cataloged:
+                return nil
+            }
+
+            record.retryTimeout?.cancel()
+            record.retryTimeout = nil
+            record.attempt += 1
+            record.phase = .attaching(
+                upstreamIndex: upstreamIndex,
+                attempt: record.attempt,
+                startedAtUptimeNs: nowUptimeNs
+            )
+            records[processID] = record
+            return Start(attempt: record.attempt, startedAtUptimeNs: nowUptimeNs)
+        }
+    }
+
+    func markInitialized(
+        processID: pid_t,
+        upstreamIndex: Int,
+        nowUptimeNs _: UInt64
+    ) -> Bool {
+        state.withLockedValue { records -> Bool in
+            guard var record = records[processID] else { return false }
+            guard case .attaching(let currentUpstreamIndex, let attempt, let startedAt) = record.phase,
+                  currentUpstreamIndex == upstreamIndex
+            else {
+                return false
+            }
+            record.phase = .initialized(
+                upstreamIndex: upstreamIndex,
+                attempt: attempt,
+                startedAtUptimeNs: startedAt
+            )
+            records[processID] = record
+            return true
+        }
+    }
+
+    func markCataloged(
+        processID: pid_t,
+        upstreamIndex: Int,
+        nowUptimeNs: UInt64
+    ) -> UInt64? {
+        state.withLockedValue { records -> UInt64? in
+            guard var record = records[processID] else { return nil }
+            let duration: UInt64
+            switch record.phase {
+            case .initialized(let currentUpstreamIndex, _, let startedAt)
+                where currentUpstreamIndex == upstreamIndex:
+                duration = nowUptimeNs &- startedAt
+            case .attaching(let currentUpstreamIndex, _, let startedAt)
+                where currentUpstreamIndex == upstreamIndex:
+                duration = nowUptimeNs &- startedAt
+            case .cataloged(let currentUpstreamIndex) where currentUpstreamIndex == upstreamIndex:
+                return nil
+            case .pending, .abandoned, .attaching, .initialized, .cataloged:
+                return nil
+            }
+            record.retryTimeout?.cancel()
+            record.retryTimeout = nil
+            record.phase = .cataloged(upstreamIndex: upstreamIndex)
+            records[processID] = record
+            return duration
+        }
+    }
+
+    func handleTimeout(
+        processID: pid_t,
+        upstreamIndex: Int,
+        attempt: Int
+    ) -> Retry? {
+        state.withLockedValue { records in
+            guard var record = records[processID] else { return nil }
+            guard case .attaching(let currentUpstreamIndex, let currentAttempt, _) = record.phase,
+                  currentUpstreamIndex == upstreamIndex,
+                  currentAttempt == attempt
+            else {
+                return nil
+            }
+            record.phase = .pending
+            records[processID] = record
+            return Self.retry(forAttempt: currentAttempt)
+        }
+    }
+
+    func handleRetryFired(processID: pid_t) -> Bool {
+        state.withLockedValue { records in
+            guard var record = records[processID] else { return false }
+            record.retryTimeout = nil
+            switch record.phase {
+            case .pending:
+                records[processID] = record
+                return true
+            case .attaching, .initialized, .cataloged, .abandoned:
+                records[processID] = record
+                return false
+            }
+        }
+    }
+
+    func storeRetry(
+        processID: pid_t,
+        timeout: RuntimeScheduledTimeout
+    ) {
+        state.withLockedValue { records in
+            var record = records[processID] ?? Record(phase: .pending)
+            record.retryTimeout?.cancel()
+            record.retryTimeout = timeout
+            records[processID] = record
+        }
+    }
+
+    func abandon(processID: pid_t, reason: String) {
+        state.withLockedValue { records in
+            var record = records[processID] ?? Record(phase: .pending)
+            record.retryTimeout?.cancel()
+            record.retryTimeout = nil
+            record.phase = .abandoned(reason: reason)
+            records[processID] = record
+        }
+    }
+
+    @discardableResult
+    func reset(processID: pid_t) -> Bool {
+        state.withLockedValue { records in
+            guard let record = records.removeValue(forKey: processID) else {
+                return false
+            }
+            record.retryTimeout?.cancel()
+            return true
+        }
+    }
+
+    func resetAll() -> [pid_t] {
+        state.withLockedValue { records in
+            let processIDs = Array(records.keys)
+            for record in records.values {
+                record.retryTimeout?.cancel()
+            }
+            records.removeAll()
+            return processIDs
+        }
+    }
+
+    func phase(processID: pid_t) -> Phase? {
+        state.withLockedValue { $0[processID]?.phase }
+    }
+
+    private static func retry(forAttempt attempt: Int) -> Retry {
+        let delayMilliseconds: Int64
+        switch attempt {
+        case ...1:
+            delayMilliseconds = 250
+        case 2:
+            delayMilliseconds = 500
+        case 3:
+            delayMilliseconds = 1_000
+        default:
+            delayMilliseconds = 2_000
+        }
+        return Retry(
+            attempt: attempt,
+            delay: .milliseconds(delayMilliseconds),
+            delayMilliseconds: delayMilliseconds
+        )
+    }
+}

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -728,6 +728,207 @@ struct RuntimeCoordinatorTests {
         )
     }
 
+    @Test func processRouteActivationCatalogTimeoutCancelsSecondaryFallbackRPC()
+        async throws
+    {
+        var config = makeConfig(requestTimeout: 20)
+        config.autoApproveXcodeDialog = true
+        let olderUpstream = TestUpstreamClient()
+        let olderTarget = xcodeProcessTarget(processID: 26628, xcodeVersion: "26.6")
+        let newerTarget = xcodeProcessTarget(processID: 27127, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: config,
+            upstreams: [olderUpstream],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let primary = TestUpstreamClient()
+                let secondary = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(contentsOf: [primary, secondary]) }
+                return [primary, secondary]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let olderInitializeFuture = fixture.registerInitialize(requestID: 1)
+        let olderInitialize = try await olderUpstream.nextSent(at: 0)
+        await olderUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: olderInitialize)))
+        )
+        _ = try await olderInitializeFuture.get()
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (olderTarget, 0, [toolDescriptor(name: "Only26")]),
+            ]
+        )
+
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_catalog_fallback_rpc_timeout"
+        )
+
+        let created = createdUpstreams.withLockedValue { $0 }
+        let primary = try #require(created.first)
+        let secondary = try #require(created.dropFirst().first)
+        let primaryInitialize = try await waitWithTimeout(
+            "waiting for primary activation initialize",
+            timeout: .seconds(2)
+        ) {
+            try await primary.nextSent(at: 0)
+        }
+        let secondaryInitialize = try await waitWithTimeout(
+            "waiting for secondary warm initialize",
+            timeout: .seconds(2)
+        ) {
+            try await secondary.nextSent(at: 0)
+        }
+
+        // The secondary initializes first; its pre-activation catalog load
+        // stays pending so the activation batch below owns the fallback RPC.
+        await secondary.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: secondaryInitialize)))
+        )
+        _ = try await waitWithTimeout(
+            "waiting for pre-activation secondary tools/list",
+            timeout: .seconds(2)
+        ) {
+            try await secondary.nextSent(
+                startingAt: 1,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+
+        let scheduledBeforePrimaryInitialized = timeoutScheduler.scheduledCount()
+        await primary.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: primaryInitialize)))
+        )
+        let primaryToolsRequest = try await waitWithTimeout(
+            "waiting for activation catalog tools/list on primary",
+            timeout: .seconds(2)
+        ) {
+            try await primary.nextSent(
+                startingAt: 1,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+
+        await primary.yield(
+            .message(
+                try JSONSerialization.data(
+                    withJSONObject: [
+                        "jsonrpc": "2.0",
+                        "id": try extractUpstreamID(from: primaryToolsRequest),
+                        "error": [
+                            "code": -32000,
+                            "message": "primary tools/list failed",
+                        ],
+                    ],
+                    options: []
+                )
+            )
+        )
+        let fallbackToolsRequest = try await waitWithTimeout(
+            "waiting for fallback tools/list on secondary",
+            timeout: .seconds(2)
+        ) {
+            try await secondary.nextSent(
+                startingAt: 2,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+
+        let catalogTimeoutIndex = try #require(
+            (scheduledBeforePrimaryInitialized..<timeoutScheduler.scheduledCount()).first {
+                timeoutScheduler.delay(at: $0)?.nanoseconds == TimeAmount.seconds(3).nanoseconds
+            }
+        )
+        let scheduledBeforeCatalogTimeoutFired = timeoutScheduler.scheduledCount()
+        #expect(timeoutScheduler.fire(at: catalogTimeoutIndex))
+        let retryIndex = try #require(
+            (scheduledBeforeCatalogTimeoutFired..<timeoutScheduler.scheduledCount()).first {
+                timeoutScheduler.delay(at: $0)?.nanoseconds
+                    == TimeAmount.milliseconds(250).nanoseconds
+            }
+        )
+
+        #expect(timeoutScheduler.fire(at: retryIndex))
+        let retryPrimary = try #require(createdUpstreams.withLockedValue { $0.dropFirst(2).first })
+        let retryInitialize = try await waitWithTimeout(
+            "waiting for retry activation initialize",
+            timeout: .seconds(2)
+        ) {
+            try await retryPrimary.nextSent(at: 0)
+        }
+        await retryPrimary.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retryInitialize)))
+        )
+        let retryToolsRequest = try await waitWithTimeout(
+            "waiting for retry activation tools/list",
+            timeout: .seconds(2)
+        ) {
+            try await retryPrimary.nextSent(
+                startingAt: 1,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+        await retryPrimary.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: retryToolsRequest),
+                    tools: [
+                        toolDescriptor(name: "Only27Retry"),
+                    ]
+                )
+            )
+        )
+        _ = try await waitWithTimeout(
+            "waiting for retry process catalog completion",
+            timeout: .seconds(2)
+        ) {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 1
+            }
+        }
+
+        // The timed-out attempt's fallback RPC was cancelled with the attempt;
+        // its late failure must not drop the catalog recorded by the retry.
+        await secondary.yield(
+            .message(
+                try JSONSerialization.data(
+                    withJSONObject: [
+                        "jsonrpc": "2.0",
+                        "id": try extractUpstreamID(from: fallbackToolsRequest),
+                        "error": [
+                            "code": -32000,
+                            "message": "stale fallback tools/list failed",
+                        ],
+                    ],
+                    options: []
+                )
+            )
+        )
+
+        #expect(
+            manager.processToolCatalogRegistry.catalog(forProcessID: newerTarget.processID) != nil
+        )
+        #expect(
+            manager.xcodeProcessRouteActivationTracker.phase(processID: newerTarget.processID)
+                == .cataloged(upstreamIndex: 1, attempt: 2)
+        )
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set([
+            "Only26",
+            "Only27Retry",
+        ]))
+    }
+
     @Test func processRouteActivationTrackerMatchesUpstreamAndAttemptExactly() {
         let tracker = XcodeProcessRouteActivationTracker()
         let processID: pid_t = 27018

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -384,7 +384,7 @@ struct RuntimeCoordinatorTests {
         }
     }
 
-    @Test func processRoutingLateXcodeKeepsOriginalInitializeTimeout()
+    @Test func processRoutingLateXcodeKeepsClientInitializeTimeoutSeparateFromActivationTimeout()
         async throws
     {
         let target = xcodeProcessTarget(processID: 27008, xcodeVersion: "27.0")
@@ -414,11 +414,386 @@ struct RuntimeCoordinatorTests {
         let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
         _ = try await upstream.nextSent(at: 0)
 
-        #expect(timeoutScheduler.scheduledCount() == 1)
+        #expect(timeoutScheduler.scheduledCount() == 2)
+        #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(5).nanoseconds)
+        #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.seconds(5).nanoseconds)
+        #expect(timeoutScheduler.fire(at: 1))
+        #expect(timeoutScheduler.scheduledCount() == 3)
+
+        let replacement = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
+        #expect(try await upstream.nextStopCount() == 1)
+        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
+        #expect(timeoutScheduler.fire(at: 2))
+        _ = try await replacement.nextSent(at: 0)
+
         timeoutScheduler.fire(at: 0)
         await #expect(throws: TimeoutError.self) {
             try await future.get()
         }
+    }
+
+    @Test func processRouteActivationUsesShortTimeoutWhenAutoApproveEnabled() async throws {
+        var config = makeConfig(requestTimeout: 5)
+        config.autoApproveXcodeDialog = true
+        let target = xcodeProcessTarget(processID: 27009, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: config,
+            upstreams: [],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+
+        fixture.manager.reconcileXcodeProcessTargets([target], reason: "test_auto_approve_timeout")
+        let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        _ = try await upstream.nextSent(at: 0)
+
+        #expect(timeoutScheduler.scheduledCount() == 1)
+        #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
+    }
+
+    @Test func processRouteActivationTrackerMatchesUpstreamAndAttemptExactly() {
+        let tracker = XcodeProcessRouteActivationTracker()
+        let processID: pid_t = 27018
+        tracker.prepare(processID: processID)
+        _ = tracker.beginAttaching(
+            processID: processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 10
+        )
+
+        #expect(tracker.markInitialized(
+            processID: processID,
+            upstreamIndex: 1,
+            nowUptimeNs: 20
+        ) == false)
+        #expect(tracker.handleTimeout(
+            processID: processID,
+            upstreamIndex: 1,
+            attempt: 1
+        ) == nil)
+        #expect(tracker.handleTimeout(
+            processID: processID,
+            upstreamIndex: 0,
+            attempt: 2
+        ) == nil)
+
+        let retry = tracker.handleTimeout(
+            processID: processID,
+            upstreamIndex: 0,
+            attempt: 1
+        )
+        #expect(retry?.delay.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
+    }
+
+    @Test func processRouteActivationClearingPreCatalogInitializedUpstreamAllowsRetry()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27019, xcodeVersion: "27.0")
+        let upstream = TestUpstreamClient()
+        let route = XcodeProcessRoute(target: target, upstreamIndices: [0])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [upstream],
+            xcodeProcessRoutes: [route],
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        manager.xcodeProcessRouteActivationTracker.prepare(processID: target.processID)
+        _ = manager.xcodeProcessRouteActivationTracker.beginAttaching(
+            processID: target.processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 0
+        )
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.clearUpstreamState(upstreamIndex: 0)
+
+        #expect(manager.xcodeProcessRouteActivationTracker.phase(processID: target.processID) == nil)
+        manager.startProcessRouteActivation(for: route)
+        let retryInitialize = try await upstream.nextSent(at: 0)
+        #expect(methodName(from: retryInitialize) == "initialize")
+    }
+
+    @Test func processRouteActivationTimeoutDoesNotReplaceAfterStateWasCleared()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27020, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [TestUpstreamClient()],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let replacement = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(replacement) }
+                return [replacement]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        manager.xcodeProcessRouteActivationTracker.prepare(processID: target.processID)
+        _ = manager.xcodeProcessRouteActivationTracker.beginAttaching(
+            processID: target.processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 0
+        )
+
+        manager.handleProcessRouteActivationTimeout(
+            processID: target.processID,
+            upstreamIndex: 0,
+            upstreamID: 123,
+            attempt: 1
+        )
+
+        #expect(timeoutScheduler.scheduledCount() == 0)
+        #expect(createdUpstreams.withLockedValue { $0.isEmpty })
+        #expect(manager.xcodeProcessRouteActivationTracker.phase(processID: target.processID) == nil)
+    }
+
+    @Test func processRouteActivationUnsupportedInitializeCompletesPendingClient()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27021, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        manager.reconcileXcodeProcessTargets([target], reason: "test_unsupported_activation")
+        let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        let initialize = try await upstream.nextSent(at: 0)
+        let initializeFuture = fixture.registerInitialize(
+            requestID: 1,
+            sessionID: "session-unsupported-activation"
+        )
+        let response: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": try extractUpstreamID(from: initialize),
+            "result": [
+                "protocolVersion": "2025-03-26",
+                "capabilities": [String: Any](),
+            ],
+        ]
+        await upstream.yield(
+            .message(try JSONSerialization.data(withJSONObject: response, options: []))
+        )
+
+        let responseObject = try decodeJSON(from: try await initializeFuture.get())
+        let error = try #require(responseObject["error"] as? [String: Any])
+        #expect(error["message"] as? String == "unsupported upstream protocol version")
+        #expect(manager.isInitialized() == false)
+    }
+
+    @Test func processRouteActivationTimeoutStopsUnusedReplacementUpstreams()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27022, xcodeVersion: "27.0")
+        let upstream = TestUpstreamClient()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [upstream],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let replacement = TestUpstreamClient()
+                let unused = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(contentsOf: [replacement, unused]) }
+                return [replacement, unused]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        manager.startProcessRouteActivation(
+            for: XcodeProcessRoute(target: target, upstreamIndices: [0])
+        )
+        _ = try await upstream.nextSent(at: 0)
+        #expect(timeoutScheduler.fire(at: 0))
+
+        let replacements = createdUpstreams.withLockedValue { $0 }
+        #expect(replacements.count == 2)
+        #expect(try await upstream.nextStopCount() == 1)
+        #expect(try await replacements[1].nextStopCount() == 1)
+        #expect(await replacements[0].stopCount() == 0)
+    }
+
+    @Test func processRouteActivationOwnsInitializeWhileReadinessWaits() async throws {
+        let readiness = ReadinessFlag(isReady: false)
+        let sleepRecorder = ControlledReadinessSleep()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let target = xcodeProcessTarget(processID: 27010, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                sleepRecorder: sleepRecorder,
+                recordPollSleeps: true
+            ),
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        manager.reconcileXcodeProcessTargets([target], reason: "test_activation_waiting")
+        let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        _ = try await sleepRecorder.nextSleep(at: 0)
+
+        let initializeFuture = fixture.registerInitialize(
+            requestID: 1,
+            sessionID: "session-joins-waiting-activation"
+        )
+        #expect(timeoutScheduler.scheduledCount() == 1)
+
+        await readiness.setReady(true)
+        await sleepRecorder.resumeNext()
+        await sleepRecorder.resumeNext()
+        let initialize = try await upstream.nextSent(at: 0)
+        #expect(methodName(from: initialize) == "initialize")
+        await upstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: initialize)))
+        )
+        let initializedNotification = try await upstream.nextSent(at: 1)
+        #expect(methodName(from: initializedNotification) == "notifications/initialized")
+        _ = try await initializeFuture.get()
+        await manager.drainRuntimeTasksForTesting()
+
+        let methods = await upstream.sent().compactMap { methodName(from: $0) }
+        #expect(methods.filter { $0 == "initialize" }.count == 1)
+    }
+
+    @Test func processRouteActivationStartsSingleRouteBeforeGlobalInitialize() async throws {
+        let firstTarget = xcodeProcessTarget(processID: 27017, xcodeVersion: "27.0")
+        let secondTarget = xcodeProcessTarget(processID: 26617, xcodeVersion: "26.6")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+
+        fixture.manager.reconcileXcodeProcessTargets(
+            [firstTarget, secondTarget],
+            reason: "test_multiple_routes_before_initialize"
+        )
+
+        _ = try await waitWithTimeout(
+            "waiting for one pre-initialize route activation",
+            timeout: .seconds(2)
+        ) {
+            while true {
+                let upstreams = createdUpstreams.withLockedValue { $0 }
+                var sentCount = 0
+                for upstream in upstreams {
+                    sentCount += await upstream.sentCount()
+                }
+                if sentCount > 0 {
+                    return sentCount
+                }
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+        }
+        await fixture.manager.drainRuntimeTasksForTesting()
+        let upstreams = createdUpstreams.withLockedValue { $0 }
+        var initializeCount = 0
+        for upstream in upstreams {
+            let methods = await upstream.sent().compactMap { methodName(from: $0) }
+            initializeCount += methods.filter { $0 == "initialize" }.count
+        }
+        #expect(initializeCount == 1)
+    }
+
+    @Test func processRouteActivationWarmsSecondarySlotsForLateAddedRouteAfterInitialize()
+        async throws
+    {
+        let existingUpstream = TestUpstreamClient()
+        let existingTarget = xcodeProcessTarget(processID: 26615, xcodeVersion: "26.6")
+        let newTarget = xcodeProcessTarget(processID: 27015, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [existingUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: existingTarget, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let primary = TestUpstreamClient()
+                let secondary = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(contentsOf: [primary, secondary]) }
+                return [primary, secondary]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let initializeFuture = fixture.registerInitialize(requestID: 1)
+        let existingInitialize = try await existingUpstream.nextSent(at: 0)
+        await existingUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: existingInitialize)))
+        )
+        _ = try await initializeFuture.get()
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (existingTarget, 0, [toolDescriptor(name: "ExistingOnly")]),
+            ]
+        )
+
+        manager.reconcileXcodeProcessTargets(
+            [existingTarget, newTarget],
+            reason: "test_late_multi_upstream_route"
+        )
+
+        let newUpstreams = createdUpstreams.withLockedValue { $0 }
+        #expect(newUpstreams.count == 2)
+        let primaryInitialize = try await newUpstreams[0].nextSent(at: 0)
+        let secondaryInitialize = try await newUpstreams[1].nextSent(at: 0)
+        #expect(methodName(from: primaryInitialize) == "initialize")
+        #expect(methodName(from: secondaryInitialize) == "initialize")
     }
 
     @Test func processRoutingNoXcodeRemovedInitializeDoesNotSuppressNextTimeout()
@@ -660,9 +1035,11 @@ struct RuntimeCoordinatorTests {
         let olderUpstream = TestUpstreamClient()
         let olderTarget = xcodeProcessTarget(processID: 26611, xcodeVersion: "26.6")
         let newerTarget = xcodeProcessTarget(processID: 27011, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
         let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
         let fixture = RuntimeCoordinatorFixture(
             upstreams: [olderUpstream],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
             ],
@@ -695,31 +1072,37 @@ struct RuntimeCoordinatorTests {
         )
 
         let newerUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
-        let firstInitialize = try await newerUpstream.nextSent(at: 0)
-        manager.handleUpstreamInitTimeout(
-            upstreamIndex: 1,
-            upstreamID: try extractUpstreamID(from: firstInitialize)
-        )
+        _ = try await newerUpstream.nextSent(at: 0)
+        #expect(timeoutScheduler.scheduledCount() == 2)
+        #expect(timeoutScheduler.fire(at: 1))
+        #expect(timeoutScheduler.scheduledCount() == 3)
+        #expect(try await newerUpstream.nextStopCount() == 1)
         let pendingSnapshot = manager.debugSnapshot()
         #expect(pendingSnapshot.processRoutes.map(\.toolsCatalogState) == [
             "pending",
             "available",
         ])
 
+        let replacementUpstream = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
+        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
         manager.reconcileXcodeProcessTargets(
             [olderTarget, newerTarget],
-            reason: "test_workspace_opened"
+            reason: "test_spurious_reconcile_before_activation_retry"
         )
-        let retriedInitialize = try await newerUpstream.nextSent(at: 1)
-        await newerUpstream.yield(
+        await manager.drainRuntimeTasksForTesting()
+        #expect(timeoutScheduler.scheduledCount() == 3)
+        #expect(await replacementUpstream.sentCount() == 0)
+        #expect(timeoutScheduler.fire(at: 2))
+        let retriedInitialize = try await replacementUpstream.nextSent(at: 0)
+        await replacementUpstream.yield(
             .message(try makeInitializeResponse(id: try extractUpstreamID(from: retriedInitialize)))
         )
-        _ = try await newerUpstream.nextSent(at: 2)
-        let toolsRequest = try await newerUpstream.nextSent(
-            startingAt: 3,
+        _ = try await replacementUpstream.nextSent(at: 1)
+        let toolsRequest = try await replacementUpstream.nextSent(
+            startingAt: 2,
             matching: { methodName(from: $0) == "tools/list" }
         )
-        await newerUpstream.yield(
+        await replacementUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
                     id: try extractUpstreamID(from: toolsRequest),
@@ -749,9 +1132,11 @@ struct RuntimeCoordinatorTests {
         async throws
     {
         let target = xcodeProcessTarget(processID: 27012, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
         let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
         let fixture = RuntimeCoordinatorFixture(
             upstreams: [],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
             processRoutingEnabled: true,
             dynamicUpstreamFactory: { _ in
                 let upstream = TestUpstreamClient()
@@ -763,31 +1148,35 @@ struct RuntimeCoordinatorTests {
         defer { fixture.shutdownAndWait() }
         let manager = fixture.manager
 
-        let failedFuture = fixture.registerInitialize(requestID: 1)
+        let initializeFuture = fixture.registerInitialize(requestID: 1)
+        #expect(timeoutScheduler.scheduledCount() == 1)
         manager.reconcileXcodeProcessTargets([target], reason: "test_initial_route")
         let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
         _ = try await upstream.nextSent(at: 0)
 
-        manager.failInitPending(error: TimeoutError())
-        await #expect(throws: TimeoutError.self) {
-            try await failedFuture.get()
-        }
+        #expect(timeoutScheduler.scheduledCount() == 2)
+        #expect(timeoutScheduler.fire(at: 1))
+        #expect(timeoutScheduler.scheduledCount() == 3)
+        #expect(try await upstream.nextStopCount() == 1)
         #expect(manager.testStateSnapshot().hasInitResult == false)
 
-        manager.reconcileXcodeProcessTargets([target], reason: "test_retry_pending_route")
-        let retriedInitialize = try await upstream.nextSent(at: 1)
+        let replacement = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
+        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
+        #expect(timeoutScheduler.fire(at: 2))
+        let retriedInitialize = try await replacement.nextSent(at: 0)
         #expect(methodName(from: retriedInitialize) == "initialize")
-        #expect(manager.testStateSnapshot().initInFlight)
 
-        await upstream.yield(
+        await replacement.yield(
             .message(try makeInitializeResponse(id: try extractUpstreamID(from: retriedInitialize)))
         )
-        let initializedNotification = try await upstream.nextSent(at: 2)
+        let initializedNotification = try await replacement.nextSent(at: 1)
         #expect(methodName(from: initializedNotification) == "notifications/initialized")
         await manager.drainRuntimeTasksForTesting()
 
         #expect(manager.testStateSnapshot().hasInitResult)
         #expect(manager.canonicalBrokerState.initializeSourceUpstream() == 0)
+        let responseForPendingClient = try decodeJSON(from: try await initializeFuture.get())
+        #expect(responseForPendingClient["result"] != nil)
         let cachedFuture = fixture.registerInitialize(requestID: 2)
         let response = try decodeJSON(from: try await cachedFuture.get())
         #expect(response["result"] != nil)

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -762,6 +762,60 @@ struct RuntimeCoordinatorTests {
         #expect(retry?.delay.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
     }
 
+    @Test func processRouteActivationCatalogCompletionCancelsStoredRPCHandle() {
+        let tracker = XcodeProcessRouteActivationTracker()
+        let processID: pid_t = 27020
+        let rpcHandle = ControlPlane.RPCHandle()
+        let cancellation = NIOLockedValueBox<ControlPlane.RPCCancelSnapshot?>(nil)
+        let registrationToken = UUID()
+
+        rpcHandle.installCancel { snapshot in
+            cancellation.withLockedValue { $0 = snapshot }
+        }
+        tracker.prepare(processID: processID)
+        let start = tracker.beginAttaching(
+            processID: processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 10
+        )
+        #expect(start?.attempt == 1)
+        _ = tracker.markInitialized(
+            processID: processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 20
+        )
+        tracker.storeCatalogRPCHandle(
+            processID: processID,
+            upstreamIndex: 0,
+            attempt: 1,
+            rpcHandle: rpcHandle
+        )
+        #expect(rpcHandle.markRegistered(
+            registrationToken: registrationToken,
+            upstreamIndex: 0
+        ))
+        #expect(rpcHandle.markAssigned(
+            registrationToken: registrationToken,
+            upstreamIndex: 0,
+            requestIDKey: "tools/list"
+        ))
+
+        let duration = tracker.markCataloged(
+            processID: processID,
+            upstreamIndex: 0,
+            catalogedUpstreamIndex: 1,
+            attempt: 1,
+            nowUptimeNs: 30
+        )
+
+        #expect(duration == 20)
+        let snapshot = cancellation.withLockedValue { $0 }
+        #expect(snapshot?.registrationToken == registrationToken)
+        #expect(snapshot?.upstreamIndex == 0)
+        #expect(snapshot?.requestIDKey == "tools/list")
+        #expect(rpcHandle.isCancelled())
+    }
+
     @Test func processRouteActivationClearingPreCatalogInitializedUpstreamAllowsRetry()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -460,6 +460,274 @@ struct RuntimeCoordinatorTests {
         #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
     }
 
+    @Test func processRouteActivationCatalogTimeoutReplacesSlotAndDropsStaleCatalog()
+        async throws
+    {
+        var config = makeConfig(requestTimeout: 20)
+        config.autoApproveXcodeDialog = true
+        let olderUpstream = TestUpstreamClient()
+        let olderTarget = xcodeProcessTarget(processID: 26626, xcodeVersion: "26.6")
+        let newerTarget = xcodeProcessTarget(processID: 27026, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: config,
+            upstreams: [olderUpstream],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let olderInitializeFuture = fixture.registerInitialize(requestID: 1)
+        let olderInitialize = try await olderUpstream.nextSent(at: 0)
+        await olderUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: olderInitialize)))
+        )
+        _ = try await olderInitializeFuture.get()
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (olderTarget, 0, [toolDescriptor(name: "Only26")]),
+            ]
+        )
+
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_catalog_timeout"
+        )
+
+        let firstAttempt = try #require(createdUpstreams.withLockedValue { $0.first })
+        let firstInitialize = try await waitWithTimeout(
+            "waiting for first activation initialize",
+            timeout: .seconds(2)
+        ) {
+            try await firstAttempt.nextSent(at: 0)
+        }
+        await firstAttempt.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: firstInitialize)))
+        )
+        _ = try await waitWithTimeout(
+            "waiting for first activation initialized notification",
+            timeout: .seconds(2)
+        ) {
+            try await firstAttempt.nextSent(at: 1)
+        }
+        let staleToolsRequest = try await waitWithTimeout(
+            "waiting for first activation tools/list",
+            timeout: .seconds(2)
+        ) {
+            try await firstAttempt.nextSent(
+                startingAt: 2,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+
+        #expect(timeoutScheduler.scheduledCount() == 3)
+        #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
+        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
+        #expect(timeoutScheduler.fire(at: 2))
+        #expect(try await firstAttempt.nextStopCount() == 1)
+        #expect(timeoutScheduler.scheduledCount() == 4)
+        #expect(timeoutScheduler.delay(at: 3)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
+
+        #expect(timeoutScheduler.fire(at: 3))
+        let retryAttempt = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
+        let retryInitialize = try await waitWithTimeout(
+            "waiting for retry activation initialize",
+            timeout: .seconds(2)
+        ) {
+            try await retryAttempt.nextSent(at: 0)
+        }
+        await retryAttempt.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retryInitialize)))
+        )
+        _ = try await waitWithTimeout(
+            "waiting for retry activation initialized notification",
+            timeout: .seconds(2)
+        ) {
+            try await retryAttempt.nextSent(at: 1)
+        }
+        let retryToolsRequest = try await waitWithTimeout(
+            "waiting for retry activation tools/list",
+            timeout: .seconds(2)
+        ) {
+            try await retryAttempt.nextSent(
+                startingAt: 2,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+
+        await firstAttempt.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: staleToolsRequest),
+                    tools: [
+                        toolDescriptor(name: "Stale27"),
+                    ]
+                )
+            )
+        )
+        #expect(manager.processToolCatalogRegistry.catalog(forProcessID: newerTarget.processID) == nil)
+
+        await retryAttempt.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: retryToolsRequest),
+                    tools: [
+                        toolDescriptor(name: "Only27"),
+                    ]
+                )
+            )
+        )
+        _ = try await waitWithTimeout(
+            "waiting for retry process catalog completion",
+            timeout: .seconds(2)
+        ) {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 1
+            }
+        }
+
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set([
+            "Only26",
+            "Only27",
+        ]))
+        #expect(Set(manager.debugSnapshot().processToolCatalogs.map(\.processID)) == Set([
+            olderTarget.processID,
+            newerTarget.processID,
+        ]))
+    }
+
+    @Test func processRouteActivationCatalogAcceptsSecondaryFallbackForCurrentAttempt()
+        async throws
+    {
+        let olderUpstream = TestUpstreamClient()
+        let olderTarget = xcodeProcessTarget(processID: 26627, xcodeVersion: "26.6")
+        let newerTarget = xcodeProcessTarget(processID: 27027, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [olderUpstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let primary = TestUpstreamClient()
+                let secondary = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(contentsOf: [primary, secondary]) }
+                return [primary, secondary]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let olderInitializeFuture = fixture.registerInitialize(requestID: 1)
+        let olderInitialize = try await olderUpstream.nextSent(at: 0)
+        await olderUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: olderInitialize)))
+        )
+        _ = try await olderInitializeFuture.get()
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (olderTarget, 0, [toolDescriptor(name: "Only26")]),
+            ]
+        )
+
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_catalog_secondary_fallback"
+        )
+
+        let created = createdUpstreams.withLockedValue { $0 }
+        let primary = try #require(created.first)
+        let secondary = try #require(created.dropFirst().first)
+        let primaryInitialize = try await waitWithTimeout(
+            "waiting for primary activation initialize",
+            timeout: .seconds(2)
+        ) {
+            try await primary.nextSent(at: 0)
+        }
+        let secondaryInitialize = try await waitWithTimeout(
+            "waiting for secondary warm initialize",
+            timeout: .seconds(2)
+        ) {
+            try await secondary.nextSent(at: 0)
+        }
+
+        await secondary.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: secondaryInitialize)))
+        )
+        _ = try await waitWithTimeout(
+            "waiting for secondary initialized notification",
+            timeout: .seconds(2)
+        ) {
+            try await secondary.nextSent(at: 1)
+        }
+
+        await primary.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: primaryInitialize)))
+        )
+        _ = try await waitWithTimeout(
+            "waiting for primary initialized notification",
+            timeout: .seconds(2)
+        ) {
+            try await primary.nextSent(at: 1)
+        }
+
+        let secondaryToolsRequest = try await waitWithTimeout(
+            "waiting for secondary fallback tools/list",
+            timeout: .seconds(2)
+        ) {
+            try await secondary.nextSent(
+                startingAt: 2,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+        await secondary.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: secondaryToolsRequest),
+                    tools: [
+                        toolDescriptor(name: "Only27Fallback"),
+                    ]
+                )
+            )
+        )
+        _ = try await waitWithTimeout(
+            "waiting for secondary fallback process catalog completion",
+            timeout: .seconds(2)
+        ) {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 2
+            }
+        }
+
+        #expect(Set(toolNames(in: manager.cachedToolsListResult() ?? .null)) == Set([
+            "Only26",
+            "Only27Fallback",
+        ]))
+        let newerCatalog = try #require(
+            manager.processToolCatalogRegistry.catalog(forProcessID: newerTarget.processID)
+        )
+        #expect(newerCatalog.upstreamIndex == 2)
+        #expect(
+            manager.xcodeProcessRouteActivationTracker.phase(processID: newerTarget.processID)
+                == .cataloged(upstreamIndex: 2)
+        )
+    }
+
     @Test func processRouteActivationTrackerMatchesUpstreamAndAttemptExactly() {
         let tracker = XcodeProcessRouteActivationTracker()
         let processID: pid_t = 27018
@@ -474,7 +742,7 @@ struct RuntimeCoordinatorTests {
             processID: processID,
             upstreamIndex: 1,
             nowUptimeNs: 20
-        ) == false)
+        ) == nil)
         #expect(tracker.handleTimeout(
             processID: processID,
             upstreamIndex: 1,

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -724,7 +724,7 @@ struct RuntimeCoordinatorTests {
         #expect(newerCatalog.upstreamIndex == 2)
         #expect(
             manager.xcodeProcessRouteActivationTracker.phase(processID: newerTarget.processID)
-                == .cataloged(upstreamIndex: 2)
+                == .cataloged(upstreamIndex: 2, attempt: 1)
         )
     }
 
@@ -4776,6 +4776,122 @@ struct RuntimeCoordinatorTests {
         #expect(manager.cachedToolsListResult() == nil)
         #expect(manager.debugSnapshot().processToolCatalogs.isEmpty)
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == nil)
+    }
+
+    @Test func sessionManagerForegroundProcessCatalogSucceedsAfterOverlappingActivationCatalogCompletes()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let target = xcodeProcessTarget(processID: 80438, xcodeVersion: "27.0")
+        let upstream = TestUpstreamClient()
+        let uptimeClock = TestUptimeClock()
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            nowUptimeNanoseconds: uptimeClock.now,
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.canonicalBrokerState.syncCanonicalInitialize(
+            try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+                "serverInfo": ["name": "cached-source"],
+            ]),
+            sourceUpstream: 0
+        )
+        manager.xcodeProcessRouteActivationTracker.prepare(processID: target.processID)
+        _ = manager.xcodeProcessRouteActivationTracker.beginAttaching(
+            processID: target.processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 0
+        )
+        _ = manager.xcodeProcessRouteActivationTracker.markInitialized(
+            processID: target.processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 1
+        )
+
+        manager.refreshMissingProcessToolsCatalogsIfNeeded(
+            reason: "test_overlap_background_refresh",
+            processIDs: [target.processID]
+        )
+        let backgroundRequest = try await sentValue(
+            from: upstream,
+            at: 0,
+            timeout: .seconds(2)
+        )
+        #expect(methodName(from: backgroundRequest) == "tools/list")
+
+        let foregroundTask = Task {
+            try await manager.sharedToolsList(
+                sessionID: "session-process-catalog-overlap",
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+        _ = try await waitWithTimeout(
+            "waiting for overlapping foreground tools/list waiter",
+            timeout: .seconds(2)
+        ) {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.waiterCounts.toolsCatalog == 1
+            }
+        }
+
+        await upstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: backgroundRequest),
+                    tools: [
+                        toolDescriptor(name: "SharedOverlapTool"),
+                    ]
+                )
+            )
+        )
+        _ = try await waitWithTimeout(
+            "waiting for overlapping background process catalog",
+            timeout: .seconds(2)
+        ) {
+            while manager.processToolCatalogRegistry.catalog(forProcessID: target.processID) == nil {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+
+        let foregroundRequest = try await sentValue(
+            from: upstream,
+            startingAt: 1,
+            matching: { methodName(from: $0) == "tools/list" },
+            timeout: .seconds(2),
+            description: "waiting for overlapping foreground tools/list"
+        )
+        await upstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: foregroundRequest),
+                    tools: [
+                        toolDescriptor(name: "SharedOverlapTool"),
+                    ]
+                )
+            )
+        )
+
+        let result = try await waitWithTimeout(
+            "waiting for overlapping foreground process catalog result",
+            timeout: .seconds(2)
+        ) {
+            try await foregroundTask.value
+        }
+        #expect(toolNames(in: result) == ["SharedOverlapTool"])
+        #expect(manager.debugSnapshot().processToolCatalogs.map(\.processID) == [
+            target.processID,
+        ])
     }
 
     @Test func sessionManagerToolsListClearsSiblingCanonicalCatalogWhenProcessRouteUnavailable()

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -816,6 +816,119 @@ struct RuntimeCoordinatorTests {
         #expect(rpcHandle.isCancelled())
     }
 
+    @Test func processRouteActivationCatalogTimeoutLetsForegroundToolsListReturnRetryCatalog()
+        async throws
+    {
+        var config = makeConfig(requestTimeout: 20)
+        config.autoApproveXcodeDialog = true
+        let target = xcodeProcessTarget(processID: 27028, xcodeVersion: "27.0")
+        let initialUpstream = TestUpstreamClient()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: config,
+            upstreams: [initialUpstream],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.canonicalBrokerState.syncCanonicalInitialize(
+            try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+                "serverInfo": ["name": "cached-source"],
+            ]),
+            sourceUpstream: 0
+        )
+        manager.xcodeProcessRouteActivationTracker.prepare(processID: target.processID)
+        _ = manager.xcodeProcessRouteActivationTracker.beginAttaching(
+            processID: target.processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 0
+        )
+        _ = manager.pendingProcessToolsCatalogRefreshProcessIDs.withLockedValue {
+            $0.insert(target.processID)
+        }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let foregroundTask = Task {
+            try await manager.sharedToolsList(
+                sessionID: "session-process-catalog-foreground-timeout",
+                requestTimeoutOverride: .seconds(20)
+            )
+        }
+        let foregroundRequest = try await waitWithTimeout(
+            "waiting for foreground activation catalog tools/list",
+            timeout: .seconds(2)
+        ) {
+            try await initialUpstream.nextSent(
+                startingAt: 0,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+        #expect(methodName(from: foregroundRequest) == "tools/list")
+
+        #expect(timeoutScheduler.scheduledCount() == 1)
+        #expect(timeoutScheduler.fire(at: 0))
+        #expect(timeoutScheduler.scheduledCount() == 2)
+        #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
+
+        #expect(timeoutScheduler.fire(at: 1))
+        let retryUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        let retryInitialize = try await waitWithTimeout(
+            "waiting for retry activation initialize",
+            timeout: .seconds(2)
+        ) {
+            try await retryUpstream.nextSent(at: 0)
+        }
+        await retryUpstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retryInitialize)))
+        )
+        _ = try await waitWithTimeout(
+            "waiting for retry activation initialized notification",
+            timeout: .seconds(2)
+        ) {
+            try await retryUpstream.nextSent(at: 1)
+        }
+        let retryToolsRequest = try await waitWithTimeout(
+            "waiting for retry activation tools/list",
+            timeout: .seconds(2)
+        ) {
+            try await retryUpstream.nextSent(
+                startingAt: 2,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
+        }
+        await retryUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: retryToolsRequest),
+                    tools: [
+                        toolDescriptor(name: "RetryForegroundTool"),
+                    ]
+                )
+            )
+        )
+
+        let result = try await waitWithTimeout(
+            "waiting for foreground tools/list to return retry catalog",
+            timeout: .seconds(2)
+        ) {
+            try await foregroundTask.value
+        }
+        #expect(toolNames(in: result) == ["RetryForegroundTool"])
+    }
+
     @Test func processRouteActivationClearingPreCatalogInitializedUpstreamAllowsRetry()
         async throws
     {
@@ -4863,24 +4976,6 @@ struct RuntimeCoordinatorTests {
                 try await Task.sleep(for: .milliseconds(10))
             }
         }
-
-        let foregroundRequest = try await sentValue(
-            from: upstream,
-            startingAt: 1,
-            matching: { methodName(from: $0) == "tools/list" },
-            timeout: .seconds(2),
-            description: "waiting for overlapping foreground tools/list"
-        )
-        await upstream.yield(
-            .message(
-                try makeDocumentationToolsListResponse(
-                    id: try extractUpstreamID(from: foregroundRequest),
-                    tools: [
-                        toolDescriptor(name: "SharedOverlapTool"),
-                    ]
-                )
-            )
-        )
 
         let result = try await waitWithTimeout(
             "waiting for overlapping foreground process catalog result",

--- a/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyInternalTestSupport/RuntimeCoordinatorTestSupport.swift
@@ -2341,6 +2341,7 @@ func makeDeterministicRuntimeTimeoutScheduler(
 
 final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
     private struct Operation {
+        let delay: TimeAmount
         let operation: @Sendable () -> Void
         var isCancelled = false
     }
@@ -2348,10 +2349,10 @@ final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
     private let operations = NIOLockedValueBox<[Operation]>([])
 
     func scheduler() -> @Sendable (TimeAmount, @escaping @Sendable () -> Void) -> RuntimeScheduledTimeout {
-        { _, operation in
+        { delay, operation in
             let index = self.operations.withLockedValue { operations in
                 let index = operations.count
-                operations.append(Operation(operation: operation))
+                operations.append(Operation(delay: delay, operation: operation))
                 return index
             }
             return RuntimeScheduledTimeout {
@@ -2371,6 +2372,13 @@ final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
         operations.withLockedValue { operations in
             guard operations.indices.contains(index) else { return false }
             return operations[index].isCancelled
+        }
+    }
+
+    func delay(at index: Int) -> TimeAmount? {
+        operations.withLockedValue { operations in
+            guard operations.indices.contains(index) else { return nil }
+            return operations[index].delay
         }
     }
 


### PR DESCRIPTION
Purpose
- Make newly launched Xcode process routes become available only after the PID-bound mcpbridge has initialized and its tools catalog has been recorded.
- Reduce restart lag when an Xcode workspace opens quickly after the process is detected.

Changes
- Adds route-level activation tracking for Xcode process routes, including retry state, timeout handling, and abandon/reset paths.
- Moves process-bound attach/retry ownership out of the pgrep readiness gate and into route activation.
- Adds catalog-phase timeout handling, RPC cancellation, slot replacement, stale catalog rejection, and secondary fallback catalog support.
- Adds state transition logging for route activation lifecycle events.
- Expands ProxyRuntimeCoordinatorTests coverage for warm activation, timeout/retry, catalog readiness, stale responses, and reset/retire behavior.

Testing
- swift test --filter processRouteActivation -Xswiftc -strict-concurrency=minimal
- swift test --filter ProxyRuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal
- swift test -Xswiftc -strict-concurrency=minimal
- codex-review against base main: no findings
