### PR TITLE
fix(proxy): log tools for each Xcode process

### DIFF
--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -635,6 +635,21 @@ extension RuntimeCoordinator {
                     ),
                 ]
             )
+            let clientVisibleResult = toolsListResultWithConfiguredOverlay(
+                baseResult: result.rawResult,
+                metadata: [
+                    "origin": .string("process_catalog_log"),
+                    "pid": .string("\(route.target.processID)"),
+                ]
+            )
+            let summary = ToolCatalogStartupLogFormatter.summary(
+                from: clientVisibleResult,
+                process: ToolCatalogStartupLogFormatter.Process(
+                    appPath: route.target.appPath,
+                    processID: route.target.processID
+                )
+            )
+            logger.info("\(summary)")
             if let raw = snapshot.canonicalToolsCatalogRaw {
                 return CanonicalToolsCatalogLoadResult(
                     rawResult: raw,

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/RuntimeCoordinator.swift
@@ -395,7 +395,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         NIOLockedValueBox<UpstreamReadinessWaiterToken?>(nil)
     let documentationProviderDiscoveryState =
         NIOLockedValueBox(DocumentationProviderDiscoveryState())
-    let toolCatalogSummaryLoggedBox = NIOLockedValueBox(false)
+    let unboundToolCatalogSummaryLoggedBox = NIOLockedValueBox(false)
     let debugRecorder: ProxyDebugRecorder
     let leaseManager: LeaseManager
     let eventLoop: EventLoop
@@ -1085,7 +1085,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 requestTimeout: self.timeAmount(until: deadline),
                 metadata: ["origin": .string("prewarm")]
             )
-            self.logToolCatalogSummaryIfNeeded(finalResult)
+            self.logUnboundToolCatalogSummaryIfNeeded(finalResult)
         }
     }
 
@@ -1497,7 +1497,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             requestTimeout: timeAmount(until: deadline),
             metadata: ["session": .string(sessionID)]
         )
-        logToolCatalogSummaryIfNeeded(finalResult)
+        logUnboundToolCatalogSummaryIfNeeded(finalResult)
         return finalResult
     }
 
@@ -1575,8 +1575,9 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         documentationProviderManager != nil
     }
 
-    private func logToolCatalogSummaryIfNeeded(_ result: JSONValue) {
-        let shouldLog = toolCatalogSummaryLoggedBox.withLockedValue { logged in
+    private func logUnboundToolCatalogSummaryIfNeeded(_ result: JSONValue) {
+        guard processRoutingEnabled == false else { return }
+        let shouldLog = unboundToolCatalogSummaryLoggedBox.withLockedValue { logged in
             if logged {
                 return false
             }
@@ -1588,27 +1589,9 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         }
 
         let summary = ToolCatalogStartupLogFormatter.summary(
-            from: result,
-            process: toolCatalogSourceProcess(),
-            exposurePolicy: processRoutingEnabled
-                ? "available_route_catalog_surface"
-                : nil
+            from: result
         )
         logger.info("\(summary)")
-    }
-
-    private func toolCatalogSourceProcess() -> ToolCatalogStartupLogFormatter.Process? {
-        guard let upstreamIndex = processControlPlane.canonicalSourceUpstream(),
-              let route = xcodeProcessRoutes.first(where: {
-                  $0.upstreamIndices.contains(upstreamIndex)
-              })
-        else {
-            return nil
-        }
-        return ToolCatalogStartupLogFormatter.Process(
-            appPath: route.target.appPath,
-            processID: route.target.processID
-        )
     }
 
     private func toolsListResultWithDocumentationOverlay(
@@ -1616,10 +1599,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         requestTimeout _: TimeAmount?,
         metadata: Logger.Metadata
     ) async -> JSONValue {
-        guard documentationProviderManager != nil else {
-            return baseResult
-        }
-        return toolsListResultExposingProxyOwnedDocumentationSearch(
+        toolsListResultWithConfiguredOverlay(
             baseResult: baseResult,
             metadata: metadata
         )
@@ -1630,19 +1610,19 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         requestTimeout _: TimeAmount?,
         metadata: Logger.Metadata
     ) async -> JSONValue {
-        guard documentationProviderManager != nil else {
-            return baseResult
-        }
-        return toolsListResultExposingProxyOwnedDocumentationSearch(
+        toolsListResultWithConfiguredOverlay(
             baseResult: baseResult,
             metadata: metadata
         )
     }
 
-    private func toolsListResultExposingProxyOwnedDocumentationSearch(
+    func toolsListResultWithConfiguredOverlay(
         baseResult: JSONValue,
         metadata: Logger.Metadata
     ) -> JSONValue {
+        guard documentationProviderManager != nil else {
+            return baseResult
+        }
         logger.debug(
             "Applied proxy-owned DocumentationSearch tools/list overlay",
             metadata: metadata

--- a/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ToolCatalogStartupLogFormatter.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Session/Runtime/ToolCatalogStartupLogFormatter.swift
@@ -14,21 +14,19 @@ enum ToolCatalogStartupLogFormatter {
 
     static func summary(
         from result: JSONValue,
-        process: Process? = nil,
-        exposurePolicy: String? = nil
+        process: Process? = nil
     ) -> String {
         let names = toolNames(in: result)
         let details = detailsLines(for: names, indent: process == nil ? "  " : "    ")
-        let policyLines = exposurePolicy.map { ["  Exposure: \($0)"] } ?? []
 
         guard let process else {
-            return (["Tools"] + policyLines + details).joined(separator: "\n")
+            return (["Tools"] + details).joined(separator: "\n")
         }
 
         return (
             [
                 "Tools",
-            ] + policyLines + [
+            ] + [
                 "  - \(process.appPath) (PID: \(process.processID))",
             ] + details
         ).joined(separator: "\n")


### PR DESCRIPTION
## Purpose

Report the available tool catalog for every successfully attached Xcode process instead of showing only the first routed catalog.

## Changes

- Emit a process-specific tool summary after each accepted `route_activation_cataloged` transition.
- Keep the existing one-time summary only for unbound upstream mode.
- Apply the configured proxy-owned `DocumentationSearch` overlay so logged availability matches the client-visible `tools/list` surface.
- Remove the misleading exposure label that associated the combined routed catalog with one canonical process.

## Testing

- `swift test -Xswiftc -strict-concurrency=minimal`
- `scripts/check.sh`
- Codex review completed with no findings
