### PR TITLE
Fix delayed Xcode process attachment retry

### DIFF
--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -267,6 +267,11 @@ final class ProcessControlPlaneAuthority: Sendable {
         var attempt: Int { lease.attemptID.rawValue }
     }
 
+    struct ChannelInitializedAttempt: Sendable {
+        let attempt: Int
+        let shouldStartCatalogLoad: Bool
+    }
+
     struct Retry: Sendable {
         let attempt: Int
         let delay: TimeAmount
@@ -1245,20 +1250,24 @@ final class ProcessControlPlaneAuthority: Sendable {
     func markChannelInitialized(
         routeID: ProcessRouteID,
         upstreamProof: UpstreamTopologyProof
-    ) -> Int? {
+    ) -> ChannelInitializedAttempt? {
         state.withLockedValue { state in
             guard let key = Self.key(routeID: routeID, in: state),
                   var record = state.recordsByKey[key],
                   var attempt = record.attempt,
                   attempt.upstreamProof == upstreamProof,
                   [.attaching, .loadingCatalog].contains(attempt.phase) else { return nil }
+            let shouldStartCatalogLoad = attempt.phase == .attaching
             attempt.retryKind = nil
-            if attempt.phase == .attaching {
+            if shouldStartCatalogLoad {
                 attempt.phase = .initialized
             }
             record.attempt = attempt
             state.recordsByKey[key] = record
-            return attempt.id.rawValue
+            return ChannelInitializedAttempt(
+                attempt: attempt.id.rawValue,
+                shouldStartCatalogLoad: shouldStartCatalogLoad
+            )
         }
     }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -1251,9 +1251,11 @@ final class ProcessControlPlaneAuthority: Sendable {
                   var record = state.recordsByKey[key],
                   var attempt = record.attempt,
                   attempt.upstreamProof == upstreamProof,
-                  attempt.phase == .attaching else { return nil }
+                  [.attaching, .loadingCatalog].contains(attempt.phase) else { return nil }
             attempt.retryKind = nil
-            attempt.phase = .initialized
+            if attempt.phase == .attaching {
+                attempt.phase = .initialized
+            }
             record.attempt = attempt
             state.recordsByKey[key] = record
             return attempt.id.rawValue

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -229,7 +229,7 @@ extension RuntimeCoordinator {
         guard let upstreamProof = initializeClaim.topologyProof,
               upstreamProof.slotID.rawValue == upstreamIndex,
               let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
-              let attempt = processControlPlane.markChannelInitialized(
+              let initialized = processControlPlane.markChannelInitialized(
                   routeID: route.id,
                   upstreamProof: upstreamProof
               ) else { return }
@@ -266,9 +266,10 @@ extension RuntimeCoordinator {
         scheduleProcessRouteActivationCatalogTimeout(
             processID: route.target.processID,
             upstreamIndex: upstreamIndex,
-            attempt: attempt,
+            attempt: initialized.attempt,
             initializeClaim: initializeClaim
         )
+        guard initialized.shouldStartCatalogLoad else { return }
         refreshProcessRouteToolsCatalog(
             route: route,
             upstreamProof: upstreamProof,

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -795,12 +795,13 @@ struct ControlPlaneAuthorityTests {
             nowUptimeNanoseconds: 3
         ))
 
-        let attempt = authority.markChannelInitialized(
+        let initialized = try #require(authority.markChannelInitialized(
             routeID: route.id,
             upstreamProof: proof
-        )
+        ))
 
-        #expect(attempt == catalogLease.attempt)
+        #expect(initialized.attempt == catalogLease.attempt)
+        #expect(initialized.shouldStartCatalogLoad == false)
         #expect(authority.validateCatalogLoad(catalogLease))
         #expect(
             authority.attemptSnapshot(processID: target.processID)?.phase

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -777,6 +777,37 @@ struct ControlPlaneAuthorityTests {
         #expect(attaching.readinessWaiterCount == 0)
     }
 
+    @Test func channelInitializationPreservesCatalogLoadStartedByForegroundRequest() throws {
+        let target = xcodeProcessTarget(processID: 41031, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let proof = testTopologyProof(0)
+        let reservation = try #require(authority.reserveActivation(
+            routeID: route.id,
+            upstreamProof: proof,
+            nowUptimeNs: 1,
+            readinessToken: UpstreamReadinessWaiterToken()
+        )).0
+        _ = try #require(authority.beginAttaching(reservation, nowUptimeNs: 2))
+        let (catalogLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: proof,
+            nowUptimeNanoseconds: 3
+        ))
+
+        let attempt = authority.markChannelInitialized(
+            routeID: route.id,
+            upstreamProof: proof
+        )
+
+        #expect(attempt == catalogLease.attempt)
+        #expect(authority.validateCatalogLoad(catalogLease))
+        #expect(
+            authority.attemptSnapshot(processID: target.processID)?.phase
+                == .loadingCatalog
+        )
+    }
+
     @Test func windowUpdatesDoNotInvalidateCatalogLease() throws {
         let target = xcodeProcessTarget(processID: 41004, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0])])


### PR DESCRIPTION
## Purpose

Ensure a newly launched Xcode process keeps its bounded mcpbridge activation watchdog when a foreground `tools/list` request races channel initialization.

## Changes

- Accept channel initialization after the activation attempt has advanced to `loadingCatalog`.
- Preserve the in-flight foreground catalog load while still registering the 10-second activation watchdog.
- Avoid issuing a duplicate activation catalog request when that foreground load already owns the work.
- Add a regression test for the interleaving that previously left only the 300-second foreground request timeout.

## Testing

- `scripts/check.sh`
  - 950 standard tests
  - 24 process runtime tests
  - 7 stdio adapter tests
- `codex-review --base main` (clean)