### PR TITLE
Stabilize route activation fallback test

### DIFF
--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -675,6 +675,14 @@ struct RuntimeCoordinatorTests {
         ) {
             try await secondary.nextSent(at: 1)
         }
+        _ = try await waitWithTimeout(
+            "waiting for secondary initialized state",
+            timeout: .seconds(2)
+        ) {
+            while manager.testStateSnapshot().upstreams[2].isInitialized == false {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
 
         await primary.yield(
             .message(try makeInitializeResponse(id: try extractUpstreamID(from: primaryInitialize)))


### PR DESCRIPTION
## Purpose

The CI failure in PR #164 was a test race in `processRouteActivationCatalogAcceptsSecondaryFallbackForCurrentAttempt`. The test observed the secondary initialized notification and then immediately advanced the primary route activation, but the notification observation does not guarantee the secondary upstream has been marked as initialized in runtime state yet.

## Changes

- Wait for the secondary upstream's initialized state before yielding the primary initialize response.
- Keep the fix scoped to the test; production behavior is unchanged.

## Testing

- `swift test --no-parallel --filter 'processRouteActivationCatalogAcceptsSecondaryFallbackForCurrentAttempt|processRouteActivationCatalogTimeoutCancelsSecondaryFallbackRPC' -Xswiftc -strict-concurrency=minimal`
- `GITHUB_ACTIONS=true scripts/check.sh`
- `git diff --check`
- Codex review: no findings
