### PR TITLE
Restore the full bridge pool after Xcode relaunch

### DIFF
--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
@@ -7,6 +7,7 @@ final class UpstreamHealthManager: Sendable {
     enum InitializeClaimOwner: Sendable, Hashable {
         case regular
         case processRouteActivation
+        case processBridgeRecovery
     }
 
     enum InitializeClaimPhase: Sendable, Equatable {

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -74,6 +74,17 @@ enum ProcessControlPlaneEffect: Sendable {
     case cancelTimeout(RuntimeScheduledTimeout)
     case cancelRPC(ControlPlane.RPCHandle)
     case cancelReadinessWaiter(UpstreamReadinessWaiterToken)
+    case restoreBridgePool(ProcessBridgePoolRecovery)
+}
+
+struct ProcessBridgePoolRecovery: Sendable {
+    let routeID: ProcessRouteID
+    let upstreamIDs: [UpstreamSlotID]
+}
+
+struct ProcessBridgeRecovery: Sendable {
+    let routeID: ProcessRouteID
+    let topologyProof: UpstreamTopologyProof
 }
 
 struct ProcessControlPlaneTransition: Sendable {
@@ -99,7 +110,7 @@ enum CatalogCommit: Sendable {
     case discarded(StaleCatalogReason, ProcessControlPlaneTransition)
 }
 
-/// Owns every process-route fact that participates in catalog validity.
+/// Owns each Xcode process's route identity, bridge-pool membership, and catalog validity.
 ///
 /// The lock protects only synchronous state transitions. Timers and RPC handles
 /// are detached as effects and are cancelled by `RuntimeCoordinator` after the
@@ -425,7 +436,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         }
     }
 
-    private struct RouteRecord: Sendable {
+    private struct XcodeProcessOwner: Sendable {
         let key: InstanceKey
         var route: XcodeProcessRoute
         var state: RouteState
@@ -438,6 +449,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         var catalogCooldown: Cooldown
         var admissionRevision: UInt64
         var catalogEligibilityEstablished: Bool
+        var pendingBridgeRecoveryUpstreamIDs: Set<UpstreamSlotID>
         var nextAttemptID: Int
         var attempt: Attempt?
 
@@ -480,7 +492,7 @@ final class ProcessControlPlaneAuthority: Sendable {
     }
 
     private struct State: Sendable {
-        var recordsByKey: [InstanceKey: RouteRecord] = [:]
+        var recordsByKey: [InstanceKey: XcodeProcessOwner] = [:]
         var order: [InstanceKey] = []
         var routeGeneration: UInt64 = 0
         var exposureEpoch: UInt64 = 0
@@ -519,6 +531,33 @@ final class ProcessControlPlaneAuthority: Sendable {
 
     func activeRoutes() -> [XcodeProcessRoute] {
         state.withLockedValue { state in Self.activeRoutes(in: state) }
+    }
+
+    func requestBridgePoolRecovery(
+        routeID: ProcessRouteID,
+        upstreamID: UpstreamSlotID
+    ) -> ProcessControlPlaneTransition {
+        state.withLockedValue { state in
+            guard let key = Self.key(routeID: routeID, in: state),
+                  var owner = state.recordsByKey[key],
+                  owner.state == .active,
+                  owner.route.upstreamIndices.contains(upstreamID.rawValue)
+            else {
+                return .none
+            }
+            owner.pendingBridgeRecoveryUpstreamIDs.insert(upstreamID)
+            let effects: [ProcessControlPlaneEffect]
+            if state.catalogsByProcessID[owner.route.target.processID] != nil {
+                effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
+            } else {
+                effects = []
+            }
+            state.recordsByKey[key] = owner
+            return ProcessControlPlaneTransition(
+                addedRoutes: [], retiredRoutes: [], effects: effects,
+                publishesToolsListChanged: false
+            )
+        }
     }
 
     func currentCatalogEpoch() -> CatalogEpoch {
@@ -702,6 +741,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                             effects.append(contentsOf: attempt.detachedEffects())
                             record.attempt = nil
                         }
+                        record.pendingBridgeRecoveryUpstreamIDs.removeAll()
                         Self.removeCatalog(
                             processID: record.route.target.processID,
                             from: &state
@@ -1469,6 +1509,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                 }
                 effects.append(contentsOf: record.clearAllCooldowns().effects)
                 attempt.phase = .cataloged
+                effects.append(contentsOf: Self.takeBridgePoolRecoveryEffects(owner: &record))
             case .unusable:
                 effects = attempt.loads.removeValue(forKey: lease.loadID)?
                     .detachedEffects() ?? []
@@ -1972,7 +2013,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         usableSlotCount: @Sendable (XcodeProcessRoute) -> Int
     ) -> [ProxyDebug.ProcessRouteSnapshot] {
         let records = state.withLockedValue { state in
-            state.order.compactMap { key -> (RouteRecord, Bool, UInt64)? in
+            state.order.compactMap { key -> (XcodeProcessOwner, Bool, UInt64)? in
                 guard let record = state.recordsByKey[key] else { return nil }
                 let hasCatalog = state.catalogsByProcessID[record.route.target.processID] != nil
                 return (record, hasCatalog, state.nowUptimeNs)
@@ -2089,7 +2130,7 @@ final class ProcessControlPlaneAuthority: Sendable {
             upstreamIndices: candidate.upstreamIndices
         )
         let key = InstanceKey(target: candidate.target)
-        state.recordsByKey[key] = RouteRecord(
+        state.recordsByKey[key] = XcodeProcessOwner(
             key: key,
             route: route,
             state: .active,
@@ -2104,6 +2145,7 @@ final class ProcessControlPlaneAuthority: Sendable {
             catalogEligibilityEstablished: Set(
                 route.upstreamIndices.map(UpstreamSlotID.init(rawValue:))
             ).isDisjoint(with: state.usability.recoveryAwareUsableUpstreamIDs) == false,
+            pendingBridgeRecoveryUpstreamIDs: [],
             nextAttemptID: 0,
             attempt: nil
         )
@@ -2120,7 +2162,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         activeRecords(in: state).map(\.route)
     }
 
-    private static func activeRecords(in state: State) -> [RouteRecord] {
+    private static func activeRecords(in state: State) -> [XcodeProcessOwner] {
         state.order.compactMap { key in
             guard let record = state.recordsByKey[key], record.state == .active else { return nil }
             return record
@@ -2166,9 +2208,25 @@ final class ProcessControlPlaneAuthority: Sendable {
         activeRecords(in: state).first { $0.route.id == routeID }?.key
     }
 
-    private static func record(routeID: ProcessRouteID, in state: State) -> RouteRecord? {
+    private static func record(routeID: ProcessRouteID, in state: State) -> XcodeProcessOwner? {
         guard let key = key(routeID: routeID, in: state) else { return nil }
         return state.recordsByKey[key]
+    }
+
+    private static func takeBridgePoolRecoveryEffects(
+        owner: inout XcodeProcessOwner
+    ) -> [ProcessControlPlaneEffect] {
+        guard owner.pendingBridgeRecoveryUpstreamIDs.isEmpty == false else { return [] }
+        let upstreamIDs = owner.pendingBridgeRecoveryUpstreamIDs.sorted {
+            $0.rawValue < $1.rawValue
+        }
+        owner.pendingBridgeRecoveryUpstreamIDs.removeAll()
+        return [
+            .restoreBridgePool(ProcessBridgePoolRecovery(
+                routeID: owner.route.id,
+                upstreamIDs: upstreamIDs
+            ))
+        ]
     }
 
     private static func routingSnapshot(

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -7,13 +7,25 @@ extension RuntimeCoordinator {
     enum WarmInitializeMode: Sendable {
         case regular
         case processRouteActivation(ProcessControlPlaneAuthority.ActivationReservation)
+        case processBridgeRecovery(ProcessBridgeRecovery)
 
         var readinessToken: UpstreamReadinessWaiterToken? {
             switch self {
-            case .regular:
+            case .regular, .processBridgeRecovery:
                 return nil
             case .processRouteActivation(let reservation):
                 return reservation.readinessToken
+            }
+        }
+
+        var claimOwner: UpstreamHealthManager.InitializeClaimOwner {
+            switch self {
+            case .regular:
+                return .regular
+            case .processRouteActivation:
+                return .processRouteActivation
+            case .processBridgeRecovery:
+                return .processBridgeRecovery
             }
         }
     }
@@ -390,6 +402,14 @@ extension RuntimeCoordinator {
         mode: WarmInitializeMode
     ) {
         guard isActiveProcessBoundUpstream(upstreamIndex) else { return }
+        if case .processBridgeRecovery(let recovery) = mode {
+            guard recovery.topologyProof.slotID.rawValue == upstreamIndex,
+                  upstreamTopology.operationLease(
+                    for: recovery.topologyProof.slotID
+                  )?.proof == recovery.topologyProof,
+                  xcodeProcessRoute(forUpstreamIndex: upstreamIndex)?.id == recovery.routeID
+            else { return }
+        }
         let activationStart = beginProcessRouteActivationIfNeeded(
             mode: mode,
             upstreamIndex: upstreamIndex
@@ -406,7 +426,7 @@ extension RuntimeCoordinator {
         }
         guard let initializeClaim = upstreamHealthManager.claimWarmInitialize(
             upstreamIndex: upstreamIndex,
-            owner: activationStart == nil ? .regular : .processRouteActivation
+            owner: mode.claimOwner
         ) else {
             if let activationStart {
                 applyProcessControlPlaneTransition(
@@ -448,8 +468,16 @@ extension RuntimeCoordinator {
                 operationLease: operationLease,
                 ensureRunning: true,
                 admission: nil,
-                onRejected: { [weak self] in
-                    self?.clearUpstreamState(initializeClaim: initializeClaim)
+                onRejected: { [weak self, mode] in
+                    guard let self else { return }
+                    if case .processBridgeRecovery(let recovery) = mode {
+                        self.handleProcessBridgeRecoveryChannelTimeout(
+                            recovery: recovery,
+                            initializeClaim: initializeClaim
+                        )
+                    } else {
+                        self.clearUpstreamState(initializeClaim: initializeClaim)
+                    }
                 }
             )
         } else {
@@ -478,6 +506,11 @@ extension RuntimeCoordinator {
                     lease: activationStart.lease,
                     initializeClaim: initializeClaim
                 )
+            case .processBridgeRecovery(let recovery):
+                self.handleProcessBridgeRecoveryChannelTimeout(
+                    recovery: recovery,
+                    initializeClaim: initializeClaim
+                )
             }
         }
         if case .processRouteActivation = mode {
@@ -501,7 +534,7 @@ extension RuntimeCoordinator {
         switch mode {
         case .regular:
             return MCP.MethodDispatcher.timeoutForInitialize(defaultSeconds: config.requestTimeout)
-        case .processRouteActivation:
+        case .processRouteActivation, .processBridgeRecovery:
             guard config.usesPermissionDialogAutomation else {
                 return MCP.MethodDispatcher.timeoutForInitialize(defaultSeconds: config.requestTimeout)
             }
@@ -524,5 +557,28 @@ extension RuntimeCoordinator {
             }
         }
         failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+    }
+
+    func handleProcessBridgeRecoveryChannelTimeout(
+        recovery: ProcessBridgeRecovery,
+        initializeClaim: UpstreamHealthManager.InitializeClaim
+    ) {
+        guard initializeClaim.owner == .processBridgeRecovery,
+              initializeClaim.topologyProof == recovery.topologyProof,
+              clearUpstreamState(
+                initializeClaim: initializeClaim,
+                resetsProcessRouteActivation: false,
+                replacesInitializedChannel: false
+              )
+        else { return }
+        logger.info(
+            "bridge_pool_recovery_timeout",
+            metadata: [
+                "pid": .string("\(recovery.routeID.processID)"),
+                "upstream": .string("\(initializeClaim.upstreamIndex)"),
+                "phase": .string("initialize"),
+            ]
+        )
+        _ = replaceOrRetireInitializeChannel(initializeClaim)
     }
 }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -806,15 +806,17 @@ extension RuntimeCoordinator {
         ownership: InitializeResponseOwnership,
         upstreamIndex: Int
     ) {
-        if ownership.initializeClaim.owner == .regular {
+        switch ownership.initializeClaim.owner {
+        case .regular:
             startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
+        case .processRouteActivation:
+            guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
+                  unavailableXcodeProcessIDs().contains(route.target.processID) == false
+            else { return }
+            startProcessRouteActivation(for: route)
+        case .processBridgeRecovery:
             return
         }
-        guard let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
-              unavailableXcodeProcessIDs().contains(route.target.processID) == false else {
-            return
-        }
-        startProcessRouteActivation(for: route)
     }
 
     private func hasOtherInitializeRouteInFlight(excluding upstreamIndex: Int) -> Bool {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -309,6 +309,42 @@ extension RuntimeCoordinator {
         )
     }
 
+    func restoreProcessBridgePool(_ recovery: ProcessBridgePoolRecovery) {
+        guard let route = xcodeProcessRoutes.first(where: { $0.id == recovery.routeID }) else {
+            return
+        }
+        let routeUpstreamIDs = Set(
+            route.upstreamIndices.map(UpstreamSlotID.init(rawValue:))
+        )
+        let recoveries = recovery.upstreamIDs.compactMap { upstreamID -> ProcessBridgeRecovery? in
+            guard routeUpstreamIDs.contains(upstreamID),
+                  let proof = upstreamTopology.operationLease(for: upstreamID)?.proof,
+                  let health = upstreamHealthManager.state(for: upstreamID),
+                  health.isInitialized == false,
+                  health.initInFlight == false
+            else { return nil }
+            return ProcessBridgeRecovery(routeID: recovery.routeID, topologyProof: proof)
+        }
+        guard recoveries.isEmpty == false else { return }
+        logger.info(
+            "bridge_pool_recovery_started",
+            metadata: [
+                "pid": .string("\(route.target.processID)"),
+                "upstreams": .string(
+                    recoveries.map { String($0.topologyProof.slotID.rawValue) }
+                        .joined(separator: ",")
+                ),
+            ]
+        )
+        for recovery in recoveries {
+            startUpstreamWarmInitialize(
+                upstreamIndex: recovery.topologyProof.slotID.rawValue,
+                applyBackoff: true,
+                mode: .processBridgeRecovery(recovery)
+            )
+        }
+    }
+
     func refreshPendingProcessToolsCatalogAfterWarmInitialize(upstreamIndex: Int) {
         refreshPendingProcessToolsCatalogForReadyUpstream(
             upstreamIndex: upstreamIndex,

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -204,7 +204,7 @@ extension RuntimeCoordinator {
                 "pid": .string("\(processID)"),
                 "upstream": .string("\(upstreamIndex)"),
                 "catalog_timeout_ms": .string(
-                    processRouteToolsCatalogTimeoutMillisecondsDescription()
+                    processRouteActivationCatalogTimeoutMillisecondsDescription()
                 ),
             ]
         )
@@ -239,7 +239,7 @@ extension RuntimeCoordinator {
                 "pid": .string("\(route.target.processID)"),
                 "upstream": .string("\(upstreamIndex)"),
                 "catalog_timeout_ms": .string(
-                    processRouteToolsCatalogTimeoutMillisecondsDescription()
+                    processRouteActivationCatalogTimeoutMillisecondsDescription()
                 ),
             ]
         )
@@ -387,7 +387,7 @@ extension RuntimeCoordinator {
         attempt: Int,
         initializeClaim: UpstreamHealthManager.InitializeClaim
     ) {
-        guard let timeoutAmount = processRouteToolsCatalogRequestTimeoutAmount() else {
+        guard let timeoutAmount = processRouteActivationCatalogTimeoutAmount() else {
             return
         }
         let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
@@ -407,6 +407,11 @@ extension RuntimeCoordinator {
             return
         }
         attachment.replaced?.cancel()
+    }
+
+    private func processRouteActivationCatalogTimeoutAmount() -> TimeAmount? {
+        guard config.requestTimeout > 0 else { return nil }
+        return MCP.MethodDispatcher.timeoutForControlPlane(defaultSeconds: config.requestTimeout)
     }
 
     private func handleProcessRouteActivationCatalogTimeout(
@@ -464,7 +469,7 @@ extension RuntimeCoordinator {
                 "attempt": .string("\(attempt)"),
                 "phase": .string("catalog"),
                 "timeout_ms": .string(
-                    processRouteToolsCatalogTimeoutMillisecondsDescription()
+                    processRouteActivationCatalogTimeoutMillisecondsDescription()
                 ),
                 "retry_delay_ms": .string("\(timeout.retry.delayMilliseconds)"),
             ]
@@ -478,8 +483,8 @@ extension RuntimeCoordinator {
         )
     }
 
-    private func processRouteToolsCatalogTimeoutMillisecondsDescription() -> String {
-        processRouteToolsCatalogRequestTimeoutAmount().map {
+    private func processRouteActivationCatalogTimeoutMillisecondsDescription() -> String {
+        processRouteActivationCatalogTimeoutAmount().map {
             String($0.nanoseconds / 1_000_000)
         } ?? "disabled"
     }
@@ -548,6 +553,12 @@ extension RuntimeCoordinator {
                 for unused in replacements.dropFirst() {
                     addRuntimeTask { await unused.stop() }
                 }
+                applyProcessControlPlaneTransition(
+                    processControlPlane.requestBridgePoolRecovery(
+                        routeID: route.id,
+                        upstreamID: replacementLease.proof.slotID
+                    )
+                )
                 return true
             }
             for unused in replacements {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
@@ -1082,6 +1082,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 handle.cancel()
             case .cancelReadinessWaiter(let token):
                 cancelUpstreamReadinessWaiter(token)
+            case .restoreBridgePool(let recovery):
+                restoreProcessBridgePool(recovery)
             }
         }
         if transition.publishesToolsListChanged {

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -47,6 +47,57 @@ struct ControlPlaneAuthorityTests {
         #expect(snapshot.canonicalSourceUpstream == 0)
     }
 
+    @Test func bridgeRecoveryWaitsForCatalogAndThenUsesProcessOwnerEffect() throws {
+        let target = xcodeProcessTarget(processID: 41031, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+
+        let pending = authority.requestBridgePoolRecovery(
+            routeID: route.id,
+            upstreamID: UpstreamSlotID(rawValue: 0)
+        )
+        #expect(pending.effects.isEmpty)
+
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: testTopologyProof(1),
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: testTopologyProof(1)),
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ) else {
+            Issue.record("expected sibling catalog to be accepted")
+            return
+        }
+        let deferredEffect = try #require(catalogTransition.effects.first { effect in
+            if case .restoreBridgePool = effect { return true }
+            return false
+        })
+        guard case .restoreBridgePool(let deferredRecovery) = deferredEffect else {
+            Issue.record("expected deferred bridge recovery effect")
+            return
+        }
+        #expect(deferredRecovery.routeID == route.id)
+        #expect(deferredRecovery.upstreamIDs == [UpstreamSlotID(rawValue: 0)])
+
+        let immediate = authority.requestBridgePoolRecovery(
+            routeID: route.id,
+            upstreamID: UpstreamSlotID(rawValue: 0)
+        )
+        let immediateEffect = try #require(immediate.effects.first { effect in
+            if case .restoreBridgePool = effect { return true }
+            return false
+        })
+        guard case .restoreBridgePool(let immediateRecovery) = immediateEffect else {
+            Issue.record("expected immediate bridge recovery effect")
+            return
+        }
+        #expect(immediateRecovery.routeID == route.id)
+        #expect(immediateRecovery.upstreamIDs == [UpstreamSlotID(rawValue: 0)])
+    }
+
     @Test func routeMembershipChangeInvalidatesLeaseAndCatalogTogether() throws {
         let target = xcodeProcessTarget(processID: 41002, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0])])

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
@@ -2574,6 +2574,19 @@ final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
         }
     }
 
+    func activeTimeoutIndex(
+        delay: TimeAmount,
+        startingAt startIndex: Int = 0
+    ) -> Int? {
+        operations.withLockedValue { operations in
+            guard startIndex <= operations.count else { return nil }
+            return operations.indices[startIndex...].first { index in
+                operations[index].isCancelled == false
+                    && operations[index].delay.nanoseconds == delay.nanoseconds
+            }
+        }
+    }
+
     @discardableResult
     func fire(at index: Int) -> Bool {
         let operation: (@Sendable () -> Void)? = operations.withLockedValue { operations in

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -532,12 +532,16 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(5).nanoseconds)
         #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.seconds(5).nanoseconds)
         #expect(timeoutScheduler.fire(at: 1))
-        #expect(timeoutScheduler.scheduledCount() == 3)
 
         let replacement = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
         #expect(try await upstream.nextStopCount() == 1)
-        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
-        #expect(timeoutScheduler.fire(at: 2))
+        let retryTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(
+                delay: .milliseconds(250),
+                startingAt: 2
+            )
+        )
+        #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
         _ = try await replacement.nextSent(at: 0)
 
         timeoutScheduler.fire(at: 0)
@@ -574,10 +578,56 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
     }
 
-    @Test func processRouteActivationCatalogTimeoutReplacesSlotAndDropsStaleCatalog()
+    @Test func processRouteActivationPreservesDisabledCatalogTimeout() async throws {
+        var config = makeConfig(requestTimeout: 0)
+        config.usesPermissionDialogAutomation = true
+        let target = xcodeProcessTarget(processID: 27025, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: config,
+            upstreams: [],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let upstream = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(upstream) }
+                return [upstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+
+        fixture.manager.reconcileXcodeProcessTargets(
+            [target],
+            reason: "test_disabled_catalog_timeout"
+        )
+        let upstream = try #require(createdUpstreams.withLockedValue { $0.first })
+        let initialize = try await sentValue(
+            from: upstream,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for activation initialize"
+        )
+        await upstream.yield(
+            .message(try makeInitializeResponse(id: try extractUpstreamID(from: initialize)))
+        )
+        _ = try await sentValue(
+            from: upstream,
+            startingAt: 1,
+            matching: { methodName(from: $0) == "tools/list" },
+            description: "waiting for activation catalog"
+        )
+
+        #expect(timeoutScheduler.scheduledCount() == 1)
+        #expect(timeoutScheduler.delay(at: 0)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
+        #expect(timeoutScheduler.isCancelled(at: 0))
+    }
+
+    @Test func processRouteActivationCatalogTimeoutStaysBoundedAndReplacesSlot()
         async throws
     {
-        var config = makeConfig(requestTimeout: 20)
+        var config = makeConfig(requestTimeout: 300)
         config.usesPermissionDialogAutomation = true
         let olderUpstream = TestUpstreamClient()
         let olderTarget = xcodeProcessTarget(processID: 26626, xcodeVersion: "26.6")
@@ -660,7 +710,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
 
         #expect(timeoutScheduler.scheduledCount() == 3)
         #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
-        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.seconds(20).nanoseconds)
+        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.seconds(10).nanoseconds)
         #expect(timeoutScheduler.fire(at: 2))
         #expect(
             try await waitWithTimeout(
@@ -669,14 +719,18 @@ struct RuntimeCoordinatorProcessRoutingTests {
             ) {
                 try await firstAttempt.nextStopCount()
             } == 1)
-        #expect(timeoutScheduler.scheduledCount() == 4)
-        #expect(timeoutScheduler.delay(at: 3)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
         #expect(createdUpstreams.withLockedValue(\.count) == 2)
 
-        #expect(timeoutScheduler.fire(at: 3))
         let retryAttempt = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
+        let retryTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(
+                delay: .milliseconds(250),
+                startingAt: 3
+            )
+        )
+        #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
         let retryInitialize = try await waitWithTimeout(
-            "waiting for retry activation initialize",
+            "waiting for activation retry initialize",
             timeout: .seconds(2)
         ) {
             try await retryAttempt.nextSent(at: 0)
@@ -743,6 +797,212 @@ struct RuntimeCoordinatorProcessRoutingTests {
                     olderTarget.processID,
                     newerTarget.processID,
                 ]))
+    }
+
+    @Test func processOwnerRestoresTimedOutBridgeWhenSiblingCatalogWins()
+        async throws
+    {
+        var config = makeConfig(requestTimeout: 300)
+        config.usesPermissionDialogAutomation = true
+        let existingUpstream = TestUpstreamClient()
+        let existingTarget = xcodeProcessTarget(processID: 26627, xcodeVersion: "26.6")
+        let recoveringTarget = xcodeProcessTarget(processID: 27027, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let readiness = ReadinessFlag(isReady: true)
+        let readinessSleep = ControlledReadinessSleep()
+        let createdPools = NIOLockedValueBox<[[TestUpstreamClient]]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: config,
+            upstreams: [existingUpstream],
+            upstreamReadinessGate: makeTestReadinessGate(
+                readiness: readiness,
+                sleepRecorder: readinessSleep
+            ),
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: existingTarget, upstreamIndices: [0])
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let pool = [TestUpstreamClient(), TestUpstreamClient()]
+                createdPools.withLockedValue { $0.append(pool) }
+                return pool
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+                "serverInfo": ["name": "cached-source"],
+            ]),
+            sourceUpstream: 0
+        )
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (existingTarget, 0, [toolDescriptor(name: "Only26")])
+            ]
+        )
+
+        manager.reconcileXcodeProcessTargets(
+            [existingTarget, recoveringTarget],
+            reason: "test_two_bridge_owner_recovery"
+        )
+        let initialPool = try #require(createdPools.withLockedValue { $0.first })
+        let activationUpstream = initialPool[0]
+        let siblingUpstream = initialPool[1]
+        let activationInitialize = try await sentValue(
+            from: activationUpstream,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for activation bridge initialize"
+        )
+        let siblingInitialize = try await sentValue(
+            from: siblingUpstream,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for sibling bridge initialize"
+        )
+        await activationUpstream.yield(
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: activationInitialize),
+                    serverName: "recovering"
+                ))
+        )
+        await siblingUpstream.yield(
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: siblingInitialize),
+                    serverName: "recovering"
+                ))
+        )
+        _ = try await sentValue(
+            from: activationUpstream,
+            startingAt: 1,
+            matching: { methodName(from: $0) == "tools/list" },
+            description: "waiting for activation bridge catalog"
+        )
+        let catalogTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(delay: .seconds(10))
+        )
+        #expect(timeoutScheduler.fire(at: catalogTimeoutIndex))
+        let replacementPool = try #require(createdPools.withLockedValue { $0.dropFirst().first })
+        let replacementUpstream = replacementPool[0]
+        #expect(try await activationUpstream.nextStopCount() == 1)
+        #expect(await replacementUpstream.sentCount() == 0)
+        let retryTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(delay: .milliseconds(250))
+        )
+
+        let siblingCatalogStartIndex = await siblingUpstream.sentCount()
+        manager.refreshPendingProcessToolsCatalogForReadyUpstream(
+            upstreamIndex: 2,
+            reason: "test_sibling_catalog_wins"
+        )
+        let siblingCatalog = try await sentValue(
+            from: siblingUpstream,
+            startingAt: siblingCatalogStartIndex,
+            matching: { methodName(from: $0) == "tools/list" },
+            description: "waiting for sibling bridge catalog"
+        )
+        await siblingUpstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: siblingCatalog),
+                    tools: [toolDescriptor(name: "Only27")]
+                ))
+        )
+
+        _ = try await waitWithTimeout(
+            "waiting for sibling catalog to win",
+            timeout: .seconds(2)
+        ) {
+            try await manager.controlPlaneDebugMirror.waitForSnapshot {
+                $0.canonicalToolsSourceUpstream == 2
+            }
+        }
+        #expect(await replacementUpstream.sentCount() == 0)
+        #expect(timeoutScheduler.isCancelled(at: retryTimeoutIndex))
+        #expect(timeoutScheduler.fire(at: retryTimeoutIndex) == false)
+
+        let recoveryBackoff = try await waitWithTimeout(
+            "waiting for bridge-pool recovery backoff",
+            timeout: .seconds(2)
+        ) {
+            try await readinessSleep.nextSleep(at: 0)
+        }
+        #expect(recoveryBackoff == 1_000_000_000)
+        #expect(await replacementUpstream.sentCount() == 0)
+        let firstRecoveryTimeoutSearchIndex = timeoutScheduler.scheduledCount()
+        await readinessSleep.resumeNext()
+        let replacementInitialize = try await sentValue(
+            from: replacementUpstream,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for process owner to restore replacement bridge"
+        )
+        let recoveryTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(
+                delay: .seconds(3),
+                startingAt: firstRecoveryTimeoutSearchIndex
+            )
+        )
+        #expect(timeoutScheduler.fire(at: recoveryTimeoutIndex))
+        #expect(try await replacementUpstream.nextStopCount() == 1)
+
+        let secondReplacementPool = try #require(
+            createdPools.withLockedValue { $0.dropFirst(2).first }
+        )
+        let secondReplacementUpstream = secondReplacementPool[0]
+        let secondRecoveryBackoff = try await waitWithTimeout(
+            "waiting for repeated bridge-pool recovery backoff",
+            timeout: .seconds(2)
+        ) {
+            try await readinessSleep.nextSleep(at: 1)
+        }
+        #expect(secondRecoveryBackoff == 2_000_000_000)
+        #expect(await secondReplacementUpstream.sentCount() == 0)
+
+        await readinessSleep.resumeNext()
+        let secondReplacementInitialize = try await sentValue(
+            from: secondReplacementUpstream,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for repeated process-owner bridge recovery"
+        )
+        await secondReplacementUpstream.yield(
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: secondReplacementInitialize),
+                    serverName: "recovering"
+                ))
+        )
+        _ = try await sentValue(
+            from: secondReplacementUpstream,
+            startingAt: 1,
+            matching: { methodName(from: $0) == "notifications/initialized" },
+            description: "waiting for replacement bridge initialized notification"
+        )
+        #expect(await replacementUpstream.sentCount() == 1)
+        await manager.drainRuntimeTasksForTesting()
+
+        let route = try #require(
+            manager.debugSnapshot().processRoutes.first {
+                $0.processID == recoveringTarget.processID
+            }
+        )
+        #expect(route.upstreamIndices == [1, 2])
+        #expect(route.usableSlotCount == 2)
+        #expect(
+            manager.processControlPlane.catalog(forProcessID: recoveringTarget.processID)?
+                .upstreamIndex == 2
+        )
     }
 
     @Test func processRouteActivationEmptyCatalogRetryPreservesCatalogTimeout()
