### PR TITLE
Recover late Xcode bridge pool attachment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -188,6 +188,7 @@ let package = Package(
         .testTarget(
             name: "XcodeMCPKitTests",
             dependencies: [
+                "XcodeMCPCoreTestSupport",
                 "XcodeMCPKit",
             ],
             path: "Tests/XcodeMCPKitTests",

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
@@ -7,7 +7,7 @@ final class UpstreamHealthManager: Sendable {
     enum InitializeClaimOwner: Sendable, Hashable {
         case regular
         case processRouteActivation
-        case processBridgeRecovery
+        case processBridgeRecovery(ProcessBridgeRecovery)
     }
 
     enum InitializeClaimPhase: Sendable, Equatable {
@@ -15,6 +15,7 @@ final class UpstreamHealthManager: Sendable {
         case sending
         case responseReceived
         case initializedAwaitingCatalog
+        case initializedAwaitingBridgeVerification
     }
 
     struct InitializeClaim: Sendable, Hashable {
@@ -26,9 +27,25 @@ final class UpstreamHealthManager: Sendable {
         var upstreamIndex: Int { upstreamID.rawValue }
     }
 
+    enum ProbePurpose: Sendable {
+        case healthRecovery
+        case processBridgeAttachment(ProcessBridgePoolRecovery)
+    }
+
     struct ProbeRequest: Sendable {
         let topologyProof: UpstreamTopologyProof
         let probeGeneration: UInt64
+        let purpose: ProbePurpose
+
+        init(
+            topologyProof: UpstreamTopologyProof,
+            probeGeneration: UInt64,
+            purpose: ProbePurpose = .healthRecovery
+        ) {
+            self.topologyProof = topologyProof
+            self.probeGeneration = probeGeneration
+            self.purpose = purpose
+        }
 
         var upstreamID: UpstreamSlotID { topologyProof.slotID }
         var upstreamIndex: Int { upstreamID.rawValue }
@@ -85,6 +102,7 @@ final class UpstreamHealthManager: Sendable {
 
     struct MarkInitializedTransition: Sendable {
         let timeout: RuntimeScheduledTimeout?
+        let bridgeVerificationProbe: ProbeRequest?
     }
 
     struct TimeoutAttachment: Sendable {
@@ -106,10 +124,25 @@ final class UpstreamHealthManager: Sendable {
     enum InitPhase: Sendable, Equatable {
         case idle
         case initializing(upstreamID: Int64?)
-        case initialized
+        case initialized(InitializedReadiness)
+
+        enum InitializedReadiness: Sendable, Equatable {
+            case usable
+            case verifyingBridge(ProcessRouteID)
+        }
 
         var isInitialized: Bool {
             guard case .initialized = self else { return false }
+            return true
+        }
+
+        var isUsableInitialized: Bool {
+            guard case .initialized(.usable) = self else { return false }
+            return true
+        }
+
+        var isVerifyingBridge: Bool {
+            guard case .initialized(.verifyingBridge) = self else { return false }
             return true
         }
 
@@ -148,7 +181,7 @@ final class UpstreamHealthManager: Sendable {
             get { initPhase.isInitialized }
             set {
                 if newValue {
-                    initPhase = .initialized
+                    initPhase = .initialized(.usable)
                 } else if initPhase.isInitialized {
                     initPhase = .idle
                 }
@@ -257,7 +290,9 @@ final class UpstreamHealthManager: Sendable {
 
     func anyInitialized() -> Bool {
         state.withLockedValue { state in
-            Self.activeIndices(in: state).contains { state.upstreamStates[$0].isInitialized }
+            Self.activeIndices(in: state).contains {
+                state.upstreamStates[$0].initPhase.isUsableInitialized
+            }
         }
     }
 
@@ -330,7 +365,7 @@ final class UpstreamHealthManager: Sendable {
         state.withLockedValue { state in
             guard Self.isActive(lease.topologyProof, state: state) else { return nil }
             let upstreamIndex = lease.topologyProof.slotID.rawValue
-            guard state.upstreamStates[upstreamIndex].isInitialized,
+            guard state.upstreamStates[upstreamIndex].initPhase.isUsableInitialized,
                   state.upstreamStates[upstreamIndex].healthProbeInFlight == false,
                   state.upstreamStates[upstreamIndex].healthProbeGeneration
                     == lease.healthProbeGeneration,
@@ -367,7 +402,7 @@ final class UpstreamHealthManager: Sendable {
         state.withLockedValue { state in
             Self.activeIndices(in: state).reduce(into: 0) { count, index in
                 let upstream = state.upstreamStates[index]
-                guard upstream.isInitialized else { return }
+                guard upstream.initPhase.isUsableInitialized else { return }
                 switch upstream.healthState {
                 case .healthy, .degraded:
                     count += 1
@@ -399,7 +434,7 @@ final class UpstreamHealthManager: Sendable {
                 isHealthyEnough = false
             }
             guard isHealthyEnough,
-                  state.upstreamStates[index].isInitialized else { return nil }
+                  state.upstreamStates[index].initPhase.isUsableInitialized else { return nil }
             return state.topology?.proof(UpstreamSlotID(rawValue: index))
         }
         return UpstreamHealthManager.UseEvaluation(
@@ -428,7 +463,9 @@ final class UpstreamHealthManager: Sendable {
                 if occupiedUpstreams.contains(candidate) {
                     continue
                 }
-                guard state.upstreamStates[candidate].isInitialized else { continue }
+                guard state.upstreamStates[candidate].initPhase.isUsableInitialized else {
+                    continue
+                }
                 let health = Self.classifyHealthAndCollectEffectsIfNeeded(
                     upstreamIndex: candidate,
                     nowUptimeNs: nowUptimeNs,
@@ -479,8 +516,10 @@ final class UpstreamHealthManager: Sendable {
             if timeoutCount >= 3 {
                 let quarantineUntil = nowUptimeNs &+ 15_000_000_000
                 state.upstreamStates[upstreamIndex].healthState = .quarantined(untilUptimeNs: quarantineUntil)
-                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
-                state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
+                if state.upstreamStates[upstreamIndex].initPhase.isVerifyingBridge == false {
+                    state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                    state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
+                }
                 return (true, timeoutCount)
             } else {
                 state.upstreamStates[upstreamIndex].healthState = .degraded
@@ -569,6 +608,56 @@ final class UpstreamHealthManager: Sendable {
         }
     }
 
+    func finishBridgeAttachVerification(
+        _ request: ProbeRequest,
+        success: Bool,
+        nowUptimeNs: UInt64,
+        commit: () -> Bool
+    ) -> (
+        recovery: ProcessBridgePoolRecovery,
+        cleared: (
+            timeout: RuntimeScheduledTimeout?,
+            initUpstreamID: Int64?,
+            didReceiveInitializeResponse: Bool,
+            didSendInitialized: Bool
+        )?
+    )? {
+        state.withLockedValue { state in
+            guard case .processBridgeAttachment(let recovery) = request.purpose,
+                  Self.isActive(request.topologyProof, state: state),
+                  recovery.upstreamID == request.topologyProof.slotID else { return nil }
+            let upstreamIndex = request.upstreamIndex
+            guard state.upstreamStates[upstreamIndex].healthProbeInFlight,
+                  state.upstreamStates[upstreamIndex].healthProbeGeneration
+                    == request.probeGeneration,
+                  state.upstreamStates[upstreamIndex].initPhase
+                    == .initialized(.verifyingBridge(recovery.routeID)),
+                  state.upstreamStates[upstreamIndex].initializeClaimPhase
+                    == .initializedAwaitingBridgeVerification,
+                  let claim = state.upstreamStates[upstreamIndex].initializeClaim,
+                  case .processBridgeRecovery(let current) = claim.owner,
+                  current.reservation == recovery,
+                  current.topologyProof == request.topologyProof,
+                  commit() else { return nil }
+            if success {
+                state.upstreamStates[upstreamIndex].initPhase = .initialized(.usable)
+                state.upstreamStates[upstreamIndex].initializeClaim = nil
+                state.upstreamStates[upstreamIndex].initializeClaimPhase = nil
+                state.upstreamStates[upstreamIndex].healthState = .healthy
+                state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
+                state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
+                state.upstreamStates[upstreamIndex].lastToolsListSuccessUptimeNs = nowUptimeNs
+                return (recovery, nil)
+            }
+            return (
+                recovery,
+                Self.clearUpstreamState(at: upstreamIndex, state: &state)
+            )
+        }
+    }
+
     func markToolsListRefreshSucceeded(
         _ proof: UpstreamTopologyProof,
         nowUptimeNs: UInt64
@@ -576,12 +665,17 @@ final class UpstreamHealthManager: Sendable {
         state.withLockedValue { state in
             guard Self.isActive(proof, state: state) else { return false }
             let upstreamIndex = proof.slotID.rawValue
-            if state.upstreamStates[upstreamIndex].healthProbeInFlight {
+            let isVerifyingBridge = state.upstreamStates[upstreamIndex]
+                .initPhase.isVerifyingBridge
+            if state.upstreamStates[upstreamIndex].healthProbeInFlight,
+               isVerifyingBridge == false {
                 state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
             }
             state.upstreamStates[upstreamIndex].healthState = .healthy
             state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
-            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            if isVerifyingBridge == false {
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            }
             state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
             state.upstreamStates[upstreamIndex].lastToolsListSuccessUptimeNs = nowUptimeNs
             return true
@@ -595,12 +689,17 @@ final class UpstreamHealthManager: Sendable {
         state.withLockedValue { state in
             guard Self.isActive(proof, state: state) else { return nil }
             let upstreamIndex = proof.slotID.rawValue
-            if state.upstreamStates[upstreamIndex].healthProbeInFlight {
+            let isVerifyingBridge = state.upstreamStates[upstreamIndex]
+                .initPhase.isVerifyingBridge
+            if state.upstreamStates[upstreamIndex].healthProbeInFlight,
+               isVerifyingBridge == false {
                 state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
             }
             let quarantineUntil = nowUptimeNs &+ 30 * 1_000_000_000
             state.upstreamStates[upstreamIndex].healthState = .quarantined(untilUptimeNs: quarantineUntil)
-            state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            if isVerifyingBridge == false {
+                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+            }
             state.upstreamStates[upstreamIndex].consecutiveToolsListFailures += 1
             return (state.upstreamStates[upstreamIndex].consecutiveToolsListFailures, quarantineUntil)
         }
@@ -681,6 +780,19 @@ final class UpstreamHealthManager: Sendable {
                   let claim = state.upstreamStates[upstreamIndex].initializeClaim,
                   Self.matches(claim, state: state) else { return nil }
             return claim
+        }
+    }
+
+    func currentBridgeRecovery(
+        for proof: UpstreamTopologyProof
+    ) -> ProcessBridgeRecovery? {
+        state.withLockedValue { state in
+            guard Self.isActive(proof, state: state),
+                  let upstream = state.upstreamStates[proof.slotID],
+                  let claim = upstream.initializeClaim,
+                  claim.topologyProof == proof,
+                  case .processBridgeRecovery(let recovery) = claim.owner else { return nil }
+            return recovery
         }
     }
 
@@ -768,8 +880,8 @@ final class UpstreamHealthManager: Sendable {
         state.withLockedValue { state in
             guard Self.isActive(proof, state: state) else { return nil }
             let upstreamIndex = proof.slotID.rawValue
-            if state.upstreamStates[upstreamIndex].initializeClaim?.owner
-                == .processRouteActivation {
+            if let owner = state.upstreamStates[upstreamIndex].initializeClaim?.owner,
+               owner != .regular {
                 return nil
             }
             if let expectedUpstreamID,
@@ -787,7 +899,10 @@ final class UpstreamHealthManager: Sendable {
             state.upstreamStates[upstreamIndex].healthProbeInFlight = false
             let timeout = state.upstreamStates[upstreamIndex].initTimeout
             state.upstreamStates[upstreamIndex].initTimeout = nil
-            return UpstreamHealthManager.MarkInitializedTransition(timeout: timeout)
+            return UpstreamHealthManager.MarkInitializedTransition(
+                timeout: timeout,
+                bridgeVerificationProbe: nil
+            )
         }
     }
 
@@ -804,12 +919,24 @@ final class UpstreamHealthManager: Sendable {
                     == .responseReceived,
                   commit() else { return nil }
             let timeout = state.upstreamStates[claim.upstreamIndex].initTimeout
-            state.upstreamStates[claim.upstreamIndex].isInitialized = true
+            let bridgeRecovery: ProcessBridgeRecovery?
+            if case .processBridgeRecovery(let recovery) = claim.owner {
+                bridgeRecovery = recovery
+                state.upstreamStates[claim.upstreamIndex].initPhase = .initialized(
+                    .verifyingBridge(recovery.routeID)
+                )
+            } else {
+                bridgeRecovery = nil
+                state.upstreamStates[claim.upstreamIndex].initPhase = .initialized(.usable)
+            }
             state.upstreamStates[claim.upstreamIndex].initInFlight = false
             state.upstreamStates[claim.upstreamIndex].initUpstreamID = nil
             if claim.owner == .processRouteActivation {
                 state.upstreamStates[claim.upstreamIndex].initializeClaimPhase =
                     .initializedAwaitingCatalog
+            } else if bridgeRecovery != nil {
+                state.upstreamStates[claim.upstreamIndex].initializeClaimPhase =
+                    .initializedAwaitingBridgeVerification
             } else {
                 state.upstreamStates[claim.upstreamIndex].initializeClaim = nil
                 state.upstreamStates[claim.upstreamIndex].initializeClaimPhase = nil
@@ -817,8 +944,24 @@ final class UpstreamHealthManager: Sendable {
             state.upstreamStates[claim.upstreamIndex].initTimeout = nil
             state.upstreamStates[claim.upstreamIndex].healthState = .healthy
             state.upstreamStates[claim.upstreamIndex].consecutiveRequestTimeouts = 0
-            state.upstreamStates[claim.upstreamIndex].healthProbeInFlight = false
-            return UpstreamHealthManager.MarkInitializedTransition(timeout: timeout)
+            let bridgeVerificationProbe: ProbeRequest?
+            if let bridgeRecovery {
+                state.upstreamStates[claim.upstreamIndex].healthProbeInFlight = true
+                state.upstreamStates[claim.upstreamIndex].healthProbeGeneration &+= 1
+                bridgeVerificationProbe = ProbeRequest(
+                    topologyProof: bridgeRecovery.topologyProof,
+                    probeGeneration: state.upstreamStates[claim.upstreamIndex]
+                        .healthProbeGeneration,
+                    purpose: .processBridgeAttachment(bridgeRecovery.reservation)
+                )
+            } else {
+                state.upstreamStates[claim.upstreamIndex].healthProbeInFlight = false
+                bridgeVerificationProbe = nil
+            }
+            return UpstreamHealthManager.MarkInitializedTransition(
+                timeout: timeout,
+                bridgeVerificationProbe: bridgeVerificationProbe
+            )
         }
     }
 
@@ -930,10 +1073,15 @@ final class UpstreamHealthManager: Sendable {
                 }
                 state.upstreamStates[upstreamIndex].healthState = .healthy
                 state.upstreamStates[upstreamIndex].consecutiveRequestTimeouts = 0
-                if state.upstreamStates[upstreamIndex].healthProbeInFlight {
+                let isVerifyingBridge = state.upstreamStates[upstreamIndex]
+                    .initPhase.isVerifyingBridge
+                if state.upstreamStates[upstreamIndex].healthProbeInFlight,
+                   isVerifyingBridge == false {
                     state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
                 }
-                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                if isVerifyingBridge == false {
+                    state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                }
                 return [.failQueuedIfNoRecovery]
 
             case .upstreamOverloaded(let proof):
@@ -942,10 +1090,15 @@ final class UpstreamHealthManager: Sendable {
                 if case .healthy = state.upstreamStates[upstreamIndex].healthState {
                     state.upstreamStates[upstreamIndex].healthState = .degraded
                 }
-                if state.upstreamStates[upstreamIndex].healthProbeInFlight {
+                let isVerifyingBridge = state.upstreamStates[upstreamIndex]
+                    .initPhase.isVerifyingBridge
+                if state.upstreamStates[upstreamIndex].healthProbeInFlight,
+                   isVerifyingBridge == false {
                     state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
                 }
-                state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                if isVerifyingBridge == false {
+                    state.upstreamStates[upstreamIndex].healthProbeInFlight = false
+                }
                 return [.failQueuedIfNoRecovery]
 
             }
@@ -1018,7 +1171,7 @@ final class UpstreamHealthManager: Sendable {
     ) -> Bool {
         guard isActive(proof, state: state),
               let source = state.upstreamStates[proof.slotID],
-              source.isInitialized else {
+              source.initPhase.isUsableInitialized else {
             return false
         }
         switch source.healthState {

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
@@ -27,9 +27,14 @@ final class UpstreamHealthManager: Sendable {
         var upstreamIndex: Int { upstreamID.rawValue }
     }
 
+    struct BridgeAttachmentVerification: Sendable {
+        let recovery: ProcessBridgeRecovery
+        let initializeParticipant: CanonicalHandshakeState.InitializeParticipantLease
+    }
+
     enum ProbePurpose: Sendable {
         case healthRecovery
-        case processBridgeAttachment(ProcessBridgePoolRecovery)
+        case processBridgeAttachment(BridgeAttachmentVerification)
     }
 
     struct ProbeRequest: Sendable {
@@ -102,7 +107,11 @@ final class UpstreamHealthManager: Sendable {
 
     struct MarkInitializedTransition: Sendable {
         let timeout: RuntimeScheduledTimeout?
-        let bridgeVerificationProbe: ProbeRequest?
+    }
+
+    struct BridgeVerificationTransition: Sendable {
+        let timeout: RuntimeScheduledTimeout?
+        let probe: ProbeRequest
     }
 
     struct TimeoutAttachment: Sendable {
@@ -623,8 +632,11 @@ final class UpstreamHealthManager: Sendable {
         )?
     )? {
         state.withLockedValue { state in
-            guard case .processBridgeAttachment(let recovery) = request.purpose,
-                  Self.isActive(request.topologyProof, state: state),
+            guard case .processBridgeAttachment(let verification) = request.purpose else {
+                return nil
+            }
+            let recovery = verification.recovery
+            guard Self.isActive(request.topologyProof, state: state),
                   recovery.upstreamID == request.topologyProof.slotID else { return nil }
             let upstreamIndex = request.upstreamIndex
             guard state.upstreamStates[upstreamIndex].healthProbeInFlight,
@@ -636,10 +648,9 @@ final class UpstreamHealthManager: Sendable {
                     == .initializedAwaitingBridgeVerification,
                   let claim = state.upstreamStates[upstreamIndex].initializeClaim,
                   case .processBridgeRecovery(let current) = claim.owner,
-                  current.reservation == recovery,
-                  current.topologyProof == request.topologyProof,
-                  commit() else { return nil }
+                  current == recovery else { return nil }
             if success {
+                let previousUpstream = state.upstreamStates[upstreamIndex]
                 state.upstreamStates[upstreamIndex].initPhase = .initialized(.usable)
                 state.upstreamStates[upstreamIndex].initializeClaim = nil
                 state.upstreamStates[upstreamIndex].initializeClaimPhase = nil
@@ -649,10 +660,15 @@ final class UpstreamHealthManager: Sendable {
                 state.upstreamStates[upstreamIndex].healthProbeGeneration &+= 1
                 state.upstreamStates[upstreamIndex].consecutiveToolsListFailures = 0
                 state.upstreamStates[upstreamIndex].lastToolsListSuccessUptimeNs = nowUptimeNs
-                return (recovery, nil)
+                guard commit() else {
+                    state.upstreamStates[upstreamIndex] = previousUpstream
+                    return nil
+                }
+                return (recovery.reservation, nil)
             }
+            guard commit() else { return nil }
             return (
-                recovery,
+                recovery.reservation,
                 Self.clearUpstreamState(at: upstreamIndex, state: &state)
             )
         }
@@ -899,10 +915,7 @@ final class UpstreamHealthManager: Sendable {
             state.upstreamStates[upstreamIndex].healthProbeInFlight = false
             let timeout = state.upstreamStates[upstreamIndex].initTimeout
             state.upstreamStates[upstreamIndex].initTimeout = nil
-            return UpstreamHealthManager.MarkInitializedTransition(
-                timeout: timeout,
-                bridgeVerificationProbe: nil
-            )
+            return UpstreamHealthManager.MarkInitializedTransition(timeout: timeout)
         }
     }
 
@@ -911,7 +924,10 @@ final class UpstreamHealthManager: Sendable {
         expectedUpstreamID: Int64,
         commit: () -> Bool
     ) -> UpstreamHealthManager.MarkInitializedTransition? {
-        state.withLockedValue { state in
+        if case .processBridgeRecovery = claim.owner {
+            return nil
+        }
+        return state.withLockedValue { state in
             guard Self.matches(claim, state: state),
                   state.upstreamStates[claim.upstreamIndex].initUpstreamID
                     == expectedUpstreamID,
@@ -919,24 +935,12 @@ final class UpstreamHealthManager: Sendable {
                     == .responseReceived,
                   commit() else { return nil }
             let timeout = state.upstreamStates[claim.upstreamIndex].initTimeout
-            let bridgeRecovery: ProcessBridgeRecovery?
-            if case .processBridgeRecovery(let recovery) = claim.owner {
-                bridgeRecovery = recovery
-                state.upstreamStates[claim.upstreamIndex].initPhase = .initialized(
-                    .verifyingBridge(recovery.routeID)
-                )
-            } else {
-                bridgeRecovery = nil
-                state.upstreamStates[claim.upstreamIndex].initPhase = .initialized(.usable)
-            }
+            state.upstreamStates[claim.upstreamIndex].initPhase = .initialized(.usable)
             state.upstreamStates[claim.upstreamIndex].initInFlight = false
             state.upstreamStates[claim.upstreamIndex].initUpstreamID = nil
             if claim.owner == .processRouteActivation {
                 state.upstreamStates[claim.upstreamIndex].initializeClaimPhase =
                     .initializedAwaitingCatalog
-            } else if bridgeRecovery != nil {
-                state.upstreamStates[claim.upstreamIndex].initializeClaimPhase =
-                    .initializedAwaitingBridgeVerification
             } else {
                 state.upstreamStates[claim.upstreamIndex].initializeClaim = nil
                 state.upstreamStates[claim.upstreamIndex].initializeClaimPhase = nil
@@ -944,23 +948,53 @@ final class UpstreamHealthManager: Sendable {
             state.upstreamStates[claim.upstreamIndex].initTimeout = nil
             state.upstreamStates[claim.upstreamIndex].healthState = .healthy
             state.upstreamStates[claim.upstreamIndex].consecutiveRequestTimeouts = 0
-            let bridgeVerificationProbe: ProbeRequest?
-            if let bridgeRecovery {
-                state.upstreamStates[claim.upstreamIndex].healthProbeInFlight = true
-                state.upstreamStates[claim.upstreamIndex].healthProbeGeneration &+= 1
-                bridgeVerificationProbe = ProbeRequest(
-                    topologyProof: bridgeRecovery.topologyProof,
-                    probeGeneration: state.upstreamStates[claim.upstreamIndex]
-                        .healthProbeGeneration,
-                    purpose: .processBridgeAttachment(bridgeRecovery.reservation)
+            state.upstreamStates[claim.upstreamIndex].healthProbeInFlight = false
+            return UpstreamHealthManager.MarkInitializedTransition(timeout: timeout)
+        }
+    }
+
+    func beginBridgeAttachVerification(
+        _ claim: InitializeClaim,
+        expectedUpstreamID: Int64,
+        initializeParticipant: CanonicalHandshakeState.InitializeParticipantLease
+    ) -> UpstreamHealthManager.BridgeVerificationTransition? {
+        guard case .processBridgeRecovery(let recovery) = claim.owner,
+              initializeParticipant.topologyProof == recovery.topologyProof else {
+            return nil
+        }
+        return state.withLockedValue { state in
+            guard Self.matches(claim, state: state),
+                  state.upstreamStates[claim.upstreamIndex].initUpstreamID
+                    == expectedUpstreamID,
+                  state.upstreamStates[claim.upstreamIndex].initializeClaimPhase
+                    == .responseReceived else { return nil }
+            let timeout = state.upstreamStates[claim.upstreamIndex].initTimeout
+            state.upstreamStates[claim.upstreamIndex].initPhase = .initialized(
+                .verifyingBridge(recovery.routeID)
+            )
+            state.upstreamStates[claim.upstreamIndex].initInFlight = false
+            state.upstreamStates[claim.upstreamIndex].initUpstreamID = nil
+            state.upstreamStates[claim.upstreamIndex].initializeClaimPhase =
+                .initializedAwaitingBridgeVerification
+            state.upstreamStates[claim.upstreamIndex].initTimeout = nil
+            state.upstreamStates[claim.upstreamIndex].healthState = .healthy
+            state.upstreamStates[claim.upstreamIndex].consecutiveRequestTimeouts = 0
+            state.upstreamStates[claim.upstreamIndex].healthProbeInFlight = true
+            state.upstreamStates[claim.upstreamIndex].healthProbeGeneration &+= 1
+            let probe = ProbeRequest(
+                topologyProof: recovery.topologyProof,
+                probeGeneration: state.upstreamStates[claim.upstreamIndex]
+                    .healthProbeGeneration,
+                purpose: .processBridgeAttachment(
+                    BridgeAttachmentVerification(
+                        recovery: recovery,
+                        initializeParticipant: initializeParticipant
+                    )
                 )
-            } else {
-                state.upstreamStates[claim.upstreamIndex].healthProbeInFlight = false
-                bridgeVerificationProbe = nil
-            }
-            return UpstreamHealthManager.MarkInitializedTransition(
+            )
+            return UpstreamHealthManager.BridgeVerificationTransition(
                 timeout: timeout,
-                bridgeVerificationProbe: bridgeVerificationProbe
+                probe: probe
             )
         }
     }

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/JSONRPCResponseRouter.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/JSONRPCResponseRouter.swift
@@ -79,9 +79,34 @@ final class JSONRPCResponseRouter: Sendable {
         timeout: TimeAmount? = nil,
         onTimeout: (@Sendable () -> Void)? = nil
     ) -> PendingRegistration {
+        registerRequestPending(
+            idKey: idKey,
+            on: eventLoop,
+            effectiveTimeout: timeout ?? requestTimeout,
+            onTimeout: onTimeout
+        )
+    }
+
+    func registerRequestPendingWithoutTimeout(
+        idKey: String,
+        on eventLoop: EventLoop
+    ) -> PendingRegistration {
+        registerRequestPending(
+            idKey: idKey,
+            on: eventLoop,
+            effectiveTimeout: nil,
+            onTimeout: nil
+        )
+    }
+
+    private func registerRequestPending(
+        idKey: String,
+        on eventLoop: EventLoop,
+        effectiveTimeout: TimeAmount?,
+        onTimeout: (@Sendable () -> Void)?
+    ) -> PendingRegistration {
         let promise = eventLoop.makePromise(of: ByteBuffer.self)
         let token = UUID()
-        let effectiveTimeout = timeout ?? requestTimeout
         let timeout = effectiveTimeout.map { timeout in
             eventLoop.scheduleTask(in: timeout) { [weak self] in
                 guard let self else { return }

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/JSONRPCResponseRouter.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/JSONRPCResponseRouter.swift
@@ -4,6 +4,11 @@ import NIO
 import NIOConcurrencyHelpers
 
 final class JSONRPCResponseRouter: Sendable {
+    typealias TimeoutScheduler = @Sendable (
+        _ delay: TimeAmount,
+        _ operation: @escaping @Sendable () -> Void
+    ) -> RuntimeScheduledTimeout
+
     struct PendingRegistration {
         let token: UUID
         let future: EventLoopFuture<ByteBuffer>
@@ -13,7 +18,7 @@ final class JSONRPCResponseRouter: Sendable {
         var token: UUID
         var eventLoop: EventLoop
         var promise: EventLoopPromise<ByteBuffer>
-        var timeout: Scheduled<Void>?
+        var timeout: RuntimeScheduledTimeout?
         var onTimeout: (@Sendable () -> Void)?
     }
 
@@ -77,41 +82,25 @@ final class JSONRPCResponseRouter: Sendable {
         idKey: String,
         on eventLoop: EventLoop,
         timeout: TimeAmount? = nil,
+        timeoutScheduler: TimeoutScheduler? = nil,
         onTimeout: (@Sendable () -> Void)? = nil
-    ) -> PendingRegistration {
-        registerRequestPending(
-            idKey: idKey,
-            on: eventLoop,
-            effectiveTimeout: timeout ?? requestTimeout,
-            onTimeout: onTimeout
-        )
-    }
-
-    func registerRequestPendingWithoutTimeout(
-        idKey: String,
-        on eventLoop: EventLoop
-    ) -> PendingRegistration {
-        registerRequestPending(
-            idKey: idKey,
-            on: eventLoop,
-            effectiveTimeout: nil,
-            onTimeout: nil
-        )
-    }
-
-    private func registerRequestPending(
-        idKey: String,
-        on eventLoop: EventLoop,
-        effectiveTimeout: TimeAmount?,
-        onTimeout: (@Sendable () -> Void)?
     ) -> PendingRegistration {
         let promise = eventLoop.makePromise(of: ByteBuffer.self)
         let token = UUID()
+        let effectiveTimeout = timeout ?? requestTimeout
         let timeout = effectiveTimeout.map { timeout in
-            eventLoop.scheduleTask(in: timeout) { [weak self] in
+            let operation: @Sendable () -> Void = { [weak self] in
                 guard let self else { return }
                 self.failTimeout(idKey: idKey, token: token)
             }
+            if let timeoutScheduler {
+                return timeoutScheduler(timeout, operation)
+            }
+            return RuntimeScheduledTimeout.schedule(
+                on: eventLoop,
+                in: timeout,
+                operation: operation
+            )
         }
         let displaced = state.withLockedValue { state -> Pending? in
             let existing = state.pendingByID[idKey]

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/InitializeManager.swift
@@ -444,6 +444,19 @@ final class InitializeManager: Sendable {
         }
     }
 
+    /// Retains a canonical participant while bridge attachment is verified.
+    /// The preparation shares the downstream waiter lock so shutdown cannot
+    /// interleave between accepting the initialized notification and owning
+    /// the deferred participant.
+    func prepareInitializeParticipantForBridgeVerification(
+        commit: () -> Bool
+    ) -> Bool {
+        state.withLockedValue { state in
+            guard !state.isShuttingDown else { return false }
+            return commit()
+        }
+    }
+
     /// Runs the topology/health/canonical commit while holding the same lock
     /// that owns downstream initialize waiters. A timeout can win before this
     /// transaction starts, or publication can win and drain the waiters, but

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -572,6 +572,27 @@ final class ProcessControlPlaneAuthority: Sendable {
         state = NIOLockedValueBox(initialState)
     }
 
+    /// Releases one configured sibling without requiring an existing catalog.
+    /// A verified sibling may be the first usable catalog source, so a catalog
+    /// barrier here would make recovery and catalog bootstrap depend on each other.
+    func beginBridgePoolRecovery(
+        routeID: ProcessRouteID
+    ) -> ProcessControlPlaneTransition {
+        state.withLockedValue { state in
+            guard let key = Self.key(routeID: routeID, in: state),
+                  var owner = state.recordsByKey[key],
+                  owner.state == .active else {
+                return .none
+            }
+            let effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
+            state.recordsByKey[key] = owner
+            return ProcessControlPlaneTransition(
+                addedRoutes: [], retiredRoutes: [], effects: effects,
+                publishesToolsListChanged: false
+            )
+        }
+    }
+
     func activeRoutes() -> [XcodeProcessRoute] {
         state.withLockedValue { state in Self.activeRoutes(in: state) }
     }
@@ -597,12 +618,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                 break
             }
             owner.bridgeRecovery.pendingUpstreamIDs.insert(upstreamID)
-            let effects: [ProcessControlPlaneEffect]
-            if state.catalogsByProcessID[owner.route.target.processID] != nil {
-                effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
-            } else {
-                effects = []
-            }
+            let effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
             state.recordsByKey[key] = owner
             return ProcessControlPlaneTransition(
                 addedRoutes: [], retiredRoutes: [], effects: effects,
@@ -627,12 +643,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                   current == recovery else { return nil }
             owner.bridgeRecovery.phase = .idle
             owner.bridgeRecovery.consecutiveFailureCount = 0
-            let effects: [ProcessControlPlaneEffect]
-            if state.catalogsByProcessID[owner.route.target.processID] != nil {
-                effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
-            } else {
-                effects = []
-            }
+            let effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
             state.recordsByKey[key] = owner
             return ProcessControlPlaneTransition(
                 addedRoutes: [], retiredRoutes: [], effects: effects,
@@ -705,13 +716,6 @@ final class ProcessControlPlaneAuthority: Sendable {
                   var owner = state.recordsByKey[key],
                   case .waitingRetry(let current, _) = owner.bridgeRecovery.phase,
                   current == recovery else { return .none }
-            guard state.catalogsByProcessID[owner.route.target.processID] != nil else {
-                owner.bridgeRecovery.generation &+= 1
-                owner.bridgeRecovery.pendingUpstreamIDs.insert(recovery.upstreamID)
-                owner.bridgeRecovery.phase = .idle
-                state.recordsByKey[key] = owner
-                return .none
-            }
             owner.bridgeRecovery.generation &+= 1
             let next = ProcessBridgePoolRecovery(
                 routeID: owner.route.id,

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -634,17 +634,23 @@ final class ProcessControlPlaneAuthority: Sendable {
     }
 
     func completeBridgeRecoveryIfCurrent(
-        _ recovery: ProcessBridgePoolRecovery
+        _ recovery: ProcessBridgePoolRecovery,
+        commit: () -> Bool = { true }
     ) -> ProcessControlPlaneTransition? {
         state.withLockedValue { state in
             guard let key = Self.key(routeID: recovery.routeID, in: state),
                   var owner = state.recordsByKey[key],
                   case .attempting(let current) = owner.bridgeRecovery.phase,
                   current == recovery else { return nil }
+            let previousOwner = owner
             owner.bridgeRecovery.phase = .idle
             owner.bridgeRecovery.consecutiveFailureCount = 0
             let effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
             state.recordsByKey[key] = owner
+            guard commit() else {
+                state.recordsByKey[key] = previousOwner
+                return nil
+            }
             return ProcessControlPlaneTransition(
                 addedRoutes: [], retiredRoutes: [], effects: effects,
                 publishesToolsListChanged: false

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -77,14 +77,23 @@ enum ProcessControlPlaneEffect: Sendable {
     case restoreBridgePool(ProcessBridgePoolRecovery)
 }
 
-struct ProcessBridgePoolRecovery: Sendable {
+struct ProcessBridgePoolRecovery: Sendable, Hashable {
     let routeID: ProcessRouteID
-    let upstreamIDs: [UpstreamSlotID]
+    let upstreamID: UpstreamSlotID
+    fileprivate let generation: UInt64
 }
 
-struct ProcessBridgeRecovery: Sendable {
-    let routeID: ProcessRouteID
+struct ProcessBridgeRecovery: Sendable, Hashable {
+    let reservation: ProcessBridgePoolRecovery
     let topologyProof: UpstreamTopologyProof
+
+    var routeID: ProcessRouteID { reservation.routeID }
+    var upstreamID: UpstreamSlotID { reservation.upstreamID }
+}
+
+struct ProcessBridgeRecoveryRetry: Sendable {
+    let reservation: ProcessBridgePoolRecovery
+    let delay: TimeAmount
 }
 
 struct ProcessControlPlaneTransition: Sendable {
@@ -454,7 +463,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         var catalogCooldown: Cooldown
         var admissionRevision: UInt64
         var catalogEligibilityEstablished: Bool
-        var pendingBridgeRecoveryUpstreamIDs: Set<UpstreamSlotID>
+        var bridgeRecovery: BridgeRecoveryState
         var nextAttemptID: Int
         var attempt: Attempt?
 
@@ -493,6 +502,35 @@ final class ProcessControlPlaneAuthority: Sendable {
 
         func isUnavailable(nowUptimeNs _: UInt64) -> Bool {
             routeCooldown.isUnavailable || catalogCooldown.isUnavailable
+        }
+    }
+
+    private struct BridgeRecoveryState: Sendable {
+        enum Phase: Sendable {
+            case idle
+            case attempting(ProcessBridgePoolRecovery)
+            case waitingRetry(ProcessBridgePoolRecovery, RuntimeScheduledTimeout?)
+        }
+
+        var pendingUpstreamIDs: Set<UpstreamSlotID>
+        var phase: Phase = .idle
+        var generation: UInt64 = 0
+        var consecutiveFailureCount = 0
+
+        mutating func reset(pendingUpstreamIDs: Set<UpstreamSlotID>)
+            -> [ProcessControlPlaneEffect]
+        {
+            let effects: [ProcessControlPlaneEffect]
+            if case .waitingRetry(_, let timeout) = phase, let timeout {
+                effects = [.cancelTimeout(timeout)]
+            } else {
+                effects = []
+            }
+            generation &+= 1
+            self.pendingUpstreamIDs = pendingUpstreamIDs
+            phase = .idle
+            consecutiveFailureCount = 0
+            return effects
         }
     }
 
@@ -550,7 +588,15 @@ final class ProcessControlPlaneAuthority: Sendable {
             else {
                 return .none
             }
-            owner.pendingBridgeRecoveryUpstreamIDs.insert(upstreamID)
+            switch owner.bridgeRecovery.phase {
+            case .attempting(let current) where current.upstreamID == upstreamID:
+                return .none
+            case .waitingRetry(let current, _) where current.upstreamID == upstreamID:
+                return .none
+            case .idle, .attempting, .waitingRetry:
+                break
+            }
+            owner.bridgeRecovery.pendingUpstreamIDs.insert(upstreamID)
             let effects: [ProcessControlPlaneEffect]
             if state.catalogsByProcessID[owner.route.target.processID] != nil {
                 effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
@@ -560,6 +606,123 @@ final class ProcessControlPlaneAuthority: Sendable {
             state.recordsByKey[key] = owner
             return ProcessControlPlaneTransition(
                 addedRoutes: [], retiredRoutes: [], effects: effects,
+                publishesToolsListChanged: false
+            )
+        }
+    }
+
+    func completeBridgeRecovery(
+        _ recovery: ProcessBridgePoolRecovery
+    ) -> ProcessControlPlaneTransition {
+        completeBridgeRecoveryIfCurrent(recovery) ?? .none
+    }
+
+    func completeBridgeRecoveryIfCurrent(
+        _ recovery: ProcessBridgePoolRecovery
+    ) -> ProcessControlPlaneTransition? {
+        state.withLockedValue { state in
+            guard let key = Self.key(routeID: recovery.routeID, in: state),
+                  var owner = state.recordsByKey[key],
+                  case .attempting(let current) = owner.bridgeRecovery.phase,
+                  current == recovery else { return nil }
+            owner.bridgeRecovery.phase = .idle
+            owner.bridgeRecovery.consecutiveFailureCount = 0
+            let effects: [ProcessControlPlaneEffect]
+            if state.catalogsByProcessID[owner.route.target.processID] != nil {
+                effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
+            } else {
+                effects = []
+            }
+            state.recordsByKey[key] = owner
+            return ProcessControlPlaneTransition(
+                addedRoutes: [], retiredRoutes: [], effects: effects,
+                publishesToolsListChanged: false
+            )
+        }
+    }
+
+    func validateBridgeRecovery(_ recovery: ProcessBridgePoolRecovery) -> Bool {
+        state.withLockedValue { state in
+            guard let key = Self.key(routeID: recovery.routeID, in: state),
+                  let owner = state.recordsByKey[key],
+                  case .attempting(let current) = owner.bridgeRecovery.phase else {
+                return false
+            }
+            return current == recovery
+        }
+    }
+
+    func prepareBridgeRecoveryRetry(
+        _ recovery: ProcessBridgePoolRecovery
+    ) -> ProcessBridgeRecoveryRetry? {
+        state.withLockedValue { state in
+            guard let key = Self.key(routeID: recovery.routeID, in: state),
+                  var owner = state.recordsByKey[key],
+                  case .attempting(let current) = owner.bridgeRecovery.phase,
+                  current == recovery else { return nil }
+            owner.bridgeRecovery.consecutiveFailureCount += 1
+            owner.bridgeRecovery.phase = .waitingRetry(recovery, nil)
+            state.recordsByKey[key] = owner
+            return ProcessBridgeRecoveryRetry(
+                reservation: recovery,
+                delay: owner.bridgeRecovery.consecutiveFailureCount == 1
+                    ? .seconds(1)
+                    : .seconds(10)
+            )
+        }
+    }
+
+    func attachBridgeRecoveryRetryTimeout(
+        _ timeout: RuntimeScheduledTimeout,
+        to recovery: ProcessBridgePoolRecovery
+    ) -> ProcessControlPlaneTransition {
+        state.withLockedValue { state in
+            guard let key = Self.key(routeID: recovery.routeID, in: state),
+                  var owner = state.recordsByKey[key],
+                  case .waitingRetry(let current, let previous) = owner.bridgeRecovery.phase,
+                  current == recovery else {
+                return ProcessControlPlaneTransition(
+                    addedRoutes: [], retiredRoutes: [],
+                    effects: [.cancelTimeout(timeout)],
+                    publishesToolsListChanged: false
+                )
+            }
+            owner.bridgeRecovery.phase = .waitingRetry(recovery, timeout)
+            state.recordsByKey[key] = owner
+            return ProcessControlPlaneTransition(
+                addedRoutes: [], retiredRoutes: [],
+                effects: previous.map { [.cancelTimeout($0)] } ?? [],
+                publishesToolsListChanged: false
+            )
+        }
+    }
+
+    func handleBridgeRecoveryRetryFired(
+        _ recovery: ProcessBridgePoolRecovery
+    ) -> ProcessControlPlaneTransition {
+        state.withLockedValue { state in
+            guard let key = Self.key(routeID: recovery.routeID, in: state),
+                  var owner = state.recordsByKey[key],
+                  case .waitingRetry(let current, _) = owner.bridgeRecovery.phase,
+                  current == recovery else { return .none }
+            guard state.catalogsByProcessID[owner.route.target.processID] != nil else {
+                owner.bridgeRecovery.generation &+= 1
+                owner.bridgeRecovery.pendingUpstreamIDs.insert(recovery.upstreamID)
+                owner.bridgeRecovery.phase = .idle
+                state.recordsByKey[key] = owner
+                return .none
+            }
+            owner.bridgeRecovery.generation &+= 1
+            let next = ProcessBridgePoolRecovery(
+                routeID: owner.route.id,
+                upstreamID: recovery.upstreamID,
+                generation: owner.bridgeRecovery.generation
+            )
+            owner.bridgeRecovery.phase = .attempting(next)
+            state.recordsByKey[key] = owner
+            return ProcessControlPlaneTransition(
+                addedRoutes: [], retiredRoutes: [],
+                effects: [.restoreBridgePool(next)],
                 publishesToolsListChanged: false
             )
         }
@@ -746,7 +909,6 @@ final class ProcessControlPlaneAuthority: Sendable {
                             effects.append(contentsOf: attempt.detachedEffects())
                             record.attempt = nil
                         }
-                        record.pendingBridgeRecoveryUpstreamIDs.removeAll()
                         Self.removeCatalog(
                             processID: record.route.target.processID,
                             from: &state
@@ -759,6 +921,9 @@ final class ProcessControlPlaneAuthority: Sendable {
                             target: target,
                             upstreamIndices: observedRoute.upstreamIndices
                         )
+                        effects.append(contentsOf: record.bridgeRecovery.reset(
+                            pendingUpstreamIDs: Self.secondaryUpstreamIDs(in: record.route)
+                        ))
                         if record.catalogEligibilityEstablished == false {
                             let replacementIDs = Set(
                                 observedRoute.upstreamIndices.map(
@@ -803,6 +968,9 @@ final class ProcessControlPlaneAuthority: Sendable {
                 record.missingSinceUptimeNs = nowUptimeNs
                 record.lastReconcileReason = reason
                 effects.append(contentsOf: record.clearAllCooldowns().effects)
+                effects.append(contentsOf: record.bridgeRecovery.reset(
+                    pendingUpstreamIDs: []
+                ))
                 if let attempt = record.attempt {
                     effects.append(contentsOf: attempt.detachedEffects())
                     record.attempt = nil
@@ -1577,13 +1745,22 @@ final class ProcessControlPlaneAuthority: Sendable {
     ) -> ProcessControlPlaneTransition {
         state.withLockedValue { state in
             state.catalogEpoch = CatalogEpoch(rawValue: state.catalogEpoch.rawValue &+ 1)
-            let effects = Self.invalidateAttempts(in: &state)
+            var effects = Self.invalidateAttempts(in: &state)
             switch reason {
             case .reset:
                 state.catalogsByProcessID.removeAll()
                 state.processIDByUpstreamID.removeAll()
                 state.unboundCatalogRaw = nil
                 state.unboundCatalogSource = nil
+                for key in state.order {
+                    guard var record = state.recordsByKey[key] else { continue }
+                    effects.append(contentsOf: record.bridgeRecovery.reset(
+                        pendingUpstreamIDs: record.state == .active
+                            ? Self.secondaryUpstreamIDs(in: record.route)
+                            : []
+                    ))
+                    state.recordsByKey[key] = record
+                }
             case .routeMembershipChanged, .exposureChanged:
                 break
             }
@@ -1610,6 +1787,11 @@ final class ProcessControlPlaneAuthority: Sendable {
             for key in state.order {
                 guard var record = state.recordsByKey[key] else { continue }
                 effects.append(contentsOf: record.clearAllCooldowns().effects)
+                effects.append(contentsOf: record.bridgeRecovery.reset(
+                    pendingUpstreamIDs: record.state == .active
+                        ? Self.secondaryUpstreamIDs(in: record.route)
+                        : []
+                ))
                 record.attempt = nil
                 record.catalogEligibilityEstablished = false
                 record.admissionRevision &+= 1
@@ -1864,6 +2046,9 @@ final class ProcessControlPlaneAuthority: Sendable {
             record.admissionRevision &+= 1
             var effects = record.attempt?.detachedEffects() ?? []
             effects.append(contentsOf: record.clearAllCooldowns().effects)
+            effects.append(contentsOf: record.bridgeRecovery.reset(
+                pendingUpstreamIDs: []
+            ))
             record.attempt = nil
             state.recordsByKey[key] = record
             Self.removeCatalog(processID: record.route.target.processID, from: &state)
@@ -2156,7 +2341,9 @@ final class ProcessControlPlaneAuthority: Sendable {
             catalogEligibilityEstablished: Set(
                 route.upstreamIndices.map(UpstreamSlotID.init(rawValue:))
             ).isDisjoint(with: state.usability.recoveryAwareUsableUpstreamIDs) == false,
-            pendingBridgeRecoveryUpstreamIDs: [],
+            bridgeRecovery: BridgeRecoveryState(
+                pendingUpstreamIDs: Self.secondaryUpstreamIDs(in: route)
+            ),
             nextAttemptID: 0,
             attempt: nil
         )
@@ -2167,6 +2354,12 @@ final class ProcessControlPlaneAuthority: Sendable {
     private static func reorderActiveKeys(_ orderedKeys: [InstanceKey], in state: inout State) {
         let activeSet = Set(orderedKeys)
         state.order = orderedKeys + state.order.filter { activeSet.contains($0) == false }
+    }
+
+    private static func secondaryUpstreamIDs(
+        in route: XcodeProcessRoute
+    ) -> Set<UpstreamSlotID> {
+        Set(route.upstreamIndices.dropFirst().map(UpstreamSlotID.init(rawValue:)))
     }
 
     private static func activeRoutes(in state: State) -> [XcodeProcessRoute] {
@@ -2227,16 +2420,20 @@ final class ProcessControlPlaneAuthority: Sendable {
     private static func takeBridgePoolRecoveryEffects(
         owner: inout XcodeProcessOwner
     ) -> [ProcessControlPlaneEffect] {
-        guard owner.pendingBridgeRecoveryUpstreamIDs.isEmpty == false else { return [] }
-        let upstreamIDs = owner.pendingBridgeRecoveryUpstreamIDs.sorted {
-            $0.rawValue < $1.rawValue
-        }
-        owner.pendingBridgeRecoveryUpstreamIDs.removeAll()
+        guard case .idle = owner.bridgeRecovery.phase,
+              let upstreamID = owner.bridgeRecovery.pendingUpstreamIDs.min(by: {
+                  $0.rawValue < $1.rawValue
+              }) else { return [] }
+        owner.bridgeRecovery.pendingUpstreamIDs.remove(upstreamID)
+        owner.bridgeRecovery.generation &+= 1
+        let recovery = ProcessBridgePoolRecovery(
+            routeID: owner.route.id,
+            upstreamID: upstreamID,
+            generation: owner.bridgeRecovery.generation
+        )
+        owner.bridgeRecovery.phase = .attempting(recovery)
         return [
-            .restoreBridgePool(ProcessBridgePoolRecovery(
-                routeID: owner.route.id,
-                upstreamIDs: upstreamIDs
-            ))
+            .restoreBridgePool(recovery)
         ]
     }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -1360,6 +1360,9 @@ extension RuntimeCoordinator {
                 ]
             )
         }
+        if case .processBridgeRecovery = initializeClaim.owner {
+            return
+        }
         guard processRoutingEnabled,
               let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) else {
             return

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -70,8 +70,10 @@ extension RuntimeCoordinator {
 
     func probeUpstreamHealth(_ probe: UpstreamHealthManager.ProbeRequest) {
         let upstreamIndex = probe.upstreamIndex
-        if case .processBridgeAttachment(let reservation) = probe.purpose,
-           processControlPlane.validateBridgeRecovery(reservation) == false {
+        if case .processBridgeAttachment(let verification) = probe.purpose,
+           processControlPlane.validateBridgeRecovery(
+            verification.recovery.reservation
+           ) == false {
             settleRejectedProcessBridgeAttachVerification(
                 probe,
                 reason: "attach_probe_reservation_stale"
@@ -96,24 +98,34 @@ extension RuntimeCoordinator {
         let probeSession = session(id: internalSessionID)
         let probeTimeout: TimeAmount = .seconds(2)
         let originalID = JSONRPC.ID(any: "__probe-\(upstreamIndex)-\(UUID().uuidString)")!
-        let registration = probeSession.router.registerRequestPending(
-            idKey: originalID.key,
-            on: eventLoop,
-            timeout: probeTimeout,
-            timeoutScheduler: scheduleRuntimeTimeout
-        )
         guard let upstreamID = assignUpstreamID(
             sessionID: internalSessionID,
             originalID: originalID,
             operationLease: operationLease
         ) else {
-            _ = probeSession.router.cancelPending(token: registration.token)
             finishHealthProbe(probe, success: false, reason: "assign_request_id_failed")
             return
         }
+        let registration = probeSession.router.registerRequestPending(
+            idKey: originalID.key,
+            on: eventLoop,
+            timeout: probeTimeout,
+            timeoutScheduler: scheduleRuntimeTimeout,
+            onTimeout: { [weak self] in
+                self?.upstreamRouter.remove(
+                    proof: operationLease.proof,
+                    upstreamID: upstreamID
+                )
+            }
+        )
 
         let request = JSONRPC.Wire.requestObject(id: upstreamID, method: "tools/list")
         guard let requestData = try? JSONRPC.Wire.data(from: request) else {
+            _ = probeSession.router.cancelPending(token: registration.token)
+            upstreamRouter.remove(
+                proof: operationLease.proof,
+                upstreamID: upstreamID
+            )
             finishHealthProbe(
                 probe,
                 success: false,
@@ -129,13 +141,18 @@ extension RuntimeCoordinator {
             admission: nil,
             onRejected: {
                 _ = probeSession.router.cancelPending(token: registration.token)
+                self.upstreamRouter.remove(
+                    proof: operationLease.proof,
+                    upstreamID: upstreamID
+                )
             }
         ) else {
             finishHealthProbe(probe, success: false, reason: "send_rejected")
             return
         }
 
-        addRuntimeTask { [weak self, probeSession, registration] in
+        testHooks.healthProbeResponseWaiterWillRegister?()
+        let waiterScheduled = addRuntimeTask { [weak self, probeSession, registration] in
             guard let self else { return }
             do {
                 var buffer = try await withTaskCancellationHandler {
@@ -195,6 +212,19 @@ extension RuntimeCoordinator {
                 )
             }
         }
+        guard waiterScheduled else {
+            _ = probeSession.router.cancelPending(token: registration.token)
+            upstreamRouter.remove(
+                proof: operationLease.proof,
+                upstreamID: upstreamID
+            )
+            finishHealthProbe(
+                probe,
+                success: false,
+                reason: "probe_waiter_rejected"
+            )
+            return
+        }
     }
 
     func finishHealthProbe(
@@ -252,99 +282,21 @@ extension RuntimeCoordinator {
         success: Bool,
         reason: String
     ) {
-        let proof = probe.topologyProof
-        var verification: (
-            recovery: ProcessBridgePoolRecovery,
-            cleared: (
-                timeout: RuntimeScheduledTimeout?,
-                initUpstreamID: Int64?,
-                didReceiveInitializeResponse: Bool,
-                didSendInitialized: Bool
-            )?
-        )?
-        var bridgeCompletion: ProcessControlPlaneTransition?
-        var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
-        let eligibility = initializeManager.finishSupportEligibilityUpdate {
-            var update: CanonicalHandshakeState.SupportEligibilityUpdate?
-            guard upstreamTopology.withValidatedSnapshot(proof, { topologySnapshot in
-                guard let result = upstreamHealthManager.finishBridgeAttachVerification(
-                    probe,
-                    success: success,
-                    nowUptimeNs: nowUptimeNanoseconds(),
-                    commit: {
-                        guard case .processBridgeAttachment(let reservation) = probe.purpose
-                        else { return false }
-                        guard success else {
-                            return processControlPlane.validateBridgeRecovery(reservation)
-                        }
-                        guard let completion = processControlPlane
-                            .completeBridgeRecoveryIfCurrent(reservation) else {
-                            return false
-                        }
-                        bridgeCompletion = completion
-                        return true
-                    }
-                ) else { return false }
-                verification = result
-                update = commitSupportEligibilityAfterHealthMutation(
-                    topologySnapshot: topologySnapshot,
-                    detachedProof: success ? nil : proof,
-                    processEligibility: &processEligibility
-                )
-                return true
-            }) == true else { return nil }
-            return update
-        }
-        guard let verification, let eligibility, let processEligibility else {
-            settleRejectedProcessBridgeAttachVerification(
-                probe,
-                reason: "attach_probe_completion_rejected"
-            )
-            return
-        }
-        applyProcessControlPlaneTransition(processEligibility.transition)
-        applySupportEligibilityCompletion(eligibility)
-
+        let completed: Bool
         if success {
-            guard let bridgeCompletion else {
-                settleRejectedProcessBridgeAttachVerification(
-                    probe,
-                    reason: "attach_probe_completion_missing"
-                )
-                return
-            }
-            applyProcessControlPlaneTransition(bridgeCompletion)
-            markXcodeProcessRouteAvailable(upstreamIndex: probe.upstreamIndex)
-            if processControlPlane.catalog(
-                forProcessID: verification.recovery.routeID.processID
-            ) == nil,
-               let route = xcodeProcessRoutes.first(where: {
-                   $0.id == verification.recovery.routeID
-               }) {
-                refreshProcessRouteToolsCatalog(
-                    route: route,
-                    upstreamProof: proof,
-                    reason: "bridge_pool_attach_verified_\(probe.upstreamIndex)"
-                )
-            }
-            upstreamSlotScheduler.wake()
-            noteUpstreamInitializationSucceeded()
-        } else {
-            if let cleared = verification.cleared {
-                finishClearingUpstreamState(
-                    proof: proof,
-                    cleared: cleared,
-                    resetsProcessRouteActivation: false
-                )
-            }
-            replaceProcessBridgeRecoveryChannelAndScheduleRetry(
-                ProcessBridgeRecovery(
-                    reservation: verification.recovery,
-                    topologyProof: proof
-                ),
-                reason: "attach_probe_\(reason)"
+            completed = finishSuccessfulProcessBridgeAttachVerification(
+                probe,
+                reason: reason
             )
-            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+        } else {
+            completed = finishFailedProcessBridgeAttachVerification(
+                probe,
+                reason: reason
+            )
+        }
+        guard completed,
+              case .processBridgeAttachment(let verification) = probe.purpose else {
+            return
         }
         logger.info(
             "bridge_pool_attach_verification_completed",
@@ -357,19 +309,190 @@ extension RuntimeCoordinator {
         )
     }
 
+    private func finishSuccessfulProcessBridgeAttachVerification(
+        _ probe: UpstreamHealthManager.ProbeRequest,
+        reason: String
+    ) -> Bool {
+        guard case .processBridgeAttachment(let bridgeVerification) = probe.purpose else {
+            return false
+        }
+        let proof = probe.topologyProof
+        var verification: (
+            recovery: ProcessBridgePoolRecovery,
+            cleared: (
+                timeout: RuntimeScheduledTimeout?,
+                initUpstreamID: Int64?,
+                didReceiveInitializeResponse: Bool,
+                didSendInitialized: Bool
+            )?
+        )?
+        var bridgeCompletion: ProcessControlPlaneTransition?
+        var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
+        var supportUpdate: CanonicalHandshakeState.SupportEligibilityUpdate?
+        var initializeCommit: CanonicalHandshakeState.InitializeCommit = .stale
+        let transaction = initializeManager.finishInitializeParticipant {
+            guard upstreamTopology.withValidatedSnapshot(proof, { topologySnapshot in
+                guard let result = upstreamHealthManager.finishBridgeAttachVerification(
+                    probe,
+                    success: true,
+                    nowUptimeNs: nowUptimeNanoseconds(),
+                    commit: {
+                        guard let completion = processControlPlane
+                            .completeBridgeRecoveryIfCurrent(
+                                bridgeVerification.recovery.reservation,
+                                commit: {
+                                    initializeCommit = canonicalHandshakeState
+                                        .commitInitializeParticipant(
+                                            bridgeVerification.initializeParticipant
+                                        )
+                                    return initializeCommit.isAccepted
+                                }
+                            ) else {
+                            return false
+                        }
+                        bridgeCompletion = completion
+                        return true
+                    }
+                ) else { return false }
+                verification = result
+                supportUpdate = commitSupportEligibilityAfterHealthMutation(
+                    topologySnapshot: topologySnapshot,
+                    detachedProof: nil,
+                    processEligibility: &processEligibility
+                )
+                return true
+            }) == true else { return initializeCommit }
+            return initializeCommit
+        }
+        guard transaction.commit.isAccepted,
+              let verification,
+              let bridgeCompletion,
+              let processEligibility,
+              let supportUpdate else {
+            settleRejectedProcessBridgeAttachVerification(
+                probe,
+                reason: "attach_probe_success_commit_rejected_\(reason)"
+            )
+            return false
+        }
+        applyProcessControlPlaneTransition(processEligibility.transition)
+        applySupportEligibilityCompletion(
+            InitializeManager.SupportEligibilityCompletion(
+                update: supportUpdate,
+                publication: nil
+            )
+        )
+        applyProcessControlPlaneTransition(bridgeCompletion)
+        markXcodeProcessRouteAvailable(upstreamIndex: probe.upstreamIndex)
+        if let publication = transaction.publication {
+            applyInitializePublication(
+                publication,
+                upstreamIndex: probe.upstreamIndex,
+                refreshPendingProcessCatalog: false
+            )
+        }
+        if processControlPlane.catalog(
+            forProcessID: verification.recovery.routeID.processID
+        ) == nil,
+           let route = xcodeProcessRoutes.first(where: {
+               $0.id == verification.recovery.routeID
+           }) {
+            refreshProcessRouteToolsCatalog(
+                route: route,
+                upstreamProof: proof,
+                reason: "bridge_pool_attach_verified_\(probe.upstreamIndex)"
+            )
+        }
+        upstreamSlotScheduler.wake()
+        noteUpstreamInitializationSucceeded()
+        return true
+    }
+
+    private func finishFailedProcessBridgeAttachVerification(
+        _ probe: UpstreamHealthManager.ProbeRequest,
+        reason: String
+    ) -> Bool {
+        guard case .processBridgeAttachment(let bridgeVerification) = probe.purpose else {
+            return false
+        }
+        let proof = probe.topologyProof
+        var verification: (
+            recovery: ProcessBridgePoolRecovery,
+            cleared: (
+                timeout: RuntimeScheduledTimeout?,
+                initUpstreamID: Int64?,
+                didReceiveInitializeResponse: Bool,
+                didSendInitialized: Bool
+            )?
+        )?
+        var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
+        let eligibility = initializeManager.finishSupportEligibilityUpdate {
+            var update: CanonicalHandshakeState.SupportEligibilityUpdate?
+            guard upstreamTopology.withValidatedSnapshot(proof, { topologySnapshot in
+                guard let result = upstreamHealthManager.finishBridgeAttachVerification(
+                    probe,
+                    success: false,
+                    nowUptimeNs: nowUptimeNanoseconds(),
+                    commit: {
+                        guard processControlPlane.validateBridgeRecovery(
+                            bridgeVerification.recovery.reservation
+                        ) else { return false }
+                        canonicalHandshakeState.cancelInitializeParticipant(
+                            bridgeVerification.initializeParticipant
+                        )
+                        return true
+                    }
+                ) else { return false }
+                verification = result
+                update = commitSupportEligibilityAfterHealthMutation(
+                    topologySnapshot: topologySnapshot,
+                    detachedProof: proof,
+                    processEligibility: &processEligibility
+                )
+                return true
+            }) == true else { return nil }
+            return update
+        }
+        guard let verification, let eligibility, let processEligibility else {
+            settleRejectedProcessBridgeAttachVerification(
+                probe,
+                reason: "attach_probe_failure_commit_rejected_\(reason)"
+            )
+            return false
+        }
+        applyProcessControlPlaneTransition(processEligibility.transition)
+        applySupportEligibilityCompletion(eligibility)
+        if let cleared = verification.cleared {
+            finishClearingUpstreamState(
+                proof: proof,
+                cleared: cleared,
+                resetsProcessRouteActivation: false
+            )
+        }
+        replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+            ProcessBridgeRecovery(
+                reservation: verification.recovery,
+                topologyProof: proof
+            ),
+            reason: "attach_probe_\(reason)"
+        )
+        failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+        return true
+    }
+
     private func settleRejectedProcessBridgeAttachVerification(
         _ probe: UpstreamHealthManager.ProbeRequest,
         reason: String
     ) {
-        guard case .processBridgeAttachment(let reservation) = probe.purpose else {
+        guard case .processBridgeAttachment(let verification) = probe.purpose else {
             return
         }
-        let recovery = ProcessBridgeRecovery(
-            reservation: reservation,
-            topologyProof: probe.topologyProof
+        canonicalHandshakeState.cancelInitializeParticipant(
+            verification.initializeParticipant
         )
-        if upstreamHealthManager.currentBridgeRecovery(for: probe.topologyProof)?
-            .reservation == reservation {
+        let recovery = verification.recovery
+        if upstreamHealthManager.currentBridgeRecovery(for: probe.topologyProof)
+            == recovery {
             _ = clearUpstreamState(
                 proof: probe.topologyProof,
                 resetsProcessRouteActivation: false
@@ -380,7 +503,7 @@ extension RuntimeCoordinator {
             )
         } else {
             scheduleProcessBridgeRecoveryRetry(
-                reservation,
+                recovery.reservation,
                 reason: reason
             )
         }
@@ -493,9 +616,9 @@ extension RuntimeCoordinator {
     }
 
     /// Commits a verified health transition and its initialize/catalog
-    /// eligibility projection under the shared lock order:
-    /// InitializeManager -> authoritative topology -> health -> canonical ->
-    /// process control plane. Effects are applied only after all locks release.
+    /// eligibility projection while InitializeManager, authoritative topology,
+    /// and health remain stable. Canonical and process projections are updated
+    /// before effects are applied outside those locks.
     func commitVerifiedHealthSupportMutation<Result>(
         proof: UpstreamTopologyProof,
         detachedProof: UpstreamTopologyProof? = nil,

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -324,6 +324,18 @@ extension RuntimeCoordinator {
             }
             applyProcessControlPlaneTransition(bridgeCompletion)
             markXcodeProcessRouteAvailable(upstreamIndex: probe.upstreamIndex)
+            if processControlPlane.catalog(
+                forProcessID: verification.recovery.routeID.processID
+            ) == nil,
+               let route = xcodeProcessRoutes.first(where: {
+                   $0.id == verification.recovery.routeID
+               }) {
+                refreshProcessRouteToolsCatalog(
+                    route: route,
+                    upstreamProof: proof,
+                    reason: "bridge_pool_attach_verified_\(probe.upstreamIndex)"
+                )
+            }
             upstreamSlotScheduler.wake()
             noteUpstreamInitializationSucceeded()
         } else {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -95,11 +95,12 @@ extension RuntimeCoordinator {
         _ = session(id: internalSessionID)
         let probeSession = session(id: internalSessionID)
         let probeTimeout: TimeAmount = .seconds(2)
-        let probeDeadlineUptimeNs = deadlineUptimeNanoseconds(for: probeTimeout)
         let originalID = JSONRPC.ID(any: "__probe-\(upstreamIndex)-\(UUID().uuidString)")!
-        let registration = probeSession.router.registerRequestPendingWithoutTimeout(
+        let registration = probeSession.router.registerRequestPending(
             idKey: originalID.key,
-            on: eventLoop
+            on: eventLoop,
+            timeout: probeTimeout,
+            timeoutScheduler: scheduleRuntimeTimeout
         )
         guard let upstreamID = assignUpstreamID(
             sessionID: internalSessionID,
@@ -138,17 +139,7 @@ extension RuntimeCoordinator {
             guard let self else { return }
             do {
                 var buffer = try await withTaskCancellationHandler {
-                    try await self.waitForEventLoopFuture(
-                        registration.future,
-                        deadlineUptimeNs: probeDeadlineUptimeNs,
-                        onTimeout: {
-                            _ = probeSession.router.cancelPending(token: registration.token)
-                            self.upstreamRouter.remove(
-                                proof: operationLease.proof,
-                                upstreamID: upstreamID
-                            )
-                        }
-                    )
+                    try await registration.future.get()
                 } onCancel: {
                     _ = probeSession.router.cancelPending(token: registration.token)
                     self.upstreamRouter.remove(

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -24,8 +24,8 @@ extension RuntimeCoordinator {
                 return .regular
             case .processRouteActivation:
                 return .processRouteActivation
-            case .processBridgeRecovery:
-                return .processBridgeRecovery
+            case .processBridgeRecovery(let recovery):
+                return .processBridgeRecovery(recovery)
             }
         }
     }
@@ -70,9 +70,24 @@ extension RuntimeCoordinator {
 
     func probeUpstreamHealth(_ probe: UpstreamHealthManager.ProbeRequest) {
         let upstreamIndex = probe.upstreamIndex
+        if case .processBridgeAttachment(let reservation) = probe.purpose,
+           processControlPlane.validateBridgeRecovery(reservation) == false {
+            settleRejectedProcessBridgeAttachVerification(
+                probe,
+                reason: "attach_probe_reservation_stale"
+            )
+            return
+        }
         guard let operationLease = upstreamTopology.operationLease(
             for: probe.topologyProof
         ) else {
+            if case .processBridgeAttachment = probe.purpose {
+                settleRejectedProcessBridgeAttachVerification(
+                    probe,
+                    reason: "attach_probe_operation_lease_unavailable"
+                )
+                return
+            }
             schedulePendingInitializeQuarantineRecovery()
             return
         }
@@ -80,11 +95,11 @@ extension RuntimeCoordinator {
         _ = session(id: internalSessionID)
         let probeSession = session(id: internalSessionID)
         let probeTimeout: TimeAmount = .seconds(2)
+        let probeDeadlineUptimeNs = deadlineUptimeNanoseconds(for: probeTimeout)
         let originalID = JSONRPC.ID(any: "__probe-\(upstreamIndex)-\(UUID().uuidString)")!
-        let registration = probeSession.router.registerRequestPending(
+        let registration = probeSession.router.registerRequestPendingWithoutTimeout(
             idKey: originalID.key,
-            on: eventLoop,
-            timeout: probeTimeout
+            on: eventLoop
         )
         guard let upstreamID = assignUpstreamID(
             sessionID: internalSessionID,
@@ -123,7 +138,17 @@ extension RuntimeCoordinator {
             guard let self else { return }
             do {
                 var buffer = try await withTaskCancellationHandler {
-                    try await registration.future.get()
+                    try await self.waitForEventLoopFuture(
+                        registration.future,
+                        deadlineUptimeNs: probeDeadlineUptimeNs,
+                        onTimeout: {
+                            _ = probeSession.router.cancelPending(token: registration.token)
+                            self.upstreamRouter.remove(
+                                proof: operationLease.proof,
+                                upstreamID: upstreamID
+                            )
+                        }
+                    )
                 } onCancel: {
                     _ = probeSession.router.cancelPending(token: registration.token)
                     self.upstreamRouter.remove(
@@ -186,6 +211,14 @@ extension RuntimeCoordinator {
         success: Bool,
         reason: String
     ) {
+        if case .processBridgeAttachment = probe.purpose {
+            finishProcessBridgeAttachVerification(
+                probe,
+                success: success,
+                reason: reason
+            )
+            return
+        }
         let upstreamIndex = probe.upstreamIndex
         let nowUptimeNs = nowUptimeNanoseconds()
         let committed: Void? = commitVerifiedHealthSupportMutation(
@@ -221,6 +254,133 @@ extension RuntimeCoordinator {
                 "reason": .string(reason),
             ]
         )
+    }
+
+    func finishProcessBridgeAttachVerification(
+        _ probe: UpstreamHealthManager.ProbeRequest,
+        success: Bool,
+        reason: String
+    ) {
+        let proof = probe.topologyProof
+        var verification: (
+            recovery: ProcessBridgePoolRecovery,
+            cleared: (
+                timeout: RuntimeScheduledTimeout?,
+                initUpstreamID: Int64?,
+                didReceiveInitializeResponse: Bool,
+                didSendInitialized: Bool
+            )?
+        )?
+        var bridgeCompletion: ProcessControlPlaneTransition?
+        var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
+        let eligibility = initializeManager.finishSupportEligibilityUpdate {
+            var update: CanonicalHandshakeState.SupportEligibilityUpdate?
+            guard upstreamTopology.withValidatedSnapshot(proof, { topologySnapshot in
+                guard let result = upstreamHealthManager.finishBridgeAttachVerification(
+                    probe,
+                    success: success,
+                    nowUptimeNs: nowUptimeNanoseconds(),
+                    commit: {
+                        guard case .processBridgeAttachment(let reservation) = probe.purpose
+                        else { return false }
+                        guard success else {
+                            return processControlPlane.validateBridgeRecovery(reservation)
+                        }
+                        guard let completion = processControlPlane
+                            .completeBridgeRecoveryIfCurrent(reservation) else {
+                            return false
+                        }
+                        bridgeCompletion = completion
+                        return true
+                    }
+                ) else { return false }
+                verification = result
+                update = commitSupportEligibilityAfterHealthMutation(
+                    topologySnapshot: topologySnapshot,
+                    detachedProof: success ? nil : proof,
+                    processEligibility: &processEligibility
+                )
+                return true
+            }) == true else { return nil }
+            return update
+        }
+        guard let verification, let eligibility, let processEligibility else {
+            settleRejectedProcessBridgeAttachVerification(
+                probe,
+                reason: "attach_probe_completion_rejected"
+            )
+            return
+        }
+        applyProcessControlPlaneTransition(processEligibility.transition)
+        applySupportEligibilityCompletion(eligibility)
+
+        if success {
+            guard let bridgeCompletion else {
+                settleRejectedProcessBridgeAttachVerification(
+                    probe,
+                    reason: "attach_probe_completion_missing"
+                )
+                return
+            }
+            applyProcessControlPlaneTransition(bridgeCompletion)
+            markXcodeProcessRouteAvailable(upstreamIndex: probe.upstreamIndex)
+            upstreamSlotScheduler.wake()
+            noteUpstreamInitializationSucceeded()
+        } else {
+            if let cleared = verification.cleared {
+                finishClearingUpstreamState(
+                    proof: proof,
+                    cleared: cleared,
+                    resetsProcessRouteActivation: false
+                )
+            }
+            replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+                ProcessBridgeRecovery(
+                    reservation: verification.recovery,
+                    topologyProof: proof
+                ),
+                reason: "attach_probe_\(reason)"
+            )
+            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+        }
+        logger.info(
+            "bridge_pool_attach_verification_completed",
+            metadata: [
+                "pid": .string("\(verification.recovery.routeID.processID)"),
+                "upstream": .string("\(probe.upstreamIndex)"),
+                "success": .string(success ? "true" : "false"),
+                "reason": .string(reason),
+            ]
+        )
+    }
+
+    private func settleRejectedProcessBridgeAttachVerification(
+        _ probe: UpstreamHealthManager.ProbeRequest,
+        reason: String
+    ) {
+        guard case .processBridgeAttachment(let reservation) = probe.purpose else {
+            return
+        }
+        let recovery = ProcessBridgeRecovery(
+            reservation: reservation,
+            topologyProof: probe.topologyProof
+        )
+        if upstreamHealthManager.currentBridgeRecovery(for: probe.topologyProof)?
+            .reservation == reservation {
+            _ = clearUpstreamState(
+                proof: probe.topologyProof,
+                resetsProcessRouteActivation: false
+            )
+            replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+                recovery,
+                reason: reason
+            )
+        } else {
+            scheduleProcessBridgeRecoveryRetry(
+                reservation,
+                reason: reason
+            )
+        }
     }
 
     func markToolsListRefreshSucceeded(
@@ -403,12 +563,19 @@ extension RuntimeCoordinator {
     ) {
         guard isActiveProcessBoundUpstream(upstreamIndex) else { return }
         if case .processBridgeRecovery(let recovery) = mode {
-            guard recovery.topologyProof.slotID.rawValue == upstreamIndex,
+            guard processControlPlane.validateBridgeRecovery(recovery.reservation),
+                  recovery.topologyProof.slotID.rawValue == upstreamIndex,
                   upstreamTopology.operationLease(
                     for: recovery.topologyProof.slotID
                   )?.proof == recovery.topologyProof,
                   xcodeProcessRoute(forUpstreamIndex: upstreamIndex)?.id == recovery.routeID
-            else { return }
+            else {
+                scheduleProcessBridgeRecoveryRetry(
+                    recovery.reservation,
+                    reason: "readiness_invalidated"
+                )
+                return
+            }
         }
         let activationStart = beginProcessRouteActivationIfNeeded(
             mode: mode,
@@ -433,12 +600,22 @@ extension RuntimeCoordinator {
                     processControlPlane.cancelActivation(activationStart)
                 )
             }
+            if case .processBridgeRecovery(let recovery) = mode {
+                handleProcessBridgeRecoveryStartRejected(
+                    recovery,
+                    reason: "initialize_claim_rejected"
+                )
+            }
             return
         }
         guard let proof = initializeClaim.topologyProof,
               let operationLease = upstreamTopology.operationLease(for: proof),
               let upstreamID = upstreamRouter.assignInitialize(proof: proof) else {
-            clearUpstreamState(initializeClaim: initializeClaim)
+            handleWarmInitializeStartFailure(
+                mode: mode,
+                initializeClaim: initializeClaim,
+                reason: "initialize_route_unavailable"
+            )
             return
         }
         guard upstreamHealthManager.setWarmInitializeUpstreamID(
@@ -451,9 +628,23 @@ extension RuntimeCoordinator {
                     processControlPlane.cancelActivation(activationStart)
                 )
             }
+            handleWarmInitializeStartFailure(
+                mode: mode,
+                initializeClaim: initializeClaim,
+                reason: "initialize_id_rejected"
+            )
             return
         }
-        guard upstreamHealthManager.validate(initializeClaim) else { return }
+        guard upstreamHealthManager.validate(initializeClaim) else {
+            if case .processBridgeRecovery = mode {
+                handleWarmInitializeStartFailure(
+                    mode: mode,
+                    initializeClaim: initializeClaim,
+                    reason: "initialize_claim_invalidated"
+                )
+            }
+            return
+        }
         scheduleUpstreamInitTimeout(
             mode: mode,
             activationStart: activationStart,
@@ -462,7 +653,16 @@ extension RuntimeCoordinator {
 
         let request = makeInternalInitializeRequest(id: upstreamID)
         if let data = try? JSONRPC.Wire.data(from: request) {
-            guard upstreamHealthManager.beginInitializeSend(initializeClaim) else { return }
+            guard upstreamHealthManager.beginInitializeSend(initializeClaim) else {
+                if case .processBridgeRecovery = mode {
+                    handleWarmInitializeStartFailure(
+                        mode: mode,
+                        initializeClaim: initializeClaim,
+                        reason: "initialize_send_claim_rejected"
+                    )
+                }
+                return
+            }
             _ = sendUpstream(
                 data,
                 operationLease: operationLease,
@@ -481,8 +681,58 @@ extension RuntimeCoordinator {
                 }
             )
         } else {
-            clearUpstreamState(initializeClaim: initializeClaim)
+            handleWarmInitializeStartFailure(
+                mode: mode,
+                initializeClaim: initializeClaim,
+                reason: "initialize_encode_failed"
+            )
         }
+    }
+
+    private func handleWarmInitializeStartFailure(
+        mode: WarmInitializeMode,
+        initializeClaim: UpstreamHealthManager.InitializeClaim,
+        reason: String
+    ) {
+        if case .processBridgeRecovery(let recovery) = mode {
+            _ = clearUpstreamState(
+                initializeClaim: initializeClaim,
+                resetsProcessRouteActivation: false,
+                replacesInitializedChannel: false
+            )
+            replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+                recovery,
+                reason: reason
+            )
+            return
+        }
+        clearUpstreamState(initializeClaim: initializeClaim)
+    }
+
+    private func handleProcessBridgeRecoveryStartRejected(
+        _ recovery: ProcessBridgeRecovery,
+        reason: String
+    ) {
+        let isCurrent = upstreamTopology.operationLease(for: recovery.topologyProof)?.proof
+            == recovery.topologyProof
+            && xcodeProcessRoute(forUpstreamIndex: recovery.upstreamID.rawValue)?.id
+                == recovery.routeID
+        if isCurrent,
+           upstreamHealthManager.currentBridgeRecovery(for: recovery.topologyProof) == recovery {
+            return
+        }
+        if isCurrent,
+           upstreamHealthManager.state(for: recovery.upstreamID)?
+            .initPhase.isUsableInitialized == true {
+            applyProcessControlPlaneTransition(
+                processControlPlane.completeBridgeRecovery(recovery.reservation)
+            )
+            return
+        }
+        scheduleProcessBridgeRecoveryRetry(
+            recovery.reservation,
+            reason: reason
+        )
     }
 
     func scheduleUpstreamInitTimeout(
@@ -563,7 +813,8 @@ extension RuntimeCoordinator {
         recovery: ProcessBridgeRecovery,
         initializeClaim: UpstreamHealthManager.InitializeClaim
     ) {
-        guard initializeClaim.owner == .processBridgeRecovery,
+        guard case .processBridgeRecovery(let claimedRecovery) = initializeClaim.owner,
+              claimedRecovery == recovery,
               initializeClaim.topologyProof == recovery.topologyProof,
               clearUpstreamState(
                 initializeClaim: initializeClaim,
@@ -579,6 +830,9 @@ extension RuntimeCoordinator {
                 "phase": .string("initialize"),
             ]
         )
-        _ = replaceOrRetireInitializeChannel(initializeClaim)
+        replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+            recovery,
+            reason: "initialize_timeout"
+        )
     }
 }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -302,7 +302,7 @@ extension RuntimeCoordinator {
                 resetsProcessRouteActivation: processRoutingEnabled
             ) else { return }
             if completePendingInitializesUsingCachedResultIfAvailable() {
-                retryInitializeAfterFailedResponse(
+                retryInitializeAfterTerminalFailure(
                     ownership: ownership,
                     upstreamIndex: upstreamIndex
                 )
@@ -317,7 +317,7 @@ extension RuntimeCoordinator {
                         upstreamID: upstreamID
                     )
                 }
-                retryInitializeAfterFailedResponse(
+                retryInitializeAfterTerminalFailure(
                     ownership: ownership,
                     upstreamIndex: upstreamIndex
                 )
@@ -339,7 +339,7 @@ extension RuntimeCoordinator {
                     failInitPending(error: TimeoutError())
                 }
             } else {
-                retryInitializeAfterFailedResponse(
+                retryInitializeAfterTerminalFailure(
                     ownership: ownership,
                     upstreamIndex: upstreamIndex
                 )
@@ -567,6 +567,15 @@ extension RuntimeCoordinator {
             kind: "initialize",
             reason: "unsupported protocol version"
         )
+        if case .processBridgeRecovery = ownership.initializeClaim.owner {
+            retryInitializeAfterTerminalFailure(
+                ownership: ownership,
+                upstreamIndex: upstreamIndex,
+                reason: "unsupported_initialize_protocol"
+            )
+            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+            return
+        }
         if handlesPrimaryInitialize {
             _ = initializeManager.yieldPrimaryInitializeToRouteActivation(
                 upstreamIndex: upstreamIndex,
@@ -718,7 +727,7 @@ extension RuntimeCoordinator {
         guard cleared else { return }
 
         if completePendingInitializesUsingCachedResultIfAvailable() {
-            retryInitializeAfterFailedResponse(
+            retryInitializeAfterTerminalFailure(
                 ownership: ownership,
                 upstreamIndex: upstreamIndex
             )
@@ -733,7 +742,7 @@ extension RuntimeCoordinator {
                     upstreamID: expectedUpstreamID
                 )
             }
-            retryInitializeAfterFailedResponse(
+            retryInitializeAfterTerminalFailure(
                 ownership: ownership,
                 upstreamIndex: upstreamIndex
             )
@@ -749,7 +758,7 @@ extension RuntimeCoordinator {
                 upstreamIndex: upstreamIndex,
                 upstreamID: expectedUpstreamID
             )
-            retryInitializeAfterFailedResponse(
+            retryInitializeAfterTerminalFailure(
                 ownership: ownership,
                 upstreamIndex: upstreamIndex
             )
@@ -778,6 +787,15 @@ extension RuntimeCoordinator {
             kind: incompatibility.kind,
             reason: incompatibility.reason
         )
+        if case .processBridgeRecovery = ownership.initializeClaim.owner {
+            retryInitializeAfterTerminalFailure(
+                ownership: ownership,
+                upstreamIndex: upstreamIndex,
+                reason: "incompatible_initialize_result"
+            )
+            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+            return
+        }
         _ = initializeManager.yieldPrimaryInitializeToRouteActivation(
             upstreamIndex: upstreamIndex,
             upstreamID: expectedUpstreamID
@@ -802,9 +820,10 @@ extension RuntimeCoordinator {
         return true
     }
 
-    private func retryInitializeAfterFailedResponse(
+    private func retryInitializeAfterTerminalFailure(
         ownership: InitializeResponseOwnership,
-        upstreamIndex: Int
+        upstreamIndex: Int,
+        reason: String = "initialize_response_failed"
     ) {
         switch ownership.initializeClaim.owner {
         case .regular:
@@ -814,8 +833,11 @@ extension RuntimeCoordinator {
                   unavailableXcodeProcessIDs().contains(route.target.processID) == false
             else { return }
             startProcessRouteActivation(for: route)
-        case .processBridgeRecovery:
-            return
+        case .processBridgeRecovery(let recovery):
+            replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+                recovery,
+                reason: reason
+            )
         }
     }
 
@@ -1021,7 +1043,14 @@ extension RuntimeCoordinator {
             cleared: cleared,
             resetsProcessRouteActivation: resetsProcessRouteActivation
         )
+        let isProcessBridgeRecovery: Bool
+        if case .processBridgeRecovery = initializeClaim.owner {
+            isProcessBridgeRecovery = true
+        } else {
+            isProcessBridgeRecovery = false
+        }
         if replacesInitializedChannel,
+           isProcessBridgeRecovery == false,
            (cleared.didReceiveInitializeResponse || cleared.didSendInitialized) {
             replaceOrRetireInitializeChannel(initializeClaim)
         }
@@ -1162,6 +1191,11 @@ extension RuntimeCoordinator {
         guard committed.canonicalCommit.isAccepted,
               let healthTransition = committed.healthTransition else { return }
         healthTransition.timeout?.cancel()
+        if let bridgeVerificationProbe = healthTransition.bridgeVerificationProbe {
+            testHooks.upstreamInitialized?(upstreamIndex)
+            probeUpstreamHealth(bridgeVerificationProbe)
+            return
+        }
         markXcodeProcessRouteAvailable(upstreamIndex: upstreamIndex)
         if ownership.initializeClaim.owner == .processRouteActivation {
             finishProcessRouteActivationChannelInitialized(
@@ -1176,22 +1210,9 @@ extension RuntimeCoordinator {
     func warmUpSecondaryUpstreams(excluding primaryUpstreamIndex: Int? = nil) {
         let resolvedPrimaryUpstreamIndex = primaryUpstreamIndex ?? currentPrimaryInitializeUpstreamIndex()
         if processRoutingEnabled {
-            // A different Xcode needs route activation and its own catalog,
-            // not a regular secondary-slot warmup.
             for route in xcodeProcessRoutes {
-                if route.upstreamIndices.contains(resolvedPrimaryUpstreamIndex) {
-                    for upstreamIndex in route.upstreamIndices
-                    where upstreamIndex != resolvedPrimaryUpstreamIndex {
-                        startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
-                    }
-                } else if processControlPlane.catalog(
-                    forProcessID: route.target.processID
-                ) == nil {
+                if processControlPlane.catalog(forProcessID: route.target.processID) == nil {
                     startProcessRouteActivation(for: route)
-                } else {
-                    for upstreamIndex in route.upstreamIndices {
-                        startUpstreamWarmInitialize(upstreamIndex: upstreamIndex)
-                    }
                 }
             }
             retryPendingProcessRouteReadiness(reason: "canonical_initialize_succeeded")
@@ -1236,7 +1257,7 @@ extension RuntimeCoordinator {
             guard let upstream = upstreamHealthManager.state(
                 for: UpstreamSlotID(rawValue: upstreamIndex)
             ) else { return false }
-            guard upstream.isInitialized else { return false }
+            guard upstream.initPhase.isUsableInitialized else { return false }
             switch upstream.healthState {
             case .healthy, .degraded:
                 return true

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -391,6 +391,26 @@ extension RuntimeCoordinator {
             initializeClaim: ownership.initializeClaim
         ) { [weak self] in
             guard let self else { return }
+            if case .processBridgeRecovery = ownership.initializeClaim.owner {
+                guard let transition = self.prepareProcessBridgeAttachVerification(
+                    expectedUpstreamID: upstreamID,
+                    ownership: ownership,
+                    participantLease: participantLease
+                ) else {
+                    self.handleInitializeParticipantFailure(
+                        participantLease,
+                        ownership: ownership,
+                        upstreamIndex: upstreamIndex,
+                        expectedUpstreamID: upstreamID,
+                        treatsAsPrimary: handlesPrimaryInitialize
+                    )
+                    return
+                }
+                transition.timeout?.cancel()
+                self.testHooks.upstreamInitialized?(upstreamIndex)
+                self.probeUpstreamHealth(transition.probe)
+                return
+            }
             var upstreamCommit: CommittedUpstreamInitialization?
             let transaction = self.initializeManager.finishInitializeParticipant {
                 let committed = self.commitUpstreamInitialized(
@@ -412,24 +432,10 @@ extension RuntimeCoordinator {
             switch transaction.commit {
             case .published:
                 guard let completion = transaction.publication else { return }
-                completion.timeout?.cancel()
-                completion.recoveryTimeout?.cancel()
-                self.upstreamSlotScheduler.wake()
-                if completion.shouldWarmSecondary {
-                    self.warmUpSecondaryUpstreams(excluding: upstreamIndex)
-                }
-                if ownership.initializeClaim.owner == .regular {
-                    self.refreshPendingProcessToolsCatalogAfterWarmInitialize(
-                        upstreamIndex: upstreamIndex
-                    )
-                }
-                self.refreshToolsListIfNeeded()
-                self.completePendingInitializes(
-                    completion.pending,
-                    result: completion.result,
-                    negotiatedProtocolVersion: Self.supportedProtocolVersion(
-                        fromInitializeResult: completion.result
-                    )
+                self.applyInitializePublication(
+                    completion,
+                    upstreamIndex: upstreamIndex,
+                    refreshPendingProcessCatalog: ownership.initializeClaim.owner == .regular
                 )
             case .joined:
                 self.upstreamSlotScheduler.wake()
@@ -464,6 +470,32 @@ extension RuntimeCoordinator {
                 treatsAsPrimary: handlesPrimaryInitialize
             )
         }
+    }
+
+    func applyInitializePublication(
+        _ completion: InitializeManager.SuccessCompletion,
+        upstreamIndex: Int,
+        refreshPendingProcessCatalog: Bool
+    ) {
+        completion.timeout?.cancel()
+        completion.recoveryTimeout?.cancel()
+        upstreamSlotScheduler.wake()
+        if completion.shouldWarmSecondary {
+            warmUpSecondaryUpstreams(excluding: upstreamIndex)
+        }
+        if refreshPendingProcessCatalog {
+            refreshPendingProcessToolsCatalogAfterWarmInitialize(
+                upstreamIndex: upstreamIndex
+            )
+        }
+        refreshToolsListIfNeeded()
+        completePendingInitializes(
+            completion.pending,
+            result: completion.result,
+            negotiatedProtocolVersion: Self.supportedProtocolVersion(
+                fromInitializeResult: completion.result
+            )
+        )
     }
 
     func takeInitializeResponseOwnership(
@@ -1183,6 +1215,28 @@ extension RuntimeCoordinator {
         )
     }
 
+    func prepareProcessBridgeAttachVerification(
+        expectedUpstreamID: Int64,
+        ownership: InitializeResponseOwnership,
+        participantLease: CanonicalHandshakeState.InitializeParticipantLease
+    ) -> UpstreamHealthManager.BridgeVerificationTransition? {
+        let initializeClaim = ownership.initializeClaim
+        guard let proof = initializeClaim.topologyProof,
+              proof == participantLease.topologyProof else { return nil }
+        var transition: UpstreamHealthManager.BridgeVerificationTransition?
+        let prepared = initializeManager.prepareInitializeParticipantForBridgeVerification {
+            upstreamTopology.withValidated(proof, {
+                transition = upstreamHealthManager.beginBridgeAttachVerification(
+                    initializeClaim,
+                    expectedUpstreamID: expectedUpstreamID,
+                    initializeParticipant: participantLease
+                )
+                return transition != nil
+            }) == true
+        }
+        return prepared ? transition : nil
+    }
+
     func finishUpstreamInitialized(
         upstreamIndex: Int,
         ownership: InitializeResponseOwnership,
@@ -1191,11 +1245,6 @@ extension RuntimeCoordinator {
         guard committed.canonicalCommit.isAccepted,
               let healthTransition = committed.healthTransition else { return }
         healthTransition.timeout?.cancel()
-        if let bridgeVerificationProbe = healthTransition.bridgeVerificationProbe {
-            testHooks.upstreamInitialized?(upstreamIndex)
-            probeUpstreamHealth(bridgeVerificationProbe)
-            return
-        }
         markXcodeProcessRouteAvailable(upstreamIndex: upstreamIndex)
         if ownership.initializeClaim.owner == .processRouteActivation {
             finishProcessRouteActivationChannelInitialized(

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -175,6 +175,7 @@ extension RuntimeCoordinator {
         let slotID = UpstreamSlotID(rawValue: upstreamIndex)
         guard proof.slotID == slotID,
               upstreamTopology.validate(proof) else { return }
+        let bridgeRecovery = upstreamHealthManager.currentBridgeRecovery(for: proof)
         guard clearUpstreamState(proof: proof) else { return }
         let globalInit = initializeManager.handleUpstreamExit(upstreamIndex: upstreamIndex)
         guard let globalInit else { return }
@@ -201,6 +202,15 @@ extension RuntimeCoordinator {
                 reason: .upstreamExit
             )
         )
+
+        if let bridgeRecovery, exitedActivePrimaryInitialize == false {
+            replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+                bridgeRecovery,
+                reason: "upstream_exit_\(status)"
+            )
+            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+            return
+        }
 
         if exitedActivePrimaryInitialize {
             if retryPrimaryInitializeOnAlternativeUpstream(
@@ -405,7 +415,21 @@ extension RuntimeCoordinator {
         let upstreamIndex = operationLease.upstreamIndex
         switch reason {
         case .terminated, .notStarted, .startFailed:
-            guard clearUpstreamState(proof: operationLease.proof) else { return }
+            let bridgeRecovery = upstreamHealthManager.currentBridgeRecovery(
+                for: operationLease.proof
+            )
+            guard clearUpstreamState(
+                proof: operationLease.proof,
+                resetsProcessRouteActivation: bridgeRecovery == nil
+            ) else { return }
+            if let bridgeRecovery {
+                replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+                    bridgeRecovery,
+                    reason: "upstream_\(reason)"
+                )
+                failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+                return
+            }
             if xcodeProcessRouteHasUsableInitializedUpstream(containing: upstreamIndex) == false {
                 markXcodeProcessRouteUnavailable(
                     upstreamIndex: upstreamIndex,
@@ -931,6 +955,7 @@ extension RuntimeCoordinator {
         let slotID = UpstreamSlotID(rawValue: upstreamIndex)
         guard proof.slotID == slotID,
               upstreamTopology.validate(proof) else { return }
+        let bridgeRecovery = upstreamHealthManager.currentBridgeRecovery(for: proof)
         debugRecorder.recordProtocolViolation(protocolViolation, upstreamIndex: upstreamIndex)
         let nowUptimeNs = nowUptimeNanoseconds()
         let initSnapshot = initializeManager.snapshot()
@@ -966,6 +991,13 @@ extension RuntimeCoordinator {
                 "uptime_ns": .string("\(nowUptimeNs)"),
             ]
         )
+        if let bridgeRecovery {
+            replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+                bridgeRecovery,
+                reason: "stdout_protocol_violation"
+            )
+            return
+        }
         if processRoutingEnabled,
            let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex) {
             startProcessRouteActivation(for: route)

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -313,36 +313,93 @@ extension RuntimeCoordinator {
         guard let route = xcodeProcessRoutes.first(where: { $0.id == recovery.routeID }) else {
             return
         }
-        let routeUpstreamIDs = Set(
-            route.upstreamIndices.map(UpstreamSlotID.init(rawValue:))
-        )
-        let recoveries = recovery.upstreamIDs.compactMap { upstreamID -> ProcessBridgeRecovery? in
-            guard routeUpstreamIDs.contains(upstreamID),
-                  let proof = upstreamTopology.operationLease(for: upstreamID)?.proof,
-                  let health = upstreamHealthManager.state(for: upstreamID),
-                  health.isInitialized == false,
-                  health.initInFlight == false
-            else { return nil }
-            return ProcessBridgeRecovery(routeID: recovery.routeID, topologyProof: proof)
+        guard route.upstreamIndices.contains(recovery.upstreamID.rawValue),
+              let proof = upstreamTopology.operationLease(for: recovery.upstreamID)?.proof,
+              let health = upstreamHealthManager.state(for: recovery.upstreamID) else {
+            scheduleProcessBridgeRecoveryRetry(
+                recovery,
+                reason: "slot_missing"
+            )
+            return
         }
-        guard recoveries.isEmpty == false else { return }
+        if health.initPhase.isUsableInitialized {
+            applyProcessControlPlaneTransition(
+                processControlPlane.completeBridgeRecovery(recovery)
+            )
+            return
+        }
+        guard
+              health.isInitialized == false,
+              health.initInFlight == false else {
+            scheduleProcessBridgeRecoveryRetry(
+                recovery,
+                reason: "slot_not_ready"
+            )
+            return
+        }
+        let resolvedRecovery = ProcessBridgeRecovery(
+            reservation: recovery,
+            topologyProof: proof
+        )
         logger.info(
             "bridge_pool_recovery_started",
             metadata: [
                 "pid": .string("\(route.target.processID)"),
-                "upstreams": .string(
-                    recoveries.map { String($0.topologyProof.slotID.rawValue) }
-                        .joined(separator: ",")
-                ),
+                "upstream": .string("\(recovery.upstreamID.rawValue)"),
             ]
         )
-        for recovery in recoveries {
-            startUpstreamWarmInitialize(
-                upstreamIndex: recovery.topologyProof.slotID.rawValue,
-                applyBackoff: true,
-                mode: .processBridgeRecovery(recovery)
+        startUpstreamWarmInitialize(
+            upstreamIndex: recovery.upstreamID.rawValue,
+            applyBackoff: false,
+            mode: .processBridgeRecovery(resolvedRecovery)
+        )
+    }
+
+    func scheduleProcessBridgeRecoveryRetry(
+        _ recovery: ProcessBridgePoolRecovery,
+        reason: String
+    ) {
+        guard let retry = processControlPlane.prepareBridgeRecoveryRetry(recovery) else {
+            return
+        }
+        logger.info(
+            "bridge_pool_recovery_retry_scheduled",
+            metadata: [
+                "pid": .string("\(recovery.routeID.processID)"),
+                "upstream": .string("\(recovery.upstreamID.rawValue)"),
+                "reason": .string(reason),
+                "delay_ms": .string("\(retry.delay.nanoseconds / 1_000_000)"),
+            ]
+        )
+        let timeout = scheduleRuntimeTimeout(retry.delay) { [weak self] in
+            guard let self else { return }
+            self.applyProcessControlPlaneTransition(
+                self.processControlPlane.handleBridgeRecoveryRetryFired(
+                    retry.reservation
+                )
             )
         }
+        applyProcessControlPlaneTransition(
+            processControlPlane.attachBridgeRecoveryRetryTimeout(
+                timeout,
+                to: retry.reservation
+            )
+        )
+    }
+
+    func replaceProcessBridgeRecoveryChannelAndScheduleRetry(
+        _ recovery: ProcessBridgeRecovery,
+        reason: String
+    ) {
+        _ = replaceOrRetireInitializeChannel(
+            recovery.topologyProof,
+            expectedRouteID: recovery.routeID,
+            requestsBridgePoolRecovery: false
+        )
+        scheduleProcessBridgeRecoveryRetry(
+            recovery.reservation,
+            reason: reason
+        )
     }
 
     func refreshPendingProcessToolsCatalogAfterWarmInitialize(upstreamIndex: Int) {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -303,6 +303,11 @@ extension RuntimeCoordinator {
             startProcessRouteActivation(for: route)
         }
         guard isInitialized() else { return }
+        for route in activeRoutes where pendingProcessIDs.contains(route.target.processID) {
+            applyProcessControlPlaneTransition(
+                processControlPlane.beginBridgePoolRecovery(routeID: route.id)
+            )
+        }
         refreshMissingProcessToolsCatalogsIfNeeded(
             reason: "pending_process_route_\(reason)",
             processIDs: pendingProcessIDs

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -119,12 +119,6 @@ extension RuntimeCoordinator {
             upstreamIndex: upstreamIndex,
             mode: .processRouteActivation(reservation)
         )
-        guard isInitialized() else {
-            return
-        }
-        for secondaryUpstreamIndex in route.upstreamIndices where secondaryUpstreamIndex != upstreamIndex {
-            startUpstreamWarmInitialize(upstreamIndex: secondaryUpstreamIndex)
-        }
     }
 
     func processRouteActivationOwnsPrimaryInitialize(upstreamIndex: Int) -> Bool {
@@ -540,8 +534,30 @@ extension RuntimeCoordinator {
         _ initializeClaim: UpstreamHealthManager.InitializeClaim
     ) -> Bool {
         guard let proof = initializeClaim.topologyProof else { return false }
+        let requestsBridgePoolRecovery: Bool
+        if initializeClaim.owner == .regular {
+            requestsBridgePoolRecovery = true
+        } else {
+            requestsBridgePoolRecovery = false
+        }
+        return replaceOrRetireInitializeChannel(
+            proof,
+            expectedRouteID: nil,
+            requestsBridgePoolRecovery: requestsBridgePoolRecovery
+        ) != nil
+    }
+
+    @discardableResult
+    func replaceOrRetireInitializeChannel(
+        _ proof: UpstreamTopologyProof,
+        expectedRouteID: ProcessRouteID?,
+        requestsBridgePoolRecovery: Bool
+    ) -> UpstreamTopologyProof? {
         let upstreamIndex = proof.slotID.rawValue
         let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex)
+        if let expectedRouteID, route?.id != expectedRouteID {
+            return nil
+        }
         if let route {
             let replacements = dynamicUpstreamFactory?(route.target) ?? []
             if let replacement = replacements.first,
@@ -554,19 +570,21 @@ extension RuntimeCoordinator {
                 for unused in replacements.dropFirst() {
                     addRuntimeTask { await unused.stop() }
                 }
-                applyProcessControlPlaneTransition(
-                    processControlPlane.requestBridgePoolRecovery(
-                        routeID: route.id,
-                        upstreamID: replacementLease.proof.slotID
+                if requestsBridgePoolRecovery {
+                    applyProcessControlPlaneTransition(
+                        processControlPlane.requestBridgePoolRecovery(
+                            routeID: route.id,
+                            upstreamID: replacementLease.proof.slotID
+                        )
                     )
-                )
-                return true
+                }
+                return replacementLease.proof
             }
             for unused in replacements {
                 addRuntimeTask { await unused.stop() }
             }
         }
-        guard let transition = upstreamTopology.retire(proof) else { return false }
+        guard let transition = upstreamTopology.retire(proof) else { return nil }
         publishUpstreamTopology(transition.snapshot)
         for retired in transition.retired {
             addRuntimeTask { await retired.slot.stop() }
@@ -579,7 +597,7 @@ extension RuntimeCoordinator {
             ))
             triggerXcodeProcessReconcile(reason: "initialize_channel_replacement_unavailable")
         }
-        return false
+        return nil
     }
 
 }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -418,7 +418,7 @@ extension RuntimeCoordinator {
     ) -> ProcessControlPlaneAuthority.UpstreamUsabilitySnapshot {
         let states = upstreamHealthManager.activeStatesSnapshot()
         let snapshotUsable = Set(states.compactMap { upstreamID, state -> Int? in
-            guard state.isInitialized else {
+            guard state.initPhase.isUsableInitialized else {
                 return nil
             }
             switch state.healthState {
@@ -1003,7 +1003,7 @@ extension RuntimeCoordinator {
             guard let upstream = upstreamHealthManager.state(
                 for: UpstreamSlotID(rawValue: upstreamIndex)
             ) else { return }
-            guard upstream.isInitialized else { return }
+            guard upstream.initPhase.isUsableInitialized else { return }
             switch upstream.healthState {
             case .healthy, .degraded:
                 count += 1
@@ -1020,7 +1020,7 @@ extension RuntimeCoordinator {
         return routableProcessBoundUpstreamIndices().contains { upstreamIndex in
             upstreamHealthManager.state(
                 for: UpstreamSlotID(rawValue: upstreamIndex)
-            )?.isInitialized == true
+            )?.initPhase.isUsableInitialized == true
         }
     }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
@@ -72,6 +72,7 @@ struct RuntimeCoordinatorTestHooks: Sendable {
         )?
     var primaryInitializeFailureCleanupCompleted: (@Sendable (_ upstreamIndex: Int?) -> Void)?
     var ownerRouteProofsResolved: (@Sendable () -> Void)?
+    var healthProbeResponseWaiterWillRegister: (@Sendable () -> Void)?
 
     init(
         upstreamEventHandled: (@Sendable (_ upstreamIndex: Int) -> Void)? = nil,
@@ -99,6 +100,7 @@ struct RuntimeCoordinatorTestHooks: Sendable {
             )? = nil,
         primaryInitializeFailureCleanupCompleted: (@Sendable (_ upstreamIndex: Int?) -> Void)? = nil,
         ownerRouteProofsResolved: (@Sendable () -> Void)? = nil,
+        healthProbeResponseWaiterWillRegister: (@Sendable () -> Void)? = nil,
     ) {
         self.upstreamEventHandled = upstreamEventHandled
         self.toolsListRefreshCompleted = toolsListRefreshCompleted
@@ -111,6 +113,7 @@ struct RuntimeCoordinatorTestHooks: Sendable {
         self.upstreamRequestWillStart = upstreamRequestWillStart
         self.primaryInitializeFailureCleanupCompleted = primaryInitializeFailureCleanupCompleted
         self.ownerRouteProofsResolved = ownerRouteProofsResolved
+        self.healthProbeResponseWaiterWillRegister = healthProbeResponseWaiterWillRegister
     }
 }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
@@ -765,8 +765,10 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                         let summary: String
                         if state.initInFlight {
                             summary = "initializing"
-                        } else if state.isInitialized {
+                        } else if state.initPhase.isUsableInitialized {
                             summary = "initialized"
+                        } else if state.isInitialized {
+                            summary = "verifying_bridge_attach"
                         } else {
                             summary = "idle"
                         }
@@ -1140,7 +1142,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         guard let documentationProviderManager else { return }
         let initializedUpstreamIndices = Set(
             upstreamHealthManager.activeStatesSnapshot().compactMap { id, state in
-                state.isInitialized ? id.rawValue : nil
+                state.initPhase.isUsableInitialized ? id.rawValue : nil
             }
         )
         guard

--- a/Sources/XcodeMCPProxyToolVerifier/main.swift
+++ b/Sources/XcodeMCPProxyToolVerifier/main.swift
@@ -122,12 +122,25 @@ private struct ProxyToolVerifier {
         }
 
         let client = try await connectToProxy(server: server)
-        defer {
-            Task {
-                await client.close()
-            }
+        do {
+            let result = try await verify(
+                client: client,
+                fixture: fixture,
+                outputRoot: outputRoot
+            )
+            await client.close()
+            return result
+        } catch {
+            await client.close()
+            throw error
         }
+    }
 
+    private func verify(
+        client: XcodeMCP,
+        fixture: FixtureLayout,
+        outputRoot: URL
+    ) async throws -> Bool {
         var state = VerificationState(fixture: fixture)
         let tools = try await client.listTools()
         state.availableTools = Set(tools.map(\.name))

--- a/Tests/XcodeMCPCoreTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPCoreTestSupport/AsyncTestSupport.swift
@@ -1,6 +1,124 @@
 import Foundation
 import NIOConcurrencyHelpers
+import Testing
 import XcodeMCPKit
+
+/// Runs synchronous `defer`-registered test cleanup without blocking the
+/// cooperative executor that must make the cleanup operation progress.
+package struct AsyncTestCleanupTrait: SuiteTrait, TestTrait, TestScoping {
+    package let isRecursive = true
+
+    package init() {}
+
+    package func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        let context = AsyncTestCleanupContext()
+        do {
+            try await AsyncTestCleanupContext.$current.withValue(context) {
+                try await function()
+            }
+        } catch {
+            // A fresh task shields cleanup from cancellation of the test body.
+            await Task { await context.run() }.value
+            throw error
+        }
+        await Task { await context.run() }.value
+    }
+}
+
+extension Trait where Self == AsyncTestCleanupTrait {
+    package static var asyncTestCleanup: Self { Self() }
+}
+
+private final class AsyncTestCleanupContext: @unchecked Sendable {
+    private struct Entry: Sendable {
+        let description: String
+        let operation: @Sendable () async throws -> Void
+    }
+
+    private struct State: Sendable {
+        var entries: [Entry] = []
+        var hasStarted = false
+    }
+
+    @TaskLocal static var current: AsyncTestCleanupContext?
+
+    private let state = NIOLockedValueBox(State())
+
+    func register(
+        description: String,
+        operation: @escaping @Sendable () async throws -> Void
+    ) -> Bool {
+        state.withLockedValue { state in
+            guard state.hasStarted == false else {
+                return false
+            }
+            state.entries.append(Entry(description: description, operation: operation))
+            return true
+        }
+    }
+
+    func run() async {
+        let entries = state.withLockedValue { state -> [Entry] in
+            precondition(state.hasStarted == false, "async test cleanup may only run once")
+            state.hasStarted = true
+            let entries = state.entries
+            state.entries.removeAll()
+            return entries
+        }
+
+        // `defer` blocks register while unwinding, so their LIFO order is already
+        // represented by insertion order (for example: manager, then its event loop).
+        for entry in entries {
+            do {
+                try await entry.operation()
+            } catch {
+                Issue.record("\(entry.description): \(error)")
+            }
+        }
+    }
+}
+
+/// Registers cleanup with the active ``AsyncTestCleanupTrait`` scope.
+@discardableResult
+package func registerAsyncTestCleanup(
+    description: String,
+    operation: @escaping @Sendable () async throws -> Void
+) -> Bool {
+    guard let context = AsyncTestCleanupContext.current else {
+        return false
+    }
+    guard context.register(description: description, operation: operation) else {
+        Issue.record("async test cleanup registered after cleanup started: \(description)")
+        return true
+    }
+    return true
+}
+
+/// Registers terminal client cleanup with the active test scope.
+package func closeAfterTest(_ client: XcodeMCP) {
+    precondition(
+        registerAsyncTestCleanup(
+            description: "XcodeMCP client close failed",
+            operation: { await client.close() }
+        ),
+        "closeAfterTest requires an AsyncTestCleanupTrait scope"
+    )
+}
+
+/// Registers terminal session cleanup with the active test scope.
+package func closeAfterTest(_ session: InitializedMCPClientSession) {
+    precondition(
+        registerAsyncTestCleanup(
+            description: "initialized MCP session close failed",
+            operation: { await session.close() }
+        ),
+        "closeAfterTest requires an AsyncTestCleanupTrait scope"
+    )
+}
 
 package struct AsyncTestTimeoutError: Error, CustomStringConvertible {
     package let description: String

--- a/Tests/XcodeMCPKitTestingTests/XcodeMCPKitTestingTests.swift
+++ b/Tests/XcodeMCPKitTestingTests/XcodeMCPKitTestingTests.swift
@@ -3,7 +3,7 @@ import XcodeMCPCoreTestSupport
 import XcodeMCPKit
 import XcodeMCPKitTesting
 
-@Suite
+@Suite(.asyncTestCleanup)
 struct XcodeMCPKitTestingTests {
     @Test func runtimeCreatesInitializedClientAndRecordsHandshake() async throws {
         let runtime = XcodeMCPTestRuntime()
@@ -77,9 +77,7 @@ struct XcodeMCPKitTestingTests {
         )
 
         let client = try await runtime.makeClient()
-        defer {
-            Task { await client.close() }
-        }
+        defer { closeAfterTest(client) }
 
         let tools = try await client.listTools()
         #expect(tools.map(\.name) == ["DocumentationSearch"])
@@ -122,9 +120,7 @@ struct XcodeMCPKitTestingTests {
         }, forMethod: "workspace/symbols")
 
         let client = try await runtime.makeClient()
-        defer {
-            Task { await client.close() }
-        }
+        defer { closeAfterTest(client) }
 
         let result = try await client.request(
             "workspace/symbols",
@@ -176,9 +172,7 @@ struct XcodeMCPKitTestingTests {
         }
 
         let client = try await runtime.makeClient()
-        defer {
-            Task { await client.close() }
-        }
+        defer { closeAfterTest(client) }
 
         let progressValues = RecordedValues<MCPProgress>()
         let result = try await client.callTool(
@@ -224,12 +218,8 @@ struct XcodeMCPKitTestingTests {
         let config = XcodeMCPConfiguration(requestTimeout: .seconds(1))
         let firstClient = try await runtime.makeClient(configuration: config)
         let secondClient = try await runtime.makeClient(configuration: config)
-        defer {
-            Task {
-                await firstClient.close()
-                await secondClient.close()
-            }
-        }
+        defer { closeAfterTest(firstClient) }
+        defer { closeAfterTest(secondClient) }
 
         let secondResult = try await secondClient.callTool(
             "DocumentationSearch",
@@ -270,9 +260,7 @@ struct XcodeMCPKitTestingTests {
         }
 
         let client = try await runtime.makeClient()
-        defer {
-            Task { await client.close() }
-        }
+        defer { closeAfterTest(client) }
 
         await #expect(throws: XcodeMCPError.serverError(
             code: -32042,

--- a/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
+++ b/Tests/XcodeMCPKitTests/XcodeMCPTests.swift
@@ -1,9 +1,10 @@
 import Foundation
 import Testing
+import XcodeMCPCoreTestSupport
 
 @testable import XcodeMCPKit
 
-@Suite(.serialized)
+@Suite(.serialized, .asyncTestCleanup)
 struct XcodeMCPTests {
     @Test func asyncInitializerPerformsMCPHandshake() async throws {
         let transport = FakeXcodeMCPTransport()
@@ -18,9 +19,7 @@ struct XcodeMCPTests {
             ),
             transport: transport
         )
-        defer {
-            Task { await xcode.close() }
-        }
+        defer { closeAfterTest(xcode) }
 
         let sent = await transport.sentMessages()
         #expect(sent.compactMap(\.method) == ["initialize", "notifications/initialized"])
@@ -73,6 +72,69 @@ struct XcodeMCPTests {
         #expect(await transport.closeCount() == 1)
     }
 
+    @Test func managedInitializerWaitsForUnsupportedHandshakeCleanupTerminal() async throws {
+        let closeGate = ManualGate()
+        let completions = RecordedValues<Void>()
+        let timeoutClock = ManualSessionTimeoutClock()
+        let transport = FakeXcodeMCPTransport(
+            initializeResult: .object([
+                "protocolVersion": .string("2099-01-01"),
+                "serverInfo": .object([
+                    "name": .string("future-server"),
+                    "version": .string("test"),
+                ]),
+                "capabilities": .object([:]),
+            ]),
+            transportCloseGate: closeGate
+        )
+        let clock = await timeoutClock.client()
+
+        let initialize = Task<Void, Error> {
+            do {
+                let authority = try await MCPClientSessionAuthority.startManaged(
+                    recipe: MCPTransportRecipe { transport },
+                    initialize: MCPManagedInitializeContext(
+                        clientName: "UnitTestClient",
+                        clientVersion: "test",
+                        capabilities: [:]
+                    ),
+                    defaultTimeout: .seconds(60),
+                    clock: clock
+                )
+                await authority.close()
+                await completions.append(())
+            } catch {
+                await completions.append(())
+                throw error
+            }
+        }
+        defer {
+            precondition(
+                registerAsyncTestCleanup(
+                    description: "managed initializer cleanup failed",
+                    operation: {
+                        await closeGate.open()
+                        initialize.cancel()
+                        _ = await initialize.result
+                    }
+                ),
+                "initializer cleanup requires an AsyncTestCleanupTrait scope"
+            )
+        }
+
+        #expect(try await transport.nextCloseCount() == 1)
+        #expect(await completions.count() == 0)
+
+        await closeGate.open()
+        #expect(try await transport.nextCloseTerminal() == 1)
+        await #expect(throws: MCPBridgeRuntimeError.invalidResponse(
+            "initialize result has unsupported protocolVersion 2099-01-01"
+        )) {
+            try await initialize.value
+        }
+        #expect(await completions.count() == 1)
+    }
+
     @Test func asyncInitializerMapsRuntimeTransportErrorsToPublicError() async throws {
         let transport = RuntimeFailingXcodeMCPTransport(
             error: MCPBridgeRuntimeError.transportUnavailable("mcpbridge write queue is full")
@@ -96,9 +158,7 @@ struct XcodeMCPTests {
     @Test func listToolsDecodesDescriptorAndPreservesDynamicFields() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(transport: transport)
-        defer {
-            Task { await xcode.close() }
-        }
+        defer { closeAfterTest(xcode) }
 
         let tools = try await xcode.listTools()
         let tool = try #require(tools.first)
@@ -112,9 +172,7 @@ struct XcodeMCPTests {
     @Test func callToolSendsShapeAndDecodesFinalResult() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(transport: transport)
-        defer {
-            Task { await xcode.close() }
-        }
+        defer { closeAfterTest(xcode) }
 
         let result = try await xcode.callTool(
             "DocumentationSearch",
@@ -146,9 +204,7 @@ struct XcodeMCPTests {
     @Test func rawRequestSendsDynamicMethodAndReturnsRawResult() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(transport: transport)
-        defer {
-            Task { await xcode.close() }
-        }
+        defer { closeAfterTest(xcode) }
 
         let result = try await xcode.request(
             "workspace/symbols",
@@ -183,9 +239,6 @@ struct XcodeMCPTests {
         let callFinished = RecordedValues<Void>()
         let handlerGate = ManualGate()
         let xcode = try await XcodeMCP(transport: transport)
-        defer {
-            Task { await xcode.close() }
-        }
 
         let callTask = Task {
             let result = try await xcode.callTool(
@@ -199,6 +252,20 @@ struct XcodeMCPTests {
             }
             await callFinished.append(())
             return result
+        }
+        defer {
+            precondition(
+                registerAsyncTestCleanup(
+                    description: "tool call cleanup failed",
+                    operation: {
+                        await handlerGate.open()
+                        callTask.cancel()
+                        await xcode.close()
+                        _ = await callTask.result
+                    }
+                ),
+                "tool call cleanup requires an AsyncTestCleanupTrait scope"
+            )
         }
 
         #expect(try await reentrantResults.nextValue())
@@ -294,9 +361,7 @@ struct XcodeMCPTests {
                 requestTimeout: .seconds(2)
             )
         )
-        defer {
-            Task { await session.close() }
-        }
+        defer { closeAfterTest(session) }
 
         let progressValues = RecordedValues<JSONValue>()
         let result = try await session.request(
@@ -344,9 +409,7 @@ struct XcodeMCPTests {
                 requestTimeout: .seconds(2)
             )
         )
-        defer {
-            Task { await session.close() }
-        }
+        defer { closeAfterTest(session) }
 
         weak var weakProbe: DeinitProbe?
         do {
@@ -476,9 +539,6 @@ struct XcodeMCPTests {
                 clock: await timeoutClock.client()
             )
         )
-        defer {
-            Task { await session.close() }
-        }
 
         let sleepBaseline = await timeoutClock.requestedSleepCount()
         let requestTask = Task {
@@ -488,7 +548,17 @@ struct XcodeMCPTests {
             )
         }
         defer {
-            requestTask.cancel()
+            precondition(
+                registerAsyncTestCleanup(
+                    description: "timed-out request cleanup failed",
+                    operation: {
+                        requestTask.cancel()
+                        await session.close()
+                        _ = await requestTask.result
+                    }
+                ),
+                "request cleanup requires an AsyncTestCleanupTrait scope"
+            )
         }
 
         _ = try await transport.nextStarted(method: "tools/list")
@@ -531,9 +601,7 @@ struct XcodeMCPTests {
     @Test func unsupportedServerRequestGetsInternalErrorResponse() async throws {
         let transport = FakeXcodeMCPTransport()
         let xcode = try await XcodeMCP(transport: transport)
-        defer {
-            Task { await xcode.close() }
-        }
+        defer { closeAfterTest(xcode) }
 
         await transport.emitServerRequest(method: "sampling/createMessage", id: .integer(99))
 
@@ -558,15 +626,22 @@ struct XcodeMCPTests {
             error: .transportUnavailable("mcpbridge write queue is full")
         )
         let xcode = try await XcodeMCP(transport: transport)
-        defer {
-            Task { await xcode.close() }
-        }
 
         let listTask = Task {
             try await xcode.listTools()
         }
         defer {
-            listTask.cancel()
+            precondition(
+                registerAsyncTestCleanup(
+                    description: "pending tools/list cleanup failed",
+                    operation: {
+                        listTask.cancel()
+                        await xcode.close()
+                        _ = await listTask.result
+                    }
+                ),
+                "request cleanup requires an AsyncTestCleanupTrait scope"
+            )
         }
         _ = try await waitWithTimeout("tools/list send did not start") {
             try await transport.nextSentMessage { message in
@@ -1114,8 +1189,16 @@ struct XcodeMCPTests {
         let session = makeFakeHTTPURLSession(server: server)
         let reconnectSleep = ManualReconnectSleep()
         defer {
-            session.invalidateAndCancel()
-            FakeStreamableHTTPURLProtocolRegistry.shared.reset()
+            precondition(
+                registerAsyncTestCleanup(
+                    description: "injected HTTP session cleanup failed",
+                    operation: {
+                        session.invalidateAndCancel()
+                        FakeStreamableHTTPURLProtocolRegistry.shared.reset()
+                    }
+                ),
+                "HTTP session cleanup requires an AsyncTestCleanupTrait scope"
+            )
         }
 
         let transport = StreamableHTTPXcodeMCPTransport(
@@ -1131,9 +1214,7 @@ struct XcodeMCPTests {
                 configuration: .init(transport: .streamableHTTP(endpoint: endpoint), requestTimeout: .seconds(2)),
             transport: transport
         )
-        defer {
-            Task { await xcode.close() }
-        }
+        defer { closeAfterTest(xcode) }
 
         let firstGET = try await waitWithTimeout("first event stream GET was not opened") {
             try await server.nextRequest { $0.httpMethod == "GET" }
@@ -3113,8 +3194,10 @@ private actor FakeXcodeMCPTransport: XcodeMCPTransport {
     private let responseErrors: [String: MCPJSONValue]
     private let progressBeforeResponseCount: Int
     private let emitsProgressBarrierServerRequest: Bool
+    private let transportCloseGate: ManualGate?
     private let sentMessageValues = RecordedValues<SentMessage>()
     private let closeValues = RecordedValues<Int>()
+    private let closeTerminalValues = RecordedValues<Int>()
     private var messages: [SentMessage] = []
     private var closed = false
     private var closes = 0
@@ -3130,7 +3213,8 @@ private actor FakeXcodeMCPTransport: XcodeMCPTransport {
         ]),
         responseErrors: [String: MCPJSONValue] = [:],
         progressBeforeResponseCount: Int = 1,
-        emitsProgressBarrierServerRequest: Bool = false
+        emitsProgressBarrierServerRequest: Bool = false,
+        transportCloseGate: ManualGate? = nil
     ) {
         let stream = AsyncStream<XcodeMCPTransportEvent>.makeStream()
         self.events = stream.stream
@@ -3139,6 +3223,7 @@ private actor FakeXcodeMCPTransport: XcodeMCPTransport {
         self.responseErrors = responseErrors
         self.progressBeforeResponseCount = progressBeforeResponseCount
         self.emitsProgressBarrierServerRequest = emitsProgressBarrierServerRequest
+        self.transportCloseGate = transportCloseGate
     }
 
     func send(
@@ -3235,8 +3320,10 @@ private actor FakeXcodeMCPTransport: XcodeMCPTransport {
         closes += 1
         let closeCount = closes
         await closeValues.append(closeCount)
+        await transportCloseGate?.wait()
         continuation.yield(.closed(nil))
         continuation.finish()
+        await closeTerminalValues.append(closeCount)
     }
 
     func emitServerRequest(method: String, id: MCPJSONValue) {
@@ -3264,6 +3351,10 @@ private actor FakeXcodeMCPTransport: XcodeMCPTransport {
 
     func nextCloseCount() async throws -> Int {
         try await closeValues.nextValue()
+    }
+
+    func nextCloseTerminal() async throws -> Int {
+        try await closeTerminalValues.nextValue()
     }
 
     private func yieldMessage(_ object: [String: MCPJSONValue]) throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -101,6 +101,26 @@ struct ControlPlaneAuthorityTests {
         #expect(immediateRecovery.upstreamID == UpstreamSlotID(rawValue: 1))
     }
 
+    @Test func bridgeRecoveryCompletionKeepsReservationWhenCommitIsRejected() throws {
+        let target = xcodeProcessTarget(processID: 41040, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        guard case .restoreBridgePool(let recovery) = authority
+            .beginBridgePoolRecovery(routeID: route.id).effects.first else {
+            Issue.record("expected bridge recovery reservation")
+            return
+        }
+
+        #expect(
+            authority.completeBridgeRecoveryIfCurrent(
+                recovery,
+                commit: { false }
+            ) == nil
+        )
+        #expect(authority.validateBridgeRecovery(recovery))
+        #expect(authority.completeBridgeRecoveryIfCurrent(recovery) != nil)
+    }
+
     @Test func bridgeRecoverySerializesSlotsAndOwnsRetryCadence() throws {
         let target = xcodeProcessTarget(processID: 41032, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0, 1, 2])])
@@ -227,12 +247,27 @@ struct ControlPlaneAuthorityTests {
         #expect(health.setWarmInitializeUpstreamID(42, for: claim))
         #expect(health.beginInitializeSend(claim))
         #expect(health.transferInitializeResponse(claim, expectedUpstreamID: 42))
-        let initialized = try #require(health.markInitialized(
+        let canonical = CanonicalHandshakeState()
+        let participant: CanonicalHandshakeState.InitializeParticipantLease
+        switch canonical.offerInitializeResult(
+            try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+            ]),
+            sourceProof: proof
+        ) {
+        case .accepted(let lease):
+            participant = lease
+        case .incompatible:
+            Issue.record("expected initialize participant")
+            return
+        }
+        let verification = try #require(health.beginBridgeAttachVerification(
             claim,
             expectedUpstreamID: 42,
-            commit: { true }
+            initializeParticipant: participant
         ))
-        let probe = try #require(initialized.bridgeVerificationProbe)
+        let probe = verification.probe
 
         #expect(health.evaluateUsableInitialized(index: 1, nowUptimeNs: 3).proof == nil)
         #expect(health.markUpstreamOverloaded(proof))
@@ -250,7 +285,12 @@ struct ControlPlaneAuthorityTests {
             success: true,
             nowUptimeNs: 4,
             commit: {
-                authority.completeBridgeRecoveryIfCurrent(reservation) != nil
+                authority.completeBridgeRecoveryIfCurrent(
+                    reservation,
+                    commit: {
+                        canonical.commitInitializeParticipant(participant).isAccepted
+                    }
+                ) != nil
             }
         ))
         #expect(health.evaluateUsableInitialized(index: 1, nowUptimeNs: 5).proof == proof)
@@ -294,12 +334,27 @@ struct ControlPlaneAuthorityTests {
         #expect(health.setWarmInitializeUpstreamID(42, for: claim))
         #expect(health.beginInitializeSend(claim))
         #expect(health.transferInitializeResponse(claim, expectedUpstreamID: 42))
-        let initialized = try #require(health.markInitialized(
+        let canonical = CanonicalHandshakeState()
+        let participant: CanonicalHandshakeState.InitializeParticipantLease
+        switch canonical.offerInitializeResult(
+            try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+            ]),
+            sourceProof: proof
+        ) {
+        case .accepted(let lease):
+            participant = lease
+        case .incompatible:
+            Issue.record("expected initialize participant")
+            return
+        }
+        let verification = try #require(health.beginBridgeAttachVerification(
             claim,
             expectedUpstreamID: 42,
-            commit: { true }
+            initializeParticipant: participant
         ))
-        let probe = try #require(initialized.bridgeVerificationProbe)
+        let probe = verification.probe
 
         let result = health.finishBridgeAttachVerification(
             probe,

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -47,10 +47,19 @@ struct ControlPlaneAuthorityTests {
         #expect(snapshot.canonicalSourceUpstream == 0)
     }
 
-    @Test func bridgeRecoveryWaitsForCatalogAndThenUsesProcessOwnerEffect() throws {
+    @Test func bridgeRecoveryBeginsBeforeCatalogAndUsesProcessOwnerEffect() throws {
         let target = xcodeProcessTarget(processID: 41031, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0, 1])])
         let route = try #require(authority.route(forProcessID: target.processID))
+
+        let bootstrap = authority.beginBridgePoolRecovery(routeID: route.id)
+        guard case .restoreBridgePool(let bootstrapRecovery) = bootstrap.effects.first else {
+            Issue.record("expected catalog bootstrap bridge recovery")
+            return
+        }
+        #expect(bootstrapRecovery.routeID == route.id)
+        #expect(bootstrapRecovery.upstreamID == UpstreamSlotID(rawValue: 1))
+        #expect(authority.beginBridgePoolRecovery(routeID: route.id).effects.isEmpty)
 
         let (lease, _) = try #require(authority.beginCatalogAttempt(
             routeID: route.id,
@@ -65,16 +74,7 @@ struct ControlPlaneAuthorityTests {
             Issue.record("expected sibling catalog to be accepted")
             return
         }
-        let deferredEffect = try #require(catalogTransition.effects.first { effect in
-            if case .restoreBridgePool = effect { return true }
-            return false
-        })
-        guard case .restoreBridgePool(let deferredRecovery) = deferredEffect else {
-            Issue.record("expected deferred bridge recovery effect")
-            return
-        }
-        #expect(deferredRecovery.routeID == route.id)
-        #expect(deferredRecovery.upstreamID == UpstreamSlotID(rawValue: 1))
+        #expect(catalogTransition.effects.isEmpty)
 
         let duplicate = authority.requestBridgePoolRecovery(
             routeID: route.id,
@@ -82,7 +82,7 @@ struct ControlPlaneAuthorityTests {
         )
         #expect(duplicate.effects.isEmpty)
 
-        let completed = authority.completeBridgeRecovery(deferredRecovery)
+        let completed = authority.completeBridgeRecovery(bootstrapRecovery)
         #expect(completed.effects.isEmpty)
 
         let immediate = authority.requestBridgePoolRecovery(
@@ -105,17 +105,9 @@ struct ControlPlaneAuthorityTests {
         let target = xcodeProcessTarget(processID: 41032, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0, 1, 2])])
         let route = try #require(authority.route(forProcessID: target.processID))
-        let (lease, _) = try #require(authority.beginCatalogAttempt(
-            routeID: route.id,
-            preferredUpstreamProof: testTopologyProof(0),
-            nowUptimeNanoseconds: 1
-        ))
-        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
-            .usable(catalog("BuildProject"), source: testTopologyProof(0)),
-            lease: lease,
-            nowUptimeNanoseconds: 2
-        ), case .restoreBridgePool(let firstAttempt) = catalogTransition.effects.first else {
-            Issue.record("expected first serialized bridge recovery")
+        guard case .restoreBridgePool(let firstAttempt) = authority
+            .beginBridgePoolRecovery(routeID: route.id).effects.first else {
+            Issue.record("expected first serialized bootstrap recovery")
             return
         }
         #expect(firstAttempt.upstreamID == UpstreamSlotID(rawValue: 1))
@@ -163,7 +155,7 @@ struct ControlPlaneAuthorityTests {
         #expect(resetRetry.delay.nanoseconds == TimeAmount.seconds(1).nanoseconds)
     }
 
-    @Test func bridgeRecoveryReturnsToCatalogBarrierWhenRetryFiresWithoutCatalog() throws {
+    @Test func bridgeRecoveryRetryContinuesWhenCatalogDisappears() throws {
         let target = xcodeProcessTarget(processID: 41034, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0, 1])])
         let route = try #require(authority.route(forProcessID: target.processID))
@@ -188,20 +180,9 @@ struct ControlPlaneAuthorityTests {
             source: sourceProof
         )
         #expect(authority.catalog(forProcessID: target.processID) == nil)
-        #expect(authority.handleBridgeRecoveryRetryFired(retry.reservation).effects.isEmpty)
-
-        let replacementProof = testTopologyProof(0, generation: 2)
-        let (replacementLease, _) = try #require(authority.beginCatalogAttempt(
-            routeID: route.id,
-            preferredUpstreamProof: replacementProof,
-            nowUptimeNanoseconds: 3
-        ))
-        guard case .accepted(_, let replacementTransition) = authority.completeCatalog(
-            .usable(catalog("BuildProject"), source: replacementProof),
-            lease: replacementLease,
-            nowUptimeNanoseconds: 4
-        ), case .restoreBridgePool(let resumedAttempt) = replacementTransition.effects.first else {
-            Issue.record("expected catalog restoration to resume bridge recovery")
+        guard case .restoreBridgePool(let resumedAttempt) = authority
+            .handleBridgeRecoveryRetryFired(retry.reservation).effects.first else {
+            Issue.record("expected bridge recovery to continue without a catalog")
             return
         }
         #expect(resumedAttempt.upstreamID == firstAttempt.upstreamID)
@@ -339,7 +320,7 @@ struct ControlPlaneAuthorityTests {
         )
     }
 
-    @Test func bridgeRecoverySuccessWaitsForCatalogBeforeStartingNextSlot() throws {
+    @Test func bridgeRecoverySuccessStartsNextSlotWithoutCatalog() throws {
         let target = xcodeProcessTarget(processID: 41036, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0, 1, 2])])
         let route = try #require(authority.route(forProcessID: target.processID))
@@ -362,7 +343,12 @@ struct ControlPlaneAuthorityTests {
             processID: target.processID,
             source: sourceProof
         )
-        #expect(authority.completeBridgeRecovery(firstAttempt).effects.isEmpty)
+        guard case .restoreBridgePool(let nextAttempt) = authority
+            .completeBridgeRecovery(firstAttempt).effects.first else {
+            Issue.record("expected successful recovery to release the next bridge slot")
+            return
+        }
+        #expect(nextAttempt.upstreamID == UpstreamSlotID(rawValue: 2))
 
         let replacementProof = testTopologyProof(0, generation: 2)
         let (replacementLease, _) = try #require(authority.beginCatalogAttempt(
@@ -374,11 +360,11 @@ struct ControlPlaneAuthorityTests {
             .usable(catalog("BuildProject"), source: replacementProof),
             lease: replacementLease,
             nowUptimeNanoseconds: 4
-        ), case .restoreBridgePool(let nextAttempt) = resumedTransition.effects.first else {
-            Issue.record("expected restored catalog to release the next bridge slot")
+        ) else {
+            Issue.record("expected restored catalog commit")
             return
         }
-        #expect(nextAttempt.upstreamID == UpstreamSlotID(rawValue: 2))
+        #expect(resumedTransition.effects.isEmpty)
     }
 
     @Test func retiringRouteCancelsBridgeRecoveryRetryAndRejectsLateCallback() throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -52,19 +52,13 @@ struct ControlPlaneAuthorityTests {
         let authority = makeAuthority([(target, [0, 1])])
         let route = try #require(authority.route(forProcessID: target.processID))
 
-        let pending = authority.requestBridgePoolRecovery(
-            routeID: route.id,
-            upstreamID: UpstreamSlotID(rawValue: 0)
-        )
-        #expect(pending.effects.isEmpty)
-
         let (lease, _) = try #require(authority.beginCatalogAttempt(
             routeID: route.id,
-            preferredUpstreamProof: testTopologyProof(1),
+            preferredUpstreamProof: testTopologyProof(0),
             nowUptimeNanoseconds: 1
         ))
         guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
-            .usable(catalog("BuildProject"), source: testTopologyProof(1)),
+            .usable(catalog("BuildProject"), source: testTopologyProof(0)),
             lease: lease,
             nowUptimeNanoseconds: 2
         ) else {
@@ -80,11 +74,20 @@ struct ControlPlaneAuthorityTests {
             return
         }
         #expect(deferredRecovery.routeID == route.id)
-        #expect(deferredRecovery.upstreamIDs == [UpstreamSlotID(rawValue: 0)])
+        #expect(deferredRecovery.upstreamID == UpstreamSlotID(rawValue: 1))
+
+        let duplicate = authority.requestBridgePoolRecovery(
+            routeID: route.id,
+            upstreamID: UpstreamSlotID(rawValue: 1)
+        )
+        #expect(duplicate.effects.isEmpty)
+
+        let completed = authority.completeBridgeRecovery(deferredRecovery)
+        #expect(completed.effects.isEmpty)
 
         let immediate = authority.requestBridgePoolRecovery(
             routeID: route.id,
-            upstreamID: UpstreamSlotID(rawValue: 0)
+            upstreamID: UpstreamSlotID(rawValue: 1)
         )
         let immediateEffect = try #require(immediate.effects.first { effect in
             if case .restoreBridgePool = effect { return true }
@@ -95,7 +98,328 @@ struct ControlPlaneAuthorityTests {
             return
         }
         #expect(immediateRecovery.routeID == route.id)
-        #expect(immediateRecovery.upstreamIDs == [UpstreamSlotID(rawValue: 0)])
+        #expect(immediateRecovery.upstreamID == UpstreamSlotID(rawValue: 1))
+    }
+
+    @Test func bridgeRecoverySerializesSlotsAndOwnsRetryCadence() throws {
+        let target = xcodeProcessTarget(processID: 41032, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1, 2])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: testTopologyProof(0),
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: testTopologyProof(0)),
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ), case .restoreBridgePool(let firstAttempt) = catalogTransition.effects.first else {
+            Issue.record("expected first serialized bridge recovery")
+            return
+        }
+        #expect(firstAttempt.upstreamID == UpstreamSlotID(rawValue: 1))
+
+        let firstRetry = try #require(authority.prepareBridgeRecoveryRetry(firstAttempt))
+        #expect(firstRetry.delay.nanoseconds == TimeAmount.seconds(1).nanoseconds)
+        guard case .restoreBridgePool(let secondAttempt) = authority
+            .handleBridgeRecoveryRetryFired(firstRetry.reservation).effects.first else {
+            Issue.record("expected early bridge recovery retry")
+            return
+        }
+        #expect(secondAttempt.upstreamID == firstAttempt.upstreamID)
+        #expect(secondAttempt != firstAttempt)
+
+        let cancelled = NIOLockedValueBox(false)
+        let staleTimeout = RuntimeScheduledTimeout {
+            cancelled.withLockedValue { $0 = true }
+        }
+        let staleAttachment = authority.attachBridgeRecoveryRetryTimeout(
+            staleTimeout,
+            to: firstRetry.reservation
+        )
+        guard case .cancelTimeout(let rejectedTimeout) = staleAttachment.effects.first else {
+            Issue.record("expected stale retry timeout cancellation")
+            return
+        }
+        rejectedTimeout.cancel()
+        #expect(cancelled.withLockedValue { $0 })
+        #expect(authority.handleBridgeRecoveryRetryFired(firstRetry.reservation).effects.isEmpty)
+
+        let periodicRetry = try #require(authority.prepareBridgeRecoveryRetry(secondAttempt))
+        #expect(periodicRetry.delay.nanoseconds == TimeAmount.seconds(10).nanoseconds)
+        guard case .restoreBridgePool(let thirdAttempt) = authority
+            .handleBridgeRecoveryRetryFired(periodicRetry.reservation).effects.first else {
+            Issue.record("expected periodic bridge recovery retry")
+            return
+        }
+        guard case .restoreBridgePool(let nextSlot) = authority
+            .completeBridgeRecovery(thirdAttempt).effects.first else {
+            Issue.record("expected next serialized bridge slot")
+            return
+        }
+        #expect(nextSlot.upstreamID == UpstreamSlotID(rawValue: 2))
+        let resetRetry = try #require(authority.prepareBridgeRecoveryRetry(nextSlot))
+        #expect(resetRetry.delay.nanoseconds == TimeAmount.seconds(1).nanoseconds)
+    }
+
+    @Test func bridgeRecoveryReturnsToCatalogBarrierWhenRetryFiresWithoutCatalog() throws {
+        let target = xcodeProcessTarget(processID: 41034, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let sourceProof = testTopologyProof(0)
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: sourceProof,
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: sourceProof),
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ), case .restoreBridgePool(let firstAttempt) = catalogTransition.effects.first else {
+            Issue.record("expected bridge recovery after catalog commit")
+            return
+        }
+        let retry = try #require(authority.prepareBridgeRecoveryRetry(firstAttempt))
+
+        _ = authority.invalidateCatalogSource(
+            processID: target.processID,
+            source: sourceProof
+        )
+        #expect(authority.catalog(forProcessID: target.processID) == nil)
+        #expect(authority.handleBridgeRecoveryRetryFired(retry.reservation).effects.isEmpty)
+
+        let replacementProof = testTopologyProof(0, generation: 2)
+        let (replacementLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: replacementProof,
+            nowUptimeNanoseconds: 3
+        ))
+        guard case .accepted(_, let replacementTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: replacementProof),
+            lease: replacementLease,
+            nowUptimeNanoseconds: 4
+        ), case .restoreBridgePool(let resumedAttempt) = replacementTransition.effects.first else {
+            Issue.record("expected catalog restoration to resume bridge recovery")
+            return
+        }
+        #expect(resumedAttempt.upstreamID == firstAttempt.upstreamID)
+        let periodicRetry = try #require(authority.prepareBridgeRecoveryRetry(resumedAttempt))
+        #expect(periodicRetry.delay.nanoseconds == TimeAmount.seconds(10).nanoseconds)
+    }
+
+    @Test func bridgeVerificationIsNotUsableUntilExactProbeSucceeds() throws {
+        let target = xcodeProcessTarget(processID: 41035, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: testTopologyProof(0),
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: testTopologyProof(0)),
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ), case .restoreBridgePool(let reservation) = catalogTransition.effects.first else {
+            Issue.record("expected bridge recovery reservation")
+            return
+        }
+
+        let topology = UpstreamTopologyAuthority([
+            TestUpstreamClient(), TestUpstreamClient(),
+        ])
+        let health = UpstreamHealthManager()
+        health.applyTopology(topology.snapshot())
+        let proof = try #require(
+            topology.operationLease(for: reservation.upstreamID)?.proof
+        )
+        let recovery = ProcessBridgeRecovery(
+            reservation: reservation,
+            topologyProof: proof
+        )
+        let claim = try #require(health.claimWarmInitialize(
+            upstreamIndex: reservation.upstreamID.rawValue,
+            owner: .processBridgeRecovery(recovery)
+        ))
+        #expect(health.setWarmInitializeUpstreamID(42, for: claim))
+        #expect(health.beginInitializeSend(claim))
+        #expect(health.transferInitializeResponse(claim, expectedUpstreamID: 42))
+        let initialized = try #require(health.markInitialized(
+            claim,
+            expectedUpstreamID: 42,
+            commit: { true }
+        ))
+        let probe = try #require(initialized.bridgeVerificationProbe)
+
+        #expect(health.evaluateUsableInitialized(index: 1, nowUptimeNs: 3).proof == nil)
+        #expect(health.markUpstreamOverloaded(proof))
+        #expect(health.state(for: proof.slotID)?.healthProbeInFlight == true)
+        _ = health.markRequestTimedOut(proof, nowUptimeNs: 3)
+        _ = health.markRequestTimedOut(proof, nowUptimeNs: 3)
+        _ = health.markRequestTimedOut(proof, nowUptimeNs: 3)
+        #expect(health.state(for: proof.slotID)?.healthProbeInFlight == true)
+        _ = try #require(health.markToolsListRefreshFailed(proof, nowUptimeNs: 3))
+        #expect(health.state(for: proof.slotID)?.healthProbeInFlight == true)
+        #expect(health.markToolsListRefreshSucceeded(proof, nowUptimeNs: 3))
+        #expect(health.state(for: proof.slotID)?.healthProbeInFlight == true)
+        _ = try #require(health.finishBridgeAttachVerification(
+            probe,
+            success: true,
+            nowUptimeNs: 4,
+            commit: {
+                authority.completeBridgeRecoveryIfCurrent(reservation) != nil
+            }
+        ))
+        #expect(health.evaluateUsableInitialized(index: 1, nowUptimeNs: 5).proof == proof)
+    }
+
+    @Test func bridgeVerificationCannotBecomeUsableAfterCatalogResetAtCommit() throws {
+        let target = xcodeProcessTarget(processID: 41039, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let sourceProof = testTopologyProof(0)
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: sourceProof,
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: sourceProof),
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ), case .restoreBridgePool(let reservation) = catalogTransition.effects.first else {
+            Issue.record("expected bridge recovery reservation")
+            return
+        }
+
+        let topology = UpstreamTopologyAuthority([
+            TestUpstreamClient(), TestUpstreamClient(),
+        ])
+        let health = UpstreamHealthManager()
+        health.applyTopology(topology.snapshot())
+        let proof = try #require(
+            topology.operationLease(for: reservation.upstreamID)?.proof
+        )
+        let recovery = ProcessBridgeRecovery(
+            reservation: reservation,
+            topologyProof: proof
+        )
+        let claim = try #require(health.claimWarmInitialize(
+            upstreamIndex: reservation.upstreamID.rawValue,
+            owner: .processBridgeRecovery(recovery)
+        ))
+        #expect(health.setWarmInitializeUpstreamID(42, for: claim))
+        #expect(health.beginInitializeSend(claim))
+        #expect(health.transferInitializeResponse(claim, expectedUpstreamID: 42))
+        let initialized = try #require(health.markInitialized(
+            claim,
+            expectedUpstreamID: 42,
+            commit: { true }
+        ))
+        let probe = try #require(initialized.bridgeVerificationProbe)
+
+        let result = health.finishBridgeAttachVerification(
+            probe,
+            success: true,
+            nowUptimeNs: 3,
+            commit: {
+                _ = authority.invalidateCatalog(.reset)
+                return authority.completeBridgeRecoveryIfCurrent(reservation) != nil
+            }
+        )
+
+        #expect(result == nil)
+        #expect(authority.validateBridgeRecovery(reservation) == false)
+        #expect(health.evaluateUsableInitialized(index: 1, nowUptimeNs: 4).proof == nil)
+        #expect(
+            health.state(for: proof.slotID)?.initPhase
+                == .initialized(.verifyingBridge(route.id))
+        )
+    }
+
+    @Test func bridgeRecoverySuccessWaitsForCatalogBeforeStartingNextSlot() throws {
+        let target = xcodeProcessTarget(processID: 41036, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1, 2])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let sourceProof = testTopologyProof(0)
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: sourceProof,
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: sourceProof),
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ), case .restoreBridgePool(let firstAttempt) = catalogTransition.effects.first else {
+            Issue.record("expected first bridge recovery")
+            return
+        }
+
+        _ = authority.invalidateCatalogSource(
+            processID: target.processID,
+            source: sourceProof
+        )
+        #expect(authority.completeBridgeRecovery(firstAttempt).effects.isEmpty)
+
+        let replacementProof = testTopologyProof(0, generation: 2)
+        let (replacementLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: replacementProof,
+            nowUptimeNanoseconds: 3
+        ))
+        guard case .accepted(_, let resumedTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: replacementProof),
+            lease: replacementLease,
+            nowUptimeNanoseconds: 4
+        ), case .restoreBridgePool(let nextAttempt) = resumedTransition.effects.first else {
+            Issue.record("expected restored catalog to release the next bridge slot")
+            return
+        }
+        #expect(nextAttempt.upstreamID == UpstreamSlotID(rawValue: 2))
+    }
+
+    @Test func retiringRouteCancelsBridgeRecoveryRetryAndRejectsLateCallback() throws {
+        let target = xcodeProcessTarget(processID: 41033, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: testTopologyProof(0),
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: testTopologyProof(0)),
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ), case .restoreBridgePool(let recovery) = catalogTransition.effects.first else {
+            Issue.record("expected bridge recovery")
+            return
+        }
+        let retry = try #require(authority.prepareBridgeRecoveryRetry(recovery))
+        let cancelled = NIOLockedValueBox(false)
+        let timeout = RuntimeScheduledTimeout {
+            cancelled.withLockedValue { $0 = true }
+        }
+        #expect(authority.attachBridgeRecoveryRetryTimeout(
+            timeout,
+            to: retry.reservation
+        ).effects.isEmpty)
+
+        let retired = authority.retireRoute(
+            routeID: route.id,
+            reason: "test_retire",
+            nowUptimeNs: 3
+        )
+        for effect in retired.effects {
+            if case .cancelTimeout(let cancelledTimeout) = effect {
+                cancelledTimeout.cancel()
+            }
+        }
+        #expect(cancelled.withLockedValue { $0 })
+        #expect(authority.handleBridgeRecoveryRetryFired(retry.reservation).effects.isEmpty)
     }
 
     @Test func routeMembershipChangeInvalidatesLeaseAndCatalogTogether() throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/JSONRPCResponseRouterTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/JSONRPCResponseRouterTests.swift
@@ -130,6 +130,33 @@ struct JSONRPCResponseRouterTests {
         #expect(bufferString(buffer) == response)
     }
 
+    @Test func responseReceiptWinsBeforeScheduledFutureDelivery() async throws {
+        let eventLoop = EmbeddedEventLoop()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let didTimeout = NIOLockedValueBox(false)
+        let router = JSONRPCResponseRouter(
+            requestTimeout: nil,
+            hasActiveClients: { false },
+            sendNotification: { _ in }
+        )
+        let registration = router.registerRequestPending(
+            idKey: "1",
+            on: eventLoop,
+            timeout: .seconds(1),
+            timeoutScheduler: timeoutScheduler.scheduler(),
+            onTimeout: { didTimeout.withLockedValue { $0 = true } }
+        )
+        let response = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"
+
+        router.handleIncoming(Data(response.utf8))
+        #expect(timeoutScheduler.fire(at: 0))
+        eventLoop.run()
+
+        let buffer = try await registration.future.get()
+        #expect(bufferString(buffer) == response)
+        #expect(didTimeout.withLockedValue { $0 } == false)
+    }
+
     @Test func responseRouterDisablesTimeoutWhenRequestTimeoutIsNil() async throws {
         let eventLoop = EmbeddedEventLoop()
         let router = JSONRPCResponseRouter(

--- a/Tests/XcodeMCPProxyRuntimeTests/JSONRPCResponseRouterTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/JSONRPCResponseRouterTests.swift
@@ -84,15 +84,21 @@ struct JSONRPCResponseRouterTests {
 
     @Test func responseRouterTimesOutRequests() async throws {
         let eventLoop = EmbeddedEventLoop()
+        let didTimeout = NIOLockedValueBox(false)
         let router = JSONRPCResponseRouter(
             requestTimeout: .seconds(1),
             hasActiveClients: { false },
             sendNotification: { _ in }
         )
 
-        let future = router.registerRequest(idKey: "1", on: eventLoop)
+        let future = router.registerRequest(
+            idKey: "1",
+            on: eventLoop,
+            onTimeout: { didTimeout.withLockedValue { $0 = true } }
+        )
         eventLoop.advanceTime(by: .seconds(1))
         eventLoop.run()
+        #expect(didTimeout.withLockedValue { $0 })
 
         do {
             _ = try await future.get()

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -877,7 +877,6 @@ struct RuntimeCoordinatorProcessRoutingTests {
             matching: { methodName(from: $0) == "initialize" },
             description: "waiting for route activation initialize"
         )
-        #expect(await secondary.sentCount() == 0)
         await primary.yield(
             .message(
                 try makeInitializeResponse(id: try extractUpstreamID(from: primaryInitialize))
@@ -2158,13 +2157,15 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(methodName(from: secondInitialize) == "initialize")
     }
 
-    @Test func processRouteActivationDefersSecondaryUntilPrimaryCatalogAndAttachProbeSucceed()
+    @Test func processRouteActivationBootstrapsCatalogFromVerifiedSecondaryAfterPrimaryFailure()
         async throws
     {
         let existingUpstream = TestUpstreamClient()
         let existingTarget = xcodeProcessTarget(processID: 26615, xcodeVersion: "26.6")
         let newTarget = xcodeProcessTarget(processID: 27015, xcodeVersion: "27.0")
         let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let toolsListRefreshes = LockedRecordedValues<(Int, Bool)>()
+        let catalogCommits = LockedRecordedValues<(pid_t, Int)>()
         let fixture = RuntimeCoordinatorFixture(
             upstreams: [existingUpstream],
             xcodeProcessRoutes: [
@@ -2177,6 +2178,10 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 createdUpstreams.withLockedValue { $0.append(contentsOf: [primary, secondary]) }
                 return [primary, secondary]
             },
+            testHooks: RuntimeCoordinatorTestHooks(
+                toolsListRefreshCompleted: { toolsListRefreshes.append(($0, $1)) },
+                processRouteCatalogCommitted: { catalogCommits.append(($0, $1)) }
+            ),
             startImmediately: false
         )
         defer { fixture.shutdownAndWait() }
@@ -2203,8 +2208,9 @@ struct RuntimeCoordinatorProcessRoutingTests {
         let newUpstreams = createdUpstreams.withLockedValue { $0 }
         #expect(newUpstreams.count == 2)
         let primaryInitialize = try await newUpstreams[0].nextSent(at: 0)
+        let secondaryInitialize = try await newUpstreams[1].nextSent(at: 0)
         #expect(methodName(from: primaryInitialize) == "initialize")
-        #expect(await newUpstreams[1].sentCount() == 0)
+        #expect(methodName(from: secondaryInitialize) == "initialize")
 
         await newUpstreams[0].yield(
             .message(
@@ -2219,19 +2225,26 @@ struct RuntimeCoordinatorProcessRoutingTests {
         let primaryToolsList = try await newUpstreams[0].nextSent(
             matching: { methodName(from: $0) == "tools/list" }
         )
-        #expect(await newUpstreams[1].sentCount() == 0)
-
+        let failedRefreshIndex = toolsListRefreshes.count()
         await newUpstreams[0].yield(
             .message(
-                try makeDocumentationToolsListResponse(
-                    id: try extractUpstreamID(from: primaryToolsList),
-                    tools: [toolDescriptor(name: "NewOnly")]
-                )
+                try JSONSerialization.data(withJSONObject: [
+                    "jsonrpc": "2.0",
+                    "id": NSNumber(value: try extractUpstreamID(from: primaryToolsList)),
+                    "error": [
+                        "code": -32000,
+                        "message": "primary catalog failed",
+                    ],
+                ])
             )
         )
+        let failedRefresh = try await nextRecordedValue(
+            toolsListRefreshes,
+            at: failedRefreshIndex
+        )
+        #expect(failedRefresh.0 == 1)
+        #expect(failedRefresh.1 == false)
 
-        let secondaryInitialize = try await newUpstreams[1].nextSent(at: 0)
-        #expect(methodName(from: secondaryInitialize) == "initialize")
         await newUpstreams[1].yield(
             .message(
                 try makeInitializeResponse(
@@ -2250,7 +2263,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 $0.processID == newTarget.processID
             }
         )
-        #expect(pendingRoute.usableSlotCount == 1)
+        #expect(pendingRoute.usableSlotCount == 0)
 
         await newUpstreams[1].yield(
             .message(
@@ -2260,13 +2273,33 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 )
             )
         )
-        await manager.drainRuntimeTasksForTesting()
+        let secondaryCatalog = try await newUpstreams[1].nextSent(
+            startingAt: 3,
+            matching: { methodName(from: $0) == "tools/list" }
+        )
+        let catalogCommitIndex = catalogCommits.count()
+        await newUpstreams[1].yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: secondaryCatalog),
+                    tools: [toolDescriptor(name: "NewOnly")]
+                )
+            )
+        )
+        #expect(
+            try await nextRecordedValue(catalogCommits, at: catalogCommitIndex)
+                == (newTarget.processID, 2)
+        )
         let attachedRoute = try #require(
             manager.debugSnapshot().processRoutes.first {
                 $0.processID == newTarget.processID
             }
         )
-        #expect(attachedRoute.usableSlotCount == 2)
+        #expect(attachedRoute.usableSlotCount == 1)
+        #expect(
+            manager.processControlPlane.catalog(forProcessID: newTarget.processID)?
+                .upstreamIndex == 2
+        )
     }
 
     @Test func processBridgeRecoveryRejectsReadinessCallbackAfterCatalogReset()
@@ -2312,6 +2345,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
             ]
         )
 
+        await readiness.setReady(false)
         manager.reconcileXcodeProcessTargets(
             [existingTarget, newTarget],
             reason: "test_stale_bridge_readiness_callback"
@@ -2319,30 +2353,6 @@ struct RuntimeCoordinatorProcessRoutingTests {
 
         let newUpstreams = createdUpstreams.withLockedValue { $0 }
         #expect(newUpstreams.count == 2)
-        let primaryInitialize = try await newUpstreams[0].nextSent(at: 0)
-        await newUpstreams[0].yield(
-            .message(
-                try makeInitializeResponse(
-                    id: try extractUpstreamID(from: primaryInitialize)
-                )
-            )
-        )
-        _ = try await newUpstreams[0].nextSent(
-            matching: { methodName(from: $0) == "notifications/initialized" }
-        )
-        let primaryToolsList = try await newUpstreams[0].nextSent(
-            matching: { methodName(from: $0) == "tools/list" }
-        )
-
-        await readiness.setReady(false)
-        await newUpstreams[0].yield(
-            .message(
-                try makeDocumentationToolsListResponse(
-                    id: try extractUpstreamID(from: primaryToolsList),
-                    tools: [toolDescriptor(name: "NewOnly")]
-                )
-            )
-        )
         _ = try await readiness.nextChangeWait(at: 0)
         #expect(await newUpstreams[1].sentCount() == 0)
 

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -936,6 +936,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
             startingAtEventIndex: firstRetrySearchIndex
         )
         #expect(try await secondary.nextStopCount() == 1)
+        #expect(manager.canonicalHandshakeState.hasInitializeParticipants() == false)
         let firstReplacement = try #require(
             createdPools.withLockedValue { $0.dropFirst().first?.first }
         )
@@ -1046,6 +1047,46 @@ struct RuntimeCoordinatorProcessRoutingTests {
         )
         #expect(route.upstreamIndices == [1, 2])
         #expect(route.usableSlotCount == 2)
+    }
+
+    @Test func healthProbeWaiterRegistrationRejectionSettlesProbe() throws {
+        let upstream = TestUpstreamClient()
+        let runtimeBox = WeakRuntimeCoordinatorBox()
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [upstream],
+            nowUptimeNanoseconds: { 15_000_000_000 },
+            testHooks: RuntimeCoordinatorTestHooks(
+                healthProbeResponseWaiterWillRegister: {
+                    _ = runtimeBox.value?.runtimeTasks.beginShutdown()
+                }
+            ),
+            startImmediately: false,
+            runtimeBox: runtimeBox
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let proof = manager.operationLeaseForTest(upstreamIndex: 0).proof
+        _ = manager.upstreamHealthManager.markRequestTimedOut(proof, nowUptimeNs: 0)
+        _ = manager.upstreamHealthManager.markRequestTimedOut(proof, nowUptimeNs: 0)
+        _ = manager.upstreamHealthManager.markRequestTimedOut(proof, nowUptimeNs: 0)
+        let lease = try #require(
+            manager.upstreamHealthManager.earliestInitializedQuarantineRecovery()
+        )
+        let probe = try #require(
+            manager.upstreamHealthManager.beginQuarantineRecovery(
+                lease,
+                nowUptimeNs: 15_000_000_000
+            )
+        )
+
+        manager.probeUpstreamHealth(probe)
+
+        #expect(
+            manager.upstreamHealthManager.state(for: proof.slotID)?
+                .healthProbeInFlight == false
+        )
+        #expect(manager.upstreamHealthManager.anyRecoveryInFlight() == false)
     }
 
     @Test func processRouteActivationEmptyCatalogRetryPreservesCatalogTimeout()
@@ -2156,7 +2197,8 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(methodName(from: secondInitialize) == "initialize")
     }
 
-    @Test func processRouteActivationBootstrapsCatalogFromVerifiedSecondaryAfterPrimaryFailure()
+    @Test
+    func processRouteActivationBootstrapsCatalogAndHandshakeFromVerifiedSecondaryAfterPrimaryFailure()
         async throws
     {
         let existingUpstream = TestUpstreamClient()
@@ -2165,8 +2207,10 @@ struct RuntimeCoordinatorProcessRoutingTests {
         let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
         let toolsListRefreshes = LockedRecordedValues<(Int, Bool)>()
         let catalogCommits = LockedRecordedValues<(pid_t, Int)>()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
         let fixture = RuntimeCoordinatorFixture(
             upstreams: [existingUpstream],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: existingTarget, upstreamIndices: [0])
             ],
@@ -2244,6 +2288,21 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(failedRefresh.0 == 1)
         #expect(failedRefresh.1 == false)
 
+        manager.reconcileXcodeProcessTargets(
+            [newTarget],
+            reason: "test_retire_last_verified_initialize_source"
+        )
+        #expect(manager.canonicalHandshakeState.initializeResult() == nil)
+        #expect(manager.canonicalHandshakeState.snapshot().supporterProofs.isEmpty)
+        let pendingInitialize = fixture.registerInitialize(
+            requestID: 2,
+            sessionID: "session-awaiting-verified-recovery"
+        )
+        let pendingCompletionCount = NIOLockedValueBox(0)
+        pendingInitialize.whenComplete { _ in
+            pendingCompletionCount.withLockedValue { $0 += 1 }
+        }
+
         await newUpstreams[1].yield(
             .message(
                 try makeInitializeResponse(
@@ -2263,6 +2322,17 @@ struct RuntimeCoordinatorProcessRoutingTests {
             }
         )
         #expect(pendingRoute.usableSlotCount == 0)
+        #expect(manager.canonicalHandshakeState.initializeResult() == nil)
+        #expect(manager.canonicalHandshakeState.snapshot().supporterProofs.isEmpty)
+        #expect(manager.initializeManager.pendingInitializes().count == 1)
+        #expect(pendingCompletionCount.withLockedValue { $0 } == 0)
+        let recoveringRoute = try #require(
+            manager.processControlPlane.route(forProcessID: newTarget.processID)
+        )
+        #expect(
+            manager.upstreamHealthManager.state(for: UpstreamSlotID(rawValue: 2))?
+                .initPhase == .initialized(.verifyingBridge(recoveringRoute.id))
+        )
 
         await newUpstreams[1].yield(
             .message(
@@ -2276,6 +2346,10 @@ struct RuntimeCoordinatorProcessRoutingTests {
             startingAt: 3,
             matching: { methodName(from: $0) == "tools/list" }
         )
+        _ = try await pendingInitialize.get()
+        #expect(manager.canonicalHandshakeState.initializeSourceUpstream() == 2)
+        #expect(manager.initializeManager.pendingInitializes().isEmpty)
+        #expect(pendingCompletionCount.withLockedValue { $0 } == 1)
         let catalogCommitIndex = catalogCommits.count()
         await newUpstreams[1].yield(
             .message(

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -828,13 +828,11 @@ struct RuntimeCoordinatorProcessRoutingTests {
         let existingUpstream = TestUpstreamClient()
         let existingTarget = xcodeProcessTarget(processID: 26627, xcodeVersion: "26.6")
         let recoveringTarget = xcodeProcessTarget(processID: 27027, xcodeVersion: "27.0")
-        let clocks = makeRuntimeCoordinatorDeterministicClocks()
         let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
         let createdPools = NIOLockedValueBox<[[TestUpstreamClient]]>([])
         let fixture = RuntimeCoordinatorFixture(
             config: config,
             upstreams: [existingUpstream],
-            clock: clocks.clock,
             scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: existingTarget, upstreamIndices: [0])
@@ -909,6 +907,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
             matching: { methodName(from: $0) == "initialize" },
             description: "waiting for secondary initialize"
         )
+        let probeTimeoutSearchIndex = timeoutScheduler.scheduledEventCount()
         await secondary.yield(
             .message(
                 try makeInitializeResponse(id: try extractUpstreamID(from: secondaryInitialize))
@@ -926,12 +925,12 @@ struct RuntimeCoordinatorProcessRoutingTests {
             matching: { methodName(from: $0) == "tools/list" },
             description: "waiting for first attach probe"
         )
-        let firstRetrySearchIndex = timeoutScheduler.scheduledEventCount()
-        try await advanceRuntimeCoordinatorTimeout(
-            timeoutClock: clocks.timeoutClock,
-            uptimeClock: clocks.uptimeClock,
-            by: .seconds(2)
+        let probeTimeoutIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .seconds(2),
+            startingAtEventIndex: probeTimeoutSearchIndex
         )
+        let firstRetrySearchIndex = timeoutScheduler.scheduledEventCount()
+        #expect(timeoutScheduler.fire(at: probeTimeoutIndex))
         let firstRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
             delay: .seconds(1),
             startingAtEventIndex: firstRetrySearchIndex
@@ -7024,6 +7023,7 @@ struct RuntimeCoordinatorRecoveryTests {
             return
         }
 
+        let initialRecoverySearchIndex = timeoutScheduler.scheduledEventCount()
         let pendingInitialize = manager.registerInitialize(
             originalID: JSONRPC.ID(any: NSNumber(value: 80429))!,
             requestObject: makeInitializeRequest(id: 80429),
@@ -7034,16 +7034,16 @@ struct RuntimeCoordinatorRecoveryTests {
             pendingCompletionCount.withLockedValue { $0 += 1 }
         }
         #expect(await upstream.sentCount() == 0)
-        #expect(timeoutScheduler.scheduledCount() == 2)
-        #expect(
-            timeoutScheduler.delay(at: 1)?.nanoseconds
-                == TimeAmount.seconds(30).nanoseconds
+        let initialRecoveryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .seconds(30),
+            startingAtEventIndex: initialRecoverySearchIndex
         )
 
         uptimeClock.advance(by: .seconds(31))
-        #expect(timeoutScheduler.fire(at: 1))
+        #expect(timeoutScheduler.fire(at: initialRecoveryIndex))
         let probeRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
         #expect(methodName(from: probeRequest) == "tools/list")
+        let nextRecoverySearchIndex = timeoutScheduler.scheduledEventCount()
         await upstream.yield(
             .message(
                 try JSONSerialization.data(withJSONObject: [
@@ -7056,14 +7056,13 @@ struct RuntimeCoordinatorRecoveryTests {
         #expect(manager.canonicalHandshakeState.initializeResult() == nil)
         #expect(manager.processControlPlane.catalog(forProcessID: target.processID) == nil)
         #expect(pendingCompletionCount.withLockedValue { $0 } == 0)
-        #expect(timeoutScheduler.scheduledCount() == 3)
-        #expect(
-            timeoutScheduler.delay(at: 2)?.nanoseconds
-                == TimeAmount.seconds(15).nanoseconds
+        let nextRecoveryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .seconds(15),
+            startingAtEventIndex: nextRecoverySearchIndex
         )
 
         uptimeClock.advance(by: .seconds(16))
-        #expect(timeoutScheduler.fire(at: 2))
+        #expect(timeoutScheduler.fire(at: nextRecoveryIndex))
         let validProbeRequest = try await sentValue(
             from: upstream,
             at: 1,
@@ -7125,8 +7124,8 @@ struct RuntimeCoordinatorRecoveryTests {
         #expect(toolNames(in: manager.cachedToolsListResult() ?? .null) == ["RecoveredRouteOnly"])
         #expect(timeoutScheduler.isCancelled(at: 0))
         let sentCountAfterRecovery = await upstream.sentCount()
-        #expect(timeoutScheduler.fireIgnoringCancellation(at: 1))
-        #expect(timeoutScheduler.fireIgnoringCancellation(at: 2))
+        #expect(timeoutScheduler.fireIgnoringCancellation(at: initialRecoveryIndex))
+        #expect(timeoutScheduler.fireIgnoringCancellation(at: nextRecoveryIndex))
         await manager.drainRuntimeTasksForTesting()
         #expect(await upstream.sentCount() == sentCountAfterRecovery)
     }
@@ -7258,22 +7257,29 @@ struct RuntimeCoordinatorRecoveryTests {
         )
         #expect(manager.canonicalHandshakeState.initializeResult() == nil)
 
+        let initialRecoverySearchIndex = timeoutScheduler.scheduledEventCount()
         let pending = manager.registerInitialize(
             originalID: JSONRPC.ID(any: NSNumber(value: 80500))!,
             requestObject: makeInitializeRequest(id: 80500),
             on: eventLoop
         )
-        #expect(timeoutScheduler.scheduledCount() == 2)
+        let initialRecoveryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .seconds(30),
+            startingAtEventIndex: initialRecoverySearchIndex
+        )
+        let nextRecoverySearchIndex = timeoutScheduler.scheduledEventCount()
         uptimeClock.advance(by: .seconds(31))
-        #expect(timeoutScheduler.fire(at: 1))
+        #expect(timeoutScheduler.fire(at: initialRecoveryIndex))
         let firstProbe = try await sentValue(
             from: firstUpstream,
             at: 0,
             timeout: .seconds(2)
         )
-        #expect(timeoutScheduler.scheduledCount() == 3)
-        #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == 0)
-        #expect(timeoutScheduler.fire(at: 2))
+        let nextRecoveryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .nanoseconds(0),
+            startingAtEventIndex: nextRecoverySearchIndex
+        )
+        #expect(timeoutScheduler.fire(at: nextRecoveryIndex))
         let secondProbe = try await sentValue(
             from: secondUpstream,
             at: 0,

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -820,7 +820,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 ]))
     }
 
-    @Test func processOwnerRestoresTimedOutBridgeWhenSiblingCatalogWins()
+    @Test func processBridgeRecoveryRetriesAttachProbeWithBoundedCadence()
         async throws
     {
         var config = makeConfig(requestTimeout: 300)
@@ -828,19 +828,13 @@ struct RuntimeCoordinatorProcessRoutingTests {
         let existingUpstream = TestUpstreamClient()
         let existingTarget = xcodeProcessTarget(processID: 26627, xcodeVersion: "26.6")
         let recoveringTarget = xcodeProcessTarget(processID: 27027, xcodeVersion: "27.0")
+        let clocks = makeRuntimeCoordinatorDeterministicClocks()
         let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
-        let readiness = ReadinessFlag(isReady: true)
-        let readinessSleep = ControlledReadinessSleep()
         let createdPools = NIOLockedValueBox<[[TestUpstreamClient]]>([])
-        let activationInitializeHandled = TestSignal()
-        let siblingInitializeHandled = TestSignal()
         let fixture = RuntimeCoordinatorFixture(
             config: config,
             upstreams: [existingUpstream],
-            upstreamReadinessGate: makeTestReadinessGate(
-                readiness: readiness,
-                sleepRecorder: readinessSleep
-            ),
+            clock: clocks.clock,
             scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
             xcodeProcessRoutes: [
                 XcodeProcessRoute(target: existingTarget, upstreamIndices: [0])
@@ -851,15 +845,6 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 createdPools.withLockedValue { $0.append(pool) }
                 return pool
             },
-            testHooks: RuntimeCoordinatorTestHooks(
-                upstreamInitialized: { upstreamIndex in
-                    if upstreamIndex == 1 {
-                        activationInitializeHandled.signal()
-                    } else if upstreamIndex == 2 {
-                        siblingInitializeHandled.signal()
-                    }
-                }
-            ),
             startImmediately: false
         )
         defer { fixture.shutdownAndWait() }
@@ -876,196 +861,184 @@ struct RuntimeCoordinatorProcessRoutingTests {
         )
         try seedProcessToolCatalogs(
             on: manager,
-            entries: [
-                (existingTarget, 0, [toolDescriptor(name: "Only26")])
-            ]
+            entries: [(existingTarget, 0, [toolDescriptor(name: "Only26")])]
         )
 
         manager.reconcileXcodeProcessTargets(
             [existingTarget, recoveringTarget],
-            reason: "test_two_bridge_owner_recovery"
+            reason: "test_bridge_attach_retry_cadence"
         )
         let initialPool = try #require(createdPools.withLockedValue { $0.first })
-        let activationUpstream = initialPool[0]
-        let siblingUpstream = initialPool[1]
-        let activationInitialize = try await sentValue(
-            from: activationUpstream,
+        let primary = initialPool[0]
+        let secondary = initialPool[1]
+        let primaryInitialize = try await sentValue(
+            from: primary,
             startingAt: 0,
             matching: { methodName(from: $0) == "initialize" },
-            description: "waiting for activation bridge initialize"
+            description: "waiting for route activation initialize"
         )
-        let siblingInitialize = try await sentValue(
-            from: siblingUpstream,
-            startingAt: 0,
-            matching: { methodName(from: $0) == "initialize" },
-            description: "waiting for sibling bridge initialize"
-        )
-        let catalogTimeoutSearchIndex = timeoutScheduler.scheduledEventCount()
-        await activationUpstream.yield(
+        #expect(await secondary.sentCount() == 0)
+        await primary.yield(
             .message(
-                try makeInitializeResponse(
-                    id: try extractUpstreamID(from: activationInitialize),
-                    serverName: "recovering"
-                ))
-        )
-        try await activationInitializeHandled.wait(
-            timeout: .seconds(5),
-            description: "waiting for activation bridge initialize commit"
-        )
-        _ = try await sentValue(
-            from: activationUpstream,
-            startingAt: 1,
-            matching: { methodName(from: $0) == "tools/list" },
-            description: "waiting for activation bridge catalog"
-        )
-        let activationCatalogAttempt = try #require(
-            manager.processControlPlane.attemptSnapshot(processID: recoveringTarget.processID)
-        )
-        #expect(activationCatalogAttempt.phase == .loadingCatalog)
-        #expect(activationCatalogAttempt.upstreamID.rawValue == 1)
-        let siblingCatalogStartIndex = await siblingUpstream.sentCount()
-        await siblingUpstream.yield(
-            .message(
-                try makeInitializeResponse(
-                    id: try extractUpstreamID(from: siblingInitialize),
-                    serverName: "recovering"
-                ))
-        )
-        try await siblingInitializeHandled.wait(
-            timeout: .seconds(5),
-            description: "waiting for sibling bridge initialize commit"
-        )
-        let catalogTimeoutIndex = try await waitWithTimeout(
-            "waiting for activation catalog timeout registration",
-            timeout: .seconds(2)
-        ) {
-            try await timeoutScheduler.nextActiveTimeoutIndex(
-                delay: .seconds(10),
-                startingAtEventIndex: catalogTimeoutSearchIndex
+                try makeInitializeResponse(id: try extractUpstreamID(from: primaryInitialize))
             )
-        }
-        let retryTimeoutSearchIndex = timeoutScheduler.scheduledCount()
-        #expect(timeoutScheduler.fire(at: catalogTimeoutIndex))
-        let replacementPool = try #require(createdPools.withLockedValue { $0.dropFirst().first })
-        let replacementUpstream = replacementPool[0]
-        #expect(try await activationUpstream.nextStopCount() == 1)
-        #expect(await replacementUpstream.sentCount() == 0)
-        let retryTimeoutIndex = try #require(
-            (retryTimeoutSearchIndex..<timeoutScheduler.scheduledCount()).first { index in
-                timeoutScheduler.delay(at: index)?.nanoseconds
-                    == TimeAmount.milliseconds(250).nanoseconds
-            }
-        )
-        let retryAttempt = try #require(
-            manager.processControlPlane.attemptSnapshot(processID: recoveringTarget.processID)
-        )
-        let retryIsActive = retryAttempt.attemptID == activationCatalogAttempt.attemptID
-            && retryAttempt.upstreamProof == activationCatalogAttempt.upstreamProof
-            && retryAttempt.phase == .backoff
-            && retryAttempt.timeoutCount == 1
-        let retryWasSupersededByCatalogLoad = retryAttempt.phase == .loadingCatalog
-            && retryAttempt.timeoutCount == 0
-        #expect(retryIsActive || retryWasSupersededByCatalogLoad)
-
-        manager.refreshPendingProcessToolsCatalogForReadyUpstream(
-            upstreamIndex: 2,
-            reason: "test_sibling_catalog_wins"
-        )
-        let siblingCatalog = try await sentValue(
-            from: siblingUpstream,
-            startingAt: siblingCatalogStartIndex,
-            matching: { methodName(from: $0) == "tools/list" },
-            description: "waiting for sibling bridge catalog"
-        )
-        let siblingCatalogAttempt = try #require(
-            manager.processControlPlane.attemptSnapshot(processID: recoveringTarget.processID)
-        )
-        #expect(siblingCatalogAttempt.phase == .loadingCatalog)
-        #expect(siblingCatalogAttempt.timeoutCount == 0)
-        #expect(siblingCatalogAttempt.rpcCount > 0)
-        #expect(timeoutScheduler.isCancelled(at: retryTimeoutIndex))
-        await siblingUpstream.yield(
-            .message(
-                try makeDocumentationToolsListResponse(
-                    id: try extractUpstreamID(from: siblingCatalog),
-                    tools: [toolDescriptor(name: "Only27")]
-                ))
-        )
-
-        _ = try await waitWithTimeout(
-            "waiting for sibling catalog to win",
-            timeout: .seconds(2)
-        ) {
-            try await manager.controlPlaneDebugMirror.waitForSnapshot {
-                $0.canonicalToolsSourceUpstream == 2
-            }
-        }
-        #expect(await replacementUpstream.sentCount() == 0)
-        #expect(timeoutScheduler.isCancelled(at: retryTimeoutIndex))
-        #expect(timeoutScheduler.fire(at: retryTimeoutIndex) == false)
-
-        let recoveryBackoff = try await waitWithTimeout(
-            "waiting for bridge-pool recovery backoff",
-            timeout: .seconds(2)
-        ) {
-            try await readinessSleep.nextSleep(at: 0)
-        }
-        #expect(recoveryBackoff == 1_000_000_000)
-        #expect(await replacementUpstream.sentCount() == 0)
-        let firstRecoveryTimeoutSearchIndex = timeoutScheduler.scheduledEventCount()
-        await readinessSleep.resumeNext()
-        _ = try await sentValue(
-            from: replacementUpstream,
-            startingAt: 0,
-            matching: { methodName(from: $0) == "initialize" },
-            description: "waiting for process owner to restore replacement bridge"
-        )
-        let recoveryTimeoutIndex = try await waitWithTimeout(
-            "waiting for bridge recovery timeout registration",
-            timeout: .seconds(2)
-        ) {
-            try await timeoutScheduler.nextActiveTimeoutIndex(
-                delay: .seconds(3),
-                startingAtEventIndex: firstRecoveryTimeoutSearchIndex
-            )
-        }
-        #expect(timeoutScheduler.fire(at: recoveryTimeoutIndex))
-        #expect(try await replacementUpstream.nextStopCount() == 1)
-
-        let secondReplacementPool = try #require(
-            createdPools.withLockedValue { $0.dropFirst(2).first }
-        )
-        let secondReplacementUpstream = secondReplacementPool[0]
-        let secondRecoveryBackoff = try await waitWithTimeout(
-            "waiting for repeated bridge-pool recovery backoff",
-            timeout: .seconds(2)
-        ) {
-            try await readinessSleep.nextSleep(at: 1)
-        }
-        #expect(secondRecoveryBackoff == 2_000_000_000)
-        #expect(await secondReplacementUpstream.sentCount() == 0)
-
-        await readinessSleep.resumeNext()
-        let secondReplacementInitialize = try await sentValue(
-            from: secondReplacementUpstream,
-            startingAt: 0,
-            matching: { methodName(from: $0) == "initialize" },
-            description: "waiting for repeated process-owner bridge recovery"
-        )
-        await secondReplacementUpstream.yield(
-            .message(
-                try makeInitializeResponse(
-                    id: try extractUpstreamID(from: secondReplacementInitialize),
-                    serverName: "recovering"
-                ))
         )
         _ = try await sentValue(
-            from: secondReplacementUpstream,
+            from: primary,
             startingAt: 1,
             matching: { methodName(from: $0) == "notifications/initialized" },
-            description: "waiting for replacement bridge initialized notification"
+            description: "waiting for route activation initialized notification"
         )
-        #expect(await replacementUpstream.sentCount() == 1)
+        let primaryCatalog = try await sentValue(
+            from: primary,
+            startingAt: 2,
+            matching: { methodName(from: $0) == "tools/list" },
+            description: "waiting for route activation catalog"
+        )
+        await primary.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: primaryCatalog),
+                    tools: [toolDescriptor(name: "Only27")]
+                )
+            )
+        )
+
+        let secondaryInitialize = try await sentValue(
+            from: secondary,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for secondary initialize"
+        )
+        await secondary.yield(
+            .message(
+                try makeInitializeResponse(id: try extractUpstreamID(from: secondaryInitialize))
+            )
+        )
+        _ = try await sentValue(
+            from: secondary,
+            startingAt: 1,
+            matching: { methodName(from: $0) == "notifications/initialized" },
+            description: "waiting for secondary initialized notification"
+        )
+        _ = try await sentValue(
+            from: secondary,
+            startingAt: 2,
+            matching: { methodName(from: $0) == "tools/list" },
+            description: "waiting for first attach probe"
+        )
+        let firstRetrySearchIndex = timeoutScheduler.scheduledEventCount()
+        try await advanceRuntimeCoordinatorTimeout(
+            timeoutClock: clocks.timeoutClock,
+            uptimeClock: clocks.uptimeClock,
+            by: .seconds(2)
+        )
+        let firstRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .seconds(1),
+            startingAtEventIndex: firstRetrySearchIndex
+        )
+        #expect(try await secondary.nextStopCount() == 1)
+        let firstReplacement = try #require(
+            createdPools.withLockedValue { $0.dropFirst().first?.first }
+        )
+        #expect(await firstReplacement.sentCount() == 0)
+        #expect(timeoutScheduler.fire(at: firstRetryIndex))
+
+        let firstReplacementInitialize = try await sentValue(
+            from: firstReplacement,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for early retry initialize"
+        )
+        let secondRetrySearchIndex = timeoutScheduler.scheduledEventCount()
+        await firstReplacement.yield(
+            .message(
+                try JSONSerialization.data(withJSONObject: [
+                    "jsonrpc": "2.0",
+                    "id": try extractUpstreamID(from: firstReplacementInitialize),
+                    "result": [
+                        "protocolVersion": "1900-01-01",
+                        "capabilities": [String: Any](),
+                    ],
+                ])
+            )
+        )
+        let secondRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .seconds(10),
+            startingAtEventIndex: secondRetrySearchIndex
+        )
+        #expect(try await firstReplacement.nextStopCount() == 1)
+        let secondReplacement = try #require(
+            createdPools.withLockedValue { $0.dropFirst(2).first?.first }
+        )
+        #expect(timeoutScheduler.fireIgnoringCancellation(at: firstRetryIndex))
+        #expect(await secondReplacement.sentCount() == 0)
+        #expect(timeoutScheduler.fire(at: secondRetryIndex))
+
+        let incompatibleInitialize = try await sentValue(
+            from: secondReplacement,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for incompatible retry initialize"
+        )
+        let thirdRetrySearchIndex = timeoutScheduler.scheduledEventCount()
+        await secondReplacement.yield(
+            .message(
+                try JSONSerialization.data(withJSONObject: [
+                    "jsonrpc": "2.0",
+                    "id": try extractUpstreamID(from: incompatibleInitialize),
+                    "result": [
+                        "protocolVersion": MCP.ProtocolVersion.current,
+                        "capabilities": [
+                            "experimental": ["different": true],
+                        ],
+                    ],
+                ])
+            )
+        )
+        let thirdRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .seconds(10),
+            startingAtEventIndex: thirdRetrySearchIndex
+        )
+        #expect(try await secondReplacement.nextStopCount() == 1)
+        let finalReplacement = try #require(
+            createdPools.withLockedValue { $0.dropFirst(3).first?.first }
+        )
+        #expect(timeoutScheduler.fireIgnoringCancellation(at: secondRetryIndex))
+        #expect(await finalReplacement.sentCount() == 0)
+        #expect(timeoutScheduler.fire(at: thirdRetryIndex))
+
+        let finalInitialize = try await sentValue(
+            from: finalReplacement,
+            startingAt: 0,
+            matching: { methodName(from: $0) == "initialize" },
+            description: "waiting for final retry initialize"
+        )
+        await finalReplacement.yield(
+            .message(
+                try makeInitializeResponse(id: try extractUpstreamID(from: finalInitialize))
+            )
+        )
+        _ = try await sentValue(
+            from: finalReplacement,
+            startingAt: 1,
+            matching: { methodName(from: $0) == "notifications/initialized" },
+            description: "waiting for periodic retry initialized notification"
+        )
+        let finalProbe = try await sentValue(
+            from: finalReplacement,
+            startingAt: 2,
+            matching: { methodName(from: $0) == "tools/list" },
+            description: "waiting for final attach probe"
+        )
+        await finalReplacement.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: finalProbe),
+                    tools: []
+                )
+            )
+        )
         await manager.drainRuntimeTasksForTesting()
 
         let route = try #require(
@@ -1075,10 +1048,6 @@ struct RuntimeCoordinatorProcessRoutingTests {
         )
         #expect(route.upstreamIndices == [1, 2])
         #expect(route.usableSlotCount == 2)
-        #expect(
-            manager.processControlPlane.catalog(forProcessID: recoveringTarget.processID)?
-                .upstreamIndex == 2
-        )
     }
 
     @Test func processRouteActivationEmptyCatalogRetryPreservesCatalogTimeout()
@@ -2189,7 +2158,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(methodName(from: secondInitialize) == "initialize")
     }
 
-    @Test func processRouteActivationWarmsSecondarySlotsForLateAddedRouteAfterInitialize()
+    @Test func processRouteActivationDefersSecondaryUntilPrimaryCatalogAndAttachProbeSucceed()
         async throws
     {
         let existingUpstream = TestUpstreamClient()
@@ -2234,9 +2203,163 @@ struct RuntimeCoordinatorProcessRoutingTests {
         let newUpstreams = createdUpstreams.withLockedValue { $0 }
         #expect(newUpstreams.count == 2)
         let primaryInitialize = try await newUpstreams[0].nextSent(at: 0)
-        let secondaryInitialize = try await newUpstreams[1].nextSent(at: 0)
         #expect(methodName(from: primaryInitialize) == "initialize")
+        #expect(await newUpstreams[1].sentCount() == 0)
+
+        await newUpstreams[0].yield(
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: primaryInitialize)
+                )
+            )
+        )
+        _ = try await newUpstreams[0].nextSent(
+            matching: { methodName(from: $0) == "notifications/initialized" }
+        )
+        let primaryToolsList = try await newUpstreams[0].nextSent(
+            matching: { methodName(from: $0) == "tools/list" }
+        )
+        #expect(await newUpstreams[1].sentCount() == 0)
+
+        await newUpstreams[0].yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: primaryToolsList),
+                    tools: [toolDescriptor(name: "NewOnly")]
+                )
+            )
+        )
+
+        let secondaryInitialize = try await newUpstreams[1].nextSent(at: 0)
         #expect(methodName(from: secondaryInitialize) == "initialize")
+        await newUpstreams[1].yield(
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: secondaryInitialize)
+                )
+            )
+        )
+        _ = try await newUpstreams[1].nextSent(
+            matching: { methodName(from: $0) == "notifications/initialized" }
+        )
+        let attachProbe = try await newUpstreams[1].nextSent(
+            matching: { methodName(from: $0) == "tools/list" }
+        )
+        let pendingRoute = try #require(
+            manager.debugSnapshot().processRoutes.first {
+                $0.processID == newTarget.processID
+            }
+        )
+        #expect(pendingRoute.usableSlotCount == 1)
+
+        await newUpstreams[1].yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: attachProbe),
+                    tools: []
+                )
+            )
+        )
+        await manager.drainRuntimeTasksForTesting()
+        let attachedRoute = try #require(
+            manager.debugSnapshot().processRoutes.first {
+                $0.processID == newTarget.processID
+            }
+        )
+        #expect(attachedRoute.usableSlotCount == 2)
+    }
+
+    @Test func processBridgeRecoveryRejectsReadinessCallbackAfterCatalogReset()
+        async throws
+    {
+        let readiness = ReadinessFlag(isReady: true)
+        let existingUpstream = TestUpstreamClient()
+        let existingTarget = xcodeProcessTarget(processID: 26616, xcodeVersion: "26.6")
+        let newTarget = xcodeProcessTarget(processID: 27016, xcodeVersion: "27.0")
+        let createdUpstreams = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            upstreams: [existingUpstream],
+            upstreamReadinessGate: makeTestReadinessGate(readiness: readiness),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: existingTarget, upstreamIndices: [0])
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let primary = TestUpstreamClient()
+                let secondary = TestUpstreamClient()
+                createdUpstreams.withLockedValue { $0.append(contentsOf: [primary, secondary]) }
+                return [primary, secondary]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let initializeFuture = fixture.registerInitialize(requestID: 1)
+        let existingInitialize = try await existingUpstream.nextSent(at: 0)
+        await existingUpstream.yield(
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: existingInitialize)
+                )
+            )
+        )
+        _ = try await initializeFuture.get()
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (existingTarget, 0, [toolDescriptor(name: "ExistingOnly")])
+            ]
+        )
+
+        manager.reconcileXcodeProcessTargets(
+            [existingTarget, newTarget],
+            reason: "test_stale_bridge_readiness_callback"
+        )
+
+        let newUpstreams = createdUpstreams.withLockedValue { $0 }
+        #expect(newUpstreams.count == 2)
+        let primaryInitialize = try await newUpstreams[0].nextSent(at: 0)
+        await newUpstreams[0].yield(
+            .message(
+                try makeInitializeResponse(
+                    id: try extractUpstreamID(from: primaryInitialize)
+                )
+            )
+        )
+        _ = try await newUpstreams[0].nextSent(
+            matching: { methodName(from: $0) == "notifications/initialized" }
+        )
+        let primaryToolsList = try await newUpstreams[0].nextSent(
+            matching: { methodName(from: $0) == "tools/list" }
+        )
+
+        await readiness.setReady(false)
+        await newUpstreams[0].yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: primaryToolsList),
+                    tools: [toolDescriptor(name: "NewOnly")]
+                )
+            )
+        )
+        _ = try await readiness.nextChangeWait(at: 0)
+        #expect(await newUpstreams[1].sentCount() == 0)
+
+        let readinessCheckCount = await readiness.checkCount()
+        manager.invalidateToolsCatalog(reason: "test_stale_bridge_readiness_callback")
+        await readiness.setReady(true)
+        _ = try await readiness.nextCheck(at: readinessCheckCount)
+        await manager.drainRuntimeTasksForTesting()
+
+        #expect(await newUpstreams[1].sentCount() == 0)
+        #expect(
+            manager.upstreamHealthManager.state(for: UpstreamSlotID(rawValue: 2))?
+                .initPhase == .idle
+        )
+        #expect(
+            manager.processControlPlane.catalog(forProcessID: newTarget.processID) == nil
+        )
     }
 
     @Test func processRoutingNoXcodeRemovedInitializeDoesNotSuppressNextTimeout()

--- a/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
+++ b/Tests/XcodeMCPProxyTestSupport/AsyncTestSupport.swift
@@ -5,104 +5,20 @@ import Testing
 import XcodeMCPCoreTestSupport
 
 package typealias AsyncTestTimeoutError = XcodeMCPCoreTestSupport.AsyncTestTimeoutError
+package typealias AsyncTestCleanupTrait = XcodeMCPCoreTestSupport.AsyncTestCleanupTrait
 package typealias RecordedValues<Value: Sendable> = XcodeMCPCoreTestSupport.RecordedValues<Value>
 package typealias TestResourceGate = XcodeMCPCoreTestSupport.TestResourceGate
 package typealias TestClock = XcodeMCPCoreTestSupport.TestClock
 
-/// Runs synchronous `defer`-registered test cleanup without blocking the
-/// cooperative executor that must make the cleanup operation progress.
-package struct AsyncTestCleanupTrait: SuiteTrait, TestTrait, TestScoping {
-    package let isRecursive = true
-
-    package init() {}
-
-    package func provideScope(
-        for test: Test,
-        testCase: Test.Case?,
-        performing function: @Sendable () async throws -> Void
-    ) async throws {
-        let context = AsyncTestCleanupContext()
-        do {
-            try await AsyncTestCleanupContext.$current.withValue(context) {
-                try await function()
-            }
-        } catch {
-            // A fresh task shields cleanup from cancellation of the test body.
-            await Task { await context.run() }.value
-            throw error
-        }
-        await Task { await context.run() }.value
-    }
-}
-
-extension Trait where Self == AsyncTestCleanupTrait {
-    package static var asyncTestCleanup: Self { Self() }
-}
-
-private final class AsyncTestCleanupContext: @unchecked Sendable {
-    private struct Entry: Sendable {
-        let description: String
-        let operation: @Sendable () async throws -> Void
-    }
-
-    private struct State: Sendable {
-        var entries: [Entry] = []
-        var hasStarted = false
-    }
-
-    @TaskLocal static var current: AsyncTestCleanupContext?
-
-    private let state = NIOLockedValueBox(State())
-
-    func register(
-        description: String,
-        operation: @escaping @Sendable () async throws -> Void
-    ) -> Bool {
-        state.withLockedValue { state in
-            guard state.hasStarted == false else {
-                return false
-            }
-            state.entries.append(Entry(description: description, operation: operation))
-            return true
-        }
-    }
-
-    func run() async {
-        let entries = state.withLockedValue { state -> [Entry] in
-            precondition(state.hasStarted == false, "async test cleanup may only run once")
-            state.hasStarted = true
-            let entries = state.entries
-            state.entries.removeAll()
-            return entries
-        }
-
-        // `defer` blocks register while unwinding, so their LIFO order is already
-        // represented by insertion order (for example: manager, then its event loop).
-        for entry in entries {
-            do {
-                try await entry.operation()
-            } catch {
-                Issue.record("\(entry.description): \(error)")
-            }
-        }
-    }
-}
-
-/// Registers cleanup with the active ``AsyncTestCleanupTrait`` scope.
-///
 @discardableResult
 package func registerAsyncTestCleanup(
     description: String,
     operation: @escaping @Sendable () async throws -> Void
 ) -> Bool {
-    guard let context = AsyncTestCleanupContext.current else {
-        return false
-    }
-    guard context.register(description: description, operation: operation) else {
-        Issue.record("async test cleanup registered after cleanup started: \(description)")
-        return true
-    }
-    return true
+    XcodeMCPCoreTestSupport.registerAsyncTestCleanup(
+        description: description,
+        operation: operation
+    )
 }
 
 package final class LockedRecordedValues<Value: Sendable>: @unchecked Sendable {


### PR DESCRIPTION
## Purpose

Ensure a late-started Xcode process receives the configured number of mcpbridge attachments instead of leaving secondary bridges unrecognized in Xcode.

## Changes

- Start serialized secondary bridge recovery before the late route has a catalog, allowing a verified sibling to establish the first catalog when the primary catalog load fails.
- Keep each recovered bridge non-routable and defer canonical initialize support until the exact pinned `tools/list` attachment probe succeeds.
- Commit health promotion, process recovery completion, and canonical initialize publication as one rollback-safe transaction.
- Keep probe timeout arbitration inside `JSONRPCResponseRouter`, remove request mappings at the winning terminal boundary, and settle waiter-registration rejection during shutdown.
- Retry the first failed attach after 1 second and subsequent failures every 10 seconds through the injected runtime scheduler.
- Add deterministic, wall-clock-independent coverage for sibling catalog bootstrap, retry cadence, delayed response delivery, shutdown rejection, invalidation, incompatible handshakes, and commit rollback.

## Testing

- `scripts/check.sh` (967 main, 24 process, and 13 stdio tests)
- Focused `RuntimeCoordinatorProcessRoutingTests`, `RuntimeCoordinatorRecoveryTests`, `ControlPlaneAuthorityTests`, and `JSONRPCResponseRouterTests`
- Branch-wide `codex-review` against pinned live `main` `8bd74384bbfe050094b80e99ce77415dff6dae98` (0 findings)