### PR TITLE
Prevent STDIO shutdown file-handle race

### DIFF
--- a/Sources/XcodeMCPProxyKit/Stdio/StdioAdapter.swift
+++ b/Sources/XcodeMCPProxyKit/Stdio/StdioAdapter.swift
@@ -4,18 +4,18 @@ import Synchronization
 import XcodeMCPKit
 import XcodeMCPProxyRuntime
 
-private final class StdioReadTaskActivation: Sendable {
+private final class StdioReadIteratorReadiness: Sendable {
     private struct State {
-        var isActivated = false
+        var isReady = false
         var waiters: [CheckedContinuation<Void, Never>] = []
     }
 
     private let state = Mutex(State())
 
-    func activate() {
+    func markReady() {
         let waiters: [CheckedContinuation<Void, Never>] = state.withLock { state in
-            guard state.isActivated == false else { return [] }
-            state.isActivated = true
+            guard state.isReady == false else { return [] }
+            state.isReady = true
             let waiters = state.waiters
             state.waiters.removeAll()
             return waiters
@@ -23,10 +23,10 @@ private final class StdioReadTaskActivation: Sendable {
         for waiter in waiters { waiter.resume() }
     }
 
-    func waitUntilActivated() async {
+    func waitUntilReady() async {
         await withCheckedContinuation { continuation in
             let shouldResume = state.withLock { state in
-                guard state.isActivated == false else { return true }
+                guard state.isReady == false else { return true }
                 state.waiters.append(continuation)
                 return false
             }
@@ -70,7 +70,7 @@ actor StdioAdapter {
     private let logger: Logger
     private let authority: MCPClientSessionAuthority
     private let shutdownPolicy: StdioAdapterShutdownPolicy
-    private let readTaskActivation = StdioReadTaskActivation()
+    private let readIteratorReadiness = StdioReadIteratorReadiness()
 
     private var framer = StdioFramer()
     private var requestTasks: [UUID: Task<Void, Never>] = [:]
@@ -153,12 +153,15 @@ actor StdioAdapter {
         lifecycle = .running
         startAuthorityEventTask()
         let input = inputHandle
-        let readTaskActivation = readTaskActivation
+        let readIteratorReadiness = readIteratorReadiness
         readTask = Task { [weak self] in
-            readTaskActivation.activate()
+            var iterator = input.bytes.makeAsyncIterator()
+            // Do not signal readiness before iterator creation: Foundation accesses the
+            // descriptor here and raises NSFileHandleOperationException if close wins.
+            readIteratorReadiness.markReady()
             var terminalError: (any Error)?
             do {
-                for try await byte in input.bytes {
+                while let byte = try await iterator.next() {
                     guard Task.isCancelled == false else { break }
                     await self?.handleInput(Data([byte]))
                 }
@@ -383,7 +386,7 @@ private extension StdioAdapter {
 
     func performClose(drainsOutput: Bool) async {
         if readTask != nil {
-            await readTaskActivation.waitUntilActivated()
+            await readIteratorReadiness.waitUntilReady()
             try? inputHandle.close()
         }
         await authority.close()

--- a/Tests/ProxyStdioAdapterTests/StdioAdapterIntegrationTests.swift
+++ b/Tests/ProxyStdioAdapterTests/StdioAdapterIntegrationTests.swift
@@ -34,6 +34,28 @@ struct StdioAdapterContractTests {
         outputPipe.fileHandleForWriting.closeFile()
     }
 
+    @Test func immediateStopWaitsForReadIteratorReadiness() async throws {
+        for _ in 0..<100 {
+            let transport = StalledStdioAdapterTransport()
+            let inputPipe = Pipe()
+            let outputPipe = Pipe()
+            let adapter = StdioAdapter(
+                requestTimeout: nil,
+                input: inputPipe.fileHandleForReading,
+                output: outputPipe.fileHandleForWriting,
+                recipe: MCPTransportRecipe { transport },
+                shutdownPolicy: .live
+            )
+
+            try await adapter.start()
+            await adapter.stop()
+
+            #expect(await adapter.connectionState().phase == .closed(.requested))
+            inputPipe.fileHandleForWriting.closeFile()
+            outputPipe.fileHandleForWriting.closeFile()
+        }
+    }
+
     @Test func deinitCancelsReadAndEventTasksWithoutAStopTask() async throws {
         let transport = StalledStdioAdapterTransport()
         let inputPipe = Pipe()


### PR DESCRIPTION
## Purpose

Prevent an immediate STDIO adapter shutdown from closing stdin before Foundation has prepared its async iterator. This race aborted the merged `main` CI run with `NSFileHandleOperationException`.

Failing job: https://github.com/lynnswap/XcodeMCPKit/actions/runs/29392946378/job/87280397262

## Changes

- Redefine reader readiness as completion of `FileHandle.AsyncBytes.Iterator` creation.
- Make shutdown wait for that readiness before closing the input descriptor.
- Add a repeated immediate start/stop regression test.

## Testing

- CI `remaining` package-test command: 296 tests passed.
- `scripts/check.sh`: 951 standard, 24 process runtime, and 8 STDIO adapter tests passed.
- `codex-review --base main`: clean.