@@ -824,10 +1084,8 @@ struct RuntimeCoordinatorProcessRoutingTests {
             )
         }
         let catalogTimeoutIndex = try #require(
-            (0..<timeoutScheduler.scheduledCount()).first {
-                timeoutScheduler.delay(at: $0)?.nanoseconds == TimeAmount.seconds(20).nanoseconds
-                    && timeoutScheduler.isCancelled(at: $0) == false
-            })
+            timeoutScheduler.activeTimeoutIndex(delay: .seconds(10))
+        )
 
         let retryScheduleIndex = timeoutScheduler.scheduledCount()
         await activationUpstream.yield(
@@ -2091,7 +2349,6 @@ struct RuntimeCoordinatorProcessRoutingTests {
         _ = try await newerUpstream.nextSent(at: 0)
         #expect(timeoutScheduler.scheduledCount() == 2)
         #expect(timeoutScheduler.fire(at: 1))
-        #expect(timeoutScheduler.scheduledCount() == 3)
         #expect(try await newerUpstream.nextStopCount() == 1)
         let pendingSnapshot = manager.debugSnapshot()
         #expect(
@@ -2101,18 +2358,27 @@ struct RuntimeCoordinatorProcessRoutingTests {
             ])
 
         let replacementUpstream = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
-        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
+        let retryTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(
+                delay: .milliseconds(250),
+                startingAt: 2
+            )
+        )
+        let scheduledBeforeReconcile = timeoutScheduler.scheduledCount()
         manager.reconcileXcodeProcessTargets(
             [olderTarget, newerTarget],
             reason: "test_spurious_reconcile_before_activation_retry"
         )
         await manager.drainRuntimeTasksForTesting()
