### PR TITLE
Stabilize runtime recovery tests

### DIFF
--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
@@ -228,6 +228,10 @@ extension RuntimeCoordinator {
         await runtimeTasks.waitUntilIdle()
     }
 
+    func drainControlPlaneLoadsForTesting() async {
+        await controlPlaneCoordinator.drainLoadsForTesting()
+    }
+
     func seedCanonicalToolsCatalog(_ result: JSONValue, sourceUpstream: Int) {
         do {
             let source = UpstreamSlotID(rawValue: sourceUpstream)
@@ -594,6 +598,17 @@ func seedProcessToolCatalogs(
                 nowUptimeNanoseconds: manager.nowUptimeNanoseconds()
             )
         )
+    }
+}
+
+extension ControlPlaneCoordinator {
+    func drainLoadsForTesting() async {
+        while completionTasks.isEmpty == false {
+            let tasks = Array(completionTasks.values)
+            for task in tasks {
+                await task.value
+            }
+        }
     }
 }
 
@@ -2583,6 +2598,21 @@ final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
             return operations.indices[startIndex...].first { index in
                 operations[index].isCancelled == false
                     && operations[index].delay.nanoseconds == delay.nanoseconds
+            }
+        }
+    }
+
+    func nextActiveTimeoutIndex(
+        delay: TimeAmount,
+        startingAt startIndex: Int = 0
+    ) async throws -> Int {
+        var scheduledValueIndex = startIndex
+        while true {
+            let operationIndex = try await nextScheduled(at: scheduledValueIndex)
+            scheduledValueIndex += 1
+            if isCancelled(at: operationIndex) == false,
+               self.delay(at: operationIndex)?.nanoseconds == delay.nanoseconds {
+                return operationIndex
             }
         }
     }

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
@@ -2571,6 +2571,10 @@ final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
         operations.withLockedValue(\.count)
     }
 
+    func scheduledEventCount() -> Int {
+        scheduledIndices.count()
+    }
+
     func nextScheduled(at index: Int) async throws -> Int {
         try await scheduledIndices.nextValue(at: index)
     }
