### PR TITLE
Fix process route catalog retry loop

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/PermissionDialog/XcodePermissionDialogAutoApprover.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/PermissionDialog/XcodePermissionDialogAutoApprover.swift
@@ -191,10 +191,8 @@ extension XcodePermissionDialog {
         }
 
         private func runMonitorLoop(dependencies: Dependencies) async {
-            let agentPathCandidates = dependencies.agentPathCandidates()
-            let assistantNameCandidates = dependencies.assistantNameCandidates()
-            let pathCandidateText = agentPathCandidates.sorted().joined(separator: " | ")
             var hasLoggedTrustedMonitoring = false
+            var loggedPathCandidateText: String?
 
             while Task.isCancelled == false {
                 if dependencies.axClient.authorizationStatus(promptIfNeeded: false) != .trusted {
@@ -202,6 +200,9 @@ extension XcodePermissionDialog {
                     continue
                 }
 
+                let agentPathCandidates = dependencies.agentPathCandidates()
+                let assistantNameCandidates = dependencies.assistantNameCandidates()
+                let pathCandidateText = agentPathCandidates.sorted().joined(separator: " | ")
                 if hasLoggedTrustedMonitoring == false {
                     dependencies.logger.info("\(Self.monitoringLogSummary())")
                     dependencies.logger.debug(
@@ -211,6 +212,15 @@ extension XcodePermissionDialog {
                         ]
                     )
                     hasLoggedTrustedMonitoring = true
+                    loggedPathCandidateText = pathCandidateText
+                } else if loggedPathCandidateText != pathCandidateText {
+                    dependencies.logger.debug(
+                        "Xcode permission dialog auto-approver candidate paths changed.",
+                        metadata: [
+                            "agent_paths": .string(pathCandidateText)
+                        ]
+                    )
+                    loggedPathCandidateText = pathCandidateText
                 }
 
                 let visibleFingerprints = scanAndApprove(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -261,6 +261,8 @@ extension RuntimeCoordinator {
     func handleUpstreamExit(_ status: Int32, upstreamIndex: Int) {
         let globalInit = initializeManager.handleUpstreamExit(upstreamIndex: upstreamIndex)
         guard let globalInit else { return }
+        let suppressProcessRouteWarmRestart =
+            clearsInitializedProcessRouteActivationBeforeCatalog(upstreamIndex: upstreamIndex)
 
         let exitedActivePrimaryInitialize =
             globalInit.primaryInitUpstreamIndex == upstreamIndex && globalInit.wasInFlight
@@ -327,7 +329,7 @@ extension RuntimeCoordinator {
         if upstreamIndex == primaryUpstreamIndex {
             if shouldResetGlobalInit || !globalInit.hadGlobalInit {
                 startEagerInitializePrimary(applyBackoff: true)
-            } else {
+            } else if suppressProcessRouteWarmRestart == false {
                 startUpstreamWarmInitialize(upstreamIndex: upstreamIndex, applyBackoff: true)
             }
         } else if globalInit.hadGlobalInit {
@@ -342,7 +344,9 @@ extension RuntimeCoordinator {
                     startEagerInitializePrimary(applyBackoff: true)
                 }
             }
-            startUpstreamWarmInitialize(upstreamIndex: upstreamIndex, applyBackoff: true)
+            if suppressProcessRouteWarmRestart == false {
+                startUpstreamWarmInitialize(upstreamIndex: upstreamIndex, applyBackoff: true)
+            }
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -5,6 +5,9 @@ import XcodeMCPKit
 
 extension RuntimeCoordinator {
     func startProcessRouteActivation(for route: XcodeProcessRoute) {
+        guard unavailableXcodeProcessIDs().contains(route.target.processID) == false else {
+            return
+        }
         guard let upstreamIndex = route.primaryUpstreamIndex else {
             abandonProcessRouteActivation(
                 processID: route.target.processID,
@@ -165,6 +168,7 @@ extension RuntimeCoordinator {
         ) else {
             return false
         }
+        markXcodeProcessRouteCatalogAvailable(upstreamIndex: upstreamIndex)
         logger.info(
             "route_activation_cataloged",
             metadata: [
@@ -234,9 +238,27 @@ extension RuntimeCoordinator {
                 processID: route.target.processID,
                 reason: "upstream_cleared_before_catalog"
             )
+            markXcodeProcessRouteUnavailableAfterCatalogFailure(
+                upstreamIndex: upstreamIndex,
+                reason: "upstream_cleared_before_catalog"
+            )
         case .pending, .cataloged, .abandoned, .attaching, .initialized, nil:
             return
         }
+    }
+
+    func clearsInitializedProcessRouteActivationBeforeCatalog(upstreamIndex: Int) -> Bool {
+        guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
+              processToolCatalogRegistry.catalog(forProcessID: route.target.processID) == nil
+        else {
+            return false
+        }
+        guard case .initialized(let activationUpstreamIndex, _, _) =
+            xcodeProcessRouteActivationTracker.phase(processID: route.target.processID)
+        else {
+            return false
+        }
+        return activationUpstreamIndex == upstreamIndex
     }
 
     func resetAllProcessRouteActivations(reason: String) {
@@ -339,19 +361,19 @@ extension RuntimeCoordinator {
                 "upstream": .string("\(upstreamIndex)"),
                 "attempt": .string("\(attempt)"),
                 "phase": .string("catalog"),
+                "cooldown_ms": .string("30000"),
             ]
         )
         testHooks.processRouteActivationEvent?(processID, upstreamIndex, "timeout")
 
         clearUpstreamState(upstreamIndex: upstreamIndex)
+        markXcodeProcessRouteUnavailableAfterCatalogFailure(
+            upstreamIndex: upstreamIndex,
+            reason: "catalog_timeout"
+        )
         guard replaceProcessBoundUpstreamSlot(processID: processID, upstreamIndex: upstreamIndex) else {
             return
         }
-        scheduleProcessRouteActivationRetry(
-            processID: processID,
-            retry: timeout.retry,
-            reason: "catalog_timeout"
-        )
     }
 
     @discardableResult

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -376,7 +376,7 @@ extension RuntimeCoordinator {
         guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) else {
             return
         }
-        unavailableXcodeProcessRoutes.withLockedValue { state in
+        _ = unavailableXcodeProcessRoutes.withLockedValue { state in
             state.removeValue(forKey: route.target.processID)
         }
     }
@@ -416,6 +416,9 @@ extension RuntimeCoordinator {
     }
 
     func usableInitializedUpstreamIndices(in route: XcodeProcessRoute) -> [Int] {
+        guard unavailableXcodeProcessIDs().contains(route.target.processID) == false else {
+            return []
+        }
         let states = upstreamHealthManager.statesSnapshot()
         return route.upstreamIndices.filter { upstreamIndex in
             guard upstreamIndex >= 0, upstreamIndex < states.count else {
@@ -886,9 +889,21 @@ extension RuntimeCoordinator {
         return Set(xcodeProcessRoutes.flatMap(\.upstreamIndices))
     }
 
+    func routableProcessBoundUpstreamIndices() -> Set<Int> {
+        guard processRoutingEnabled else {
+            return Set(upstreams.indices)
+        }
+        let unavailable = unavailableXcodeProcessIDs()
+        return Set(
+            xcodeProcessRoutes
+                .filter { unavailable.contains($0.target.processID) == false }
+                .flatMap(\.upstreamIndices)
+        )
+    }
+
     func inactiveProcessBoundUpstreamIndices() -> Set<Int> {
         guard processRoutingEnabled else { return [] }
-        return Set(upstreams.indices).subtracting(activeProcessBoundUpstreamIndices())
+        return Set(upstreams.indices).subtracting(routableProcessBoundUpstreamIndices())
     }
 
     func secondaryUpstreamIndices(excluding upstreamIndex: Int) -> [Int] {
@@ -903,7 +918,7 @@ extension RuntimeCoordinator {
             return upstreamHealthManager.initializedHealthyishCount()
         }
         let states = upstreamHealthManager.statesSnapshot()
-        return activeProcessBoundUpstreamIndices().reduce(into: 0) { count, upstreamIndex in
+        return routableProcessBoundUpstreamIndices().reduce(into: 0) { count, upstreamIndex in
             guard upstreamIndex >= 0, upstreamIndex < states.count else { return }
             let upstream = states[upstreamIndex]
             guard upstream.isInitialized else { return }
@@ -921,7 +936,7 @@ extension RuntimeCoordinator {
             return upstreamHealthManager.anyInitialized()
         }
         let states = upstreamHealthManager.statesSnapshot()
-        return activeProcessBoundUpstreamIndices().contains { upstreamIndex in
+        return routableProcessBoundUpstreamIndices().contains { upstreamIndex in
             guard upstreamIndex >= 0, upstreamIndex < states.count else { return false }
             return states[upstreamIndex].isInitialized
         }
@@ -932,7 +947,7 @@ extension RuntimeCoordinator {
             return upstreamHealthManager.anyRecoveryInFlight()
         }
         let states = upstreamHealthManager.statesSnapshot()
-        return activeProcessBoundUpstreamIndices().contains { upstreamIndex in
+        return routableProcessBoundUpstreamIndices().contains { upstreamIndex in
             guard upstreamIndex >= 0, upstreamIndex < states.count else { return false }
             let upstream = states[upstreamIndex]
             return upstream.initInFlight || upstream.healthProbeInFlight

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -3,9 +3,40 @@ import Logging
 import NIOCore
 import XcodeMCPKit
 
+struct XcodeProcessRouteUnavailableRecord: Sendable, Equatable {
+    var routeUnavailableUntilUptimeNs: UInt64?
+    var catalogUnavailableUntilUptimeNs: UInt64?
+
+    var unavailableUntilUptimeNs: UInt64 {
+        max(routeUnavailableUntilUptimeNs ?? 0, catalogUnavailableUntilUptimeNs ?? 0)
+    }
+
+    var isUnavailable: Bool {
+        unavailableUntilUptimeNs > 0
+    }
+
+    mutating func pruneExpired(nowUptimeNs: UInt64) {
+        if let routeUnavailableUntilUptimeNs,
+           routeUnavailableUntilUptimeNs <= nowUptimeNs {
+            self.routeUnavailableUntilUptimeNs = nil
+        }
+        if let catalogUnavailableUntilUptimeNs,
+           catalogUnavailableUntilUptimeNs <= nowUptimeNs {
+            self.catalogUnavailableUntilUptimeNs = nil
+        }
+    }
+}
+
 extension RuntimeCoordinator {
     private static let xcodeProcessRouteUnavailableCooldownNanoseconds: UInt64 =
         2_000_000_000
+    private static let xcodeProcessRouteCatalogUnavailableCooldownNanoseconds: UInt64 =
+        30_000_000_000
+
+    private enum XcodeProcessRouteUnavailableScope {
+        case route
+        case catalog
+    }
 
     private struct ToolRoutingRequest: Sendable {
         let id: JSONRPC.ID?
@@ -242,7 +273,11 @@ extension RuntimeCoordinator {
     func unavailableXcodeProcessIDs() -> Set<pid_t> {
         let now = nowUptimeNanoseconds()
         return unavailableXcodeProcessRoutes.withLockedValue { state in
-            state = state.filter { $0.value > now }
+            state = state.compactMapValues { record in
+                var pruned = record
+                pruned.pruneExpired(nowUptimeNs: now)
+                return pruned.isUnavailable ? pruned : nil
+            }
             return Set(state.keys)
         }
     }
@@ -251,13 +286,52 @@ extension RuntimeCoordinator {
         upstreamIndex: Int,
         reason: String
     ) {
+        markXcodeProcessRouteUnavailable(
+            upstreamIndex: upstreamIndex,
+            reason: reason,
+            cooldownNanoseconds: Self.xcodeProcessRouteUnavailableCooldownNanoseconds,
+            scope: .route
+        )
+    }
+
+    func markXcodeProcessRouteUnavailableAfterCatalogFailure(
+        upstreamIndex: Int,
+        reason: String
+    ) {
+        markXcodeProcessRouteUnavailable(
+            upstreamIndex: upstreamIndex,
+            reason: reason,
+            cooldownNanoseconds: Self.xcodeProcessRouteCatalogUnavailableCooldownNanoseconds,
+            scope: .catalog
+        )
+    }
+
+    private func markXcodeProcessRouteUnavailable(
+        upstreamIndex: Int,
+        reason: String,
+        cooldownNanoseconds: UInt64,
+        scope: XcodeProcessRouteUnavailableScope
+    ) {
         guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) else {
             return
         }
         let unavailableUntil = nowUptimeNanoseconds()
-            &+ Self.xcodeProcessRouteUnavailableCooldownNanoseconds
+            &+ cooldownNanoseconds
         unavailableXcodeProcessRoutes.withLockedValue { state in
-            state[route.target.processID] = unavailableUntil
+            var record = state[route.target.processID] ?? XcodeProcessRouteUnavailableRecord()
+            switch scope {
+            case .route:
+                record.routeUnavailableUntilUptimeNs = max(
+                    record.routeUnavailableUntilUptimeNs ?? 0,
+                    unavailableUntil
+                )
+            case .catalog:
+                record.catalogUnavailableUntilUptimeNs = max(
+                    record.catalogUnavailableUntilUptimeNs ?? 0,
+                    unavailableUntil
+                )
+            }
+            state[route.target.processID] = record
         }
         processToolCatalogRegistry.removeCatalog(forProcessID: route.target.processID)
         resyncProcessToolsCatalogSurfaceAfterRemoving(
@@ -273,6 +347,7 @@ extension RuntimeCoordinator {
                 "xcode_version": .string(route.target.xcodeVersion),
                 "upstream": .string("\(upstreamIndex)"),
                 "reason": .string(reason),
+                "cooldown_ms": .string("\(cooldownNanoseconds / 1_000_000)"),
                 "unavailable_until_uptime_ns": .string("\(unavailableUntil)"),
             ]
         )
@@ -282,7 +357,26 @@ extension RuntimeCoordinator {
         guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) else {
             return
         }
-        _ = unavailableXcodeProcessRoutes.withLockedValue { state in
+        let now = nowUptimeNanoseconds()
+        unavailableXcodeProcessRoutes.withLockedValue { state in
+            guard var record = state[route.target.processID] else {
+                return
+            }
+            record.routeUnavailableUntilUptimeNs = nil
+            record.pruneExpired(nowUptimeNs: now)
+            if record.isUnavailable {
+                state[route.target.processID] = record
+            } else {
+                state.removeValue(forKey: route.target.processID)
+            }
+        }
+    }
+
+    func markXcodeProcessRouteCatalogAvailable(upstreamIndex: Int) {
+        guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) else {
+            return
+        }
+        unavailableXcodeProcessRoutes.withLockedValue { state in
             state.removeValue(forKey: route.target.processID)
         }
     }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -613,13 +613,16 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             gate: resolvedReadinessGate,
             logger: ProxyLogging.make("upstream.readiness")
         )
-        let activeProcessBoundUpstreamIndices: @Sendable () -> Set<Int> = {
+        let routableProcessBoundUpstreamIndices: @Sendable () -> Set<Int> = { [runtimeBox] in
             guard resolvedProcessRoutingEnabled else { return [] }
-            return Set(xcodeProcessRegistry.activeRoutes().flatMap(\.upstreamIndices))
+            guard let runtime = runtimeBox.value else {
+                return Set(xcodeProcessRegistry.activeRoutes().flatMap(\.upstreamIndices))
+            }
+            return runtime.routableProcessBoundUpstreamIndices()
         }
         let inactiveProcessBoundUpstreamIndices: @Sendable () -> Set<Int> = {
             guard resolvedProcessRoutingEnabled else { return [] }
-            let active = activeProcessBoundUpstreamIndices()
+            let active = routableProcessBoundUpstreamIndices()
             let upstreamCount = upstreamStore.withLockedValue { $0.count }
             return Set(0..<upstreamCount).subtracting(active)
         }
@@ -631,7 +634,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                     return UpstreamHealthManager.UseEvaluation(isUsable: false, effects: [])
                 }
                 if resolvedProcessRoutingEnabled,
-                   activeProcessBoundUpstreamIndices().contains(upstreamIndex) == false {
+                   routableProcessBoundUpstreamIndices().contains(upstreamIndex) == false {
                     return UpstreamHealthManager.UseEvaluation(isUsable: false, effects: [])
                 }
                 return upstreamHealthManager.evaluateUsableInitialized(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -424,7 +424,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let pendingProcessToolsCatalogRefreshProcessIDs = NIOLockedValueBox<Set<pid_t>>([])
     let xcodeProcessRouteActivationTracker = XcodeProcessRouteActivationTracker()
     let unavailableXcodeProcessRoutes =
-        NIOLockedValueBox<[pid_t: UInt64]>([:])
+        NIOLockedValueBox<[pid_t: XcodeProcessRouteUnavailableRecord]>([:])
     let prewarmDocumentationProviderOnStartup: Bool
     let testHooks: RuntimeCoordinatorTestHooks
     private let lifecycleStartedBox = NIOLockedValueBox(false)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/XcodeProcessRouteActivationTracker.swift
@@ -29,7 +29,6 @@ final class XcodeProcessRouteActivationTracker: Sendable {
     }
 
     struct CatalogTimeout: Sendable {
-        let retry: Retry
         let rpcHandles: [ControlPlane.RPCHandle]
     }
 
@@ -233,10 +232,7 @@ final class XcodeProcessRouteActivationTracker: Sendable {
             record.catalogTimeout = nil
             record.phase = .pending
             records[processID] = record
-            return CatalogTimeout(
-                retry: Self.retry(forAttempt: currentAttempt),
-                rpcHandles: rpcHandles
-            )
+            return CatalogTimeout(rpcHandles: rpcHandles)
         }
     }
 

--- a/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
+++ b/Sources/XcodeMCPProxyKit/XcodeMCPProxyServer.swift
@@ -424,10 +424,11 @@ public final class XcodeMCPProxyServer {
 
         static func live(config: ProxyConfig) -> Self {
             let executableLookupClient = ExecutableLookupClient.liveValue
+            let xcodeTargetDiscovery = LiveXcodeTargetDiscovery()
             return Self(
                 executableLookupClient: executableLookupClient,
                 runningXcodeTargets: {
-                    LiveXcodeTargetDiscovery().runningXcodeTargets()
+                    xcodeTargetDiscovery.runningXcodeTargets()
                 },
                 makeAutoApprover: {
                     let additionalCandidates = XcodeMCPProxyServer.additionalPermissionDialogExecutableCandidates(
@@ -437,8 +438,12 @@ public final class XcodeMCPProxyServer {
                     return XcodePermissionDialog.AutoApprover(
                         dependencies: .live(
                             agentPathCandidates: {
-                                XcodePermissionDialog.AutoApprover.defaultAgentPathCandidates(
-                                    additionalExecutableCandidates: additionalCandidates
+                                let processBoundCandidates = xcodeTargetDiscovery
+                                    .runningXcodeTargets()
+                                    .map(\.mcpbridgePath)
+                                return XcodePermissionDialog.AutoApprover.defaultAgentPathCandidates(
+                                    additionalExecutableCandidates:
+                                        additionalCandidates + processBoundCandidates
                                 )
                             },
                             assistantNameCandidates: {
@@ -452,7 +457,7 @@ public final class XcodeMCPProxyServer {
                         config: config,
                         eventLoop: eventLoop,
                         upstreamReadinessGate: .liveDefault(config: config, clock: .liveValue),
-                        xcodeTargetDiscovery: LiveXcodeTargetDiscovery(),
+                        xcodeTargetDiscovery: xcodeTargetDiscovery,
                         startImmediately: false
                     )
                 }

--- a/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodePermissionDialogAutoApproverTests.swift
@@ -428,6 +428,55 @@ struct XcodePermissionDialogAutoApproverTests {
         #expect(snapshot.promptCalls == 1)
         #expect(snapshot.windowScanCalls == 0)
     }
+
+    @Test func autoApproverRefreshesAgentPathCandidatesWhileMonitoring() async throws {
+        let processID: pid_t = 4317
+        let bridgePath = "/Applications/Xcode.app/Contents/Developer/usr/bin/mcpbridge"
+        let axClient = RecordingAXClient(
+            status: .trusted,
+            windowsByProcessID: [
+                processID: [
+                    XcodePermissionDialog.AXWindow(
+                        processID: processID,
+                        snapshot: makeSnapshot(
+                            processBundleIdentifier: "com.apple.dt.Xcode",
+                            title: "Access",
+                            textValues: [
+                                "The agent at \(bridgePath) wants to use Xcode's tools for XcodeMCPKit."
+                            ]
+                        ),
+                        defaultButton: AXUIElementCreateSystemWide()
+                    )
+                ]
+            ]
+        )
+        let candidateCounter = CandidateCounter()
+        let approver = XcodePermissionDialog.AutoApprover(
+            dependencies: .init(
+                axClient: axClient,
+                agentPathCandidates: {
+                    candidateCounter.nextCandidateSet(first: [], later: [bridgePath])
+                },
+                assistantNameCandidates: { ["XcodeMCPKit"] },
+                serverProcessIDCandidates: { [] },
+                sleep: { _ in
+                    try? await Task.sleep(for: .milliseconds(1))
+                },
+                pollInterval: .milliseconds(1),
+                logger: ProxyLogging.make("tests.permission")
+            )
+        )
+        defer { approver.stop() }
+
+        approver.start()
+
+        let deadline = Date().addingTimeInterval(2)
+        while axClient.snapshot().pressCalls == 0, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(axClient.snapshot().pressCalls == 1)
+    }
 }
 
 private func makeSnapshot(
@@ -480,12 +529,18 @@ private func makeButton(
 
 private final class RecordingAXClient: @unchecked Sendable, XcodePermissionDialog.AXAccessing {
     private let status: XcodePermissionDialog.AccessibilityStatus
+    private let windowsByProcessID: [pid_t: [XcodePermissionDialog.AXWindow]]
     private let lock = NSLock()
     private var promptCalls = 0
     private var windowScanCalls = 0
+    private var pressCalls = 0
 
-    init(status: XcodePermissionDialog.AccessibilityStatus) {
+    init(
+        status: XcodePermissionDialog.AccessibilityStatus,
+        windowsByProcessID: [pid_t: [XcodePermissionDialog.AXWindow]] = [:]
+    ) {
         self.status = status
+        self.windowsByProcessID = windowsByProcessID
     }
 
     func authorizationStatus(promptIfNeeded: Bool) -> XcodePermissionDialog.AccessibilityStatus {
@@ -500,19 +555,35 @@ private final class RecordingAXClient: @unchecked Sendable, XcodePermissionDialo
     func runningXcodeProcessIDs() -> [pid_t] {
         lock.withLock {
             windowScanCalls += 1
-            return []
+            return windowsByProcessID.keys.sorted()
         }
     }
 
     func openWindows(for processID: pid_t) throws -> [XcodePermissionDialog.AXWindow] {
-        []
+        windowsByProcessID[processID] ?? []
     }
 
-    func pressDefaultButton(in window: XcodePermissionDialog.AXWindow) throws {}
-
-    func snapshot() -> (promptCalls: Int, windowScanCalls: Int) {
+    func pressDefaultButton(in window: XcodePermissionDialog.AXWindow) throws {
         lock.withLock {
-            (promptCalls, windowScanCalls)
+            pressCalls += 1
+        }
+    }
+
+    func snapshot() -> (promptCalls: Int, windowScanCalls: Int, pressCalls: Int) {
+        lock.withLock {
+            (promptCalls, windowScanCalls, pressCalls)
+        }
+    }
+}
+
+private final class CandidateCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func nextCandidateSet(first: Set<String>, later: Set<String>) -> Set<String> {
+        lock.withLock {
+            count += 1
+            return count == 1 ? first : later
         }
     }
 }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -5300,6 +5300,88 @@ struct RuntimeCoordinatorTests {
         #expect(manager.unavailableXcodeProcessIDs().contains(target.processID) == false)
     }
 
+    @Test func processRouteCatalogCooldownExcludesSiblingSlotsFromScheduling()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let failedTarget = xcodeProcessTarget(processID: 80424, xcodeVersion: "27.0")
+        let healthyTarget = xcodeProcessTarget(processID: 80425, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [
+                TestUpstreamClient(),
+                TestUpstreamClient(),
+                TestUpstreamClient(),
+            ],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: failedTarget, upstreamIndices: [0, 1]),
+                XcodeProcessRoute(target: healthyTarget, upstreamIndices: [2]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        manager.markUpstreamInitialized(upstreamIndex: 2)
+
+        manager.markXcodeProcessRouteUnavailableAfterCatalogFailure(
+            upstreamIndex: 0,
+            reason: "catalog_timeout"
+        )
+
+        #expect(manager.unavailableXcodeProcessIDs().contains(failedTarget.processID))
+        #expect(manager.chooseUpstreamIndex() == 2)
+
+        let preferredDescriptor = SessionRequestPipeline.Descriptor(
+            sessionID: "session-catalog-cooldown-preferred",
+            label: "tools/call:BuildProject",
+            isBatch: false,
+            expectsResponse: true,
+            isTopLevelClientRequest: false
+        )
+        let preferredLeaseID = manager.createRequestLease(descriptor: preferredDescriptor)
+        let preferredStartedUpstream = NIOLockedValueBox<Int?>(nil)
+        let preferredFuture: EventLoopFuture<Void> = manager.enqueueOnUpstreamSlot(
+            leaseID: preferredLeaseID,
+            descriptor: preferredDescriptor,
+            on: eventLoop,
+            preferredUpstreamIndices: [1]
+        ) { selectedUpstreamIndex in
+            preferredStartedUpstream.withLockedValue { $0 = selectedUpstreamIndex }
+            return eventLoop.makeSucceededFuture(())
+        }
+
+        await #expect(throws: UpstreamSlotScheduler.AcquisitionError.self) {
+            try await preferredFuture.get()
+        }
+        #expect(preferredStartedUpstream.withLockedValue { $0 } == nil)
+
+        let genericDescriptor = SessionRequestPipeline.Descriptor(
+            sessionID: "session-catalog-cooldown-generic",
+            label: "tools/call:XcodeRead",
+            isBatch: false,
+            expectsResponse: true,
+            isTopLevelClientRequest: false
+        )
+        let genericLeaseID = manager.createRequestLease(descriptor: genericDescriptor)
+        let genericStartedUpstream = NIOLockedValueBox<Int?>(nil)
+        let genericFuture: EventLoopFuture<Void> = manager.enqueueOnUpstreamSlot(
+            leaseID: genericLeaseID,
+            descriptor: genericDescriptor,
+            on: eventLoop
+        ) { selectedUpstreamIndex in
+            genericStartedUpstream.withLockedValue { $0 = selectedUpstreamIndex }
+            return eventLoop.makeSucceededFuture(())
+        }
+
+        _ = try await genericFuture.get()
+        #expect(genericStartedUpstream.withLockedValue { $0 } == 2)
+        manager.completeRequestLease(genericLeaseID)
+    }
+
     @Test func sessionManagerToolsListRetriesSiblingBeforeDroppingProcessCatalog()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -527,10 +527,12 @@ struct RuntimeCoordinatorTests {
         let olderTarget = xcodeProcessTarget(processID: 26626, xcodeVersion: "26.6")
         let newerTarget = xcodeProcessTarget(processID: 27026, xcodeVersion: "27.0")
         let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let uptimeClock = TestUptimeClock()
         let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
         let fixture = RuntimeCoordinatorFixture(
             config: config,
             upstreams: [olderUpstream],
+            nowUptimeNanoseconds: uptimeClock.now,
             scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
@@ -595,10 +597,19 @@ struct RuntimeCoordinatorTests {
         #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.seconds(10).nanoseconds)
         #expect(timeoutScheduler.fire(at: 2))
         #expect(try await firstAttempt.nextStopCount() == 1)
-        #expect(timeoutScheduler.scheduledCount() == 4)
-        #expect(timeoutScheduler.delay(at: 3)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
+        #expect(timeoutScheduler.scheduledCount() == 3)
 
-        #expect(timeoutScheduler.fire(at: 3))
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_catalog_timeout_before_cooldown"
+        )
+        #expect(createdUpstreams.withLockedValue(\.count) == 2)
+
+        uptimeClock.advance(by: .seconds(31))
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_catalog_timeout_after_cooldown"
+        )
         let retryAttempt = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
         let retryInitialize = try await waitWithTimeout(
             "waiting for retry activation initialize",
@@ -803,10 +814,12 @@ struct RuntimeCoordinatorTests {
         let olderTarget = xcodeProcessTarget(processID: 26628, xcodeVersion: "26.6")
         let newerTarget = xcodeProcessTarget(processID: 27127, xcodeVersion: "27.0")
         let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let uptimeClock = TestUptimeClock()
         let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
         let fixture = RuntimeCoordinatorFixture(
             config: config,
             upstreams: [olderUpstream],
+            nowUptimeNanoseconds: uptimeClock.now,
             scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: olderTarget, upstreamIndices: [0]),
@@ -918,14 +931,19 @@ struct RuntimeCoordinatorTests {
         )
         let scheduledBeforeCatalogTimeoutFired = timeoutScheduler.scheduledCount()
         #expect(timeoutScheduler.fire(at: catalogTimeoutIndex))
-        let retryIndex = try #require(
-            (scheduledBeforeCatalogTimeoutFired..<timeoutScheduler.scheduledCount()).first {
-                timeoutScheduler.delay(at: $0)?.nanoseconds
-                    == TimeAmount.milliseconds(250).nanoseconds
-            }
-        )
 
-        #expect(timeoutScheduler.fire(at: retryIndex))
+        #expect(timeoutScheduler.scheduledCount() == scheduledBeforeCatalogTimeoutFired)
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_catalog_fallback_timeout_before_cooldown"
+        )
+        #expect(createdUpstreams.withLockedValue(\.count) == 4)
+
+        uptimeClock.advance(by: .seconds(31))
+        manager.reconcileXcodeProcessTargets(
+            [olderTarget, newerTarget],
+            reason: "test_catalog_fallback_timeout_after_cooldown"
+        )
         let retryPrimary = try #require(createdUpstreams.withLockedValue { $0.dropFirst(2).first })
         let retryInitialize = try await waitWithTimeout(
             "waiting for retry activation initialize",
@@ -1097,10 +1115,12 @@ struct RuntimeCoordinatorTests {
         let target = xcodeProcessTarget(processID: 27028, xcodeVersion: "27.0")
         let initialUpstream = TestUpstreamClient()
         let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let uptimeClock = TestUptimeClock()
         let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
         let fixture = RuntimeCoordinatorFixture(
             config: config,
             upstreams: [initialUpstream],
+            nowUptimeNanoseconds: uptimeClock.now,
             scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: target, upstreamIndices: [0]),
@@ -1137,7 +1157,7 @@ struct RuntimeCoordinatorTests {
         let foregroundTask = Task {
             try await manager.sharedToolsList(
                 sessionID: "session-process-catalog-foreground-timeout",
-                requestTimeoutOverride: .seconds(20)
+                requestTimeoutOverride: .seconds(40)
             )
         }
         let foregroundRequest = try await waitWithTimeout(
@@ -1154,10 +1174,19 @@ struct RuntimeCoordinatorTests {
         #expect(timeoutScheduler.scheduledCount() == 1)
         #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(10).nanoseconds)
         #expect(timeoutScheduler.fire(at: 0))
-        #expect(timeoutScheduler.scheduledCount() == 2)
-        #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
+        #expect(timeoutScheduler.scheduledCount() == 1)
 
-        #expect(timeoutScheduler.fire(at: 1))
+        manager.reconcileXcodeProcessTargets(
+            [target],
+            reason: "test_foreground_catalog_timeout_before_cooldown"
+        )
+        #expect(createdUpstreams.withLockedValue(\.count) == 1)
+
+        uptimeClock.advance(by: .seconds(31))
+        manager.reconcileXcodeProcessTargets(
+            [target],
+            reason: "test_foreground_catalog_timeout_after_cooldown"
+        )
         let retryUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
         let retryInitialize = try await waitWithTimeout(
             "waiting for retry activation initialize",
@@ -1203,14 +1232,16 @@ struct RuntimeCoordinatorTests {
         #expect(toolNames(in: result) == ["RetryForegroundTool"])
     }
 
-    @Test func processRouteActivationClearingPreCatalogInitializedUpstreamAllowsRetry()
+    @Test func processRouteActivationClearingPreCatalogInitializedUpstreamWaitsForCooldownBeforeRetry()
         async throws
     {
         let target = xcodeProcessTarget(processID: 27019, xcodeVersion: "27.0")
         let upstream = TestUpstreamClient()
         let route = XcodeProcessRoute(target: target, upstreamIndices: [0])
+        let uptimeClock = TestUptimeClock()
         let fixture = RuntimeCoordinatorFixture(
             upstreams: [upstream],
+            nowUptimeNanoseconds: uptimeClock.now,
             xcodeProcessRoutes: [route],
             processRoutingEnabled: true,
             startImmediately: false
@@ -1228,6 +1259,10 @@ struct RuntimeCoordinatorTests {
         manager.clearUpstreamState(upstreamIndex: 0)
 
         #expect(manager.xcodeProcessRouteActivationTracker.phase(processID: target.processID) == nil)
+        manager.startProcessRouteActivation(for: route)
+        #expect(await upstream.sentCount() == 0)
+
+        uptimeClock.advance(by: .seconds(31))
         manager.startProcessRouteActivation(for: route)
         let retryInitialize = try await upstream.nextSent(at: 0)
         #expect(methodName(from: retryInitialize) == "initialize")
@@ -5237,6 +5272,32 @@ struct RuntimeCoordinatorTests {
         #expect(await badUpstream.sentCount() == 0)
         #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["XcodeRead"])
         #expect(manager.debugSnapshot().controlPlane?.canonicalToolsSourceUpstream == 1)
+    }
+
+    @Test func processRouteCatalogCooldownSurvivesRouteAvailabilitySuccess() async throws {
+        let upstream = TestUpstreamClient()
+        let target = xcodeProcessTarget(processID: 80423, xcodeVersion: "27.0")
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [upstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        manager.markXcodeProcessRouteUnavailableAfterCatalogFailure(
+            upstreamIndex: 0,
+            reason: "catalog_timeout"
+        )
+        manager.markXcodeProcessRouteAvailable(upstreamIndex: 0)
+
+        #expect(manager.unavailableXcodeProcessIDs().contains(target.processID))
+
+        manager.markXcodeProcessRouteCatalogAvailable(upstreamIndex: 0)
+        #expect(manager.unavailableXcodeProcessIDs().contains(target.processID) == false)
     }
 
     @Test func sessionManagerToolsListRetriesSiblingBeforeDroppingProcessCatalog()


### PR DESCRIPTION
## Purpose
Fix the repeated route activation timeout loop when a process-bound Xcode route initializes but cannot complete its `tools/list` catalog.

## Changes
- Treat catalog timeout and pre-catalog upstream clearing as catalog failures that temporarily mark the affected Xcode process route unavailable instead of immediately retrying.
- Keep catalog-failure cooldown separate from ordinary route availability so stale `XcodeListWindows` successes cannot clear the catalog backoff.
- Exclude catalog-cooldown process routes from generic and preferred upstream scheduling so sibling slots cannot receive traffic during backoff.
- Refresh Xcode permission dialog auto-approver executable candidates while monitoring and include process-bound `mcpbridge` paths.
- Update runtime and permission dialog tests for the new cooldown behavior.

## Testing
- `codex-review` clean after review fix
- `swift test --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter RuntimeCoordinatorTests.processRouteCatalogCooldownExcludesSiblingSlotsFromScheduling -Xswiftc -strict-concurrency=minimal`
- `swift test --filter XcodePermissionDialogAutoApproverTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter RuntimeCoordinatorTests.processRouteCatalogCooldownSurvivesRouteAvailabilitySuccess -Xswiftc -strict-concurrency=minimal`
- `swift test --filter StdioAdapterFacadeIntegrationTests.stdioAdapterFacadeDeletesUninitializedSessionAfterInitializeWithoutProtocol -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- `git diff --check`