-        #expect(timeoutScheduler.scheduledCount() == 3)
+        #expect(timeoutScheduler.scheduledCount() == scheduledBeforeReconcile)
         #expect(await replacementUpstream.sentCount() == 0)
-        #expect(timeoutScheduler.fire(at: 2))
-        let retriedInitialize = try await replacementUpstream.nextSent(at: 0)
+        #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
+        let replacementInitialize = try await replacementUpstream.nextSent(at: 0)
         await replacementUpstream.yield(
-            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retriedInitialize)))
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: replacementInitialize)
+                ))
         )
         _ = try await replacementUpstream.nextSent(at: 1)
         let toolsRequest = try await replacementUpstream.nextSent(
@@ -2181,18 +2447,25 @@ struct RuntimeCoordinatorProcessRoutingTests {
 
         #expect(timeoutScheduler.scheduledCount() == 2)
         #expect(timeoutScheduler.fire(at: 1))
-        #expect(timeoutScheduler.scheduledCount() == 3)
         #expect(try await upstream.nextStopCount() == 1)
         #expect(manager.testStateSnapshot().hasInitResult == false)
 
         let replacement = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
-        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.milliseconds(250).nanoseconds)
-        #expect(timeoutScheduler.fire(at: 2))
-        let retriedInitialize = try await replacement.nextSent(at: 0)
-        #expect(methodName(from: retriedInitialize) == "initialize")
+        let retryTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(
+                delay: .milliseconds(250),
+                startingAt: 2
+            )
+        )
+        #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
+        let replacementInitialize = try await replacement.nextSent(at: 0)
+        #expect(methodName(from: replacementInitialize) == "initialize")
 
         await replacement.yield(
-            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retriedInitialize)))
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: replacementInitialize)
+                ))
         )
         let initializedNotification = try await replacement.nextSent(at: 1)
         #expect(methodName(from: initializedNotification) == "notifications/initialized")
