### PR TITLE
Parallelize release package validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,18 @@
 name: CI
 
 on:
+  workflow_call:
+    inputs:
+      concurrency_group:
+        description: Concurrency group override for callers.
+        required: false
+        type: string
+        default: ""
+      run_process_tests:
+        description: Run opt-in process integration tests.
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -17,7 +29,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ inputs.concurrency_group || format('ci-{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:
@@ -127,4 +139,50 @@ jobs:
             --skip-build \
             --no-parallel \
             --filter "${filter}" \
+            -Xswiftc -strict-concurrency=minimal
+
+  process-tests:
+    name: Process Tests (macOS, ${{ matrix.suite }})
+    if: ${{ inputs.run_process_tests }}
+    needs: package-build
+    runs-on: macos-26
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - XcodeMCPProcessRuntimeTests
+          - ProxyStdioAdapterTests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Select latest Xcode
+        id: toolchain
+        run: |
+          set -euo pipefail
+          xcode_path="$(
+            ruby -e 'candidates = Dir["/Applications/Xcode*.app"].filter_map { |path| version = File.basename(path)[/\AXcode[_-](\d+(?:\.\d+)*)\.app\z/, 1]; version ? [version.split(".").map(&:to_i), path] : nil }; abort "No versioned Xcode apps found" if candidates.empty?; puts candidates.max_by(&:first).last'
+          )"
+          sudo xcode-select -s "${xcode_path}/Contents/Developer"
+          xcodebuild -version
+          swift --version
+          cache_id="$(xcodebuild -version | tr '\n ' '--' | tr -cd '[:alnum:]._-')"
+          echo "cache-id=${cache_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore built package tests
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build
+          key: spm-build-v2-debug-strict-minimal-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.cache-id }}-${{ hashFiles('Package.swift', 'Package.resolved') }}-${{ github.sha }}
+          fail-on-cache-miss: true
+
+      - name: Run process tests
+        env:
+          XCODE_MCP_RUN_PROCESS_TESTS: "1"
+        run: |
+          ./scripts/ci-test-watchdog.sh swift test \
+            --skip-build \
+            --no-parallel \
+            --filter "${{ matrix.suite }}" \
             -Xswiftc -strict-concurrency=minimal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-release:
-    name: Build Release
-    runs-on: macos-26
-    timeout-minutes: 10
+  verify-release:
+    name: Verify Release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions:
       contents: read
-    outputs:
-      archive_sha256: ${{ steps.release_digests.outputs.archive_sha256 }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -77,6 +75,31 @@ jobs:
             echo "Existing draft release will be repaired: ${RELEASE_VERSION}"
           fi
 
+  package-checks:
+    name: Package Checks
+    needs: verify-release
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci.yml
+    with:
+      concurrency_group: release-package-checks-${{ inputs.version }}
+      run_process_tests: true
+
+  build-release:
+    name: Build Release
+    needs: package-checks
+    runs-on: macos-26
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      archive_sha256: ${{ steps.release_digests.outputs.archive_sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.sha }}
+
       - name: Select latest Xcode
         run: |
           set -euo pipefail
@@ -86,9 +109,6 @@ jobs:
           sudo xcode-select -s "${xcode_path}/Contents/Developer"
           xcodebuild -version
           swift --version
-
-      - name: Run package checks
-        run: scripts/check.sh
 
       - name: Build release binaries
         env:


### PR DESCRIPTION
## Purpose

Align release validation with the PR CI build-once, test-sharded pipeline while preserving release-only process integration coverage.

## Changes

- Expose the CI workflow through `workflow_call` with caller-scoped concurrency and optional process tests.
- Reuse the CI package build and eight test shards from the Release workflow.
- Run the two opt-in process integration suites as a release-only matrix.
- Verify release inputs before allocating macOS test runners, then build release assets only after all package checks pass.
- Preserve per-version Release concurrency so different release versions do not cancel each other.

## Testing

- `actionlint`
- `git diff --check`
- External action full-SHA pin scan
- Verified pinned action tags and Node 24 runtimes
- `codex-review` (clean after fixing a reusable-workflow concurrency collision)

Swift tests were not run locally because this is a workflow-only change. The PR CI run is not being monitored as part of this task.