### PR TITLE
Use control-plane timeout for route activation catalog

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -296,8 +296,7 @@ extension RuntimeCoordinator {
         upstreamIndex: Int,
         attempt: Int
     ) {
-        let mode = WarmInitializeMode.processRouteActivation(processID: processID)
-        guard let timeoutAmount = upstreamInitTimeoutAmount(for: mode) else {
+        guard let timeoutAmount = processRouteActivationCatalogTimeoutAmount() else {
             return
         }
         let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
@@ -313,6 +312,10 @@ extension RuntimeCoordinator {
             attempt: attempt,
             timeout: timeout
         )
+    }
+
+    private func processRouteActivationCatalogTimeoutAmount() -> TimeAmount? {
+        MCP.MethodDispatcher.timeoutForControlPlane(defaultSeconds: config.requestTimeout)
     }
 
     private func handleProcessRouteActivationCatalogTimeout(

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -486,6 +486,38 @@ struct RuntimeCoordinatorTests {
         #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
     }
 
+    @Test func processRouteActivationCatalogUsesControlPlaneTimeoutWhenAutoApproveEnabled()
+        async throws
+    {
+        var config = makeConfig(requestTimeout: 5)
+        config.autoApproveXcodeDialog = true
+        let target = xcodeProcessTarget(processID: 27010, xcodeVersion: "27.0")
+        let upstream = TestUpstreamClient()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let route = XcodeProcessRoute(target: target, upstreamIndices: [0])
+        let fixture = RuntimeCoordinatorFixture(
+            config: config,
+            upstreams: [upstream],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [route],
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        manager.xcodeProcessRouteActivationTracker.prepare(processID: target.processID)
+        _ = manager.xcodeProcessRouteActivationTracker.beginAttaching(
+            processID: target.processID,
+            upstreamIndex: 0,
+            nowUptimeNs: 0
+        )
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        #expect(timeoutScheduler.scheduledCount() == 1)
+        #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(5).nanoseconds)
+    }
+
     @Test func processRouteActivationCatalogTimeoutReplacesSlotAndDropsStaleCatalog()
         async throws
     {
@@ -560,7 +592,7 @@ struct RuntimeCoordinatorTests {
 
         #expect(timeoutScheduler.scheduledCount() == 3)
         #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
-        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
+        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.seconds(10).nanoseconds)
         #expect(timeoutScheduler.fire(at: 2))
         #expect(try await firstAttempt.nextStopCount() == 1)
         #expect(timeoutScheduler.scheduledCount() == 4)
@@ -881,7 +913,7 @@ struct RuntimeCoordinatorTests {
 
         let catalogTimeoutIndex = try #require(
             (scheduledBeforePrimaryInitialized..<timeoutScheduler.scheduledCount()).first {
-                timeoutScheduler.delay(at: $0)?.nanoseconds == TimeAmount.seconds(3).nanoseconds
+                timeoutScheduler.delay(at: $0)?.nanoseconds == TimeAmount.seconds(10).nanoseconds
             }
         )
         let scheduledBeforeCatalogTimeoutFired = timeoutScheduler.scheduledCount()
@@ -1114,6 +1146,7 @@ struct RuntimeCoordinatorTests {
         #expect(methodName(from: foregroundRequest) == "tools/list")
 
         #expect(timeoutScheduler.scheduledCount() == 1)
+        #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(10).nanoseconds)
         #expect(timeoutScheduler.fire(at: 0))
         #expect(timeoutScheduler.scheduledCount() == 2)
         #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -936,12 +936,18 @@ struct RuntimeCoordinatorTests {
         await retryPrimary.yield(
             .message(try makeInitializeResponse(id: try extractUpstreamID(from: retryInitialize)))
         )
+        _ = try await waitWithTimeout(
+            "waiting for retry activation initialized notification",
+            timeout: .seconds(2)
+        ) {
+            try await retryPrimary.nextSent(at: 1)
+        }
         let retryToolsRequest = try await waitWithTimeout(
             "waiting for retry activation tools/list",
             timeout: .seconds(2)
         ) {
             try await retryPrimary.nextSent(
-                startingAt: 1,
+                startingAt: 2,
                 matching: { methodName(from: $0) == "tools/list" }
             )
         }


### PR DESCRIPTION
## Purpose
Fix route activation retries that can be triggered when the `tools/list` catalog phase reuses the short auto-approve initialize timeout.

## Changes
- Keep the process route activation initialize phase on the existing short upstream init timeout.
- Switch the route activation catalog watchdog to the dispatcher control-plane timeout.
- Update RuntimeCoordinator tests for 5 second request timeouts, 10 second control-plane caps, stale catalog drops, and retry catalog adoption.

## Testing
- `swift test --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`
- Codex review: no findings