### PR TITLE
Run release checks through the CI watchdog

### DIFF
--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -8465,15 +8465,7 @@ struct RuntimeCoordinatorTests {
         #expect(clientInfo["version"] as? String == InitializeHandshakeParams.defaultClientVersion(for: "Claude"))
     }
 
-    @Test func xcodeChatClientVersionFallsBackToCodeAliasWhenExactStemMissing() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
-        let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
-
+    @Test func xcodeChatClientVersionFallsBackToCodeAliasWhenExactStemMissing() {
         let version = InitializeHandshakeParams.xcodeChatClientVersion(
             for: "Claude",
             defaults: [
@@ -8484,15 +8476,7 @@ struct RuntimeCoordinatorTests {
         #expect(version == "9.9.9")
     }
 
-    @Test func xcodeChatClientVersionPrefersExactStemMatchOverGenericCodeAlias() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { shutdownAndWait(group) }
-        let eventLoop = group.next()
-        let upstream = TestUpstreamClient()
-        let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
-        defer { manager.shutdownAndWait() }
-
+    @Test func xcodeChatClientVersionPrefersExactStemMatchOverGenericCodeAlias() {
         let version = InitializeHandshakeParams.xcodeChatClientVersion(
             for: "Claude",
             defaults: [

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -33,16 +33,24 @@ run_group() {
   return "$status"
 }
 
-run_group "swift test" swift test \
+run_with_ci_watchdog() {
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    "$repo_root/scripts/ci-test-watchdog.sh" "$@"
+  else
+    "$@"
+  fi
+}
+
+run_group "swift test" run_with_ci_watchdog swift test \
   --no-parallel \
   -Xswiftc -strict-concurrency=minimal
 
-run_group "XcodeMCPProcessRuntimeTests" env XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
+run_group "XcodeMCPProcessRuntimeTests" run_with_ci_watchdog env XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
   --no-parallel \
   --filter XcodeMCPProcessRuntimeTests \
   -Xswiftc -strict-concurrency=minimal
 
-run_group "ProxyStdioAdapterTests" env XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
+run_group "ProxyStdioAdapterTests" run_with_ci_watchdog env XCODE_MCP_RUN_PROCESS_TESTS=1 swift test \
   --no-parallel \
   --filter ProxyStdioAdapterTests \
   -Xswiftc -strict-concurrency=minimal


### PR DESCRIPTION
## Purpose

Release verification can currently stall without the same fail-fast diagnostics used by normal CI. The release workflow runs `scripts/check.sh`, but that script did not route test commands through the CI watchdog when running on GitHub Actions.

## Changes

- Wrap `scripts/check.sh` test invocations with `scripts/ci-test-watchdog.sh` when `GITHUB_ACTIONS=true`.
- Keep local `scripts/check.sh` behavior unchanged.
- Remove unused `RuntimeCoordinator` and event loop setup from two pure `xcodeChatClientVersion` helper tests.

## Testing

- `bash -n scripts/check.sh scripts/ci-test-watchdog.sh`
- `swift test --no-parallel --filter 'xcodeChatClientVersion' -Xswiftc -strict-concurrency=minimal`
- `GITHUB_ACTIONS=true scripts/check.sh`
- `git diff --check`
- Codex review: no findings
