### PR TITLE
Fix removed session initialize lifecycle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -179,6 +179,7 @@ let package = Package(
         .testTarget(
             name: "XcodeMCPKitTestingTests",
             dependencies: [
+                "XcodeMCPCoreTestSupport",
                 "XcodeMCPKit",
                 "XcodeMCPKitTesting",
             ],

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -91,6 +91,7 @@ final class InitializeManager: Sendable {
         let timeout: RuntimeScheduledTimeout?
         let cancelledPrimaryUpstreamIndex: Int?
         let cancelledPrimaryUpstreamID: Int64?
+        let cancelledPrimaryReadinessToken: UpstreamReadinessWaiterToken?
     }
 
     struct Snapshot: Sendable {
@@ -106,10 +107,17 @@ final class InitializeManager: Sendable {
         var initPending: [PendingInitialize] = []
         var primaryInitializePhase: PrimaryInitializePhase = .idle
         var primaryInitializeRequiresPendingWaiter = false
+        var primaryInitializeReadinessToken: UpstreamReadinessWaiterToken?
+        var cancelledPrimaryInitializeAttempts: [CancelledPrimaryInitializeAttempt] = []
         var initTimeout: RuntimeScheduledTimeout?
         var isShuttingDown = false
         var didWarmSecondary = false
         var warmInitRecoveryIntent: WarmInitRecoveryIntent = .none
+    }
+
+    private struct CancelledPrimaryInitializeAttempt: Sendable, Equatable {
+        let upstreamIndex: Int
+        let upstreamID: Int64
     }
 
     private let state = NIOLockedValueBox(State())
@@ -127,6 +135,8 @@ final class InitializeManager: Sendable {
             state.isShuttingDown = true
             state.primaryInitializePhase = .idle
             state.primaryInitializeRequiresPendingWaiter = false
+            state.primaryInitializeReadinessToken = nil
+            state.cancelledPrimaryInitializeAttempts.removeAll()
             let pending = state.initPending
             state.initPending.removeAll()
             let timeout = state.initTimeout
@@ -143,42 +153,59 @@ final class InitializeManager: Sendable {
                     pending: [],
                     timeout: nil,
                     cancelledPrimaryUpstreamIndex: nil,
-                    cancelledPrimaryUpstreamID: nil
+                    cancelledPrimaryUpstreamID: nil,
+                    cancelledPrimaryReadinessToken: nil
                 )
             }
             state.initPending.removeAll { $0.sessionID == sessionID }
             let timeout: RuntimeScheduledTimeout?
             let cancelledPrimaryUpstreamIndex: Int?
             let cancelledPrimaryUpstreamID: Int64?
+            let cancelledPrimaryReadinessToken: UpstreamReadinessWaiterToken?
             if state.initPending.isEmpty {
                 if state.primaryInitializeRequiresPendingWaiter,
                    state.primaryInitializePhase.isInFlight {
                     cancelledPrimaryUpstreamIndex = state.primaryInitializePhase.upstreamIndex
                     cancelledPrimaryUpstreamID = state.primaryInitializePhase.upstreamID
+                    if let upstreamIndex = cancelledPrimaryUpstreamIndex,
+                       let upstreamID = cancelledPrimaryUpstreamID
+                    {
+                        recordCancelledPrimaryInitializeAttemptLocked(
+                            upstreamIndex: upstreamIndex,
+                            upstreamID: upstreamID,
+                            state: &state
+                        )
+                    }
+                    cancelledPrimaryReadinessToken = state.primaryInitializeReadinessToken
                     state.primaryInitializePhase = .idle
                     state.primaryInitializeRequiresPendingWaiter = false
+                    state.primaryInitializeReadinessToken = nil
                     timeout = state.initTimeout
                     state.initTimeout = nil
                 } else if state.primaryInitializePhase.isInFlight == false {
                     cancelledPrimaryUpstreamIndex = nil
                     cancelledPrimaryUpstreamID = nil
+                    cancelledPrimaryReadinessToken = nil
                     timeout = state.initTimeout
                     state.initTimeout = nil
                 } else {
                     cancelledPrimaryUpstreamIndex = nil
                     cancelledPrimaryUpstreamID = nil
+                    cancelledPrimaryReadinessToken = nil
                     timeout = nil
                 }
             } else {
                 cancelledPrimaryUpstreamIndex = nil
                 cancelledPrimaryUpstreamID = nil
+                cancelledPrimaryReadinessToken = nil
                 timeout = nil
             }
             return PendingRemovalResult(
                 pending: removed,
                 timeout: timeout,
                 cancelledPrimaryUpstreamIndex: cancelledPrimaryUpstreamIndex,
-                cancelledPrimaryUpstreamID: cancelledPrimaryUpstreamID
+                cancelledPrimaryUpstreamID: cancelledPrimaryUpstreamID,
+                cancelledPrimaryReadinessToken: cancelledPrimaryReadinessToken
             )
         }
     }
@@ -199,8 +226,29 @@ final class InitializeManager: Sendable {
                 return (false, false)
             }
             state.primaryInitializePhase = .pendingSend(upstreamIndex: upstreamIndex)
-            state.primaryInitializeRequiresPendingWaiter = false
+            state.primaryInitializeRequiresPendingWaiter = state.initPending.isEmpty == false
+            state.primaryInitializeReadinessToken = nil
             return (true, state.initTimeout == nil)
+        }
+    }
+
+    func setPrimaryInitializeReadinessToken(_ token: UpstreamReadinessWaiterToken) -> Bool {
+        state.withLockedValue { state in
+            guard !state.isShuttingDown,
+                  case .pendingSend = state.primaryInitializePhase
+            else {
+                return false
+            }
+            state.primaryInitializeReadinessToken = token
+            return true
+        }
+    }
+
+    func clearPrimaryInitializeReadinessToken(_ token: UpstreamReadinessWaiterToken) {
+        state.withLockedValue { state in
+            if state.primaryInitializeReadinessToken === token {
+                state.primaryInitializeReadinessToken = nil
+            }
         }
     }
 
