### PR TITLE
Route Xcode tools by window owner

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Broker/ProxyUpstreamRequestRuntime.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/RuntimeCore/Broker/ProxyUpstreamRequestRuntime.swift
@@ -8,6 +8,11 @@ protocol ProxyUpstreamRequestRuntimePort: Sendable {
     func removeUpstreamIDMapping(sessionID: String, requestIDKey: String, upstreamIndex: Int)
     func onRequestTimeout(sessionID: String, requestIDKey: String, upstreamIndex: Int)
     func onRequestSucceeded(sessionID: String, requestIDKey: String, upstreamIndex: Int)
+    func rewriteOwnerBoundRequest(
+        bodyData: Data,
+        parsedRequestJSON: Any,
+        upstreamIndex: Int
+    ) -> (bodyData: Data, parsedRequestJSON: Any)
     func sendUpstream(_ data: Data, upstreamIndex: Int, ensureRunning: Bool)
     func activateRequestLease(
         _ leaseID: LeaseManager.ID,
@@ -18,6 +23,14 @@ protocol ProxyUpstreamRequestRuntimePort: Sendable {
 }
 
 extension ProxyUpstreamRequestRuntimePort {
+    func rewriteOwnerBoundRequest(
+        bodyData: Data,
+        parsedRequestJSON: Any,
+        upstreamIndex _: Int
+    ) -> (bodyData: Data, parsedRequestJSON: Any) {
+        (bodyData, parsedRequestJSON)
+    }
+
     func sendUpstream(_ data: Data, upstreamIndex: Int) {
         sendUpstream(data, upstreamIndex: upstreamIndex, ensureRunning: false)
     }
@@ -92,9 +105,14 @@ struct ProxyUpstreamRequestRuntime: Sendable {
             upstreamIndex = chosen
         }
 
+        let rewritten = port.rewriteOwnerBoundRequest(
+            bodyData: bodyData,
+            parsedRequestJSON: parsedRequestJSON,
+            upstreamIndex: upstreamIndex
+        )
         let transform = try RequestInspector.transform(
-            bodyData,
-            parsedJSON: parsedRequestJSON,
+            rewritten.bodyData,
+            parsedJSON: rewritten.parsedRequestJSON,
             sessionID: sessionID,
             mapID: { sessionID, originalID in
                 port.assignUpstreamID(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ProcessToolSurfaceStore.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ProcessToolSurfaceStore.swift
@@ -303,6 +303,17 @@ final class ProcessToolSurfaceStore: Sendable {
         catalog(forProcessID: processID)?.toolsByName[toolName] != nil
     }
 
+    func tool(
+        _ toolName: String,
+        processID: pid_t,
+        requiresArgument argumentName: String
+    ) -> Bool {
+        guard let tool = catalog(forProcessID: processID)?.toolsByName[toolName] else {
+            return false
+        }
+        return Self.tool(tool, requiresArgument: argumentName)
+    }
+
     func toolsListResult(forUpstreamIndex upstreamIndex: Int) -> JSONValue? {
         catalog(forUpstreamIndex: upstreamIndex)?.rawResult
     }
@@ -381,6 +392,18 @@ final class ProcessToolSurfaceStore: Sendable {
             }
         }
         return false
+    }
+
+    static func tool(_ tool: JSONValue, requiresArgument argumentName: String) -> Bool {
+        guard case .object(let toolObject) = tool,
+              case .object(let inputSchema)? = toolObject["inputSchema"],
+              case .array(let required)? = inputSchema["required"] else {
+            return false
+        }
+        return required.contains { value in
+            guard case .string(let key) = value else { return false }
+            return key == argumentName
+        }
     }
 
     private static func ownerBoundToolNames(in result: JSONValue) -> Set<String> {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -550,12 +550,12 @@ extension RuntimeCoordinator {
         let processToolCatalogs = processToolSurfaceStore.debugSnapshots(
             exposedCatalog: brokerSnapshot.toolsCatalogRaw,
             canonicalSourceUpstream: brokerSnapshot.toolsSourceUpstream,
-            tabOwnerCountsByProcessID: ownerCountsByProcessID(
-                tabOwnerProcessIDs.withLockedValue { $0 }
-            ),
-            workspaceOwnerCountsByProcessID: ownerCountsByProcessID(
-                workspaceOwnerProcessIDs.withLockedValue { $0 }
-            )
+            tabOwnerCountsByProcessID: windowOwnerIndex.withLockedValue {
+                $0.tabOwnerCountsByProcessID()
+            },
+            workspaceOwnerCountsByProcessID: windowOwnerIndex.withLockedValue {
+                $0.workspaceOwnerCountsByProcessID()
+            }
         )
         let processIDsWithToolCatalog = Set(processToolCatalogs.map(\.processID))
         let pendingToolCatalogProcessIDs =
@@ -602,12 +602,6 @@ extension RuntimeCoordinator {
         descriptor: SessionRequestPipeline.Descriptor
     ) -> LeaseManager.ID {
         leaseManager.createLease(descriptor: descriptor)
-    }
-
-    private func ownerCountsByProcessID(_ owners: [String: pid_t]) -> [pid_t: Int] {
-        owners.values.reduce(into: [:]) { counts, processID in
-            counts[processID, default: 0] += 1
-        }
     }
 
     func activateRequestLease(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -526,18 +526,19 @@ extension RuntimeCoordinator {
                 for: requests,
                 unresolvedOwnerBoundRequests: ownerResolution.unresolved
             )
-        if ownerResolution.unresolved.isEmpty == false {
-            if inferredOwnerProcessID == nil {
-                _ = try? await refreshXcodeWindowOwnersForRouting(
-                    requestTimeoutOverride: requestTimeoutOverride
+        let needsOwnerRefresh =
+            ownerResolution.conflicts.isEmpty == false
+            || (ownerResolution.unresolved.isEmpty == false && inferredOwnerProcessID == nil)
+        if needsOwnerRefresh {
+            _ = try? await refreshXcodeWindowOwnersForRouting(
+                requestTimeoutOverride: requestTimeoutOverride
+            )
+            ownerResolution = resolvedOwnerProcessIDs(for: ownerBoundRequests)
+            inferredOwnerProcessID =
+                inferredUnambiguousOwnerProcessID(
+                    for: requests,
+                    unresolvedOwnerBoundRequests: ownerResolution.unresolved
                 )
-                ownerResolution = resolvedOwnerProcessIDs(for: ownerBoundRequests)
-                inferredOwnerProcessID =
-                    inferredUnambiguousOwnerProcessID(
-                        for: requests,
-                        unresolvedOwnerBoundRequests: ownerResolution.unresolved
-                    )
-            }
         }
 
         if ownerResolution.conflicts.isEmpty == false {
@@ -1368,13 +1369,13 @@ extension RuntimeCoordinator {
                 forRawTabIdentifier: tabIdentifier,
                 eligibleProcessIDs: eligibleProcessIDs
             )
-            let processIDs = Set(rawIdentities.map(\.processID))
-            switch processIDs.count {
+            switch rawIdentities.count {
             case 0:
                 return .unresolved
             case 1:
-                return .resolved(processID: processIDs.first!, ownerLabel: tabIdentifier)
+                return .resolved(processID: rawIdentities[0].processID, ownerLabel: tabIdentifier)
             default:
+                let processIDs = Set(rawIdentities.map(\.processID))
                 let candidates = processIDs.map(String.init).sorted().joined(separator: ",")
                 return .conflict(
                     "ambiguous raw Xcode tabIdentifier '\(tabIdentifier)'"

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -1266,21 +1266,26 @@ extension RuntimeCoordinator {
         tabIdentifier: String?,
         workspacePath: String?
     ) -> CachedOwnerResolution {
-        windowOwnerIndex.withLockedValue { index in
+        let eligibleProcessIDs = activeAvailableOwnerProcessIDs()
+        return windowOwnerIndex.withLockedValue { index in
             let nonEmptyWorkspacePath = workspacePath.flatMap { $0.isEmpty ? nil : $0 }
             let nonEmptyTabIdentifier = tabIdentifier.flatMap { $0.isEmpty ? nil : $0 }
 
             if let workspacePath = nonEmptyWorkspacePath {
-                switch index.owner(forWorkspacePath: workspacePath) {
+                switch index.owner(
+                    forWorkspacePath: workspacePath,
+                    eligibleProcessIDs: eligibleProcessIDs
+                ) {
                 case .resolved(let processID):
                     if let tabIdentifier = nonEmptyTabIdentifier,
                        let conflict = tabConflictMessage(
                            tabIdentifier: tabIdentifier,
                            workspacePath: workspacePath,
                            ownerProcessID: processID,
-                           index: index
+                           index: index,
+                           eligibleProcessIDs: eligibleProcessIDs
                        ) {
-                        return .conflict(conflict)
+                        return CachedOwnerResolution.conflict(conflict)
                     }
                     return .resolved(processID: processID, ownerLabel: workspacePath)
                 case .conflicting(let processIDs):
@@ -1310,6 +1315,11 @@ extension RuntimeCoordinator {
                 return .unresolved
             }
             if let identity = index.identity(forProxyTabIdentifier: tabIdentifier) {
+                guard eligibleProcessIDs.contains(identity.processID) else {
+                    return .conflict(
+                        "stale or unavailable XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
+                    )
+                }
                 return .resolved(
                     processID: identity.processID,
                     ownerLabel: identity.proxyTabIdentifier
@@ -1321,7 +1331,10 @@ extension RuntimeCoordinator {
                 )
             }
 
-            let rawIdentities = index.identities(forRawTabIdentifier: tabIdentifier)
+            let rawIdentities = index.identities(
+                forRawTabIdentifier: tabIdentifier,
+                eligibleProcessIDs: eligibleProcessIDs
+            )
             let processIDs = Set(rawIdentities.map(\.processID))
             switch processIDs.count {
             case 0:
@@ -1338,11 +1351,23 @@ extension RuntimeCoordinator {
         }
     }
 
+    private func activeAvailableOwnerProcessIDs() -> Set<pid_t> {
+        let unavailable = unavailableXcodeProcessIDs()
+        return Set(
+            xcodeProcessRoutes.compactMap { route in
+                unavailable.contains(route.target.processID)
+                    ? nil
+                    : route.target.processID
+            }
+        )
+    }
+
     private func tabConflictMessage(
         tabIdentifier: String,
         workspacePath: String,
         ownerProcessID: pid_t,
-        index: WindowOwnerIndex
+        index: WindowOwnerIndex,
+        eligibleProcessIDs: Set<pid_t>
     ) -> String? {
         if let identity = index.identity(forProxyTabIdentifier: tabIdentifier) {
             guard identity.processID == ownerProcessID,
@@ -1354,7 +1379,10 @@ extension RuntimeCoordinator {
         if tabIdentifier.hasPrefix(WindowOwnerIndex.proxyTabIdentifierPrefix) {
             return "stale or unknown XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
         }
-        let rawIdentities = index.identities(forRawTabIdentifier: tabIdentifier)
+        let rawIdentities = index.identities(
+            forRawTabIdentifier: tabIdentifier,
+            eligibleProcessIDs: eligibleProcessIDs
+        )
         guard rawIdentities.isEmpty == false else {
             return nil
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -1108,7 +1108,7 @@ extension RuntimeCoordinator {
            rawTabIdentifier != tabIdentifier {
             arguments["tabIdentifier"] = rawTabIdentifier
             changed = true
-        } else if arguments["tabIdentifier"] == nil,
+        } else if (arguments["tabIdentifier"] as? String)?.isEmpty ?? true,
                   let workspacePath = arguments["workspacePath"] as? String,
                   workspacePath.isEmpty == false,
                   processToolSurfaceStore.tool(
@@ -1273,7 +1273,7 @@ extension RuntimeCoordinator {
         tabIdentifier: String?,
         workspacePath: String?
     ) -> CachedOwnerResolution {
-        let eligibleProcessIDs = activeAvailableOwnerProcessIDs()
+        let eligibleProcessIDs = ownerRoutingEligibleProcessIDs()
         return windowOwnerIndex.withLockedValue { index in
             let nonEmptyWorkspacePath = workspacePath.flatMap { $0.isEmpty ? nil : $0 }
             let nonEmptyTabIdentifier = tabIdentifier.flatMap { $0.isEmpty ? nil : $0 }
@@ -1385,15 +1385,8 @@ extension RuntimeCoordinator {
         }
     }
 
-    private func activeAvailableOwnerProcessIDs() -> Set<pid_t> {
-        let unavailable = unavailableXcodeProcessIDs()
-        return Set(
-            xcodeProcessRoutes.compactMap { route in
-                unavailable.contains(route.target.processID)
-                    ? nil
-                    : route.target.processID
-            }
-        )
+    private func ownerRoutingEligibleProcessIDs() -> Set<pid_t> {
+        processRouteExposure(policy: .ownerRouting).processIDs
     }
 
     private func tabConflictMessage(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -1171,17 +1171,23 @@ extension RuntimeCoordinator {
         guard isKnownOwnerBoundTool(toolName) else {
             return nil
         }
-        if let workspacePath = arguments["workspacePath"] as? String,
-           workspacePath.isEmpty == false {
-            return upstreamIndexForOwner(workspacePath: workspacePath)
+        let tabIdentifier = (arguments["tabIdentifier"] as? String).flatMap {
+            $0.isEmpty ? nil : $0
         }
-        if let tabIdentifier = arguments["tabIdentifier"] as? String,
-           tabIdentifier.isEmpty == false,
-           let upstreamIndex = upstreamIndexForOwner(tabIdentifier: tabIdentifier)
-        {
-            return upstreamIndex
+        let workspacePath = (arguments["workspacePath"] as? String).flatMap {
+            $0.isEmpty ? nil : $0
         }
-        return nil
+        guard tabIdentifier != nil || workspacePath != nil,
+              case .resolved(let processID, _) = cachedOwnerResolution(
+                  tabIdentifier: tabIdentifier,
+                  workspacePath: workspacePath
+              ),
+              let route = xcodeProcessRoutes.first(where: {
+                  $0.target.processID == processID
+              }) else {
+            return nil
+        }
+        return firstUsableInitializedUpstreamIndex(in: route)
     }
 
     private func toolRoutingRequests(in value: Any) -> [ToolRoutingRequest] {
@@ -1271,7 +1277,44 @@ extension RuntimeCoordinator {
             let nonEmptyWorkspacePath = workspacePath.flatMap { $0.isEmpty ? nil : $0 }
             let nonEmptyTabIdentifier = tabIdentifier.flatMap { $0.isEmpty ? nil : $0 }
 
+            func proxyTabResolution(
+                tabIdentifier: String,
+                workspacePath: String?
+            ) -> CachedOwnerResolution? {
+                guard tabIdentifier.hasPrefix(WindowOwnerIndex.proxyTabIdentifierPrefix) else {
+                    return nil
+                }
+                guard let identity = index.identity(forProxyTabIdentifier: tabIdentifier) else {
+                    return .conflict(
+                        "stale or unknown XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
+                    )
+                }
+                guard eligibleProcessIDs.contains(identity.processID) else {
+                    return .conflict(
+                        "stale or unavailable XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
+                    )
+                }
+                if let workspacePath, identity.workspacePath != workspacePath {
+                    return .conflict(
+                        "tabIdentifier '\(tabIdentifier)' does not belong to workspacePath"
+                            + " '\(workspacePath)'"
+                    )
+                }
+                return .resolved(
+                    processID: identity.processID,
+                    ownerLabel: identity.proxyTabIdentifier
+                )
+            }
+
             if let workspacePath = nonEmptyWorkspacePath {
+                if let tabIdentifier = nonEmptyTabIdentifier,
+                   let resolution = proxyTabResolution(
+                       tabIdentifier: tabIdentifier,
+                       workspacePath: workspacePath
+                   ) {
+                    return resolution
+                }
+
                 switch index.owner(
                     forWorkspacePath: workspacePath,
                     eligibleProcessIDs: eligibleProcessIDs
@@ -1314,21 +1357,11 @@ extension RuntimeCoordinator {
             guard let tabIdentifier = nonEmptyTabIdentifier else {
                 return .unresolved
             }
-            if let identity = index.identity(forProxyTabIdentifier: tabIdentifier) {
-                guard eligibleProcessIDs.contains(identity.processID) else {
-                    return .conflict(
-                        "stale or unavailable XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
-                    )
-                }
-                return .resolved(
-                    processID: identity.processID,
-                    ownerLabel: identity.proxyTabIdentifier
-                )
-            }
-            if tabIdentifier.hasPrefix(WindowOwnerIndex.proxyTabIdentifierPrefix) {
-                return .conflict(
-                    "stale or unknown XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
-                )
+            if let resolution = proxyTabResolution(
+                tabIdentifier: tabIdentifier,
+                workspacePath: nil
+            ) {
+                return resolution
             }
 
             let rawIdentities = index.identities(
@@ -1415,28 +1448,6 @@ extension RuntimeCoordinator {
             }
         }
         return (resolved, unresolved, conflicts)
-    }
-
-    private func upstreamIndexForOwner(tabIdentifier: String) -> Int? {
-        guard case .resolved(let processID, _) = cachedOwnerResolution(
-            tabIdentifier: tabIdentifier,
-            workspacePath: nil
-        ),
-              let route = xcodeProcessRoutes.first(where: { $0.target.processID == processID }) else {
-            return nil
-        }
-        return firstUsableInitializedUpstreamIndex(in: route)
-    }
-
-    private func upstreamIndexForOwner(workspacePath: String) -> Int? {
-        guard case .resolved(let processID, _) = cachedOwnerResolution(
-            tabIdentifier: nil,
-            workspacePath: workspacePath
-        ),
-              let route = xcodeProcessRoutes.first(where: { $0.target.processID == processID }) else {
-            return nil
-        }
-        return firstUsableInitializedUpstreamIndex(in: route)
     }
 
     private func cachedOwnerBoundToolNames() -> Set<String> {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -38,6 +38,17 @@ extension RuntimeCoordinator {
         case reject
     }
 
+    private struct OwnerResolutionConflict: Sendable {
+        let request: ToolRoutingRequest
+        let message: String
+    }
+
+    private enum CachedOwnerResolution: Sendable {
+        case resolved(processID: pid_t, ownerLabel: String)
+        case unresolved
+        case conflict(String)
+    }
+
     func liveXcodeListWindowsAcrossProcessRoutes(
         deadlineUptimeNs: UInt64?,
         routeScope: XcodeListWindowsRouteScope
@@ -132,7 +143,12 @@ extension RuntimeCoordinator {
 
             let orderedRouteResults = results.sorted { $0.ordinal < $1.ordinal }
             recordXcodeWindowOwners(fromOrderedRouteResults: orderedRouteResults)
-            let orderedResults = orderedRouteResults.map(\.result)
+            let orderedResults = orderedRouteResults.map {
+                rewriteXcodeListWindowsResultForClients(
+                    $0.result,
+                    upstreamIndex: $0.upstreamIndex
+                )
+            }
             if let merged = Self.mergedXcodeListWindowsResult(orderedResults) {
                 return merged
             }
@@ -327,17 +343,33 @@ extension RuntimeCoordinator {
     }
 
     func removeXcodeWindowOwners(forProcessID processID: pid_t) {
-        tabOwnerProcessIDs.withLockedValue { owners in
-            owners = owners.filter { $0.value != processID }
+        let changed = windowOwnerIndex.withLockedValue { index in
+            index.remove(processID: processID)
         }
-        workspaceOwnerProcessIDs.withLockedValue { owners in
-            owners = owners.filter { $0.value != processID }
+        if changed {
+            invalidateControlPlane(
+                reason: "xcode_window_owners_updated",
+                clearInitialize: false,
+                clearToolsCatalog: true
+            )
         }
     }
 
     func clearXcodeWindowOwners() {
-        tabOwnerProcessIDs.withLockedValue { $0.removeAll() }
-        workspaceOwnerProcessIDs.withLockedValue { $0.removeAll() }
+        let changed = windowOwnerIndex.withLockedValue { index in
+            guard index.isEmpty == false else {
+                return false
+            }
+            index.removeAll()
+            return true
+        }
+        if changed {
+            invalidateControlPlane(
+                reason: "xcode_window_owners_updated",
+                clearInitialize: false,
+                clearToolsCatalog: true
+            )
+        }
     }
 
     func documentationUpstreamIndex(for target: XcodeProcessTarget) -> Int? {
@@ -506,6 +538,22 @@ extension RuntimeCoordinator {
                         unresolvedOwnerBoundRequests: ownerResolution.unresolved
                     )
             }
+        }
+
+        if ownerResolution.conflicts.isEmpty == false {
+            let errors = ownerResolution.conflicts.compactMap { conflict -> ToolRoutingError? in
+                guard let id = conflict.request.id else { return nil }
+                return ToolRoutingError(id: id, message: conflict.message)
+            }
+            return .reject(
+                errors: errors.isEmpty
+                    ? toolRoutingErrors(
+                        for: requests,
+                        message: "conflicting Xcode window owners for one or more tools"
+                    )
+                    : errors,
+                forceBatchArray: requestJSON is [Any]
+            )
         }
 
         if ownerResolution.unresolved.isEmpty == false, inferredOwnerProcessID == nil {
@@ -752,15 +800,28 @@ extension RuntimeCoordinator {
         fromOrderedRouteResults results: [(ordinal: Int, upstreamIndex: Int, result: JSONValue)]
     ) {
         let processIDs = Set(results.compactMap { processID(forUpstreamIndex: $0.upstreamIndex) })
-        for processID in processIDs {
-            removeXcodeWindowOwners(forProcessID: processID)
+        let entriesByProcessID: [(processID: pid_t, entries: [XcodeListWindowsEntry])] =
+            results.compactMap { result in
+                guard let processID = processID(forUpstreamIndex: result.upstreamIndex) else {
+                    return nil
+                }
+                return (processID, Self.windowEntries(in: result.result))
+            }
+        let changed = windowOwnerIndex.withLockedValue { index in
+            let before = index
+            for processID in processIDs {
+                index.remove(processID: processID)
+            }
+            for entry in entriesByProcessID {
+                index.record(processID: entry.processID, entries: entry.entries)
+            }
+            return index != before
         }
-        for result in results {
-            _ = recordXcodeWindowOwners(
-                from: result.result,
-                upstreamIndex: result.upstreamIndex,
-                removeExistingOwners: false,
-                overwriteExistingOwners: false
+        if changed {
+            invalidateControlPlane(
+                reason: "xcode_window_owners_updated",
+                clearInitialize: false,
+                clearToolsCatalog: true
             )
         }
     }
@@ -770,43 +831,28 @@ extension RuntimeCoordinator {
         from result: JSONValue,
         upstreamIndex: Int,
         removeExistingOwners: Bool,
-        overwriteExistingOwners: Bool
+        overwriteExistingOwners _: Bool
     ) -> Bool {
         guard let processID = processID(forUpstreamIndex: upstreamIndex) else {
             return false
         }
-        let previousTabOwners = tabOwnerProcessIDs.withLockedValue { $0 }
-        let previousWorkspaceOwners = workspaceOwnerProcessIDs.withLockedValue { $0 }
-        if removeExistingOwners {
-            removeXcodeWindowOwners(forProcessID: processID)
-        }
         let entries = Self.windowEntries(in: result)
-        guard entries.isEmpty == false else {
-            return false
-        }
-        tabOwnerProcessIDs.withLockedValue { owners in
-            for entry in entries {
-                if overwriteExistingOwners || owners[entry.tabIdentifier] == nil {
-                    owners[entry.tabIdentifier] = processID
-                }
+        let changed = windowOwnerIndex.withLockedValue { index in
+            let before = index
+            if removeExistingOwners {
+                index.remove(processID: processID)
             }
+            index.record(processID: processID, entries: entries)
+            return index != before
         }
-        workspaceOwnerProcessIDs.withLockedValue { owners in
-            for entry in entries {
-                if overwriteExistingOwners || owners[entry.workspacePath] == nil {
-                    owners[entry.workspacePath] = processID
-                }
-            }
-        }
-        if tabOwnerProcessIDs.withLockedValue({ $0 }) != previousTabOwners
-            || workspaceOwnerProcessIDs.withLockedValue({ $0 }) != previousWorkspaceOwners {
+        if changed {
             invalidateControlPlane(
                 reason: "xcode_window_owners_updated",
                 clearInitialize: false,
                 clearToolsCatalog: true
             )
         }
-        return true
+        return entries.isEmpty == false
     }
 
     static func mergedXcodeListWindowsResult(
@@ -823,6 +869,54 @@ extension RuntimeCoordinator {
                 ?? results.first
         }
         let message = messages.joined(separator: "\n")
+        let encodedMessage: String
+        if let data = try? JSONSerialization.data(
+            withJSONObject: ["message": message],
+            options: [.sortedKeys]
+        ) {
+            encodedMessage = String(decoding: data, as: UTF8.self)
+        } else {
+            encodedMessage = message
+        }
+        return .object([
+            "content": .array([
+                .object([
+                    "type": .string("text"),
+                    "text": .string(encodedMessage),
+                ]),
+            ]),
+            "structuredContent": .object([
+                "message": .string(message),
+            ]),
+        ])
+    }
+
+    private func rewriteXcodeListWindowsResultForClients(
+        _ result: JSONValue,
+        upstreamIndex: Int
+    ) -> JSONValue {
+        guard let processID = processID(forUpstreamIndex: upstreamIndex) else {
+            return result
+        }
+        let entries = Self.windowEntries(in: result)
+        guard entries.isEmpty == false else {
+            return result
+        }
+        let message = windowOwnerIndex.withLockedValue { index in
+            entries.map { entry in
+                let proxyTabIdentifier = index.proxyTabIdentifier(
+                    processID: processID,
+                    rawTabIdentifier: entry.tabIdentifier,
+                    workspacePath: entry.workspacePath
+                )
+                return "* tabIdentifier: \(proxyTabIdentifier), workspacePath: \(entry.workspacePath)"
+            }
+            .joined(separator: "\n")
+        }
+        return Self.xcodeListWindowsResult(message: message)
+    }
+
+    private static func xcodeListWindowsResult(message: String) -> JSONValue {
         let encodedMessage: String
         if let data = try? JSONSerialization.data(
             withJSONObject: ["message": message],
@@ -944,6 +1038,129 @@ extension RuntimeCoordinator {
         xcodeProcessRoute(forUpstreamIndex: upstreamIndex)?.target.processID
     }
 
+    func rewriteOwnerBoundRequest(
+        bodyData: Data,
+        parsedRequestJSON: Any,
+        upstreamIndex: Int
+    ) -> (bodyData: Data, parsedRequestJSON: Any) {
+        guard processRoutingEnabled,
+              let processID = processID(forUpstreamIndex: upstreamIndex) else {
+            return (bodyData, parsedRequestJSON)
+        }
+        let rewritten = rewriteOwnerBoundRequestJSON(
+            parsedRequestJSON,
+            processID: processID
+        )
+        guard rewritten.changed else {
+            return (bodyData, parsedRequestJSON)
+        }
+        guard JSONSerialization.isValidJSONObject(rewritten.value),
+              let data = try? JSONSerialization.data(
+                withJSONObject: rewritten.value,
+                options: []
+              ) else {
+            return (bodyData, parsedRequestJSON)
+        }
+        return (data, rewritten.value)
+    }
+
+    private func rewriteOwnerBoundRequestJSON(
+        _ value: Any,
+        processID: pid_t
+    ) -> (value: Any, changed: Bool) {
+        if let object = value as? [String: Any] {
+            return rewriteOwnerBoundRequestObject(object, processID: processID)
+        }
+        guard let array = value as? [Any] else {
+            return (value, false)
+        }
+        var changed = false
+        let rewritten = array.map { item -> Any in
+            guard let object = item as? [String: Any] else {
+                return item
+            }
+            let result = rewriteOwnerBoundRequestObject(object, processID: processID)
+            changed = changed || result.changed
+            return result.value
+        }
+        return (rewritten, changed)
+    }
+
+    private func rewriteOwnerBoundRequestObject(
+        _ object: [String: Any],
+        processID: pid_t
+    ) -> (value: [String: Any], changed: Bool) {
+        guard JSONRPC.Message.Inspector.method(from: object) == "tools/call",
+              var params = object["params"] as? [String: Any],
+              let toolName = params["name"] as? String,
+              var arguments = params["arguments"] as? [String: Any] else {
+            return (object, false)
+        }
+        var changed = false
+
+        if let tabIdentifier = arguments["tabIdentifier"] as? String,
+           tabIdentifier.isEmpty == false,
+           let rawTabIdentifier = rawTabIdentifierForForwarding(
+            tabIdentifier: tabIdentifier,
+            processID: processID
+           ),
+           rawTabIdentifier != tabIdentifier {
+            arguments["tabIdentifier"] = rawTabIdentifier
+            changed = true
+        } else if arguments["tabIdentifier"] == nil,
+                  let workspacePath = arguments["workspacePath"] as? String,
+                  workspacePath.isEmpty == false,
+                  processToolSurfaceStore.tool(
+                    toolName,
+                    processID: processID,
+                    requiresArgument: "tabIdentifier"
+                  ),
+                  let rawTabIdentifier = singleRawTabIdentifier(
+                    workspacePath: workspacePath,
+                    processID: processID
+                  ) {
+            arguments["tabIdentifier"] = rawTabIdentifier
+            changed = true
+        }
+
+        guard changed else {
+            return (object, false)
+        }
+        params["arguments"] = arguments
+        var rewritten = object
+        rewritten["params"] = params
+        return (rewritten, true)
+    }
+
+    private func rawTabIdentifierForForwarding(
+        tabIdentifier: String,
+        processID: pid_t
+    ) -> String? {
+        windowOwnerIndex.withLockedValue { index in
+            guard let identity = index.identity(forProxyTabIdentifier: tabIdentifier),
+                  identity.processID == processID else {
+                return nil
+            }
+            return identity.rawTabIdentifier
+        }
+    }
+
+    private func singleRawTabIdentifier(
+        workspacePath: String,
+        processID: pid_t
+    ) -> String? {
+        windowOwnerIndex.withLockedValue { index in
+            let identities = index.identities(
+                workspacePath: workspacePath,
+                processID: processID
+            )
+            guard identities.count == 1 else {
+                return nil
+            }
+            return identities[0].rawTabIdentifier
+        }
+    }
+
     private func preferredUpstreamIndex(in object: [String: Any]) -> Int? {
         guard JSONRPC.Message.Inspector.method(from: object) == "tools/call",
               let params = object["params"] as? [String: Any],
@@ -954,15 +1171,13 @@ extension RuntimeCoordinator {
         guard isKnownOwnerBoundTool(toolName) else {
             return nil
         }
+        if let workspacePath = arguments["workspacePath"] as? String,
+           workspacePath.isEmpty == false {
+            return upstreamIndexForOwner(workspacePath: workspacePath)
+        }
         if let tabIdentifier = arguments["tabIdentifier"] as? String,
            tabIdentifier.isEmpty == false,
            let upstreamIndex = upstreamIndexForOwner(tabIdentifier: tabIdentifier)
-        {
-            return upstreamIndex
-        }
-        if let workspacePath = arguments["workspacePath"] as? String,
-           workspacePath.isEmpty == false,
-           let upstreamIndex = upstreamIndexForOwner(workspacePath: workspacePath)
         {
             return upstreamIndex
         }
@@ -1040,34 +1255,145 @@ extension RuntimeCoordinator {
         )
     }
 
+    private func cachedOwnerResolution(for request: ToolRoutingRequest) -> CachedOwnerResolution {
+        cachedOwnerResolution(
+            tabIdentifier: request.tabIdentifier,
+            workspacePath: request.workspacePath
+        )
+    }
+
+    private func cachedOwnerResolution(
+        tabIdentifier: String?,
+        workspacePath: String?
+    ) -> CachedOwnerResolution {
+        windowOwnerIndex.withLockedValue { index in
+            let nonEmptyWorkspacePath = workspacePath.flatMap { $0.isEmpty ? nil : $0 }
+            let nonEmptyTabIdentifier = tabIdentifier.flatMap { $0.isEmpty ? nil : $0 }
+
+            if let workspacePath = nonEmptyWorkspacePath {
+                switch index.owner(forWorkspacePath: workspacePath) {
+                case .resolved(let processID):
+                    if let tabIdentifier = nonEmptyTabIdentifier,
+                       let conflict = tabConflictMessage(
+                           tabIdentifier: tabIdentifier,
+                           workspacePath: workspacePath,
+                           ownerProcessID: processID,
+                           index: index
+                       ) {
+                        return .conflict(conflict)
+                    }
+                    return .resolved(processID: processID, ownerLabel: workspacePath)
+                case .conflicting(let processIDs):
+                    let candidates = processIDs.map(String.init).sorted().joined(separator: ",")
+                    return .conflict(
+                        "conflicting Xcode window owners for workspacePath '\(workspacePath)'"
+                            + " (processes: \(candidates))"
+                    )
+                case .unresolved:
+                    if let tabIdentifier = nonEmptyTabIdentifier {
+                        if index.identity(forProxyTabIdentifier: tabIdentifier) != nil {
+                            return .conflict(
+                                "tabIdentifier '\(tabIdentifier)' does not belong to workspacePath '\(workspacePath)'"
+                            )
+                        }
+                        if tabIdentifier.hasPrefix(WindowOwnerIndex.proxyTabIdentifierPrefix) {
+                            return .conflict(
+                                "stale or unknown XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
+                            )
+                        }
+                    }
+                    return .unresolved
+                }
+            }
+
+            guard let tabIdentifier = nonEmptyTabIdentifier else {
+                return .unresolved
+            }
+            if let identity = index.identity(forProxyTabIdentifier: tabIdentifier) {
+                return .resolved(
+                    processID: identity.processID,
+                    ownerLabel: identity.proxyTabIdentifier
+                )
+            }
+            if tabIdentifier.hasPrefix(WindowOwnerIndex.proxyTabIdentifierPrefix) {
+                return .conflict(
+                    "stale or unknown XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
+                )
+            }
+
+            let rawIdentities = index.identities(forRawTabIdentifier: tabIdentifier)
+            let processIDs = Set(rawIdentities.map(\.processID))
+            switch processIDs.count {
+            case 0:
+                return .unresolved
+            case 1:
+                return .resolved(processID: processIDs.first!, ownerLabel: tabIdentifier)
+            default:
+                let candidates = processIDs.map(String.init).sorted().joined(separator: ",")
+                return .conflict(
+                    "ambiguous raw Xcode tabIdentifier '\(tabIdentifier)'"
+                        + " (processes: \(candidates))"
+                )
+            }
+        }
+    }
+
+    private func tabConflictMessage(
+        tabIdentifier: String,
+        workspacePath: String,
+        ownerProcessID: pid_t,
+        index: WindowOwnerIndex
+    ) -> String? {
+        if let identity = index.identity(forProxyTabIdentifier: tabIdentifier) {
+            guard identity.processID == ownerProcessID,
+                  identity.workspacePath == workspacePath else {
+                return "tabIdentifier '\(tabIdentifier)' does not belong to workspacePath '\(workspacePath)'"
+            }
+            return nil
+        }
+        if tabIdentifier.hasPrefix(WindowOwnerIndex.proxyTabIdentifierPrefix) {
+            return "stale or unknown XcodeMCPKit tabIdentifier '\(tabIdentifier)'"
+        }
+        let rawIdentities = index.identities(forRawTabIdentifier: tabIdentifier)
+        guard rawIdentities.isEmpty == false else {
+            return nil
+        }
+        let matchesWorkspaceOwner = rawIdentities.contains {
+            $0.processID == ownerProcessID && $0.workspacePath == workspacePath
+        }
+        return matchesWorkspaceOwner
+            ? nil
+            : "tabIdentifier '\(tabIdentifier)' does not belong to workspacePath '\(workspacePath)'"
+    }
+
     private func resolvedOwnerProcessIDs(
         for requests: [ToolRoutingRequest]
     ) -> (
         resolved: [(request: ToolRoutingRequest, processID: pid_t, ownerLabel: String)],
-        unresolved: [ToolRoutingRequest]
+        unresolved: [ToolRoutingRequest],
+        conflicts: [OwnerResolutionConflict]
     ) {
         var resolved: [(request: ToolRoutingRequest, processID: pid_t, ownerLabel: String)] = []
         var unresolved: [ToolRoutingRequest] = []
+        var conflicts: [OwnerResolutionConflict] = []
         for request in requests {
-            if let tabIdentifier = request.tabIdentifier,
-               tabIdentifier.isEmpty == false,
-               let processID = tabOwnerProcessIDs.withLockedValue({ $0[tabIdentifier] }) {
-                resolved.append((request, processID, tabIdentifier))
-                continue
+            switch cachedOwnerResolution(for: request) {
+            case .resolved(let processID, let ownerLabel):
+                resolved.append((request, processID, ownerLabel))
+            case .unresolved:
+                unresolved.append(request)
+            case .conflict(let message):
+                conflicts.append(OwnerResolutionConflict(request: request, message: message))
             }
-            if let workspacePath = request.workspacePath,
-               workspacePath.isEmpty == false,
-               let processID = workspaceOwnerProcessIDs.withLockedValue({ $0[workspacePath] }) {
-                resolved.append((request, processID, workspacePath))
-                continue
-            }
-            unresolved.append(request)
         }
-        return (resolved, unresolved)
+        return (resolved, unresolved, conflicts)
     }
 
     private func upstreamIndexForOwner(tabIdentifier: String) -> Int? {
-        guard let processID = tabOwnerProcessIDs.withLockedValue({ $0[tabIdentifier] }),
+        guard case .resolved(let processID, _) = cachedOwnerResolution(
+            tabIdentifier: tabIdentifier,
+            workspacePath: nil
+        ),
               let route = xcodeProcessRoutes.first(where: { $0.target.processID == processID }) else {
             return nil
         }
@@ -1075,7 +1401,10 @@ extension RuntimeCoordinator {
     }
 
     private func upstreamIndexForOwner(workspacePath: String) -> Int? {
-        guard let processID = workspaceOwnerProcessIDs.withLockedValue({ $0[workspacePath] }),
+        guard case .resolved(let processID, _) = cachedOwnerResolution(
+            tabIdentifier: nil,
+            workspacePath: workspacePath
+        ),
               let route = xcodeProcessRoutes.first(where: { $0.target.processID == processID }) else {
             return nil
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -892,7 +892,7 @@ extension RuntimeCoordinator {
         ])
     }
 
-    private func rewriteXcodeListWindowsResultForClients(
+    func rewriteXcodeListWindowsResultForClients(
         _ result: JSONValue,
         upstreamIndex: Int
     ) -> JSONValue {

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -429,8 +429,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     var xcodeProcessRoutes: [XcodeProcessRoute] {
         processRouteStore.activeRoutes()
     }
-    let tabOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
-    let workspaceOwnerProcessIDs = NIOLockedValueBox<[String: pid_t]>([:])
+    let windowOwnerIndex = NIOLockedValueBox(WindowOwnerIndex())
     let availableToolsCatalogRefreshKeys = NIOLockedValueBox<Set<String>>([])
     let processRouteReadinessStore = ProcessRouteReadinessStore()
     let prewarmDocumentationProviderOnStartup: Bool

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -1442,6 +1442,12 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             }
             if case .pinnedUpstream(let upstreamIndex) = route {
                 recordXcodeWindowOwners(from: result, upstreamIndex: upstreamIndex)
+                if processRoutingEnabled {
+                    return rewriteXcodeListWindowsResultForClients(
+                        result,
+                        upstreamIndex: upstreamIndex
+                    )
+                }
             }
             return result
         }

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/WindowOwnerIndex.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/WindowOwnerIndex.swift
@@ -13,16 +13,18 @@ struct WindowOwnerIndex: Sendable, Equatable {
             self.rawTabIdentifier = rawTabIdentifier
             self.proxyTabIdentifier = Self.proxyTabIdentifier(
                 processID: processID,
-                rawTabIdentifier: rawTabIdentifier
+                rawTabIdentifier: rawTabIdentifier,
+                workspacePath: workspacePath
             )
             self.workspacePath = workspacePath
         }
 
         private static func proxyTabIdentifier(
             processID: pid_t,
-            rawTabIdentifier: String
+            rawTabIdentifier: String,
+            workspacePath: String
         ) -> String {
-            let input = "\(processID)\u{0}\(rawTabIdentifier)"
+            let input = "\(processID)\u{0}\(rawTabIdentifier)\u{0}\(workspacePath)"
             let digest = SHA256.hash(data: Data(input.utf8))
             let token = digest.map { byte -> String in
                 let hex = String(byte, radix: 16)

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/WindowOwnerIndex.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/WindowOwnerIndex.swift
@@ -73,10 +73,14 @@ struct WindowOwnerIndex: Sendable, Equatable {
         return identities != before
     }
 
-    func owner(forWorkspacePath workspacePath: String) -> ProcessOwnerLookup {
+    func owner(
+        forWorkspacePath workspacePath: String,
+        eligibleProcessIDs: Set<pid_t>
+    ) -> ProcessOwnerLookup {
         let processIDs = Set(
             identities
                 .filter { $0.workspacePath == workspacePath }
+                .filter { eligibleProcessIDs.contains($0.processID) }
                 .map(\.processID)
         )
         switch processIDs.count {
@@ -93,8 +97,14 @@ struct WindowOwnerIndex: Sendable, Equatable {
         identities.first { $0.proxyTabIdentifier == tabIdentifier }
     }
 
-    func identities(forRawTabIdentifier tabIdentifier: String) -> [Identity] {
-        identities.filter { $0.rawTabIdentifier == tabIdentifier }
+    func identities(
+        forRawTabIdentifier tabIdentifier: String,
+        eligibleProcessIDs: Set<pid_t>
+    ) -> [Identity] {
+        identities.filter {
+            $0.rawTabIdentifier == tabIdentifier
+                && eligibleProcessIDs.contains($0.processID)
+        }
     }
 
     func identities(

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/WindowOwnerIndex.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/WindowOwnerIndex.swift
@@ -1,0 +1,151 @@
+import CryptoKit
+import Foundation
+
+struct WindowOwnerIndex: Sendable, Equatable {
+    struct Identity: Sendable, Hashable {
+        let processID: pid_t
+        let rawTabIdentifier: String
+        let proxyTabIdentifier: String
+        let workspacePath: String
+
+        init(processID: pid_t, rawTabIdentifier: String, workspacePath: String) {
+            self.processID = processID
+            self.rawTabIdentifier = rawTabIdentifier
+            self.proxyTabIdentifier = Self.proxyTabIdentifier(
+                processID: processID,
+                rawTabIdentifier: rawTabIdentifier
+            )
+            self.workspacePath = workspacePath
+        }
+
+        private static func proxyTabIdentifier(
+            processID: pid_t,
+            rawTabIdentifier: String
+        ) -> String {
+            let input = "\(processID)\u{0}\(rawTabIdentifier)"
+            let digest = SHA256.hash(data: Data(input.utf8))
+            let token = digest.map { byte -> String in
+                let hex = String(byte, radix: 16)
+                return byte < 16 ? "0\(hex)" : hex
+            }.joined()
+            return "\(WindowOwnerIndex.proxyTabIdentifierPrefix)\(token)"
+        }
+    }
+
+    enum ProcessOwnerLookup: Sendable, Equatable {
+        case resolved(pid_t)
+        case unresolved
+        case conflicting(Set<pid_t>)
+    }
+
+    static let proxyTabIdentifierPrefix = "xcode-mcpkit:"
+
+    private var identities: [Identity] = []
+
+    var isEmpty: Bool {
+        identities.isEmpty
+    }
+
+    mutating func removeAll() {
+        identities.removeAll()
+    }
+
+    @discardableResult
+    mutating func remove(processID: pid_t) -> Bool {
+        let countBefore = identities.count
+        identities.removeAll { $0.processID == processID }
+        return identities.count != countBefore
+    }
+
+    @discardableResult
+    mutating func record(processID: pid_t, entries: [XcodeListWindowsEntry]) -> Bool {
+        let before = identities
+        for entry in entries {
+            let identity = Identity(
+                processID: processID,
+                rawTabIdentifier: entry.tabIdentifier,
+                workspacePath: entry.workspacePath
+            )
+            if identities.contains(identity) == false {
+                identities.append(identity)
+            }
+        }
+        return identities != before
+    }
+
+    func owner(forWorkspacePath workspacePath: String) -> ProcessOwnerLookup {
+        let processIDs = Set(
+            identities
+                .filter { $0.workspacePath == workspacePath }
+                .map(\.processID)
+        )
+        switch processIDs.count {
+        case 0:
+            return .unresolved
+        case 1:
+            return .resolved(processIDs.first!)
+        default:
+            return .conflicting(processIDs)
+        }
+    }
+
+    func identity(forProxyTabIdentifier tabIdentifier: String) -> Identity? {
+        identities.first { $0.proxyTabIdentifier == tabIdentifier }
+    }
+
+    func identities(forRawTabIdentifier tabIdentifier: String) -> [Identity] {
+        identities.filter { $0.rawTabIdentifier == tabIdentifier }
+    }
+
+    func identities(
+        workspacePath: String,
+        processID: pid_t
+    ) -> [Identity] {
+        identities.filter {
+            $0.workspacePath == workspacePath && $0.processID == processID
+        }
+    }
+
+    func proxyTabIdentifier(
+        processID: pid_t,
+        rawTabIdentifier: String,
+        workspacePath: String
+    ) -> String {
+        identity(
+            processID: processID,
+            rawTabIdentifier: rawTabIdentifier,
+            workspacePath: workspacePath
+        )?.proxyTabIdentifier
+            ?? Identity(
+                processID: processID,
+                rawTabIdentifier: rawTabIdentifier,
+                workspacePath: workspacePath
+            ).proxyTabIdentifier
+    }
+
+    func identity(
+        processID: pid_t,
+        rawTabIdentifier: String,
+        workspacePath: String
+    ) -> Identity? {
+        identities.first {
+            $0.processID == processID
+                && $0.rawTabIdentifier == rawTabIdentifier
+                && $0.workspacePath == workspacePath
+        }
+    }
+
+    func tabOwnerCountsByProcessID() -> [pid_t: Int] {
+        identities.reduce(into: [:]) { counts, identity in
+            counts[identity.processID, default: 0] += 1
+        }
+    }
+
+    func workspaceOwnerCountsByProcessID() -> [pid_t: Int] {
+        var workspacePathsByProcessID: [pid_t: Set<String>] = [:]
+        for identity in identities {
+            workspacePathsByProcessID[identity.processID, default: []].insert(identity.workspacePath)
+        }
+        return workspacePathsByProcessID.mapValues(\.count)
+    }
+}

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -8830,6 +8830,79 @@ struct RuntimeCoordinatorTests {
         #expect(errors.first?.message.contains("conflicting Xcode window owners") == true)
     }
 
+    @Test func unavailableCachedWorkspaceOwnerDoesNotConflictWithAvailableOwner()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let unavailableTarget = xcodeProcessTarget(processID: 616, xcodeVersion: "27.0")
+        let availableTarget = xcodeProcessTarget(processID: 617, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [TestUpstreamClient(), TestUpstreamClient()],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: unavailableTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: availableTarget, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (unavailableTarget, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (availableTarget, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
+        manager.markXcodeProcessRouteUnavailable(
+            upstreamIndex: 0,
+            reason: "test_unavailable_stale_owner"
+        )
+        #expect(manager.unavailableXcodeProcessIDs().contains(unavailableTarget.processID))
+
+        let workspacePath = "/Work/SharedAfterUnavailable.xcworkspace"
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: stale-tab, workspacePath: \(workspacePath)",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: live-tab, workspacePath: \(workspacePath)",
+                    ],
+                ]),
+                upstreamIndex: 1
+            )
+        )
+
+        let request = toolsCallObject(
+            id: 8702,
+            name: "BuildProject",
+            arguments: ["workspacePath": workspacePath]
+        )
+        #expect(manager.preferredUpstreamIndex(for: request) == 1)
+        let decision = await manager.toolRoutingDecision(
+            for: request,
+            requestTimeoutOverride: .seconds(2)
+        )
+        guard case .forwardAny(let preferredUpstreamIndices) = decision else {
+            Issue.record("expected unavailable stale owner to be ignored")
+            return
+        }
+        #expect(preferredUpstreamIndices == [1])
+    }
+
     @Test func sessionManagerSkipsUninitializedProcessRoutesDuringWindowFanout()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -10386,6 +10386,81 @@ struct RuntimeCoordinatorTests {
         #expect(message.contains("/Work/A.xcworkspace"))
     }
 
+    @Test func pinnedLiveXcodeListWindowsReturnsClientProxyTabIdentifiers()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = xcodeProcessTarget(processID: 634, xcodeVersion: "27.0")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (
+                    target,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+            ]
+        )
+
+        let task = Task {
+            try await manager.liveXcodeListWindowsResult(
+                route: .pinnedUpstream(0),
+                requestTimeoutOverride: .seconds(5)
+            )
+        }
+        let request = try await upstream.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        await upstream.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: request),
+                    message: "* tabIdentifier: raw-pinned-tab, "
+                        + "workspacePath: /Work/Pinned.xcworkspace"
+                )
+            )
+        )
+
+        let result = try await task.value
+        guard case .object(let object) = result,
+              case .object(let structuredContent)? = object["structuredContent"],
+              case .string(let message)? = structuredContent["message"],
+              let proxyTabIdentifier = firstTabIdentifier(in: message) else {
+            Issue.record("expected pinned XcodeListWindows to return a proxied tab")
+            return
+        }
+        #expect(proxyTabIdentifier.hasPrefix("xcode-mcpkit:"))
+        #expect(proxyTabIdentifier != "raw-pinned-tab")
+        #expect(message.contains("/Work/Pinned.xcworkspace"))
+
+        #expect(
+            manager.preferredUpstreamIndex(
+                for: toolsCallObject(
+                    id: 8707,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": proxyTabIdentifier]
+                )
+            ) == 0
+        )
+    }
+
     @Test func liveXcodeListWindowsIgnoresCatalogsFromUnavailableRoutes() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -8903,6 +8903,80 @@ struct RuntimeCoordinatorTests {
         #expect(preferredUpstreamIndices == [1])
     }
 
+    @Test func proxyTabIdentifierDisambiguatesDuplicateWorkspaceOwners() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let target0 = xcodeProcessTarget(processID: 618, xcodeVersion: "27.0")
+        let target1 = xcodeProcessTarget(processID: 619, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [TestUpstreamClient(), TestUpstreamClient()],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target0, upstreamIndices: [0]),
+                XcodeProcessRoute(target: target1, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (target1, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
+
+        let workspacePath = "/Work/SharedWithProxyTab.xcworkspace"
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: tab-a, workspacePath: \(workspacePath)",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: tab-b, workspacePath: \(workspacePath)",
+                    ],
+                ]),
+                upstreamIndex: 1
+            )
+        )
+
+        let proxyTabIdentifier = WindowOwnerIndex().proxyTabIdentifier(
+            processID: target1.processID,
+            rawTabIdentifier: "tab-b",
+            workspacePath: workspacePath
+        )
+        let request = toolsCallObject(
+            id: 8703,
+            name: "BuildProject",
+            arguments: [
+                "tabIdentifier": proxyTabIdentifier,
+                "workspacePath": workspacePath,
+            ]
+        )
+        #expect(manager.preferredUpstreamIndex(for: request) == 1)
+        let decision = await manager.toolRoutingDecision(
+            for: request,
+            requestTimeoutOverride: .seconds(2)
+        )
+        guard case .forwardAny(let preferredUpstreamIndices) = decision else {
+            Issue.record("expected proxy tab identifier to disambiguate duplicate workspace")
+            return
+        }
+        #expect(preferredUpstreamIndices == [1])
+    }
+
     @Test func sessionManagerSkipsUninitializedProcessRoutesDuringWindowFanout()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -8977,6 +8977,74 @@ struct RuntimeCoordinatorTests {
         #expect(preferredUpstreamIndices == [1])
     }
 
+    @Test func proxyTabIdentifierDisambiguatesRawTabCollisionWithinProcess() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let target = xcodeProcessTarget(processID: 620, xcodeVersion: "27.0")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [TestUpstreamClient()],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
+
+        let workspaceA = "/Work/RawCollisionA.xcworkspace"
+        let workspaceB = "/Work/RawCollisionB.xcworkspace"
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: reused-tab, workspacePath: \(workspaceA)\n"
+                            + "* tabIdentifier: reused-tab, workspacePath: \(workspaceB)",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+
+        let proxyTabA = WindowOwnerIndex().proxyTabIdentifier(
+            processID: target.processID,
+            rawTabIdentifier: "reused-tab",
+            workspacePath: workspaceA
+        )
+        let proxyTabB = WindowOwnerIndex().proxyTabIdentifier(
+            processID: target.processID,
+            rawTabIdentifier: "reused-tab",
+            workspacePath: workspaceB
+        )
+        #expect(proxyTabA != proxyTabB)
+        let request = toolsCallObject(
+            id: 8704,
+            name: "BuildProject",
+            arguments: [
+                "tabIdentifier": proxyTabB,
+                "workspacePath": workspaceB,
+            ]
+        )
+        #expect(manager.preferredUpstreamIndex(for: request) == 0)
+        let decision = await manager.toolRoutingDecision(
+            for: request,
+            requestTimeoutOverride: .seconds(2)
+        )
+        guard case .forwardAny(let preferredUpstreamIndices) = decision else {
+            Issue.record("expected proxy tab identifier to include workspace identity")
+            return
+        }
+        #expect(preferredUpstreamIndices == [0])
+    }
+
     @Test func sessionManagerSkipsUninitializedProcessRoutesDuringWindowFanout()
         async throws
     {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -8794,12 +8794,18 @@ struct RuntimeCoordinatorTests {
                 (
                     target0,
                     0,
-                    [ownerBoundToolDescriptor(name: "XcodeSomeWorkspaceScopedTool")]
+                    [
+                        ownerBoundToolDescriptor(name: "XcodeSomeWorkspaceScopedTool"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
                 ),
                 (
                     target1,
                     1,
-                    [ownerBoundToolDescriptor(name: "XcodeSomeWorkspaceScopedTool")]
+                    [
+                        ownerBoundToolDescriptor(name: "XcodeSomeWorkspaceScopedTool"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
                 ),
             ]
         )
@@ -8814,14 +8820,47 @@ struct RuntimeCoordinatorTests {
             ],
         ]
         #expect(manager.preferredUpstreamIndex(for: workspaceRequest) == nil)
-        let decision = await manager.toolRoutingDecision(
-            for: toolsCallObject(
-                id: 8701,
-                name: "XcodeSomeWorkspaceScopedTool",
-                arguments: ["workspacePath": workspacePath]
-            ),
-            requestTimeoutOverride: .seconds(2)
+        let refreshStart0 = await upstream0.sentCount()
+        let refreshStart1 = await upstream1.sentCount()
+        let decisionTask = Task {
+            await manager.toolRoutingDecision(
+                for: toolsCallObject(
+                    id: 8701,
+                    name: "XcodeSomeWorkspaceScopedTool",
+                    arguments: ["workspacePath": workspacePath]
+                ),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        let refreshRequest0 = try await upstream0.nextSent(
+            startingAt: refreshStart0,
+            matching: {
+                methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+            }
         )
+        await upstream0.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: refreshRequest0),
+                    message: message0
+                )
+            )
+        )
+        let refreshRequest1 = try await upstream1.nextSent(
+            startingAt: refreshStart1,
+            matching: {
+                methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+            }
+        )
+        await upstream1.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: refreshRequest1),
+                    message: message1
+                )
+            )
+        )
+        let decision = await decisionTask.value
         guard case .reject(let errors, _) = decision else {
             Issue.record("expected duplicate workspace owner to reject")
             return
@@ -8981,11 +9020,12 @@ struct RuntimeCoordinatorTests {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
         let target = xcodeProcessTarget(processID: 620, xcodeVersion: "27.0")
         let manager = RuntimeCoordinator(
             config: makeConfig(requestTimeout: 5),
             eventLoop: eventLoop,
-            upstreams: [TestUpstreamClient()],
+            upstreams: [upstream],
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: target, upstreamIndices: [0]),
             ],
@@ -8996,23 +9036,60 @@ struct RuntimeCoordinatorTests {
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
-                (target, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (
+                    target,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
             ]
         )
 
         let workspaceA = "/Work/RawCollisionA.xcworkspace"
         let workspaceB = "/Work/RawCollisionB.xcworkspace"
+        let windowsMessage = "* tabIdentifier: reused-tab, workspacePath: \(workspaceA)\n"
+            + "* tabIdentifier: reused-tab, workspacePath: \(workspaceB)"
         #expect(
             manager.recordXcodeWindowOwners(
                 from: try jsonValue([
                     "structuredContent": [
-                        "message": "* tabIdentifier: reused-tab, workspacePath: \(workspaceA)\n"
-                            + "* tabIdentifier: reused-tab, workspacePath: \(workspaceB)",
+                        "message": windowsMessage,
                     ],
                 ]),
                 upstreamIndex: 0
             )
         )
+
+        let ambiguousTask = Task {
+            await manager.toolRoutingDecision(
+                for: toolsCallObject(
+                    id: 8705,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": "reused-tab"]
+                ),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        let refreshRequest = try await upstream.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        await upstream.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: refreshRequest),
+                    message: windowsMessage
+                )
+            )
+        )
+        let ambiguousDecision = await ambiguousTask.value
+        guard case .reject(let errors, _) = ambiguousDecision else {
+            Issue.record("expected raw tab collision within one process to reject")
+            return
+        }
+        #expect(errors.map(\.id.key) == ["8705"])
+        #expect(errors.first?.message.contains("ambiguous raw Xcode tabIdentifier") == true)
 
         let proxyTabA = WindowOwnerIndex().proxyTabIdentifier(
             processID: target.processID,
@@ -9597,12 +9674,14 @@ struct RuntimeCoordinatorTests {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
         let target0 = xcodeProcessTarget(processID: 612, xcodeVersion: "27.0")
         let target1 = xcodeProcessTarget(processID: 613, xcodeVersion: "26.6")
         let manager = RuntimeCoordinator(
             config: makeConfig(requestTimeout: 5),
             eventLoop: eventLoop,
-            upstreams: [TestUpstreamClient(), TestUpstreamClient()],
+            upstreams: [upstream0, upstream1],
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: target0, upstreamIndices: [0]),
                 XcodeProcessRoute(target: target1, upstreamIndices: [1]),
@@ -9615,8 +9694,22 @@ struct RuntimeCoordinatorTests {
         try seedProcessToolCatalogs(
             on: manager,
             entries: [
-                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
-                (target1, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (
+                    target0,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+                (
+                    target1,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
             ]
         )
         #expect(
@@ -9640,14 +9733,39 @@ struct RuntimeCoordinatorTests {
             )
         )
 
-        let ambiguousDecision = await manager.toolRoutingDecision(
-            for: toolsCallObject(
-                id: 9301,
-                name: "BuildProject",
-                arguments: ["tabIdentifier": "windowtab1"]
-            ),
-            requestTimeoutOverride: .seconds(2)
+        let ambiguousTask = Task {
+            await manager.toolRoutingDecision(
+                for: toolsCallObject(
+                    id: 9301,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": "windowtab1"]
+                ),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        let refresh0 = try await upstream0.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        await upstream0.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: refresh0),
+                    message: "* tabIdentifier: windowtab1, workspacePath: /Work/A.xcworkspace"
+                )
+            )
         )
+        let refresh1 = try await upstream1.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        await upstream1.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: refresh1),
+                    message: "* tabIdentifier: windowtab1, workspacePath: /Work/B.xcworkspace"
+                )
+            )
+        )
+        let ambiguousDecision = await ambiguousTask.value
         guard case .reject(let errors, _) = ambiguousDecision else {
             Issue.record("expected raw tab-only request to reject")
             return
@@ -10751,6 +10869,124 @@ struct RuntimeCoordinatorTests {
         let decision = await task.value
         guard case .forwardAny(let preferredUpstreamIndices) = decision else {
             Issue.record("expected refreshed owner-bound request to forward")
+            return
+        }
+        #expect(preferredUpstreamIndices == [1])
+    }
+
+    @Test func ownerBoundToolRefreshesStaleWorkspaceConflictBeforeRejecting()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream0 = TestUpstreamClient()
+        let upstream1 = TestUpstreamClient()
+        let target0 = xcodeProcessTarget(processID: 632, xcodeVersion: "27.0")
+        let target1 = xcodeProcessTarget(processID: 633, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream0, upstream1],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target0, upstreamIndices: [0]),
+                XcodeProcessRoute(target: target1, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (
+                    target0,
+                    0,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+                (
+                    target1,
+                    1,
+                    [
+                        ownerBoundToolDescriptor(name: "BuildProject"),
+                        toolDescriptor(name: "XcodeListWindows"),
+                    ]
+                ),
+            ]
+        )
+
+        let workspacePath = "/Work/StaleConflict.xcworkspace"
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: stale-tab, workspacePath: \(workspacePath)",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: live-tab, workspacePath: \(workspacePath)",
+                    ],
+                ]),
+                upstreamIndex: 1
+            )
+        )
+        #expect(
+            manager.preferredUpstreamIndex(
+                for: toolsCallObject(
+                    id: 8706,
+                    name: "BuildProject",
+                    arguments: ["workspacePath": workspacePath]
+                )
+            ) == nil
+        )
+
+        let task = Task {
+            await manager.toolRoutingDecision(
+                for: toolsCallObject(
+                    id: 8706,
+                    name: "BuildProject",
+                    arguments: ["workspacePath": workspacePath]
+                ),
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+
+        let request0 = try await upstream0.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        await upstream0.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: request0),
+                    message: ""
+                )
+            )
+        )
+        let request1 = try await upstream1.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        await upstream1.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: request1),
+                    message: "* tabIdentifier: live-tab, workspacePath: \(workspacePath)"
+                )
+            )
+        )
+
+        let decision = await task.value
+        guard case .forwardAny(let preferredUpstreamIndices) = decision else {
+            Issue.record("expected stale workspace conflict to refresh before rejecting")
             return
         }
         #expect(preferredUpstreamIndices == [1])

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -8942,6 +8942,73 @@ struct RuntimeCoordinatorTests {
         #expect(preferredUpstreamIndices == [1])
     }
 
+    @Test func unusableCachedWorkspaceOwnerDoesNotConflictWithUsableOwner()
+        async throws
+    {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let unusableTarget = xcodeProcessTarget(processID: 636, xcodeVersion: "27.0")
+        let usableTarget = xcodeProcessTarget(processID: 637, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [TestUpstreamClient(), TestUpstreamClient()],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: unusableTarget, upstreamIndices: [0]),
+                XcodeProcessRoute(target: usableTarget, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (unusableTarget, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (usableTarget, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
+
+        let workspacePath = "/Work/SharedAfterUnusable.xcworkspace"
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: stale-tab, workspacePath: \(workspacePath)",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: live-tab, workspacePath: \(workspacePath)",
+                    ],
+                ]),
+                upstreamIndex: 1
+            )
+        )
+
+        let request = toolsCallObject(
+            id: 8708,
+            name: "BuildProject",
+            arguments: ["workspacePath": workspacePath]
+        )
+        #expect(manager.preferredUpstreamIndex(for: request) == 1)
+        let decision = await manager.toolRoutingDecision(
+            for: request,
+            requestTimeoutOverride: .seconds(2)
+        )
+        guard case .forwardAny(let preferredUpstreamIndices) = decision else {
+            Issue.record("expected unusable stale owner to be ignored")
+            return
+        }
+        #expect(preferredUpstreamIndices == [1])
+    }
+
     @Test func proxyTabIdentifierDisambiguatesDuplicateWorkspaceOwners() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -9941,6 +10008,25 @@ struct RuntimeCoordinatorTests {
             upstreamIndex: 0
         )
         #expect(tabIdentifier(in: rewrittenWorkspaceOnly.bodyData) == "tab-a")
+
+        let emptyTabWorkspaceRequest = toolsCallObject(
+            id: 9305,
+            name: "BuildProject",
+            arguments: [
+                "tabIdentifier": "",
+                "workspacePath": "/Work/A.xcworkspace",
+            ]
+        )
+        let emptyTabWorkspaceData = try JSONSerialization.data(
+            withJSONObject: emptyTabWorkspaceRequest,
+            options: []
+        )
+        let rewrittenEmptyTabWorkspace = manager.rewriteOwnerBoundRequest(
+            bodyData: emptyTabWorkspaceData,
+            parsedRequestJSON: emptyTabWorkspaceRequest,
+            upstreamIndex: 0
+        )
+        #expect(tabIdentifier(in: rewrittenEmptyTabWorkspace.bodyData) == "tab-a")
     }
 
     @Test func ownerHintRoutesBeforeProcessToolCatalogIsAvailable() async throws {

--- a/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
+++ b/Tests/ProxyRuntimeCoordinatorTests/RuntimeCoordinatorTests.swift
@@ -8483,7 +8483,9 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected merged XcodeListWindows structuredContent")
             return
         }
-        #expect(mergedMessage == "\(message0)\n\(message1)")
+        #expect(mergedMessage.components(separatedBy: "xcode-mcpkit:").count == 3)
+        #expect(mergedMessage.contains("/Work/A.xcworkspace"))
+        #expect(mergedMessage.contains("/Work/B.xcworkspace"))
 
         try seedProcessToolCatalogs(
             on: manager,
@@ -8611,7 +8613,8 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected XcodeListWindows structuredContent")
             return
         }
-        #expect(resultMessage == message)
+        #expect(resultMessage.contains("xcode-mcpkit:"))
+        #expect(resultMessage.contains("/Work/S.xcworkspace"))
         #expect(manager.documentationCandidateProcessIDs() == Set([target.processID]))
         try seedProcessToolCatalogs(
             on: manager,
@@ -8689,7 +8692,8 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected XcodeListWindows structuredContent")
             return
         }
-        #expect(resultMessage == message)
+        #expect(resultMessage.contains("xcode-mcpkit:"))
+        #expect(resultMessage.contains("/Work/T.xcworkspace"))
         #expect(manager.documentationCandidateProcessIDs() == Set([target.processID]))
         try seedProcessToolCatalogs(
             on: manager,
@@ -8708,7 +8712,7 @@ struct RuntimeCoordinatorTests {
         ]) != nil)
     }
 
-    @Test func sessionManagerCachesDuplicateWorkspaceOwnerByRoutePriority() async throws {
+    @Test func sessionManagerRejectsDuplicateWorkspaceOwnersAcrossProcesses() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
@@ -8781,7 +8785,8 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected merged XcodeListWindows structuredContent")
             return
         }
-        #expect(mergedMessage == "\(message0)\n\(message1)")
+        #expect(mergedMessage.components(separatedBy: "xcode-mcpkit:").count == 3)
+        #expect(mergedMessage.contains(workspacePath))
 
         try seedProcessToolCatalogs(
             on: manager,
@@ -8808,7 +8813,21 @@ struct RuntimeCoordinatorTests {
                 ],
             ],
         ]
-        #expect(manager.preferredUpstreamIndex(for: workspaceRequest) == 0)
+        #expect(manager.preferredUpstreamIndex(for: workspaceRequest) == nil)
+        let decision = await manager.toolRoutingDecision(
+            for: toolsCallObject(
+                id: 8701,
+                name: "XcodeSomeWorkspaceScopedTool",
+                arguments: ["workspacePath": workspacePath]
+            ),
+            requestTimeoutOverride: .seconds(2)
+        )
+        guard case .reject(let errors, _) = decision else {
+            Issue.record("expected duplicate workspace owner to reject")
+            return
+        }
+        #expect(errors.map(\.id.key) == ["8701"])
+        #expect(errors.first?.message.contains("conflicting Xcode window owners") == true)
     }
 
     @Test func sessionManagerSkipsUninitializedProcessRoutesDuringWindowFanout()
@@ -9359,6 +9378,238 @@ struct RuntimeCoordinatorTests {
         #expect(preferredUpstreamIndices == [0])
     }
 
+    @Test func rawTabCollisionRequiresWorkspaceDisambiguation() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let target0 = xcodeProcessTarget(processID: 612, xcodeVersion: "27.0")
+        let target1 = xcodeProcessTarget(processID: 613, xcodeVersion: "26.6")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [TestUpstreamClient(), TestUpstreamClient()],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target0, upstreamIndices: [0]),
+                XcodeProcessRoute(target: target1, upstreamIndices: [1]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target0, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+                (target1, 1, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: windowtab1, workspacePath: /Work/A.xcworkspace",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: windowtab1, workspacePath: /Work/B.xcworkspace",
+                    ],
+                ]),
+                upstreamIndex: 1
+            )
+        )
+
+        let ambiguousDecision = await manager.toolRoutingDecision(
+            for: toolsCallObject(
+                id: 9301,
+                name: "BuildProject",
+                arguments: ["tabIdentifier": "windowtab1"]
+            ),
+            requestTimeoutOverride: .seconds(2)
+        )
+        guard case .reject(let errors, _) = ambiguousDecision else {
+            Issue.record("expected raw tab-only request to reject")
+            return
+        }
+        #expect(errors.map(\.id.key) == ["9301"])
+        #expect(errors.first?.message.contains("ambiguous raw Xcode tabIdentifier") == true)
+
+        let disambiguatedDecision = await manager.toolRoutingDecision(
+            for: toolsCallObject(
+                id: 9302,
+                name: "BuildProject",
+                arguments: [
+                    "tabIdentifier": "windowtab1",
+                    "workspacePath": "/Work/B.xcworkspace",
+                ]
+            ),
+            requestTimeoutOverride: .seconds(2)
+        )
+        guard case .forwardAny(let preferredUpstreamIndices) = disambiguatedDecision else {
+            Issue.record("expected workspacePath to disambiguate raw tab")
+            return
+        }
+        #expect(preferredUpstreamIndices == [1])
+    }
+
+    @Test func workspacePathTakesPrecedenceOverRawTabFallback() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let target = xcodeProcessTarget(processID: 615, xcodeVersion: "27.0")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [TestUpstreamClient()],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target, 0, [ownerBoundToolDescriptor(name: "BuildProject")]),
+            ]
+        )
+        #expect(
+            manager.recordXcodeWindowOwners(
+                from: try jsonValue([
+                    "structuredContent": [
+                        "message": "* tabIdentifier: windowtab1, workspacePath: /Work/A.xcworkspace",
+                    ],
+                ]),
+                upstreamIndex: 0
+            )
+        )
+
+        #expect(
+            manager.preferredUpstreamIndex(
+                for: toolsCallObject(
+                    id: 9401,
+                    name: "BuildProject",
+                    arguments: ["tabIdentifier": "windowtab1"]
+                )
+            ) == 0
+        )
+        #expect(
+            manager.preferredUpstreamIndex(
+                for: toolsCallObject(
+                    id: 9402,
+                    name: "BuildProject",
+                    arguments: [
+                        "tabIdentifier": "windowtab1",
+                        "workspacePath": "/Work/Other.xcworkspace",
+                    ]
+                )
+            ) == nil
+        )
+    }
+
+    @Test func proxyTabIdentifierIsRewrittenBeforeForwarding() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(group) }
+        let eventLoop = group.next()
+        let upstream = TestUpstreamClient()
+        let target = xcodeProcessTarget(processID: 614, xcodeVersion: "27.0")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0]),
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (
+                    target,
+                    0,
+                    [
+                        toolDescriptor(name: "XcodeListWindows"),
+                        toolDescriptor(
+                            name: "BuildProject",
+                            inputProperties: [
+                                "tabIdentifier": ["type": "string"],
+                                "workspacePath": ["type": "string"],
+                            ],
+                            required: ["tabIdentifier"]
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        let task = Task {
+            try await manager.liveXcodeListWindowsResult(
+                route: .anyHealthy,
+                requestTimeoutOverride: .seconds(2)
+            )
+        }
+        let listRequest = try await upstream.nextSent {
+            methodName(from: $0) == "tools/call" && toolCallName(from: $0) == "XcodeListWindows"
+        }
+        await upstream.yield(
+            .message(
+                try makeXcodeListWindowsResponse(
+                    id: try extractUpstreamID(from: listRequest),
+                    message: "* tabIdentifier: tab-a, workspacePath: /Work/A.xcworkspace"
+                )
+            )
+        )
+        let result = try await task.value
+        guard case .object(let resultObject) = result,
+              case .object(let structuredContent)? = resultObject["structuredContent"],
+              case .string(let message)? = structuredContent["message"],
+              let proxyTab = firstTabIdentifier(in: message) else {
+            Issue.record("expected proxied XcodeListWindows tab")
+            return
+        }
+        #expect(proxyTab.hasPrefix("xcode-mcpkit:"))
+        #expect(proxyTab != "tab-a")
+
+        let proxyTabRequest = toolsCallObject(
+            id: 9303,
+            name: "BuildProject",
+            arguments: ["tabIdentifier": proxyTab]
+        )
+        let proxyTabData = try JSONSerialization.data(withJSONObject: proxyTabRequest, options: [])
+        let rewrittenProxyTab = manager.rewriteOwnerBoundRequest(
+            bodyData: proxyTabData,
+            parsedRequestJSON: proxyTabRequest,
+            upstreamIndex: 0
+        )
+        #expect(tabIdentifier(in: rewrittenProxyTab.bodyData) == "tab-a")
+
+        let workspaceOnlyRequest = toolsCallObject(
+            id: 9304,
+            name: "BuildProject",
+            arguments: ["workspacePath": "/Work/A.xcworkspace"]
+        )
+        let workspaceOnlyData = try JSONSerialization.data(
+            withJSONObject: workspaceOnlyRequest,
+            options: []
+        )
+        let rewrittenWorkspaceOnly = manager.rewriteOwnerBoundRequest(
+            bodyData: workspaceOnlyData,
+            parsedRequestJSON: workspaceOnlyRequest,
+            upstreamIndex: 0
+        )
+        #expect(tabIdentifier(in: rewrittenWorkspaceOnly.bodyData) == "tab-a")
+    }
+
     @Test func ownerHintRoutesBeforeProcessToolCatalogIsAvailable() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { shutdownAndWait(group) }
@@ -9798,7 +10049,8 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected structured XcodeListWindows message")
             return
         }
-        #expect(message.contains("tab-a"))
+        #expect(message.contains("xcode-mcpkit:"))
+        #expect(message.contains("/Work/A.xcworkspace"))
     }
 
     @Test func liveXcodeListWindowsIgnoresCatalogsFromUnavailableRoutes() async throws {
@@ -9862,7 +10114,8 @@ struct RuntimeCoordinatorTests {
             Issue.record("expected structured XcodeListWindows message")
             return
         }
-        #expect(message.contains("tab-b"))
+        #expect(message.contains("xcode-mcpkit:"))
+        #expect(message.contains("/Work/B.xcworkspace"))
     }
 
     @Test func liveXcodeListWindowsClearsOwnersForCatalogFilteredRoutes() async throws {
@@ -14586,6 +14839,27 @@ private actor AutoToolsListUpstreamClient: UpstreamSlotControlling {
     func sentCount() async -> Int {
         await sentMessages.count()
     }
+}
+
+private func firstTabIdentifier(in message: String) -> String? {
+    for line in message.split(separator: "\n") {
+        let prefix = "* tabIdentifier: "
+        guard line.hasPrefix(prefix),
+              let delimiter = line.range(of: ", workspacePath: ") else {
+            continue
+        }
+        return String(line[line.index(line.startIndex, offsetBy: prefix.count)..<delimiter.lowerBound])
+    }
+    return nil
+}
+
+private func tabIdentifier(in data: Data) -> String? {
+    guard let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+          let params = object["params"] as? [String: Any],
+          let arguments = params["arguments"] as? [String: Any] else {
+        return nil
+    }
+    return arguments["tabIdentifier"] as? String
 }
 
 private final class BlockingSequencedXcodeTargetDiscovery:


### PR DESCRIPTION
## Purpose

Route owner-bound Xcode tool calls to the Xcode process that owns the target workspace/window, even when multiple Xcode processes are running.

## Changes

- Add a window owner index keyed by workspace path, raw upstream tab ID, proxy tab ID, and Xcode process ID.
- Return proxy-global opaque tab identifiers from public `XcodeListWindows` responses while keeping the mcpbridge-compatible message shape.
- Rewrite proxy tab identifiers back to raw upstream tab identifiers immediately before forwarding to mcpbridge.
- Treat `workspacePath` as the primary routing key, reject duplicate workspace owners, and keep raw tab routing only as a unique compatibility fallback.
- Add runtime coordinator tests for duplicate workspace owners, raw tab collisions, workspace precedence, and proxy-tab rewrite behavior.

## Testing

- `git diff --check`
- `swift test --filter RuntimeCoordinatorTests -Xswiftc -strict-concurrency=minimal`
- `swift test --filter HTTPHandlerTests -Xswiftc -strict-concurrency=minimal`
- `swift test -Xswiftc -strict-concurrency=minimal`

Note: `codex-review` was intentionally not run per request.