### PR TITLE
fix(proxy): keep initialize timeout armed until pending initializes resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,17 @@ jobs:
 
       - name: Run package tests
         run: |
-          swift test \
+          ./scripts/ci-test-watchdog.sh swift test \
             --no-parallel \
             -Xswiftc -strict-concurrency=minimal
 
       - name: Run process tests
         run: |
-          XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
+          XCODE_MCP_RUN_PROCESS_TESTS=1 ./scripts/ci-test-watchdog.sh swift test \
             --no-parallel \
             --filter XcodeMCPProcessRuntimeTests \
             -Xswiftc -strict-concurrency=minimal
-          XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
+          XCODE_MCP_RUN_PROCESS_TESTS=1 ./scripts/ci-test-watchdog.sh swift test \
             --no-parallel \
             --filter ProxyStdioAdapterTests \
             -Xswiftc -strict-concurrency=minimal

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -60,9 +60,13 @@ final class InitializeManager: Sendable {
     }
 
     struct SuccessPreparation: Sendable {
-        let timeout: RuntimeScheduledTimeout?
         let shouldWarmSecondary: Bool
         let cachedResult: JSONValue?
+    }
+
+    struct SuccessCompletion: Sendable {
+        let pending: [PendingInitialize]
+        let timeout: RuntimeScheduledTimeout?
     }
 
     struct FailureResult: Sendable {
@@ -288,39 +292,50 @@ final class InitializeManager: Sendable {
         }
     }
 
+    /// Success preparation must not disarm the init timeout: pending
+    /// initializes are only resolved later by the asynchronous
+    /// initialized-notification chain, and the timeout is the guarantee
+    /// that a stalled or stale-aborted chain surfaces as TimeoutError
+    /// instead of leaking the pending promises forever. The timeout is
+    /// released only at the points that actually resolve `initPending`.
     func preparePrimaryInitializeSuccess() -> SuccessPreparation? {
         state.withLockedValue { state in
             guard !state.isShuttingDown else { return nil }
-            let timeout = state.initTimeout
-            state.initTimeout = nil
             let shouldWarmSecondary = !state.didWarmSecondary
             let cachedResult = brokerState.initializeResult()
             return SuccessPreparation(
-                timeout: timeout,
                 shouldWarmSecondary: shouldWarmSecondary,
                 cachedResult: cachedResult
             )
         }
     }
 