@@ -2430,6 +2703,42 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(await oldUpstream.sentCount() == oldSentCountAfterRetire)
     }
 
+    @Test func processOwnerRetiresEveryBridgeWhenXcodeCrashes() async throws {
+        let oldBridges = [TestUpstreamClient(), TestUpstreamClient()]
+        let oldTarget = xcodeProcessTarget(processID: 26652, xcodeVersion: "26.6")
+        let relaunchedTarget = xcodeProcessTarget(processID: 26653, xcodeVersion: "26.6")
+        let createdPools = NIOLockedValueBox<[[TestUpstreamClient]]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: oldBridges,
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: oldTarget, upstreamIndices: [0, 1])
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let pool = [TestUpstreamClient(), TestUpstreamClient()]
+                createdPools.withLockedValue { $0.append(pool) }
+                return pool
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+
+        fixture.manager.reconcileXcodeProcessTargets(
+            [relaunchedTarget],
+            reason: "test_xcode_owner_relaunch"
+        )
+
+        #expect(try await oldBridges[0].nextStopCount() == 1)
+        #expect(try await oldBridges[1].nextStopCount() == 1)
+        #expect(createdPools.withLockedValue(\.count) == 1)
+        let routes = fixture.manager.debugSnapshot().processRoutes
+        #expect(routes.first { $0.processID == oldTarget.processID }?.state == "retired")
+        #expect(
+            routes.first { $0.processID == relaunchedTarget.processID }?.upstreamIndices
+                == [2, 3]
+        )
+    }
+
     @Test func processRoutingRetriesRelaunchedProcessCatalogAfterWorkspaceBecomesReady()
         async throws
     {
@@ -2521,11 +2830,8 @@ struct RuntimeCoordinatorProcessRoutingTests {
             return
         }
         let retryIndex = try #require(
-            (0..<timeoutScheduler.scheduledCount()).first {
-                timeoutScheduler.delay(at: $0)?.nanoseconds
-                    == TimeAmount.milliseconds(250).nanoseconds
-                    && timeoutScheduler.isCancelled(at: $0) == false
-            })
+            timeoutScheduler.activeTimeoutIndex(delay: .milliseconds(250))
+        )
         #expect(timeoutScheduler.fire(at: retryIndex))
         let readyCatalogRequest = try await relaunchedUpstream.nextSent(
             startingAt: 3,
@@ -2685,10 +2991,8 @@ struct RuntimeCoordinatorProcessRoutingTests {
         }
 
         let catalogTimeoutIndex = try #require(
-            (0..<timeoutScheduler.scheduledCount()).first {
-                timeoutScheduler.delay(at: $0)?.nanoseconds == TimeAmount.seconds(20).nanoseconds
-                    && timeoutScheduler.isCancelled(at: $0) == false
-            })
+            timeoutScheduler.activeTimeoutIndex(delay: .seconds(10))
+        )
         let scheduledBeforeCatalogTimeout = timeoutScheduler.scheduledCount()
         #expect(timeoutScheduler.fire(at: catalogTimeoutIndex))
         #expect(
