### PR TITLE
Stabilize HTTP pending response delivery tests

### DIFF
--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTestSupport.swift
@@ -12,6 +12,7 @@ import XcodeMCPProxyTestSupport
 
 enum HTTPTestError: Error {
     case missingResponseHead
+    case missingPendingResponse
 }
 
 private let httpTestSessionRegistry = NIOLockedValueBox<[String: any RuntimeCoordinating]>([:])
@@ -1038,13 +1039,15 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         state.withLockedValue { $0.initialized = value }
     }
 
-    func deliverNextPendingResponse() {
+    func deliverNextPendingResponse() throws {
         let update = state.withLockedValue { state -> (State.PendingResponse, Int)? in
             guard state.pendingResponses.isEmpty == false else { return nil }
             let pending = state.pendingResponses.removeFirst()
             return (pending, state.pendingResponses.count)
         }
-        guard let (pending, pendingCount) = update else { return }
+        guard let (pending, pendingCount) = update else {
+            throw HTTPTestError.missingPendingResponse
+        }
         pendingResponseCountRecords.append(pendingCount)
         let session = session(id: pending.sessionID)
         session.router.handleIncoming(pending.data)

--- a/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/HTTPHandlerTests.swift
@@ -255,7 +255,8 @@ struct HTTPHandlerTests {
             #expect(activeLease.sessionID == "session-debug-state")
             #expect(activeLease.upstreamIndex == nil)
 
-            sessionManager.deliverNextPendingResponse()
+            try await sessionManager.waitForPendingResponseCount(1)
+            try sessionManager.deliverNextPendingResponse()
             _ = try await refreshTask.value
 
             let (completedResponse, completedData) = try await getHTTPData(

--- a/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/ProxyHTTPGatewayTests/RefreshCodeIssuesHTTPTests.swift
@@ -2023,7 +2023,7 @@ extension HTTPHandlerTests {
             for expectedCount in 1...requestCount {
                 #expect(sessionManager.sentUpstreamCount() == expectedCount)
                 #expect(sessionManager.pendingResponseCount() == 1)
-                sessionManager.deliverNextPendingResponse()
+                try sessionManager.deliverNextPendingResponse()
                 if expectedCount < requestCount {
                     try await sessionManager.waitForPendingResponseCount(1)
                     #expect(sessionManager.sentUpstreamCount() == expectedCount + 1)
@@ -2145,7 +2145,7 @@ extension HTTPHandlerTests {
             for expectedRequests in 1...requestCount {
                 #expect(sessionManager.sentUpstreamCount() == expectedRequests * 2)
                 #expect(sessionManager.pendingResponseCount() == 1)
-                sessionManager.deliverNextPendingResponse()
+                try sessionManager.deliverNextPendingResponse()
                 if expectedRequests < requestCount {
                     try await sessionManager.waitForPendingResponseCount(1)
                     #expect(sessionManager.sentUpstreamCount() == (expectedRequests + 1) * 2)
@@ -2618,7 +2618,8 @@ extension HTTPHandlerTests {
             #expect(inFlightLease.releaseReason == nil)
             #expect(inFlightLease.timeoutAt == nil)
 
-            sessionManager.deliverNextPendingResponse()
+            try await sessionManager.waitForPendingResponseCount(1)
+            try sessionManager.deliverNextPendingResponse()
 
             let response = try await requestTask.value
             #expect(response.statusCode == 200)


### PR DESCRIPTION
## Purpose

Fix a flaky HTTP gateway test failure where a manually delivered upstream response could race ahead of the test helper's pending-response registration.

## Changes

- Make `deliverNextPendingResponse()` fail fast when no pending response exists instead of silently doing nothing.
- Wait for `pendingResponseCount == 1` before manual delivery in HTTP gateway tests that depend on a queued upstream response.
- Update all direct manual-delivery callers to use the throwing helper.

## Testing

Local runs are only a smoke signal because the CI machines are slower and more likely to expose this flake.

- `swift test --no-parallel --filter HTTPHandlerTests -Xswiftc -strict-concurrency=minimal`
- `swift test --no-parallel -Xswiftc -strict-concurrency=minimal`
- Targeted `httpRefreshCodeIssuesRequeuesLeaseAcrossRetryAttempts` repeated 20x locally
- Full package repeated 3x locally

The PR is draft so GitHub Actions can provide the meaningful signal before this is considered ready.