@@ -2604,7 +2608,7 @@ final class RecordingRuntimeTimeoutScheduler: @unchecked Sendable {
 
     func nextActiveTimeoutIndex(
         delay: TimeAmount,
-        startingAt startIndex: Int = 0
+        startingAtEventIndex startIndex: Int = 0
     ) async throws -> Int {
         var scheduledValueIndex = startIndex
         while true {

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -868,7 +868,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
             matching: { methodName(from: $0) == "initialize" },
             description: "waiting for sibling bridge initialize"
         )
-        let catalogTimeoutSearchIndex = timeoutScheduler.scheduledCount()
+        let catalogTimeoutSearchIndex = timeoutScheduler.scheduledEventCount()
         await activationUpstream.yield(
             .message(
                 try makeInitializeResponse(
@@ -895,7 +895,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
         ) {
             try await timeoutScheduler.nextActiveTimeoutIndex(
                 delay: .seconds(10),
-                startingAt: catalogTimeoutSearchIndex
+                startingAtEventIndex: catalogTimeoutSearchIndex
             )
         }
         #expect(timeoutScheduler.fire(at: catalogTimeoutIndex))
@@ -946,7 +946,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
         }
         #expect(recoveryBackoff == 1_000_000_000)
         #expect(await replacementUpstream.sentCount() == 0)
-        let firstRecoveryTimeoutSearchIndex = timeoutScheduler.scheduledCount()
+        let firstRecoveryTimeoutSearchIndex = timeoutScheduler.scheduledEventCount()
         await readinessSleep.resumeNext()
         _ = try await sentValue(
             from: replacementUpstream,
@@ -960,7 +960,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
         ) {
             try await timeoutScheduler.nextActiveTimeoutIndex(
                 delay: .seconds(3),
-                startingAt: firstRecoveryTimeoutSearchIndex
+                startingAtEventIndex: firstRecoveryTimeoutSearchIndex
             )
         }
         #expect(timeoutScheduler.fire(at: recoveryTimeoutIndex))
@@ -1097,7 +1097,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
             timeoutScheduler.activeTimeoutIndex(delay: .seconds(10))
         )
 
-        let retryScheduleIndex = timeoutScheduler.scheduledCount()
+        let retryScheduleIndex = timeoutScheduler.scheduledEventCount()
         await activationUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -868,6 +868,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
             matching: { methodName(from: $0) == "initialize" },
             description: "waiting for sibling bridge initialize"
         )
+        let catalogTimeoutSearchIndex = timeoutScheduler.scheduledCount()
         await activationUpstream.yield(
             .message(
                 try makeInitializeResponse(
@@ -888,9 +889,15 @@ struct RuntimeCoordinatorProcessRoutingTests {
             matching: { methodName(from: $0) == "tools/list" },
             description: "waiting for activation bridge catalog"
         )
-        let catalogTimeoutIndex = try #require(
-            timeoutScheduler.activeTimeoutIndex(delay: .seconds(10))
-        )
+        let catalogTimeoutIndex = try await waitWithTimeout(
+            "waiting for activation catalog timeout registration",
+            timeout: .seconds(2)
+        ) {
+            try await timeoutScheduler.nextActiveTimeoutIndex(
+                delay: .seconds(10),
+                startingAt: catalogTimeoutSearchIndex
+            )
+        }
         #expect(timeoutScheduler.fire(at: catalogTimeoutIndex))
         let replacementPool = try #require(createdPools.withLockedValue { $0.dropFirst().first })
         let replacementUpstream = replacementPool[0]
@@ -941,18 +948,21 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(await replacementUpstream.sentCount() == 0)
         let firstRecoveryTimeoutSearchIndex = timeoutScheduler.scheduledCount()
         await readinessSleep.resumeNext()
-        let replacementInitialize = try await sentValue(
+        _ = try await sentValue(
             from: replacementUpstream,
             startingAt: 0,
             matching: { methodName(from: $0) == "initialize" },
             description: "waiting for process owner to restore replacement bridge"
         )
-        let recoveryTimeoutIndex = try #require(
-            timeoutScheduler.activeTimeoutIndex(
+        let recoveryTimeoutIndex = try await waitWithTimeout(
+            "waiting for bridge recovery timeout registration",
+            timeout: .seconds(2)
+        ) {
+            try await timeoutScheduler.nextActiveTimeoutIndex(
                 delay: .seconds(3),
                 startingAt: firstRecoveryTimeoutSearchIndex
             )
-        )
+        }
         #expect(timeoutScheduler.fire(at: recoveryTimeoutIndex))
         #expect(try await replacementUpstream.nextStopCount() == 1)
 
@@ -5709,6 +5719,9 @@ struct RuntimeCoordinatorRecoveryTests {
             try await manager.controlPlaneDebugMirror.waitForSnapshot {
                 $0.waiterCounts.toolsCatalog == 0 && $0.inFlightControlPlaneRequests.isEmpty
             }
+        }
+        _ = try await waitWithTimeout("waiting for timed-out tools/list request cleanup") {
+            await manager.drainControlPlaneLoadsForTesting()
         }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
 


### PR DESCRIPTION
## Purpose

Fix deterministic races exposed by the failing main CI run, where tests observed scheduler and request-correlation state before the owning async tasks had reached their terminal state.

Related run: https://github.com/lynnswap/XcodeMCPKit/actions/runs/29329773634

## Changes

- Wait for timeout registration through the recording scheduler's event stream instead of taking an immediate snapshot.
- Add a test-only ControlPlane drain seam so correlation cleanup assertions run after load completion tasks finish.
- Keep wall-clock timeouts only as fail-fast bounds; test sequencing is driven by owner events and completion.
- Leave production runtime behavior unchanged.

## Testing

- Repeated both previously failing tests 30 times each with Xcode 26.5 / Swift 6.3.2.
- Passed `RuntimeCoordinatorProcessRoutingTests` (51 tests).
- Passed `RuntimeCoordinatorRecoveryTests` (41 tests).
- Passed `RuntimeCoordinatorWindowRoutingTests` (44 tests).
- Passed `scripts/check.sh`.
- Passed Codex self-review with no findings.