@@ -2702,12 +3006,21 @@ struct RuntimeCoordinatorProcessRoutingTests {
             manager.unavailableXcodeProcessIDs().contains(
                 relaunched26Target.processID
             ) == false)
-        #expect(timeoutScheduler.scheduledCount() == scheduledBeforeCatalogTimeout + 1)
-        #expect(
-            timeoutScheduler.delay(at: scheduledBeforeCatalogTimeout)?.nanoseconds
-                == TimeAmount.milliseconds(250).nanoseconds
-        )
         #expect(createdUpstreams.withLockedValue(\.count) == 2)
+        let retryTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(
+                delay: .milliseconds(250),
+                startingAt: scheduledBeforeCatalogTimeout
+            )
+        )
+        let retryAttempt = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
+        #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
+        let retryInitialize = try await waitWithTimeout(
+            "waiting for activation-retried relaunched 26 initialize",
+            timeout: .seconds(2)
+        ) {
+            try await retryAttempt.nextSent(at: 0)
+        }
 
         await firstAttempt.yield(
             .message(
@@ -2724,14 +3037,6 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 forProcessID: relaunched26Target.processID
             ) == nil)
 
-        #expect(timeoutScheduler.fire(at: scheduledBeforeCatalogTimeout))
-        let retryAttempt = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
-        let retryInitialize = try await waitWithTimeout(
-            "waiting for relaunched 26 retry initialize",
-            timeout: .seconds(2)
-        ) {
-            try await retryAttempt.nextSent(at: 0)
-        }
         let catalogCommitIndex = catalogCommits.count()
         await retryAttempt.yield(
             .message(


### PR DESCRIPTION
## Purpose

Fix proxy recovery after Xcode crashes or relaunches when multiple `mcpbridge` processes are configured for one Xcode process. Previously, a sibling bridge completing catalog discovery could cancel the shared route retry and leave a replaced bridge uninitialized.

## Changes

- Make each Xcode process the owner of its route identity, bridge-pool membership, catalog validity, and pending exact bridge recovery.
- Preserve pending bridge recovery until the route has a valid catalog, then recover each missing bridge independently of shared route activation.
- Replace and retry the exact proof-bound bridge when recovery initialization times out.
- Keep recovery initialization bounded without starting a long `tools/list` refresh, while preserving disabled timeout behavior for `requestTimeout=0`.
- Retire every bridge owned by an Xcode process when that process exits.
- Add deterministic regression coverage using injected timeout scheduling and controlled readiness sleep instead of wall-clock waits.

## Testing

- `swift test -q --filter ControlPlaneAuthorityTests`
- `swift test -q --filter RuntimeCoordinatorProcessRoutingTests`
- `scripts/check.sh`
- Codex self-review completed with no actionable findings