@@ -216,6 +264,7 @@ final class InitializeManager: Sendable {
                 upstreamIndex: upstreamIndex,
                 upstreamID: upstreamID
             )
+            state.primaryInitializeReadinessToken = nil
             return true
         }
     }
@@ -282,6 +331,7 @@ final class InitializeManager: Sendable {
 
             state.primaryInitializePhase = .pendingSend(upstreamIndex: primaryUpstreamIndex)
             state.primaryInitializeRequiresPendingWaiter = true
+            state.primaryInitializeReadinessToken = nil
             return RegisterDecision(
                 promise: promise,
                 cachedResult: nil,
@@ -325,6 +375,7 @@ final class InitializeManager: Sendable {
             }
             state.primaryInitializePhase = .pendingSend(upstreamIndex: upstreamIndex)
             state.primaryInitializeRequiresPendingWaiter = true
+            state.primaryInitializeReadinessToken = nil
             return true
         }
     }
@@ -352,6 +403,7 @@ final class InitializeManager: Sendable {
             guard !state.isShuttingDown else { return nil }
             state.primaryInitializePhase = .idle
             state.primaryInitializeRequiresPendingWaiter = false
+            state.primaryInitializeReadinessToken = nil
             state.warmInitRecoveryIntent = .none
             let pending = state.initPending
             state.initPending.removeAll()
@@ -370,6 +422,7 @@ final class InitializeManager: Sendable {
             guard !state.isShuttingDown, let result = brokerState.initializeResult() else { return nil }
             state.primaryInitializePhase = .idle
             state.primaryInitializeRequiresPendingWaiter = false
+            state.primaryInitializeReadinessToken = nil
             let pending = state.initPending
             state.initPending.removeAll()
             let timeout = state.initTimeout
@@ -382,6 +435,7 @@ final class InitializeManager: Sendable {
         state.withLockedValue { state in
             state.primaryInitializePhase = .idle
             state.primaryInitializeRequiresPendingWaiter = false
+            state.primaryInitializeReadinessToken = nil
         }
     }
 
@@ -403,6 +457,7 @@ final class InitializeManager: Sendable {
             let timeout = state.initTimeout
             state.primaryInitializePhase = .idle
             state.primaryInitializeRequiresPendingWaiter = false
+            state.primaryInitializeReadinessToken = nil
             state.initTimeout = nil
             let pending = state.initPending
             state.initPending.removeAll()
@@ -465,6 +520,7 @@ final class InitializeManager: Sendable {
             {
                 state.primaryInitializePhase = .idle
                 state.primaryInitializeRequiresPendingWaiter = false
+                state.primaryInitializeReadinessToken = nil
             }
 
             return result
@@ -483,6 +539,8 @@ final class InitializeManager: Sendable {
             state.initPending.removeAll()
             state.primaryInitializePhase = .idle
             state.primaryInitializeRequiresPendingWaiter = false
+            state.primaryInitializeReadinessToken = nil
+            state.cancelledPrimaryInitializeAttempts.removeAll()
             state.initTimeout = nil
             state.isShuttingDown = false
             state.didWarmSecondary = false
@@ -505,6 +563,21 @@ final class InitializeManager: Sendable {
         }
     }
 
+    func consumeCancelledPrimaryInitializeAttempt(upstreamIndex: Int, upstreamID: Int64) -> Bool {
+        state.withLockedValue { state in
+            guard let index = state.cancelledPrimaryInitializeAttempts.firstIndex(
+                of: CancelledPrimaryInitializeAttempt(
+                    upstreamIndex: upstreamIndex,
+                    upstreamID: upstreamID
+                )
+            ) else {
+                return false
+            }
+            state.cancelledPrimaryInitializeAttempts.remove(at: index)
+            return true
+        }
+    }
+
     private func consumeWarmInitRecoveryIntentLocked(
         state: inout State,
         policy: WarmInitRecoveryConsumptionPolicy
@@ -522,6 +595,24 @@ final class InitializeManager: Sendable {
         }
         state.warmInitRecoveryIntent = .none
         return true
+    }
+
+    private func recordCancelledPrimaryInitializeAttemptLocked(
+        upstreamIndex: Int,
+        upstreamID: Int64,
+        state: inout State
+    ) {
+        let attempt = CancelledPrimaryInitializeAttempt(
+            upstreamIndex: upstreamIndex,
+            upstreamID: upstreamID
+        )
+        state.cancelledPrimaryInitializeAttempts.removeAll { $0 == attempt }
+        state.cancelledPrimaryInitializeAttempts.append(attempt)
+        if state.cancelledPrimaryInitializeAttempts.count > 16 {
+            state.cancelledPrimaryInitializeAttempts.removeFirst(
+                state.cancelledPrimaryInitializeAttempts.count - 16
+            )
+        }
     }
 
     func snapshot() -> Snapshot {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -163,18 +163,22 @@ final class InitializeManager: Sendable {
             let cancelledPrimaryUpstreamID: Int64?
             let cancelledPrimaryReadinessToken: UpstreamReadinessWaiterToken?
             if state.initPending.isEmpty {
-                if state.primaryInitializeRequiresPendingWaiter,
-                   state.primaryInitializePhase.isInFlight {
-                    cancelledPrimaryUpstreamIndex = state.primaryInitializePhase.upstreamIndex
-                    cancelledPrimaryUpstreamID = state.primaryInitializePhase.upstreamID
-                    if let upstreamIndex = cancelledPrimaryUpstreamIndex,
-                       let upstreamID = cancelledPrimaryUpstreamID
-                    {
+                if state.primaryInitializeRequiresPendingWaiter {
+                    switch state.primaryInitializePhase {
+                    case .pendingSend(let upstreamIndex):
+                        cancelledPrimaryUpstreamIndex = upstreamIndex
+                        cancelledPrimaryUpstreamID = nil
+                    case .sent(let upstreamIndex, let upstreamID):
+                        cancelledPrimaryUpstreamIndex = upstreamIndex
+                        cancelledPrimaryUpstreamID = upstreamID
                         recordCancelledPrimaryInitializeAttemptLocked(
                             upstreamIndex: upstreamIndex,
                             upstreamID: upstreamID,
                             state: &state
                         )
+                    case .idle:
+                        cancelledPrimaryUpstreamIndex = nil
+                        cancelledPrimaryUpstreamID = nil
                     }
                     cancelledPrimaryReadinessToken = state.primaryInitializeReadinessToken
                     state.primaryInitializePhase = .idle

--- a/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/ControlPlane/InitializeManager.swift
@@ -89,6 +89,8 @@ final class InitializeManager: Sendable {
     struct PendingRemovalResult: Sendable {
         let pending: [PendingInitialize]
         let timeout: RuntimeScheduledTimeout?
+        let cancelledPrimaryUpstreamIndex: Int?
+        let cancelledPrimaryUpstreamID: Int64?
     }
 
     struct Snapshot: Sendable {
@@ -103,6 +105,7 @@ final class InitializeManager: Sendable {
     private struct State: Sendable {
         var initPending: [PendingInitialize] = []
         var primaryInitializePhase: PrimaryInitializePhase = .idle
+        var primaryInitializeRequiresPendingWaiter = false
         var initTimeout: RuntimeScheduledTimeout?
         var isShuttingDown = false
         var didWarmSecondary = false
@@ -123,6 +126,7 @@ final class InitializeManager: Sendable {
         state.withLockedValue { state in
             state.isShuttingDown = true
             state.primaryInitializePhase = .idle
+            state.primaryInitializeRequiresPendingWaiter = false
             let pending = state.initPending
             state.initPending.removeAll()
             let timeout = state.initTimeout
@@ -135,17 +139,47 @@ final class InitializeManager: Sendable {
         state.withLockedValue { state in
             let removed = state.initPending.filter { $0.sessionID == sessionID }
             guard removed.isEmpty == false else {
-                return PendingRemovalResult(pending: [], timeout: nil)
+                return PendingRemovalResult(
+                    pending: [],
+                    timeout: nil,
+                    cancelledPrimaryUpstreamIndex: nil,
+                    cancelledPrimaryUpstreamID: nil
+                )
             }
             state.initPending.removeAll { $0.sessionID == sessionID }
             let timeout: RuntimeScheduledTimeout?
-            if state.initPending.isEmpty, state.primaryInitializePhase.isInFlight == false {
-                timeout = state.initTimeout
-                state.initTimeout = nil
+            let cancelledPrimaryUpstreamIndex: Int?
+            let cancelledPrimaryUpstreamID: Int64?
+            if state.initPending.isEmpty {
+                if state.primaryInitializeRequiresPendingWaiter,
+                   state.primaryInitializePhase.isInFlight {
+                    cancelledPrimaryUpstreamIndex = state.primaryInitializePhase.upstreamIndex
+                    cancelledPrimaryUpstreamID = state.primaryInitializePhase.upstreamID
+                    state.primaryInitializePhase = .idle
+                    state.primaryInitializeRequiresPendingWaiter = false
+                    timeout = state.initTimeout
+                    state.initTimeout = nil
+                } else if state.primaryInitializePhase.isInFlight == false {
+                    cancelledPrimaryUpstreamIndex = nil
+                    cancelledPrimaryUpstreamID = nil
+                    timeout = state.initTimeout
+                    state.initTimeout = nil
+                } else {
+                    cancelledPrimaryUpstreamIndex = nil
+                    cancelledPrimaryUpstreamID = nil
+                    timeout = nil
+                }
             } else {
+                cancelledPrimaryUpstreamIndex = nil
+                cancelledPrimaryUpstreamID = nil
                 timeout = nil
             }
-            return PendingRemovalResult(pending: removed, timeout: timeout)
+            return PendingRemovalResult(
+                pending: removed,
+                timeout: timeout,
+                cancelledPrimaryUpstreamIndex: cancelledPrimaryUpstreamIndex,
+                cancelledPrimaryUpstreamID: cancelledPrimaryUpstreamID
+            )
         }
     }
 
@@ -165,6 +199,7 @@ final class InitializeManager: Sendable {
                 return (false, false)
             }
             state.primaryInitializePhase = .pendingSend(upstreamIndex: upstreamIndex)
+            state.primaryInitializeRequiresPendingWaiter = false
             return (true, state.initTimeout == nil)
         }
     }
@@ -246,6 +281,7 @@ final class InitializeManager: Sendable {
             }
 
             state.primaryInitializePhase = .pendingSend(upstreamIndex: primaryUpstreamIndex)
+            state.primaryInitializeRequiresPendingWaiter = true
             return RegisterDecision(
                 promise: promise,
                 cachedResult: nil,
@@ -288,6 +324,7 @@ final class InitializeManager: Sendable {
                 return false
             }
             state.primaryInitializePhase = .pendingSend(upstreamIndex: upstreamIndex)
+            state.primaryInitializeRequiresPendingWaiter = true
             return true
         }
     }
@@ -314,6 +351,7 @@ final class InitializeManager: Sendable {
         state.withLockedValue { state in
             guard !state.isShuttingDown else { return nil }
             state.primaryInitializePhase = .idle
+            state.primaryInitializeRequiresPendingWaiter = false
             state.warmInitRecoveryIntent = .none
             let pending = state.initPending
             state.initPending.removeAll()
@@ -331,6 +369,7 @@ final class InitializeManager: Sendable {
         state.withLockedValue { state in
             guard !state.isShuttingDown, let result = brokerState.initializeResult() else { return nil }
             state.primaryInitializePhase = .idle
+            state.primaryInitializeRequiresPendingWaiter = false
             let pending = state.initPending
             state.initPending.removeAll()
             let timeout = state.initTimeout
@@ -342,6 +381,7 @@ final class InitializeManager: Sendable {
     func reopenPrimaryInitializeForRetry() {
         state.withLockedValue { state in
             state.primaryInitializePhase = .idle
+            state.primaryInitializeRequiresPendingWaiter = false
         }
     }
 
@@ -362,6 +402,7 @@ final class InitializeManager: Sendable {
             let upstreamIndex = state.primaryInitializePhase.upstreamIndex
             let timeout = state.initTimeout
             state.primaryInitializePhase = .idle
+            state.primaryInitializeRequiresPendingWaiter = false
             state.initTimeout = nil
             let pending = state.initPending
             state.initPending.removeAll()
@@ -423,6 +464,7 @@ final class InitializeManager: Sendable {
                state.primaryInitializePhase.isInFlight
             {
                 state.primaryInitializePhase = .idle
+                state.primaryInitializeRequiresPendingWaiter = false
             }
 
             return result
@@ -440,6 +482,7 @@ final class InitializeManager: Sendable {
             let result = (pending: state.initPending, timeout: state.initTimeout)
             state.initPending.removeAll()
             state.primaryInitializePhase = .idle
+            state.primaryInitializeRequiresPendingWaiter = false
             state.initTimeout = nil
             state.isShuttingDown = false
             state.didWarmSecondary = false

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -62,6 +62,7 @@ extension RuntimeCoordinator {
     func startPrimaryInitializeRequestWhenReady(applyBackoff: Bool = false) {
         let token = upstreamReadinessGate.isEnabled ? UpstreamReadinessWaiterToken() : nil
         if let token {
+            guard initializeManager.setPrimaryInitializeReadinessToken(token) else { return }
             replacePrimaryInitializeReadinessWaiter(with: token)
         }
         runWhenUpstreamReady(
@@ -213,6 +214,13 @@ extension RuntimeCoordinator {
             upstreamIndex: upstreamIndex,
             expectedUpstreamID: upstreamID
         ) else {
+            return
+        }
+        if initializeManager.consumeCancelledPrimaryInitializeAttempt(
+            upstreamIndex: upstreamIndex,
+            upstreamID: upstreamID
+        ) {
+            clearUpstreamState(upstreamIndex: upstreamIndex, expectedUpstreamID: upstreamID)
             return
         }
         let isPrimaryInitialize = initializeManager.primaryInitializeMatches(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Readiness.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+Readiness.swift
@@ -77,6 +77,7 @@ extension RuntimeCoordinator {
                 current = nil
             }
         }
+        initializeManager.clearPrimaryInitializeReadinessToken(token)
     }
 
     func cancelPrimaryInitializeReadinessWaiter() {
@@ -86,8 +87,19 @@ extension RuntimeCoordinator {
             return token
         }
         if let token {
+            initializeManager.clearPrimaryInitializeReadinessToken(token)
             cancelUpstreamReadinessWaiter(token)
         }
+    }
+
+    func cancelPrimaryInitializeReadinessWaiter(_ token: UpstreamReadinessWaiterToken) {
+        primaryInitializeReadinessTokenBox.withLockedValue { current in
+            if current === token {
+                current = nil
+            }
+        }
+        initializeManager.clearPrimaryInitializeReadinessToken(token)
+        cancelUpstreamReadinessWaiter(token)
     }
 
 }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -795,7 +795,9 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             if let upstreamID = pendingInitializes.cancelledPrimaryUpstreamID {
                 clearUpstreamState(upstreamIndex: upstreamIndex, expectedUpstreamID: upstreamID)
             }
-            cancelPrimaryInitializeReadinessWaiter()
+            if let readinessToken = pendingInitializes.cancelledPrimaryReadinessToken {
+                cancelPrimaryInitializeReadinessWaiter(readinessToken)
+            }
         }
         for pending in pendingInitializes.pending {
             pending.eventLoop.execute {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -791,6 +791,12 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         context?.notificationHub.closeAll()
         let pendingInitializes = initializeManager.removePendingInitializes(sessionID: id)
         pendingInitializes.timeout?.cancel()
+        if let upstreamIndex = pendingInitializes.cancelledPrimaryUpstreamIndex {
+            if let upstreamID = pendingInitializes.cancelledPrimaryUpstreamID {
+                clearUpstreamState(upstreamIndex: upstreamIndex, expectedUpstreamID: upstreamID)
+            }
+            cancelPrimaryInitializeReadinessWaiter()
+        }
         for pending in pendingInitializes.pending {
             pending.eventLoop.execute {
                 pending.promise.fail(CancellationError())

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -3445,6 +3445,183 @@ struct RuntimeCoordinatorTests {
         #expect(snapshot.upstreams[0].isInitialized == false)
     }
 
+    @Test func sessionManagerIgnoresRemovedInitializeResponseBeforeUpstreamStateClears() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            ),
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-removed-before-clear"
+        _ = manager.session(id: sessionID)
+        let future = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let sent = await upstream.sent()
+        let initID = try extractUpstreamID(from: sent[0])
+
+        let context = manager.sessionRegistry.removeSession(id: sessionID)
+        context?.notificationHub.closeAll()
+        let pendingInitializes = manager.initializeManager.removePendingInitializes(
+            sessionID: sessionID
+        )
+        pendingInitializes.timeout?.cancel()
+        for pending in pendingInitializes.pending {
+            pending.eventLoop.execute {
+                pending.promise.fail(CancellationError())
+            }
+        }
+
+        let responseEventIndex = upstreamEvents.count()
+        await upstream.yield(.message(try makeInitializeResponse(id: initID)))
+        _ = try await nextRecordedValue(upstreamEvents, at: responseEventIndex)
+
+        await #expect(throws: CancellationError.self) {
+            try await future.get()
+        }
+        let snapshot = manager.testStateSnapshot()
+        #expect(snapshot.hasInitResult == false)
+        #expect(snapshot.initInFlight == false)
+        #expect(snapshot.upstreams[0].isInitialized == false)
+    }
+
+    @Test func sessionManagerCancelsWaiterOwnedPrimaryRetryWhenSessionIsRemoved()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let upstreamEvents = LockedRecordedValues<Int>()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            testHooks: RuntimeCoordinatorTestHooks(
+                upstreamEventHandled: { upstreamEvents.append($0) }
+            ),
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+
+        let sessionID = "session-removed-primary-retry"
+        let future = manager.registerInitialize(
+            sessionID: sessionID,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+
+        try await waitForSentCount(upstream, count: 1, timeoutSeconds: 2)
+        let initialSent = await upstream.sent()
+        let initialID = try extractUpstreamID(from: initialSent[0])
+
+        manager.initializeManager.reopenPrimaryInitializeForRetry()
+        manager.handleInitializedNotificationSendOverload(
+            upstreamIndex: 0,
+            expectedUpstreamID: initialID,
+            treatsAsPrimary: true
+        )
+        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
+        let retrySent = await upstream.sent()
+        let retryID = try extractUpstreamID(from: retrySent[1])
+
+        manager.removeSession(id: sessionID)
+        await #expect(throws: CancellationError.self) {
+            try await future.get()
+        }
+
+        let responseEventIndex = upstreamEvents.count()
+        await upstream.yield(.message(try makeInitializeResponse(id: retryID)))
+        _ = try await nextRecordedValue(upstreamEvents, at: responseEventIndex)
+
+        let snapshot = manager.testStateSnapshot()
+        #expect(snapshot.hasInitResult == false)
+        #expect(snapshot.initInFlight == false)
+        #expect(snapshot.upstreams[0].isInitialized == false)
+    }
+
+    @Test func sessionManagerCancelsOnlyRemovedInitializeReadinessWaiter() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let readiness = ReadinessFlag(isReady: false)
+        let sleepRecorder = ControlledReadinessSleep()
+        let config = makeConfig(requestTimeout: 5)
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                sleepRecorder: sleepRecorder,
+                recordPollSleeps: true
+            ),
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+
+        let removedSessionID = "session-readiness-removed"
+        let removedFuture = manager.registerInitialize(
+            sessionID: removedSessionID,
+            originalID: JSONRPC.ID(any: NSNumber(value: 1))!,
+            requestObject: makeInitializeRequest(id: 1),
+            on: eventLoop
+        )
+        _ = try await sleepRecorder.nextSleep(at: 0)
+
+        let context = manager.sessionRegistry.removeSession(id: removedSessionID)
+        context?.notificationHub.closeAll()
+        let pendingInitializes = manager.initializeManager.removePendingInitializes(
+            sessionID: removedSessionID
+        )
+        pendingInitializes.timeout?.cancel()
+        for pending in pendingInitializes.pending {
+            pending.eventLoop.execute {
+                pending.promise.fail(CancellationError())
+            }
+        }
+
+        let replacementFuture = manager.registerInitialize(
+            sessionID: "session-readiness-replacement",
+            originalID: JSONRPC.ID(any: NSNumber(value: 2))!,
+            requestObject: makeInitializeRequest(id: 2),
+            on: eventLoop
+        )
+        if let readinessToken = pendingInitializes.cancelledPrimaryReadinessToken {
+            manager.cancelPrimaryInitializeReadinessWaiter(readinessToken)
+        }
+
+        await #expect(throws: CancellationError.self) {
+            try await removedFuture.get()
+        }
+
+        await readiness.setReady(true)
+        await sleepRecorder.resumeNext()
+        let replacementInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let replacementID = try extractUpstreamID(from: replacementInitialize)
+        await upstream.yield(.message(try makeInitializeResponse(id: replacementID)))
+        _ = try await replacementFuture.get()
+    }
+
     @Test func sessionManagerRoutesUnmappedNotificationsToCachedInitializeSessionsUntilClientConnects()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -3606,9 +3606,10 @@ struct RuntimeCoordinatorTests {
             requestObject: makeInitializeRequest(id: 2),
             on: eventLoop
         )
-        if let readinessToken = pendingInitializes.cancelledPrimaryReadinessToken {
-            manager.cancelPrimaryInitializeReadinessWaiter(readinessToken)
-        }
+        #expect(pendingInitializes.cancelledPrimaryUpstreamIndex == 0)
+        #expect(pendingInitializes.cancelledPrimaryUpstreamID == nil)
+        let readinessToken = try #require(pendingInitializes.cancelledPrimaryReadinessToken)
+        manager.cancelPrimaryInitializeReadinessWaiter(readinessToken)
 
         await #expect(throws: CancellationError.self) {
             try await removedFuture.get()

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -232,6 +232,32 @@ struct RuntimeCoordinatorTests {
         #expect(response["result"] != nil)
     }
 
+    @Test func sessionManagerDoesNotCancelEagerInitializeWhenJoinedSessionIsRemoved() async throws {
+        let upstream = TestUpstreamClient()
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let eagerInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
+        let eagerUpstreamID = try extractUpstreamID(from: eagerInitialize)
+        let sessionID = "session-eager-removed"
+        let future = fixture.registerInitialize(requestID: 1, sessionID: sessionID)
+        #expect(await upstream.sentCount() == 1)
+
+        manager.removeSession(id: sessionID)
+        await #expect(throws: CancellationError.self) {
+            try await future.get()
+        }
+
+        await upstream.yield(.message(try makeInitializeResponse(id: eagerUpstreamID)))
+        let initializedNotification = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
+        #expect(methodName(from: initializedNotification) == "notifications/initialized")
+        await manager.drainRuntimeTasksForTesting()
+
+        #expect(manager.hasSession(id: sessionID) == false)
+        #expect(manager.testStateSnapshot().hasInitResult)
+    }
+
     @Test func processRoutingWaitsForLateXcodeBeforeCompletingInitialize()
         async throws
     {
@@ -3158,7 +3184,8 @@ struct RuntimeCoordinatorTests {
             upstreams: [upstream],
             testHooks: RuntimeCoordinatorTestHooks(
                 upstreamEventHandled: { upstreamEvents.append($0) }
-            )
+            ),
+            startImmediately: false
         )
         defer { manager.shutdownAndWait() }
 
@@ -3216,7 +3243,8 @@ struct RuntimeCoordinatorTests {
             upstreams: [upstream],
             testHooks: RuntimeCoordinatorTestHooks(
                 upstreamEventHandled: { upstreamEvents.append($0) }
-            )
+            ),
+            startImmediately: false
         )
         defer { manager.shutdownAndWait() }
 
@@ -3327,7 +3355,8 @@ struct RuntimeCoordinatorTests {
             upstreams: [upstream],
             testHooks: RuntimeCoordinatorTestHooks(
                 upstreamEventHandled: { upstreamEvents.append($0) }
-            )
+            ),
+            startImmediately: false
         )
         defer { manager.shutdownAndWait() }
 
@@ -3353,6 +3382,10 @@ struct RuntimeCoordinatorTests {
         _ = try await nextRecordedValue(upstreamEvents, at: responseEventIndex)
 
         #expect(manager.hasSession(id: sessionID) == false)
+        let snapshot = manager.testStateSnapshot()
+        #expect(snapshot.hasInitResult == false)
+        #expect(snapshot.initInFlight == false)
+        #expect(snapshot.upstreams[0].isInitialized == false)
     }
 
     @Test func sessionManagerDoesNotApplyRemovedInitializeStateToRecreatedSession() async throws {
@@ -3368,7 +3401,8 @@ struct RuntimeCoordinatorTests {
             upstreams: [upstream],
             testHooks: RuntimeCoordinatorTestHooks(
                 upstreamEventHandled: { upstreamEvents.append($0) }
-            )
+            ),
+            startImmediately: false
         )
         defer { manager.shutdownAndWait() }
 
@@ -3405,6 +3439,10 @@ struct RuntimeCoordinatorTests {
         }
         manager.routeUpstreamMessage(notification, upstreamIndex: 0)
         #expect(replacement.router.drainBufferedNotifications().isEmpty)
+        let snapshot = manager.testStateSnapshot()
+        #expect(snapshot.hasInitResult == false)
+        #expect(snapshot.initInFlight == false)
+        #expect(snapshot.upstreams[0].isInitialized == false)
     }
 
     @Test func sessionManagerRoutesUnmappedNotificationsToCachedInitializeSessionsUntilClientConnects()

--- a/Tests/XcodeMCPKitTestingTests/XcodeMCPKitTestingTests.swift
+++ b/Tests/XcodeMCPKitTestingTests/XcodeMCPKitTestingTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import XcodeMCPCoreTestSupport
 import XcodeMCPKit
 import XcodeMCPKitTesting
 
@@ -191,7 +192,7 @@ struct XcodeMCPKitTestingTests {
             Task { await client.close() }
         }
 
-        let progressValues = ProgressRecorder()
+        let progressValues = RecordedValues<MCPProgress>()
         let result = try await client.callTool(
             "DocumentationSearch",
             arguments: [
@@ -204,7 +205,10 @@ struct XcodeMCPKitTestingTests {
         #expect(result.structuredContent == [
             "progressTokenWasPresent": true,
         ])
-        let progress = await progressValues.values
+        _ = try await waitWithTimeout("runtime progress updates were not delivered") {
+            try await progressValues.nextValue(at: 1)
+        }
+        let progress = await progressValues.snapshot()
         #expect(progress.map(\.message) == ["Preparing", "Done"])
         #expect(progress.allSatisfy { $0.progressToken.isEmpty == false })
     }
@@ -291,13 +295,5 @@ struct XcodeMCPKitTestingTests {
         )) {
             _ = try await client.callTool("DocumentationSearch")
         }
-    }
-}
-
-private actor ProgressRecorder {
-    private(set) var values: [MCPProgress] = []
-
-    func append(_ value: MCPProgress) {
-        values.append(value)
     }
 }


### PR DESCRIPTION
## Purpose
Fix the recurring CI hang around removed sessions completing an in-flight initialize after the session waiter has been cancelled, and stabilize the PR test suite after the follow-up CI run exposed an async progress callback race.

Related failing runs:
- https://github.com/lynnswap/XcodeMCPKit/actions/runs/28613050827/job/84850000614
- https://github.com/lynnswap/XcodeMCPKit/actions/runs/28628583409/job/84900422058

## Changes
- Track whether the active primary initialize is owned by pending session waiters or by eager global initialization.
- Preserve waiter ownership across primary initialize retries while pending session waiters still exist.
- Cancel and clear a primary initialize only when removing the last session waiter that owns it.
- Cancel only the removed initialize attempt’s upstream readiness waiter, not a newer current waiter.
- Record removed sent initialize attempts so stale responses cannot populate canonical initialize or upstream state before cleanup finishes.
- Keep eager global initialization alive when a joined session waiter is removed.
- Add regression tests for removed session cleanup, retry cleanup, stale response handling, and readiness waiter cancellation.
- Stabilize the test runtime progress assertion by waiting for async progress callbacks through the shared test support recorder.

## Testing
- `swift test --no-parallel --filter XcodeMCPKitTestingTests/runtimeRoutesProgressAndDynamicToolHandler -Xswiftc -strict-concurrency=minimal`
- `swift test --no-parallel --filter XcodeMCPKitTestingTests -Xswiftc -strict-concurrency=minimal`
- `swift test --no-parallel --filter 'sessionManagerIgnoresRemovedInitializeResponseBeforeUpstreamStateClears|sessionManagerCancelsWaiterOwnedPrimaryRetryWhenSessionIsRemoved|sessionManagerCancelsOnlyRemovedInitializeReadinessWaiter|sessionManagerDoesNotCancelEagerInitializeWhenJoinedSessionIsRemoved|sessionManagerDoesNotRecreateRemovedSessionWhenInitializeCompletes|sessionManagerDoesNotApplyRemovedInitializeStateToRecreatedSession' -Xswiftc -strict-concurrency=minimal`
- `git diff --check`
- `GITHUB_ACTIONS=true scripts/check.sh`
- Codex review of uncommitted CI fix: no findings
- Branch-wide Codex review against `refs/pr-fix/base/166/5da6bc6a8f677494c2736d5a17ac8c8e8dad3b43`: no findings