-    func finishPrimaryInitializeSuccess() -> [PendingInitialize]? {
+    func finishPrimaryInitializeSuccess() -> SuccessCompletion? {
         state.withLockedValue { state in
             guard !state.isShuttingDown else { return nil }
             state.primaryInitializePhase = .idle
             state.warmInitRecoveryIntent = .none
             let pending = state.initPending
             state.initPending.removeAll()
-            return pending
+            let timeout = state.initTimeout
+            state.initTimeout = nil
+            return SuccessCompletion(pending: pending, timeout: timeout)
         }
     }
 
-    func finishPrimaryInitializeUsingCachedResult() -> (pending: [PendingInitialize], result: JSONValue)? {
+    func finishPrimaryInitializeUsingCachedResult() -> (
+        pending: [PendingInitialize],
+        result: JSONValue,
+        timeout: RuntimeScheduledTimeout?
+    )? {
         state.withLockedValue { state in
             guard !state.isShuttingDown, let result = brokerState.initializeResult() else { return nil }
             state.primaryInitializePhase = .idle
             let pending = state.initPending
             state.initPending.removeAll()
-            return (pending, result)
+            let timeout = state.initTimeout
+            state.initTimeout = nil
+            return (pending, result, timeout)
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -383,6 +383,30 @@ final class InitializeManager: Sendable {
         }
     }
 
+    /// Re-arms the init timeout for a retry attempt, but only while pending
+    /// initializes remain unresolved. A retry with no waiters (e.g. after
+    /// pending initializes were satisfied from the cached result) must not
+    /// leave a global timer armed: a stale timer would stop the next eager
+    /// attempt from arming its own fresh window and could fail it early.
+    /// Returns the timeout the caller must cancel.
+    func rearmInitTimeoutForRetry(
+        makeTimeout: () -> RuntimeScheduledTimeout?
+    ) -> RuntimeScheduledTimeout? {
+        state.withLockedValue { state in
+            guard state.initPending.isEmpty == false else {
+                let stale = state.initTimeout
+                state.initTimeout = nil
+                return stale
+            }
+            guard let timeout = makeTimeout() else {
+                return nil
+            }
+            let previous = state.initTimeout
+            state.initTimeout = timeout
+            return previous
+        }
+    }
+
     func handleUpstreamExit(upstreamIndex: Int) -> ExitResult? {
         state.withLockedValue { state in
             guard !state.isShuttingDown else { return nil }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -311,7 +311,6 @@ extension RuntimeCoordinator {
 
         let update = initializeManager.preparePrimaryInitializeSuccess()
         guard let update else { return }
-        update.timeout?.cancel()
 
         sendInitializedNotificationIfNeeded(
             upstreamIndex: upstreamIndex,
@@ -328,7 +327,8 @@ extension RuntimeCoordinator {
                 result,
                 sourceUpstream: upstreamIndex
             )
-            guard let pending = self.initializeManager.finishPrimaryInitializeSuccess() else { return }
+            guard let completion = self.initializeManager.finishPrimaryInitializeSuccess() else { return }
+            completion.timeout?.cancel()
             self.upstreamSlotScheduler.wake()
             if update.shouldWarmSecondary {
                 self.initializeManager.markSecondaryWarmupStarted()
@@ -336,7 +336,7 @@ extension RuntimeCoordinator {
             }
             self.refreshToolsListIfNeeded()
             self.completePendingInitializes(
-                pending,
+                completion.pending,
                 result: result,
                 negotiatedProtocolVersion: negotiatedProtocolVersion
             )
@@ -352,6 +352,7 @@ extension RuntimeCoordinator {
                 self.hasUsableInitializedSecondaryUpstreams(excluding: upstreamIndex),
                 let completion = self.initializeManager.finishPrimaryInitializeUsingCachedResult()
             {
+                completion.timeout?.cancel()
                 self.completePendingInitializes(
                     completion.pending,
                     result: completion.result,
@@ -618,6 +619,12 @@ extension RuntimeCoordinator {
             )
         }
         if handlesPrimaryInitialize {
+            // The retry attempt gets a fresh full timeout window. This must
+            // replace the still-armed previous timeout (never disarm first):
+            // pending initializes stay timeout-guarded at every instant, so a
+            // retry chain that stalls or aborts on a stale guard fails with
+            // TimeoutError instead of leaking the pending promises forever.
+            scheduleInitTimeout()
             if hasHealthySecondary {
                 initializeManager.setWarmInitRecoveryIntent(.retryPrimaryWhenNoCachedInitialize)
                 startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -619,12 +619,12 @@ extension RuntimeCoordinator {
             )
         }
         if handlesPrimaryInitialize {
-            // The retry attempt gets a fresh full timeout window. This must
-            // replace the still-armed previous timeout (never disarm first):
-            // pending initializes stay timeout-guarded at every instant, so a
-            // retry chain that stalls or aborts on a stale guard fails with
-            // TimeoutError instead of leaking the pending promises forever.
-            scheduleInitTimeout()
+            // A retry that still owns unresolved pending initializes gets a
+            // fresh full timeout window, replacing the still-armed previous
+            // timeout (never disarm first) so the pending promises stay
+            // timeout-guarded at every instant. A retry with no waiters
+            // drops the armed timeout instead of re-arming it.
+            initializeManager.rearmInitTimeoutForRetry { makeInitTimeout() }?.cancel()
             if hasHealthySecondary {
                 initializeManager.setWarmInitRecoveryIntent(.retryPrimaryWhenNoCachedInitialize)
                 startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
@@ -638,16 +638,22 @@ extension RuntimeCoordinator {
         failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
     }
 
-    func scheduleInitTimeout() {
+    func makeInitTimeout() -> RuntimeScheduledTimeout? {
         guard
             let timeoutAmount = MCP.MethodDispatcher.timeoutForInitialize(
                 defaultSeconds: config.requestTimeout)
         else {
-            return
+            return nil
         }
-        let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
+        return scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
             guard let self else { return }
             self.failInitPending(error: TimeoutError())
+        }
+    }
+
+    func scheduleInitTimeout() {
+        guard let timeout = makeInitTimeout() else {
+            return
         }
         let previous = initializeManager.replaceInitTimeout(timeout)
         previous?.cancel()

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -2959,6 +2959,52 @@ struct RuntimeCoordinatorTests {
         #expect(response["result"] != nil, "initializeResponse=\(response)")
     }
 
+    @Test func sessionManagerInitializeTimeoutStaysArmedWhileInitializedNotificationIsInFlight()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = BlockingInitializedNotificationUpstreamClient()
+        let timeoutClock = TestClock()
+        let config = makeConfig(requestTimeout: 0.3)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            scheduleRuntimeTimeout: makeDeterministicRuntimeTimeoutScheduler(clock: timeoutClock)
+        )
+        defer { manager.shutdownAndWait() }
+
+        let future = manager.registerInitialize(
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        let sent = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let upstreamID = try extractUpstreamID(from: sent)
+
+        await upstream.blockNextInitializedNotification()
+        await upstream.yield(.message(try makeInitializeResponse(id: upstreamID)))
+        try await upstream.waitForBlockedInitializedNotification()
+
+        try await timeoutClock.sleep(untilSuspendedBy: 1)
+        timeoutClock.advance(by: .milliseconds(300))
+
+        do {
+            _ = try await waitWithTimeout(
+                "initialize should fail at its deadline while the initialized notification is in flight",
+                timeout: .seconds(2)
+            ) {
+                try await future.get()
+            }
+            Issue.record("initialize must not remain pending past its deadline")
+        } catch is TimeoutError {
+        }
+
+        await upstream.releaseBlockedInitializedNotification()
+    }
+
     @Test func sessionManagerRunsSecondaryWarmupAfterRecoveredInitializedNotification()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -3005,6 +3005,58 @@ struct RuntimeCoordinatorTests {
         await upstream.releaseBlockedInitializedNotification()
     }
 
+    @Test func initializeManagerRearmsRetryTimeoutOnlyWhilePendingInitializesRemain() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let manager = InitializeManager(brokerState: CanonicalBrokerState())
+        let factoryCalls = NIOLockedValueBox(0)
+
+        let staleCancelled = NIOLockedValueBox(false)
+        _ = manager.replaceInitTimeout(
+            RuntimeScheduledTimeout { staleCancelled.withLockedValue { $0 = true } }
+        )
+        manager.rearmInitTimeoutForRetry {
+            factoryCalls.withLockedValue { $0 += 1 }
+            return RuntimeScheduledTimeout {}
+        }?.cancel()
+        #expect(staleCancelled.withLockedValue { $0 })
+        #expect(factoryCalls.withLockedValue { $0 } == 0)
+
+        _ = manager.registerInitialize(
+            sessionID: "session-rearm-retry-timeout",
+            sessionGeneration: 0,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
+            primaryUpstreamIndex: 0,
+            on: eventLoop
+        )
+        let replacedCancelled = NIOLockedValueBox(false)
+        _ = manager.replaceInitTimeout(
+            RuntimeScheduledTimeout { replacedCancelled.withLockedValue { $0 = true } }
+        )
+        manager.rearmInitTimeoutForRetry {
+            factoryCalls.withLockedValue { $0 += 1 }
+            return RuntimeScheduledTimeout {}
+        }?.cancel()
+        #expect(replacedCancelled.withLockedValue { $0 })
+        #expect(factoryCalls.withLockedValue { $0 } == 1)
+
+        let keptCancelled = NIOLockedValueBox(false)
+        _ = manager.replaceInitTimeout(
+            RuntimeScheduledTimeout { keptCancelled.withLockedValue { $0 = true } }
+        )
+        #expect(manager.rearmInitTimeoutForRetry { nil } == nil)
+        #expect(keptCancelled.withLockedValue { $0 } == false)
+
+        let shutdownState = manager.beginShutdown()
+        shutdownState.timeout?.cancel()
+        for pending in shutdownState.pending {
+            pending.eventLoop.execute {
+                pending.promise.fail(CancellationError())
+            }
+        }
+    }
+
     @Test func sessionManagerRunsSecondaryWarmupAfterRecoveredInitializedNotification()
         async throws
     {

--- a/scripts/ci-test-watchdog.sh
+++ b/scripts/ci-test-watchdog.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Runs a test command and watches its output for stalls. If the command
+# produces no output for STALL_SECONDS, the test process has hung (the
+# swift-testing runner emits events continuously); dump thread backtraces
+# of every test-related process with `sample` so the hang site is visible
+# in the CI log, then fail fast instead of waiting for the job timeout.
+set -uo pipefail
+
+STALL_SECONDS="${STALL_SECONDS:-120}"
+POLL_SECONDS=10
+
+log="$(mktemp -t ci-test-watchdog)"
+
+"$@" > >(tee "$log") 2>&1 &
+runner=$!
+
+sample_process() {
+    local pid=$1
+    echo "===== sample of pid ${pid} ($(ps -o comm= -p "${pid}" 2>/dev/null)) ====="
+    if command -v sudo > /dev/null 2>&1 && sudo -n true 2> /dev/null; then
+        sudo sample "${pid}" 5 -mayDie 2>&1 || true
+    else
+        sample "${pid}" 5 -mayDie 2>&1 || true
+    fi
+}
+
+dump_hang_diagnostics() {
+    echo "::error::test run produced no output for ${STALL_SECONDS}s; dumping thread backtraces"
+    ps -ef | grep -E 'swift|xctest' | grep -v grep || true
+    local pids
+    pids=$(pgrep -f 'swiftpm-testing-helper|PackageTests|xctest' || true)
+    for pid in ${pids}; do
+        sample_process "${pid}"
+    done
+    sample_process "${runner}"
+}
+
+last_size=-1
+stalled_for=0
+while kill -0 "${runner}" 2> /dev/null; do
+    sleep "${POLL_SECONDS}"
+    size=$(stat -f%z "${log}" 2> /dev/null || echo 0)
+    if [ "${size}" -eq "${last_size}" ]; then
+        stalled_for=$((stalled_for + POLL_SECONDS))
+    else
+        stalled_for=0
+        last_size=${size}
+    fi
+    if [ "${stalled_for}" -ge "${STALL_SECONDS}" ]; then
+        dump_hang_diagnostics
+        pkill -9 -f 'swiftpm-testing-helper|PackageTests|xctest' || true
+        kill -9 "${runner}" 2> /dev/null || true
+        exit 70
+    fi
+done
+
+wait "${runner}"


### PR DESCRIPTION
## Purpose

Fix the root cause of the intermittent CI hangs where `RuntimeCoordinatorTests` session-manager tests froze with no output until the 10-minute job timeout cancelled the run (e.g. runs 28600597911, 28419528587, and ~18% of the last 200 CI runs since the move to macos-26 arm64 runners on 2026-06-23).

## Root cause

Broken invariant: **every promise registered in `InitializeManager.initPending` must resolve** — guaranteed by either an armed init timeout or an in-flight flow that owns the pending list.

`handleInitializeResponse`'s primary success path disarmed the init timeout the moment the upstream response arrived (`preparePrimaryInitializeSuccess()`), while the pending initializes were only resolved later by the asynchronous initialized-notification chain (runtime task → `onAccepted`). That chain has several stale-guard early returns (`markInitializedNotificationSent` / `markUpstreamInitialized` failing after the attempt was cleared by exit/retry/per-upstream timeout, attempt mismatch, task supervisor rejection). If any of them fired inside that window, the pending initializes were left with no timeout guard, the client `initialize` never resolved, and the serialized test run hung silently forever. The slow 3–4 core CI runners widen this race window, which is why it never reproduced locally (40 filtered + 12 full-suite iterations under CPU load, all passing).

## Changes

- `InitializeManager`: `preparePrimaryInitializeSuccess()` no longer detaches the init timeout; `finishPrimaryInitializeSuccess()` / `finishPrimaryInitializeUsingCachedResult()` now hand the timeout out together with the pending list, so it is released only where `initPending` is actually resolved.
- `RuntimeCoordinator+Initialization`: the initialized-notification overload retry rearms the timeout atomically via `InitializeManager.rearmInitTimeoutForRetry` — while pending initializes remain, it replaces the still-armed timeout with a fresh window instead of cancel-then-rearm, preserving the existing per-attempt fresh-window contract (`sessionManagerCancelsOriginalInitTimeoutBeforeRetryingInitializedNotificationOverload`) while keeping pending initializes timeout-guarded at every instant; when the retry has no waiters (e.g. after the cached-result fallback already completed them), it drops the armed timeout instead, so no stale global timer can gate or fail a later eager attempt. A stalled or stale-aborted chain now surfaces as `TimeoutError` instead of hanging.
- Regression test `sessionManagerInitializeTimeoutStaysArmedWhileInitializedNotificationIsInFlight`: blocks the initialized notification in flight and advances a deterministic clock past the deadline. On the old implementation it fails with "timed out waiting for 1 suspended fake clock sleeper(s)" — proving the timeout guard was gone entirely; with the fix the initialize fails at its deadline.
- CI watchdog (`scripts/ci-test-watchdog.sh`, wired into `ci.yml`): if a test run produces no output for 120s, it `sample`s every test-related process so full thread backtraces land in the CI log, then fails immediately — replacing the silent 10-minute cancellation. If another hang variant remains (the cancellation-path tests may have a separate lost-continuation mode), the next occurrence will self-diagnose.

## Verification

- `swift test --no-parallel -Xswiftc -strict-concurrency=minimal`: all 788 tests pass (multiple runs, including under CPU load).
- Regression test verified to fail on the old implementation (sources stashed) and pass with the fix.
- Watchdog verified locally: exit 0 on a normal run; on a stalled run it samples the process and exits 70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
