### PR TITLE
Fix SSE notification routing and stale session cleanup

### DIFF
--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -90,8 +90,10 @@ flowchart LR
 - When `MCP-Protocol-Version` is omitted, the server uses the session's negotiated version. If no negotiated version exists, it evaluates the protocol-defined fallback `2025-03-26` and returns `400` when that version is unsupported.
 - Missing session ids return `400`; unknown or terminated session ids return `404`.
 - `DELETE /mcp` terminates the session; later requests with that session id return `404`.
+- A client transport session with no in-flight HTTP request and no open SSE stream is retained for five minutes after its last client activity so that an interrupted SSE connection can reconnect. A one-minute sweep then terminates stale sessions and their buffered notifications; outbound server notifications do not extend this lifetime. Runtime-internal control-plane and health-probe sessions do not participate in transport expiry.
 - Empty, singleton, and mixed JSON-RPC arrays return `400`; the internal executor and response router operate on typed single messages. An array response from an upstream is a protocol violation.
-- When a session's SSE notification buffer overflows, the session owner increments its dropped-notification counter and emits a rate-limited warning. Unhandled server notifications remain debug-level events.
+- Upstream `notifications/progress` is delivered only to the session that owns the active operation lease. It is dropped when no owner exists; globally scoped server notifications continue to fan out to initialized sessions.
+- HTTP owns each session's bounded SSE notification buffer. On overflow it drops the oldest notification and emits at most one warning per 30 seconds per session. `dropped_notifications` is cumulative for that session, while the warning also reports the dropped delta and sanitized methods of the notifications actually evicted; notification payloads are never logged. Unhandled server notifications remain debug-level events.
 
 ## Discovery Contract
 

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -86,7 +86,7 @@ When the proxy runs in `--refresh-code-issues-mode upstream`, Xcode's live diagn
 - If you need Xcode's native live diagnostics behavior, start the proxy with `--refresh-code-issues-mode upstream` (or `MCP_XCODE_REFRESH_CODE_ISSUES_MODE=upstream`).
 
 ## `session not found`
-Ensure the client is using the server-issued `MCP-Session-Id`. Initialize requests must not rely on a caller-provided session id, and `DELETE /mcp` permanently terminates the session.
+Ensure the client is using the server-issued `MCP-Session-Id`. Initialize requests must not rely on a caller-provided session id. `DELETE /mcp` permanently terminates the session, and the proxy also expires a session after it has had no in-flight request, open SSE stream, or other client activity for five minutes. A client that receives `404` for a session-bound request must initialize a new session; the bundled SDK and STDIO adapter perform that recovery automatically.
 
 ## `protocol version required` / `protocol version mismatch`
 The proxy only accepts `MCP-Protocol-Version: 2025-06-18` after initialize. Reinitialize the client session if it cached an older protocol version or omitted the header.

--- a/Sources/XcodeMCPKit/Internal/CoreRuntime/RequestInspector.swift
+++ b/Sources/XcodeMCPKit/Internal/CoreRuntime/RequestInspector.swift
@@ -8,7 +8,18 @@ package struct RequestTransform {
     package let method: String?
     package let toolName: String?
     package let originalID: JSONRPC.ID?
+    package let progressTokenMapping: ProgressTokenMapping?
     package let isCacheableToolsListRequest: Bool
+}
+
+package struct ProgressTokenMapping: Equatable, Sendable {
+    package let clientToken: JSONValue
+    package let upstreamToken: String
+
+    package init(clientToken: JSONValue, upstreamToken: String) {
+        self.clientToken = clientToken
+        self.upstreamToken = upstreamToken
+    }
 }
 
 package enum RequestInspector {
@@ -16,6 +27,7 @@ package enum RequestInspector {
         _ data: Data,
         parsedJSON: Any? = nil,
         sessionID: String,
+        mapProgressToken: ((JSONValue) -> String)? = nil,
         mapID: (_ sessionID: String, _ originalID: JSONRPC.ID) throws -> Int64
     ) throws -> RequestTransform {
         let json = try parsedJSON ?? JSONSerialization.jsonObject(with: data, options: [])
@@ -27,6 +39,10 @@ package enum RequestInspector {
         let method = JSONRPC.Message.Inspector.method(from: object)
         let toolName = toolName(from: object, method: method)
         if case .request(let method, let rpcID) = kind {
+            let progressTokenMapping = rewriteProgressToken(
+                in: &object,
+                mapProgressToken: mapProgressToken
+            )
             let upstreamID = try mapID(sessionID, rpcID)
             object["id"] = upstreamID
             return RequestTransform(
@@ -37,6 +53,7 @@ package enum RequestInspector {
                 method: method,
                 toolName: toolName,
                 originalID: rpcID,
+                progressTokenMapping: progressTokenMapping,
                 // tools/list is stable even when clients attach pagination-like params.
                 isCacheableToolsListRequest: method == "tools/list"
             )
@@ -50,8 +67,41 @@ package enum RequestInspector {
             method: method,
             toolName: toolName,
             originalID: nil,
+            progressTokenMapping: nil,
             isCacheableToolsListRequest: false
         )
+    }
+
+    private static func rewriteProgressToken(
+        in object: inout [String: Any],
+        mapProgressToken: ((JSONValue) -> String)?
+    ) -> ProgressTokenMapping? {
+        guard let mapProgressToken,
+            var params = object["params"] as? [String: Any],
+            var meta = params["_meta"] as? [String: Any],
+            let rawClientToken = meta["progressToken"],
+            let clientToken = JSONValue(any: rawClientToken),
+            Self.isValidProgressToken(clientToken)
+        else {
+            return nil
+        }
+        let upstreamToken = mapProgressToken(clientToken)
+        meta["progressToken"] = upstreamToken
+        params["_meta"] = meta
+        object["params"] = params
+        return ProgressTokenMapping(
+            clientToken: clientToken,
+            upstreamToken: upstreamToken
+        )
+    }
+
+    private static func isValidProgressToken(_ token: JSONValue) -> Bool {
+        switch token {
+        case .string, .number(.int):
+            return true
+        case .number(.double), .object, .array, .bool, .null:
+            return false
+        }
     }
 
     private static func toolName(from object: [String: Any], method: String?) -> String? {

--- a/Sources/XcodeMCPProxyHTTP/HTTP/HTTPControlService.swift
+++ b/Sources/XcodeMCPProxyHTTP/HTTP/HTTPControlService.swift
@@ -13,6 +13,10 @@ struct HTTPNotificationOverflowWarning: Equatable, Sendable {
     let bufferLimit: Int
 }
 
+private enum HTTPEventDeliveryStoreError: Error {
+    case sessionNotOpen
+}
+
 final class HTTPEventDeliveryStore: Sendable {
     private static let maxDroppedMethodBuckets = 16
     private static let additionalDroppedMethodsBucket = "<additional-methods>"
@@ -58,6 +62,12 @@ final class HTTPEventDeliveryStore: Sendable {
 
     func receive(_ event: ProxyRuntimeEvent) {
         switch event {
+        case .sessionOpened(let sessionID):
+            sessions.withLockedValue { sessions in
+                if sessions[sessionID] == nil {
+                    sessions[sessionID] = SessionDelivery()
+                }
+            }
         case .notification(let sessionID, let data):
             receiveNotification(data, sessionID: sessionID)
         case .sessionClosed(let sessionID):
@@ -66,9 +76,10 @@ final class HTTPEventDeliveryStore: Sendable {
         }
     }
 
-    func open(sessionID: ProxySessionID, channel: Channel) {
+    @discardableResult
+    func open(sessionID: ProxySessionID, channel: Channel) -> Bool {
         sessions.withLockedValue { sessions in
-            var delivery = sessions[sessionID] ?? SessionDelivery()
+            guard var delivery = sessions[sessionID] else { return false }
             switch delivery.hub.add(channel) {
             case .firstActiveClient:
                 let bufferedNotifications = delivery.bufferedNotifications
@@ -86,6 +97,7 @@ final class HTTPEventDeliveryStore: Sendable {
                 break
             }
             sessions[sessionID] = delivery
+            return true
         }
     }
 
@@ -96,10 +108,8 @@ final class HTTPEventDeliveryStore: Sendable {
     }
 
     func waitForClient(sessionID: ProxySessionID) async throws {
-        let hub = sessions.withLockedValue { sessions -> SSEHub in
-            let delivery = sessions[sessionID] ?? SessionDelivery()
-            sessions[sessionID] = delivery
-            return delivery.hub
+        guard let hub = sessions.withLockedValue({ $0[sessionID]?.hub }) else {
+            throw HTTPEventDeliveryStoreError.sessionNotOpen
         }
         try await hub.waitForClient()
     }
@@ -130,14 +140,14 @@ final class HTTPEventDeliveryStore: Sendable {
     ) {
         var warning: HTTPNotificationOverflowWarning?
         sessions.withLockedValue { sessions in
-            let currentDelivery = sessions[sessionID]
+            guard let currentDelivery = sessions[sessionID] else { return }
             if let expectedHub {
-                guard let currentDelivery, currentDelivery.hub === expectedHub else {
+                guard currentDelivery.hub === expectedHub else {
                     return
                 }
             }
 
-            var delivery = currentDelivery ?? SessionDelivery()
+            var delivery = currentDelivery
             if case .unavailable = broadcast(
                 notification,
                 sessionID: sessionID,
@@ -384,7 +394,7 @@ final class HTTPControlService: Sendable {
     func beginRequest(
         _ request: ProxyRuntimeRequest,
         sessionID: ProxySessionID?
-    ) -> any ProxyRuntimeRequestOperating {
+    ) -> (any ProxyRuntimeRequestOperating)? {
         runtime.beginRequest(request, in: sessionID)
     }
 
@@ -405,7 +415,10 @@ final class HTTPControlService: Sendable {
     @discardableResult
     func openSSE(sessionID: ProxySessionID, channel: Channel) -> Bool {
         guard runtime.clientEventStreamOpened(sessionID) else { return false }
-        deliveryStore.open(sessionID: sessionID, channel: channel)
+        guard deliveryStore.open(sessionID: sessionID, channel: channel) else {
+            runtime.clientEventStreamClosed(sessionID)
+            return false
+        }
         return true
     }
 

--- a/Sources/XcodeMCPProxyHTTP/HTTP/HTTPControlService.swift
+++ b/Sources/XcodeMCPProxyHTTP/HTTP/HTTPControlService.swift
@@ -2,21 +2,58 @@ import Foundation
 import Logging
 import NIO
 import NIOConcurrencyHelpers
+import XcodeMCPKit
 import XcodeMCPProxyRuntime
 
+struct HTTPNotificationOverflowWarning: Equatable, Sendable {
+    let sessionID: ProxySessionID
+    let droppedNotificationCount: UInt64
+    let droppedSinceLastWarning: UInt64
+    let droppedMethodsSinceLastWarning: [String: UInt64]
+    let bufferLimit: Int
+}
+
 final class HTTPEventDeliveryStore: Sendable {
+    private static let maxDroppedMethodBuckets = 16
+    private static let additionalDroppedMethodsBucket = "<additional-methods>"
+
+    private struct BufferedNotification: Sendable {
+        let data: Data
+        let method: String
+    }
+
     private struct SessionDelivery: Sendable {
         let hub = SSEHub()
-        var bufferedNotifications: [Data] = []
+        var bufferedNotifications: [BufferedNotification] = []
+        var droppedNotificationCount: UInt64 = 0
+        var droppedSinceLastWarning: UInt64 = 0
+        var droppedMethodsSinceLastWarning: [String: UInt64] = [:]
+        var lastNotificationOverflowWarningUptimeNanoseconds: UInt64?
     }
 
     private let sessions = NIOLockedValueBox<[ProxySessionID: SessionDelivery]>([:])
     private let logger = ProxyLogging.make("http.sse")
     private let bufferLimit: Int
+    private let notificationOverflowWarningIntervalNanoseconds: UInt64
+    private let uptimeNanoseconds: @Sendable () -> UInt64
+    private let overflowWarningSink: (@Sendable (HTTPNotificationOverflowWarning) -> Void)?
 
-    init(bufferLimit: Int = 50) {
+    init(
+        bufferLimit: Int = 50,
+        notificationOverflowWarningInterval: TimeAmount = .seconds(30),
+        uptimeNanoseconds: @escaping @Sendable () -> UInt64 = {
+            DispatchTime.now().uptimeNanoseconds
+        },
+        overflowWarningSink: (@Sendable (HTTPNotificationOverflowWarning) -> Void)? = nil
+    ) {
         precondition(bufferLimit >= 0)
+        precondition(notificationOverflowWarningInterval.nanoseconds >= 0)
         self.bufferLimit = bufferLimit
+        self.notificationOverflowWarningIntervalNanoseconds = UInt64(
+            notificationOverflowWarningInterval.nanoseconds
+        )
+        self.uptimeNanoseconds = uptimeNanoseconds
+        self.overflowWarningSink = overflowWarningSink
     }
 
     func receive(_ event: ProxyRuntimeEvent) {
@@ -36,13 +73,13 @@ final class HTTPEventDeliveryStore: Sendable {
             case .firstActiveClient:
                 let bufferedNotifications = delivery.bufferedNotifications
                 delivery.bufferedNotifications.removeAll(keepingCapacity: true)
-                for data in bufferedNotifications {
+                for notification in bufferedNotifications {
                     if case .unavailable = broadcast(
-                        data,
+                        notification,
                         sessionID: sessionID,
                         hub: delivery.hub
                     ) {
-                        delivery.bufferedNotifications.append(data)
+                        delivery.bufferedNotifications.append(notification)
                     }
                 }
             case .additionalActiveClient, .inactive:
@@ -79,15 +116,19 @@ final class HTTPEventDeliveryStore: Sendable {
     }
 
     private func receiveNotification(_ data: Data, sessionID: ProxySessionID) {
-        deliverOrBuffer(data, sessionID: sessionID, expectedHub: nil)
+        deliverOrBuffer(
+            BufferedNotification(data: data, method: Self.messageMethod(from: data)),
+            sessionID: sessionID,
+            expectedHub: nil
+        )
     }
 
     private func deliverOrBuffer(
-        _ data: Data,
+        _ notification: BufferedNotification,
         sessionID: ProxySessionID,
         expectedHub: SSEHub?
     ) {
-        var droppedNotificationCount = 0
+        var warning: HTTPNotificationOverflowWarning?
         sessions.withLockedValue { sessions in
             let currentDelivery = sessions[sessionID]
             if let expectedHub {
@@ -98,55 +139,229 @@ final class HTTPEventDeliveryStore: Sendable {
 
             var delivery = currentDelivery ?? SessionDelivery()
             if case .unavailable = broadcast(
-                data,
+                notification,
                 sessionID: sessionID,
                 hub: delivery.hub
             ) {
-                delivery.bufferedNotifications.append(data)
+                delivery.bufferedNotifications.append(notification)
                 if delivery.bufferedNotifications.count > bufferLimit {
-                    droppedNotificationCount = delivery.bufferedNotifications.count - bufferLimit
-                    delivery.bufferedNotifications.removeFirst(droppedNotificationCount)
+                    let droppedCount = delivery.bufferedNotifications.count - bufferLimit
+                    let droppedNotifications = Array(
+                        delivery.bufferedNotifications.prefix(droppedCount)
+                    )
+                    delivery.bufferedNotifications.removeFirst(droppedCount)
+
+                    let increment = UInt64(droppedCount)
+                    let (nextTotal, totalOverflowed) =
+                        delivery.droppedNotificationCount.addingReportingOverflow(increment)
+                    precondition(!totalOverflowed, "notification drop counter overflow")
+                    delivery.droppedNotificationCount = nextTotal
+
+                    let (nextDelta, deltaOverflowed) =
+                        delivery.droppedSinceLastWarning.addingReportingOverflow(increment)
+                    precondition(!deltaOverflowed, "notification warning delta overflow")
+                    delivery.droppedSinceLastWarning = nextDelta
+                    for droppedNotification in droppedNotifications {
+                        let methodBucket = Self.droppedMethodBucket(
+                            for: droppedNotification.method,
+                            counts: delivery.droppedMethodsSinceLastWarning
+                        )
+                        let current = delivery.droppedMethodsSinceLastWarning[
+                            methodBucket,
+                            default: 0
+                        ]
+                        let (nextCount, methodCountOverflowed) =
+                            current.addingReportingOverflow(1)
+                        precondition(!methodCountOverflowed, "notification method counter overflow")
+                        delivery.droppedMethodsSinceLastWarning[methodBucket] = nextCount
+                    }
+
+                    let now = uptimeNanoseconds()
+                    let shouldWarn: Bool
+                    if let lastWarning =
+                        delivery.lastNotificationOverflowWarningUptimeNanoseconds
+                    {
+                        shouldWarn =
+                            now &- lastWarning
+                            >= notificationOverflowWarningIntervalNanoseconds
+                    } else {
+                        shouldWarn = true
+                    }
+                    if shouldWarn {
+                        warning = HTTPNotificationOverflowWarning(
+                            sessionID: sessionID,
+                            droppedNotificationCount: delivery.droppedNotificationCount,
+                            droppedSinceLastWarning: delivery.droppedSinceLastWarning,
+                            droppedMethodsSinceLastWarning:
+                                delivery.droppedMethodsSinceLastWarning,
+                            bufferLimit: bufferLimit
+                        )
+                        delivery.lastNotificationOverflowWarningUptimeNanoseconds = now
+                        delivery.droppedSinceLastWarning = 0
+                        delivery.droppedMethodsSinceLastWarning.removeAll(
+                            keepingCapacity: true
+                        )
+                    }
                 }
             }
             sessions[sessionID] = delivery
         }
-        if droppedNotificationCount > 0 {
-            logger.warning(
-                "SSE notification buffer overflow",
-                metadata: [
-                    "session": .string(sessionID.rawValue),
-                    "dropped_notifications": .string("\(droppedNotificationCount)"),
-                ]
-            )
+        if let warning {
+            if let overflowWarningSink {
+                overflowWarningSink(warning)
+            } else {
+                log(warning)
+            }
         }
     }
 
     private func broadcast(
-        _ data: Data,
+        _ notification: BufferedNotification,
         sessionID: ProxySessionID,
         hub: SSEHub
     ) -> SSEHub.BroadcastResult {
-        hub.broadcast(data) { [weak self] in
+        hub.broadcast(notification.data) { [weak self] in
             self?.deliverOrBuffer(
-                data,
+                notification,
                 sessionID: sessionID,
                 expectedHub: hub
             )
         }
     }
+
+    private func log(_ warning: HTTPNotificationOverflowWarning) {
+        let methods = warning.droppedMethodsSinceLastWarning
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ",")
+        logger.warning(
+            "SSE notification buffer overflow",
+            metadata: [
+                "session": .string(warning.sessionID.rawValue),
+                "dropped_notifications": .string("\(warning.droppedNotificationCount)"),
+                "dropped_since_last_warning": .string("\(warning.droppedSinceLastWarning)"),
+                "dropped_methods_since_last_warning": .string(methods),
+                "buffer_limit": .string("\(warning.bufferLimit)"),
+            ]
+        )
+    }
+
+    private static func messageMethod(from data: Data) -> String {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let method = object["method"] as? String,
+            method.isEmpty == false,
+            method.utf8.count <= 128,
+            method.utf8.allSatisfy({ (0x21...0x7e).contains($0) })
+        else {
+            return "<unknown>"
+        }
+        return method
+    }
+
+    private static func droppedMethodBucket(
+        for method: String,
+        counts: [String: UInt64]
+    ) -> String {
+        if counts[method] != nil || counts.count < maxDroppedMethodBuckets - 1 {
+            return method
+        }
+        return additionalDroppedMethodsBucket
+    }
+}
+
+final class HTTPSessionExpirySweep: Sendable {
+    private struct State: Sendable {
+        var isStarted = false
+        var isCancelled = false
+        var timeout: RuntimeScheduledTimeout?
+    }
+
+    private let state = NIOLockedValueBox(State())
+    private let interval: TimeAmount
+    private let expire: @Sendable () -> Void
+
+    init(interval: TimeAmount, expire: @escaping @Sendable () -> Void) {
+        precondition(interval.nanoseconds > 0)
+        self.interval = interval
+        self.expire = expire
+    }
+
+    func start(on eventLoop: EventLoop) {
+        let shouldSchedule = state.withLockedValue { state -> Bool in
+            guard state.isStarted == false, state.isCancelled == false else {
+                return false
+            }
+            state.isStarted = true
+            return true
+        }
+        if shouldSchedule {
+            scheduleNext(on: eventLoop)
+        }
+    }
+
+    func cancel() {
+        let timeout = state.withLockedValue { state -> RuntimeScheduledTimeout? in
+            state.isCancelled = true
+            let timeout = state.timeout
+            state.timeout = nil
+            return timeout
+        }
+        timeout?.cancel()
+    }
+
+    private func scheduleNext(on eventLoop: EventLoop) {
+        let timeout = RuntimeScheduledTimeout.schedule(on: eventLoop, in: interval) {
+            [weak self] in
+            self?.fire(on: eventLoop)
+        }
+        let shouldCancel = state.withLockedValue { state -> Bool in
+            guard state.isCancelled == false else { return true }
+            state.timeout = timeout
+            return false
+        }
+        if shouldCancel {
+            timeout.cancel()
+        }
+    }
+
+    private func fire(on eventLoop: EventLoop) {
+        let shouldExpire = state.withLockedValue { state -> Bool in
+            guard state.isCancelled == false else { return false }
+            state.timeout = nil
+            return true
+        }
+        guard shouldExpire else { return }
+        expire()
+        scheduleNext(on: eventLoop)
+    }
 }
 
 final class HTTPControlService: Sendable {
+    static let defaultSessionInactivityGrace: TimeAmount = .seconds(5 * 60)
+    static let defaultSessionExpirySweepInterval: TimeAmount = .seconds(60)
+
     private let runtime: any ProxyRuntimeServing
     private let deliveryStore: HTTPEventDeliveryStore
+    private let sessionExpirySweep: HTTPSessionExpirySweep
     private let cancelEventSubscription: @Sendable () -> Void
 
     init(
         runtime: any ProxyRuntimeServing,
-        deliveryStore: HTTPEventDeliveryStore = HTTPEventDeliveryStore()
+        deliveryStore: HTTPEventDeliveryStore = HTTPEventDeliveryStore(),
+        sessionInactivityGrace: TimeAmount = HTTPControlService.defaultSessionInactivityGrace,
+        sessionExpirySweepInterval: TimeAmount =
+            HTTPControlService.defaultSessionExpirySweepInterval
     ) {
+        precondition(sessionInactivityGrace.nanoseconds > 0)
         self.runtime = runtime
         self.deliveryStore = deliveryStore
+        self.sessionExpirySweep = HTTPSessionExpirySweep(
+            interval: sessionExpirySweepInterval,
+            expire: { [runtime] in
+                runtime.expireInactiveSessions(inactiveFor: sessionInactivityGrace)
+            }
+        )
         self.cancelEventSubscription = runtime.subscribeToEvents { [deliveryStore] event in
             deliveryStore.receive(event)
         }
@@ -157,6 +372,7 @@ final class HTTPControlService: Sendable {
     }
 
     func cancel() {
+        sessionExpirySweep.cancel()
         cancelEventSubscription()
         deliveryStore.closeAll()
     }
@@ -172,18 +388,30 @@ final class HTTPControlService: Sendable {
         runtime.beginRequest(request, in: sessionID)
     }
 
+    func clientRequestFinished(_ sessionID: ProxySessionID) {
+        runtime.clientRequestFinished(sessionID)
+    }
+
+    func startSessionExpirySweep(on eventLoop: EventLoop) {
+        sessionExpirySweep.start(on: eventLoop)
+    }
+
     func debugSnapshotData(includeSensitiveDebugPayloads: Bool = false) -> Data? {
         runtime.debugSnapshotData(
             includeSensitivePayloads: includeSensitiveDebugPayloads
         )
     }
 
-    func openSSE(sessionID: ProxySessionID, channel: Channel) {
+    @discardableResult
+    func openSSE(sessionID: ProxySessionID, channel: Channel) -> Bool {
+        guard runtime.clientEventStreamOpened(sessionID) else { return false }
         deliveryStore.open(sessionID: sessionID, channel: channel)
+        return true
     }
 
     func closeSSE(sessionID: ProxySessionID, channel: Channel) {
         deliveryStore.close(sessionID: sessionID, channel: channel)
+        runtime.clientEventStreamClosed(sessionID)
     }
 
     func waitForSSEClient(sessionID: ProxySessionID) async throws {

--- a/Sources/XcodeMCPProxyHTTP/HTTP/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxyHTTP/HTTP/HTTPHandler.swift
@@ -325,6 +325,21 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             return
         }
 
+        guard controlService.openSSE(
+            sessionID: ProxySessionID(rawValue: sessionID),
+            channel: context.channel
+        ) else {
+            _ = sendPlain(
+                on: context.channel,
+                status: .notFound,
+                body: "session not found",
+                keepAlive: head.isKeepAlive,
+                sessionID: sessionID,
+                requestLog: requestLog
+            )
+            return
+        }
+
         state.withLockedValue { state in
             state.isSSE = true
             state.sseSessionID = sessionID
@@ -342,18 +357,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         var buffer = context.channel.allocator.buffer(capacity: 8)
         buffer.writeString(": ok\n\n")
         context.writeAndFlush(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
-
-        guard controlService.openSSE(
-            sessionID: ProxySessionID(rawValue: sessionID),
-            channel: context.channel
-        ) else {
-            logger.warning(
-                "Closing SSE stream after its session expired during admission",
-                metadata: ["session": .string(sessionID)]
-            )
-            context.close(promise: nil)
-            return
-        }
 
         if let remote = requestLog.remoteAddress {
             logger.info("SSE connected", metadata: ["remote": .string(remote), "session": .string(sessionID)])

--- a/Sources/XcodeMCPProxyHTTP/HTTP/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxyHTTP/HTTP/HTTPHandler.swift
@@ -18,6 +18,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let remoteAddress: String?
     }
 
+    struct ActivePostRequest: Sendable {
+        let operation: any ProxyRuntimeRequestOperating
+        let sessionID: ProxySessionID?
+    }
+
     struct State: Sendable {
         var requestHead: HTTPRequestHead?
         var bodyBuffer: ByteBuffer?
@@ -25,7 +30,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         var sseSessionID: String?
         var bodyTooLarge = false
         var originRejected = false
-        var activePostRequestOperations: [String: any ProxyRuntimeRequestOperating] = [:]
+        var activePostRequests: [String: ActivePostRequest] = [:]
         var responseWriteTail: EventLoopFuture<Void>?
     }
 
@@ -109,10 +114,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     }
 
     func channelInactive(context: ChannelHandlerContext) {
-        let (sessionID, activePostRequestOperations) = state.withLockedValue { state in
-            let operations = Array(state.activePostRequestOperations.values)
-            state.activePostRequestOperations.removeAll()
-            return (state.sseSessionID, operations)
+        let (sessionID, activePostRequests) = state.withLockedValue { state in
+            let requests = Array(state.activePostRequests.values)
+            state.activePostRequests.removeAll()
+            return (state.sseSessionID, requests)
         }
         if let sessionID {
             controlService.closeSSE(
@@ -120,8 +125,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 channel: context.channel
             )
         }
-        for operation in activePostRequestOperations {
-            operation.cancel(reason: .channelInactive)
+        for request in activePostRequests {
+            request.operation.cancel(reason: .channelInactive)
+            if let sessionID = request.sessionID {
+                controlService.clientRequestFinished(sessionID)
+            }
         }
         if let remote = remoteAddressString(for: context.channel) {
             if let sessionID {
@@ -335,10 +343,17 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         buffer.writeString(": ok\n\n")
         context.writeAndFlush(wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
 
-        controlService.openSSE(
+        guard controlService.openSSE(
             sessionID: ProxySessionID(rawValue: sessionID),
             channel: context.channel
-        )
+        ) else {
+            logger.warning(
+                "Closing SSE stream after its session expired during admission",
+                metadata: ["session": .string(sessionID)]
+            )
+            context.close(promise: nil)
+            return
+        }
 
         if let remote = requestLog.remoteAddress {
             logger.info("SSE connected", metadata: ["remote": .string(remote), "session": .string(sessionID)])
@@ -469,52 +484,62 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             sessionID: effectiveSessionID.map(ProxySessionID.init(rawValue:))
         )
         state.withLockedValue { state in
-            state.activePostRequestOperations[requestLog.id] = operation
+            state.activePostRequests[requestLog.id] = ActivePostRequest(
+                operation: operation,
+                sessionID: effectiveSessionID.map(ProxySessionID.init(rawValue:))
+            )
         }
         operation.whenComplete { result in
             self.scheduleResponseCompletion(eventLoop) {
                 switch result {
                 case .success(let resolution):
-                let writeFuture = self.enqueueOrderedWrite(on: channel) {
-                    self.sendPostResolution(
-                        resolution,
-                        on: channel,
-                        keepAlive: keepAlive,
-                        requestLog: requestLog
-                    )
-                }
-                writeFuture.whenFailure { error in
-                    self.logger.warning(
-                        "HTTP response write failed",
-                        metadata: [
-                            "request_id": .string(requestLog.id),
-                            "disconnect_source": .string("responseWriteFailure"),
-                            "error": .string("\(error)"),
-                        ]
-                    )
-                    operation.cancel(reason: .responseWriteFailure)
-                }
-                writeFuture.whenComplete { _ in
-                    _ = self.state.withLockedValue { state in
-                        state.activePostRequestOperations.removeValue(forKey: requestLog.id)
+                    let writeFuture = self.enqueueOrderedWrite(on: channel) {
+                        self.sendPostResolution(
+                            resolution,
+                            on: channel,
+                            keepAlive: keepAlive,
+                            requestLog: requestLog
+                        )
+                    }
+                    writeFuture.whenFailure { error in
+                        self.logger.warning(
+                            "HTTP response write failed",
+                            metadata: [
+                                "request_id": .string(requestLog.id),
+                                "disconnect_source": .string("responseWriteFailure"),
+                                "error": .string("\(error)"),
+                            ]
+                        )
+                        operation.cancel(reason: .responseWriteFailure)
+                    }
+                    writeFuture.whenComplete { _ in
+                        self.finishActivePostRequest(requestID: requestLog.id)
+                    }
+                case .failure:
+                    let writeFuture = self.enqueueOrderedWrite(on: channel) {
+                        self.sendPlain(
+                            on: channel,
+                            status: .internalServerError,
+                            body: "internal server error",
+                            keepAlive: keepAlive,
+                            sessionID: effectiveSessionID,
+                            requestLog: requestLog
+                        )
+                    }
+                    writeFuture.whenComplete { _ in
+                        self.finishActivePostRequest(requestID: requestLog.id)
                     }
                 }
-                case .failure:
-                _ = self.state.withLockedValue { state in
-                    state.activePostRequestOperations.removeValue(forKey: requestLog.id)
-                }
-                _ = self.enqueueOrderedWrite(on: channel) {
-                    self.sendPlain(
-                        on: channel,
-                        status: .internalServerError,
-                        body: "internal server error",
-                        keepAlive: keepAlive,
-                        sessionID: effectiveSessionID,
-                        requestLog: requestLog
-                    )
-                }
             }
-            }
+        }
+    }
+
+    private func finishActivePostRequest(requestID: String) {
+        let sessionID = state.withLockedValue { state in
+            state.activePostRequests.removeValue(forKey: requestID)?.sessionID
+        }
+        if let sessionID {
+            controlService.clientRequestFinished(sessionID)
         }
     }
 

--- a/Sources/XcodeMCPProxyHTTP/HTTP/HTTPHandler.swift
+++ b/Sources/XcodeMCPProxyHTTP/HTTP/HTTPHandler.swift
@@ -475,14 +475,24 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let keepAlive = head.isKeepAlive
         let channel = context.channel
         let eventLoop = context.eventLoop
-        let operation = controlService.beginRequest(
+        guard let operation = controlService.beginRequest(
             ProxyRuntimeRequest(
                 data: bodyData,
                 headerSessionExists: headerSessionExists,
                 prefersEventStream: prefersEventStream
             ),
             sessionID: effectiveSessionID.map(ProxySessionID.init(rawValue:))
-        )
+        ) else {
+            _ = sendPlain(
+                on: channel,
+                status: .notFound,
+                body: "session not found",
+                keepAlive: keepAlive,
+                sessionID: effectiveSessionID,
+                requestLog: requestLog
+            )
+            return
+        }
         state.withLockedValue { state in
             state.activePostRequests[requestLog.id] = ActivePostRequest(
                 operation: operation,

--- a/Sources/XcodeMCPProxyHTTP/HTTP/ProxyHTTPChildChannelInitializer.swift
+++ b/Sources/XcodeMCPProxyHTTP/HTTP/ProxyHTTPChildChannelInitializer.swift
@@ -19,6 +19,7 @@ package final class ProxyHTTPChildChannelInitializer: @unchecked Sendable {
     }
 
     package func initialize(_ channel: Channel) -> EventLoopFuture<Void> {
+        controlService.startSessionExpirySweep(on: channel.eventLoop)
         let pipeline = channel.pipeline
         return pipeline.configureHTTPServerPipeline(withErrorHandling: true).flatMap {
             pipeline.addHandler(

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/LeaseManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/LeaseManager.swift
@@ -100,10 +100,16 @@ final class LeaseManager: Sendable {
         }
     }
 
+    struct ProgressTarget: Equatable, Sendable {
+        let sessionID: String
+        let clientToken: JSONValue
+    }
+
     private struct LeaseRecord: Sendable {
         let leaseID: LeaseManager.ID
         let descriptor: SessionRequestPipeline.Descriptor
         var requestIDKey: String?
+        var progressTokenMapping: ProgressTokenMapping?
         var upstreamIndex: Int?
         var startedAt: Date?
         var timeoutAt: Date?
@@ -134,6 +140,7 @@ final class LeaseManager: Sendable {
                 leaseID: leaseID,
                 descriptor: descriptor,
                 requestIDKey: nil,
+                progressTokenMapping: nil,
                 upstreamIndex: nil,
                 startedAt: nil,
                 timeoutAt: nil,
@@ -150,7 +157,8 @@ final class LeaseManager: Sendable {
         _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
-        timeoutAt: Date?
+        timeoutAt: Date?,
+        progressTokenMapping: ProgressTokenMapping? = nil
     ) {
         state.withLockedValue { state in
             guard var record = state.leasesByID[leaseID] else { return }
@@ -161,6 +169,8 @@ final class LeaseManager: Sendable {
                 return
             }
             record.requestIDKey = requestIDKey ?? record.requestIDKey
+            record.progressTokenMapping =
+                progressTokenMapping ?? record.progressTokenMapping
             record.upstreamIndex = upstreamIndex ?? record.upstreamIndex
             record.startedAt = record.startedAt ?? Date()
             record.timeoutAt = timeoutAt
@@ -184,6 +194,7 @@ final class LeaseManager: Sendable {
             let upstreamIndex = record.upstreamIndex
             record.state = .queued
             record.requestIDKey = nil
+            record.progressTokenMapping = nil
             record.upstreamIndex = nil
             record.timeoutAt = nil
             state.leasesByID[leaseID] = record
@@ -350,6 +361,29 @@ final class LeaseManager: Sendable {
                 }
                 return (lhs.startedAt ?? .distantPast) < (rhs.startedAt ?? .distantPast)
             }.first?.descriptor.sessionID
+        }
+    }
+
+    func activeProgressTarget(
+        upstreamIndex: Int,
+        upstreamToken: String
+    ) -> ProgressTarget? {
+        state.withLockedValue { state in
+            let leaseIDs = state.activeLeaseIDsByUpstream[upstreamIndex] ?? []
+            let matches = leaseIDs.compactMap { state.leasesByID[$0] }.filter { record in
+                record.state == .active
+                    && record.progressTokenMapping?.upstreamToken == upstreamToken
+            }
+            guard matches.count == 1,
+                let record = matches.first,
+                let mapping = record.progressTokenMapping
+            else {
+                return nil
+            }
+            return ProgressTarget(
+                sessionID: record.descriptor.sessionID,
+                clientToken: mapping.clientToken
+            )
         }
     }
 

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/ProxyUpstreamRequestRuntime.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/ProxyUpstreamRequestRuntime.swift
@@ -41,7 +41,8 @@ protocol ProxyUpstreamRequestRuntimePort: Sendable {
         _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
-        timeout: TimeAmount?
+        timeout: TimeAmount?,
+        progressTokenMapping: ProgressTokenMapping?
     )
 }
 
@@ -137,9 +138,16 @@ struct ProxyUpstreamRequestRuntime: Sendable {
     }
 
     private let port: any ProxyUpstreamRequestRuntimePort
+    private let makeUpstreamProgressToken: @Sendable () -> String
 
-    init(port: any ProxyUpstreamRequestRuntimePort) {
+    init(
+        port: any ProxyUpstreamRequestRuntimePort,
+        makeUpstreamProgressToken: @escaping @Sendable () -> String = {
+            UUID().uuidString
+        }
+    ) {
         self.port = port
+        self.makeUpstreamProgressToken = makeUpstreamProgressToken
     }
 
     func prepareRequest(
@@ -169,6 +177,7 @@ struct ProxyUpstreamRequestRuntime: Sendable {
             rewritten.bodyData,
             parsedJSON: rewritten.parsedRequestJSON,
             sessionID: sessionID,
+            mapProgressToken: { _ in makeUpstreamProgressToken() },
             mapID: { sessionID, originalID in
                 guard let upstreamID = port.assignUpstreamID(
                     sessionID: sessionID,
@@ -212,7 +221,8 @@ struct ProxyUpstreamRequestRuntime: Sendable {
                 leaseID,
                 requestIDKey: prepared.transform.responseID?.key,
                 upstreamIndex: prepared.upstreamIndex,
-                timeout: requestTimeout
+                timeout: requestTimeout,
+                progressTokenMapping: prepared.transform.progressTokenMapping
             )
         }
         let reject: @Sendable () -> Void = {

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor.swift
@@ -283,7 +283,8 @@ final class ClientMCPRequestExecutor: Sendable {
                     ?? Self.topLevelRequestTimeoutOverride(
                         method: nil,
                         defaultSeconds: requestTimeoutSeconds
-                    )
+                    ),
+                progressTokenMapping: nil
             )
             return ClientMCPRequestExecutor.Operation(
                 future: makeTopLevelRequestFuture(
@@ -348,7 +349,8 @@ final class ClientMCPRequestExecutor: Sendable {
                         leaseID,
                         requestIDKey: nil,
                         upstreamIndex: operationLease.upstreamIndex,
-                        timeout: nil
+                        timeout: nil,
+                        progressTokenMapping: nil
                     )
                     return self.makeTopLevelRequestFuture(
                         filteredRequest: filteredRequest,

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/ProxyRuntimeAPI.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/ProxyRuntimeAPI.swift
@@ -13,6 +13,7 @@ package struct ProxySessionID: Hashable, Sendable {
 }
 
 package enum ProxyRuntimeEvent: Sendable {
+    case sessionOpened(sessionID: ProxySessionID)
     case notification(sessionID: ProxySessionID, data: Data)
     case sessionClosed(sessionID: ProxySessionID)
 }
@@ -122,7 +123,7 @@ package protocol ProxyRuntimeServing: Sendable {
     func beginRequest(
         _ message: ProxyRuntimeRequest,
         in sessionID: ProxySessionID?
-    ) -> any ProxyRuntimeRequestOperating
+    ) -> (any ProxyRuntimeRequestOperating)?
     func clientRequestFinished(_ id: ProxySessionID)
     func sessionState(_ id: ProxySessionID) -> ProxyRuntimeSessionState
     func clientEventStreamOpened(_ id: ProxySessionID) -> Bool
@@ -451,12 +452,23 @@ package final class ProxyRuntime: ProxyRuntimeServing, Sendable {
     package func beginRequest(
         _ message: ProxyRuntimeRequest,
         in sessionID: ProxySessionID?
-    ) -> any ProxyRuntimeRequestOperating {
+    ) -> (any ProxyRuntimeRequestOperating)? {
+        let createsSession = sessionID != nil && message.headerSessionExists == false
+        if let sessionID, createsSession {
+            // Reserve delivery before admission so a concurrent close cannot overtake
+            // the open event. Generated session IDs are not exposed until the response.
+            eventSource.emit(.sessionOpened(sessionID: sessionID))
+        }
         if let sessionID {
-            _ = coordinator.beginClientRequest(
+            guard coordinator.beginClientRequest(
                 id: sessionID.rawValue,
                 createIfMissing: message.headerSessionExists == false
-            )
+            ) else {
+                if createsSession {
+                    eventSource.emit(.sessionClosed(sessionID: sessionID))
+                }
+                return nil
+            }
         }
         return ProxyRuntimeRequestOperation(
             executor: requestExecutor,

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/ProxyRuntimeAPI.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/ProxyRuntimeAPI.swift
@@ -123,7 +123,11 @@ package protocol ProxyRuntimeServing: Sendable {
         _ message: ProxyRuntimeRequest,
         in sessionID: ProxySessionID?
     ) -> any ProxyRuntimeRequestOperating
+    func clientRequestFinished(_ id: ProxySessionID)
     func sessionState(_ id: ProxySessionID) -> ProxyRuntimeSessionState
+    func clientEventStreamOpened(_ id: ProxySessionID) -> Bool
+    func clientEventStreamClosed(_ id: ProxySessionID)
+    func expireInactiveSessions(inactiveFor: TimeAmount)
     func removeSession(_ id: ProxySessionID)
     func snapshot() -> ProxyRuntimeSnapshot
     func inventorySnapshot() -> ProxyRuntimeInventorySnapshot
@@ -448,7 +452,13 @@ package final class ProxyRuntime: ProxyRuntimeServing, Sendable {
         _ message: ProxyRuntimeRequest,
         in sessionID: ProxySessionID?
     ) -> any ProxyRuntimeRequestOperating {
-        ProxyRuntimeRequestOperation(
+        if let sessionID {
+            _ = coordinator.beginClientRequest(
+                id: sessionID.rawValue,
+                createIfMissing: message.headerSessionExists == false
+            )
+        }
+        return ProxyRuntimeRequestOperation(
             executor: requestExecutor,
             operation: requestExecutor.handle(
                 bodyData: message.data,
@@ -460,13 +470,26 @@ package final class ProxyRuntime: ProxyRuntimeServing, Sendable {
         )
     }
 
+    package func clientRequestFinished(_ id: ProxySessionID) {
+        coordinator.endClientRequest(id: id.rawValue)
+    }
+
     package func sessionState(_ id: ProxySessionID) -> ProxyRuntimeSessionState {
-        guard coordinator.hasSession(id: id.rawValue) else { return .missing }
-        guard coordinator.isSessionInitialized(id: id.rawValue) else {
-            return .uninitialized
-        }
-        return .initialized(
-            protocolVersion: coordinator.negotiatedProtocolVersion(id: id.rawValue)
+        coordinator.sessionStateAndTouch(id: id.rawValue)
+    }
+
+    package func clientEventStreamOpened(_ id: ProxySessionID) -> Bool {
+        coordinator.openClientEventStream(id: id.rawValue)
+    }
+
+    package func clientEventStreamClosed(_ id: ProxySessionID) {
+        coordinator.closeClientEventStream(id: id.rawValue)
+    }
+
+    package func expireInactiveSessions(inactiveFor: TimeAmount) {
+        precondition(inactiveFor.nanoseconds > 0)
+        coordinator.expireInactiveSessions(
+            inactiveForNanoseconds: UInt64(inactiveFor.nanoseconds)
         )
     }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -4,6 +4,12 @@ import NIO
 import XcodeMCPKit
 
 extension RuntimeCoordinator {
+    private enum ServerInitiatedRoutingPolicy: Equatable {
+        case serverRequest
+        case operationOwnerNotification
+        case broadcastNotification
+    }
+
     func failQueuedRequestsIfNoHealthyOrRecoveringUpstream() {
         guard activeInitializedHealthyishCount() == 0 else { return }
         guard anyActiveRecoveryInFlight() == false else { return }
@@ -27,7 +33,8 @@ extension RuntimeCoordinator {
     private struct ServerInitiatedPayload {
         let data: Data
         let object: [String: Any]
-        let expectsResponse: Bool
+        let method: String
+        let routingPolicy: ServerInitiatedRoutingPolicy
 
         func routedData(
             for session: SessionContext,
@@ -795,13 +802,26 @@ extension RuntimeCoordinator {
         originalData: Data
     ) -> ServerInitiatedPayload? {
         let kind = JSONRPC.Message.Inspector.kind(of: object)
-        guard kind.isServerInitiated else {
+        let method: String
+        let routingPolicy: ServerInitiatedRoutingPolicy
+        switch kind {
+        case .request(let requestMethod, _):
+            method = requestMethod
+            routingPolicy = .serverRequest
+        case .notification(let notificationMethod):
+            method = notificationMethod
+            routingPolicy =
+                notificationMethod == "notifications/progress"
+                ? .operationOwnerNotification
+                : .broadcastNotification
+        case .response, .malformed, .other:
             return nil
         }
         return ServerInitiatedPayload(
             data: originalData,
             object: object,
-            expectsResponse: kind.requestID != nil
+            method: method,
+            routingPolicy: routingPolicy
         )
     }
 
@@ -843,16 +863,17 @@ extension RuntimeCoordinator {
         let owningTarget =
             owningTargetOverride ?? activeLeaseSessionTarget(upstreamIndex: upstreamIndex)
         let payloadTargets = serverInitiatedTargets(
-            expectsResponse: serverInitiatedPayload.expectsResponse,
+            routingPolicy: serverInitiatedPayload.routingPolicy,
             owningTarget: owningTarget,
             pendingInitializeTargets: pendingInitializeTargets,
             routedTargets: routedTargets
         )
-        if serverInitiatedPayload.expectsResponse && payloadTargets.isEmpty {
+        if serverInitiatedPayload.routingPolicy == .serverRequest && payloadTargets.isEmpty {
             logger.debug(
                 "Dropping response-requiring server request without an owning session",
                 metadata: [
                     "upstream": .string("\(upstreamIndex)"),
+                    "method": .string(serverInitiatedPayload.method),
                     "bytes": .string("\(serverInitiatedPayload.data.count)"),
                 ]
             )
@@ -876,6 +897,7 @@ extension RuntimeCoordinator {
                 "Dropping unmapped upstream message (no routed target sessions)",
                 metadata: [
                     "upstream": .string("\(upstreamIndex)"),
+                    "method": .string(serverInitiatedPayload.method),
                     "bytes": .string("\(sourceByteCount)"),
                 ]
             )
@@ -894,13 +916,18 @@ extension RuntimeCoordinator {
     }
 
     private func serverInitiatedTargets(
-        expectsResponse: Bool,
+        routingPolicy: ServerInitiatedRoutingPolicy,
         owningTarget: SessionContext?,
         pendingInitializeTargets: [SessionContext],
         routedTargets: [SessionContext]
     ) -> [SessionContext] {
-        guard expectsResponse else {
+        switch routingPolicy {
+        case .broadcastNotification:
             return routedTargets
+        case .operationOwnerNotification:
+            return owningTarget.map { [$0] } ?? []
+        case .serverRequest:
+            break
         }
         if let owningTarget {
             return [owningTarget]

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -35,11 +35,22 @@ extension RuntimeCoordinator {
         let object: [String: Any]
         let method: String
         let routingPolicy: ServerInitiatedRoutingPolicy
+        let upstreamProgressToken: String?
 
         func routedData(
             for session: SessionContext,
-            operationLease: UpstreamOperationLease
+            operationLease: UpstreamOperationLease,
+            clientProgressToken: JSONValue?
         ) -> Data? {
+            if let clientProgressToken {
+                guard var params = object["params"] as? [String: Any] else {
+                    return nil
+                }
+                params["progressToken"] = clientProgressToken.foundationObject
+                var routedObject = object
+                routedObject["params"] = params
+                return try? JSONRPC.Wire.data(from: routedObject)
+            }
             guard case .request(_, let upstreamID) =
                 JSONRPC.Message.Inspector.kind(of: object)
             else {
@@ -604,7 +615,8 @@ extension RuntimeCoordinator {
         _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
-        timeout: TimeAmount?
+        timeout: TimeAmount?,
+        progressTokenMapping: ProgressTokenMapping? = nil
     ) {
         let timeoutAt = timeout.map {
             Date().addingTimeInterval(Double($0.nanoseconds) / 1_000_000_000)
@@ -613,7 +625,8 @@ extension RuntimeCoordinator {
             leaseID,
             requestIDKey: requestIDKey,
             upstreamIndex: upstreamIndex,
-            timeoutAt: timeoutAt
+            timeoutAt: timeoutAt,
+            progressTokenMapping: progressTokenMapping
         )
     }
 
@@ -821,8 +834,16 @@ extension RuntimeCoordinator {
             data: originalData,
             object: object,
             method: method,
-            routingPolicy: routingPolicy
+            routingPolicy: routingPolicy,
+            upstreamProgressToken: routingPolicy == .operationOwnerNotification
+                ? Self.progressToken(from: object)
+                : nil
         )
+    }
+
+    private static func progressToken(from object: [String: Any]) -> String? {
+        guard let params = object["params"] as? [String: Any] else { return nil }
+        return params["progressToken"] as? String
     }
 
     @discardableResult
@@ -860,8 +881,23 @@ extension RuntimeCoordinator {
             routedTargets.append(target)
         }
 
-        let owningTarget =
-            owningTargetOverride ?? activeLeaseSessionTarget(upstreamIndex: upstreamIndex)
+        let progressTarget: LeaseManager.ProgressTarget?
+        let owningTarget: SessionContext?
+        if serverInitiatedPayload.routingPolicy == .operationOwnerNotification {
+            progressTarget = serverInitiatedPayload.upstreamProgressToken.flatMap {
+                leaseManager.activeProgressTarget(
+                    upstreamIndex: upstreamIndex,
+                    upstreamToken: $0
+                )
+            }
+            owningTarget = progressTarget.flatMap {
+                sessionRegistry.contextIfPresent(id: $0.sessionID)
+            }
+        } else {
+            progressTarget = nil
+            owningTarget =
+                owningTargetOverride ?? activeLeaseSessionTarget(upstreamIndex: upstreamIndex)
+        }
         let payloadTargets = serverInitiatedTargets(
             routingPolicy: serverInitiatedPayload.routingPolicy,
             owningTarget: owningTarget,
@@ -884,7 +920,8 @@ extension RuntimeCoordinator {
         for session in payloadTargets {
             guard let routedData = serverInitiatedPayload.routedData(
                 for: session,
-                operationLease: operationLease
+                operationLease: operationLease,
+                clientProgressToken: progressTarget?.clientToken
             ) else {
                 continue
             }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
@@ -245,7 +245,8 @@ protocol RuntimeRequestLeasePort: Sendable {
         _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
-        timeout: TimeAmount?
+        timeout: TimeAmount?,
+        progressTokenMapping: ProgressTokenMapping?
     )
     func completeRequestLease(_ leaseID: LeaseManager.ID)
     func requeueRequestLease(_ leaseID: LeaseManager.ID)

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
@@ -164,6 +164,12 @@ protocol RuntimeSessionRegistryPort: Sendable {
     func hasSession(id: String) -> Bool
     func isSessionInitialized(id: String) -> Bool
     func negotiatedProtocolVersion(id: String) -> String?
+    func sessionStateAndTouch(id: String) -> ProxyRuntimeSessionState
+    func beginClientRequest(id: String, createIfMissing: Bool) -> Bool
+    func endClientRequest(id: String)
+    func openClientEventStream(id: String) -> Bool
+    func closeClientEventStream(id: String)
+    func expireInactiveSessions(inactiveForNanoseconds: UInt64)
     func removeSession(id: String)
     func isInitialized() -> Bool
 }
@@ -302,6 +308,29 @@ extension RuntimeSessionRegistryPort {
     func negotiatedProtocolVersion(id _: String) -> String? {
         nil
     }
+
+    func sessionStateAndTouch(id: String) -> ProxyRuntimeSessionState {
+        guard hasSession(id: id) else { return .missing }
+        guard isSessionInitialized(id: id) else { return .uninitialized }
+        return .initialized(protocolVersion: negotiatedProtocolVersion(id: id))
+    }
+
+    func beginClientRequest(id: String, createIfMissing: Bool) -> Bool {
+        if createIfMissing {
+            _ = session(id: id)
+        }
+        return hasSession(id: id)
+    }
+
+    func endClientRequest(id _: String) {}
+
+    func openClientEventStream(id: String) -> Bool {
+        hasSession(id: id)
+    }
+
+    func closeClientEventStream(id _: String) {}
+
+    func expireInactiveSessions(inactiveForNanoseconds _: UInt64) {}
 
 }
 
@@ -641,7 +670,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.sessionRegistry = SessionRegistry(
             configuration: config,
             notificationSink: notificationSink,
-            sessionClosedSink: sessionClosedSink
+            sessionClosedSink: sessionClosedSink,
+            nowUptimeNanoseconds: uptimeProvider
         )
         let initialTopology = upstreamTopology.snapshot()
         let debugRecorder = ProxyDebugRecorder()
@@ -940,8 +970,41 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         sessionRegistry.negotiatedProtocolVersion(id: id)
     }
 
+    func sessionStateAndTouch(id: String) -> ProxyRuntimeSessionState {
+        sessionRegistry.sessionStateAndTouch(id: id)
+    }
+
+    func beginClientRequest(id: String, createIfMissing: Bool) -> Bool {
+        sessionRegistry.beginClientRequest(id: id, createIfMissing: createIfMissing)
+    }
+
+    func endClientRequest(id: String) {
+        sessionRegistry.endClientRequest(id: id)
+    }
+
+    func openClientEventStream(id: String) -> Bool {
+        sessionRegistry.openEventStream(id: id)
+    }
+
+    func closeClientEventStream(id: String) {
+        sessionRegistry.closeEventStream(id: id)
+    }
+
+    func expireInactiveSessions(inactiveForNanoseconds: UInt64) {
+        let removedSessionIDs = sessionRegistry.removeInactiveSessions(
+            inactiveForNanoseconds: inactiveForNanoseconds
+        )
+        for sessionID in removedSessionIDs {
+            cleanupRemovedSession(id: sessionID)
+        }
+    }
+
     func removeSession(id: String) {
         _ = sessionRegistry.removeSession(id: id)
+        cleanupRemovedSession(id: id)
+    }
+
+    private func cleanupRemovedSession(id: String) {
         let pendingInitializes = initializeManager.removePendingInitializes(sessionID: id)
         pendingInitializes.timeout?.cancel()
         pendingInitializes.recoveryTimeout?.cancel()

--- a/Sources/XcodeMCPProxyRuntime/Session/Session/SessionRegistry.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Session/SessionRegistry.swift
@@ -6,6 +6,10 @@ struct SessionRecord: Sendable {
     let generation: UInt64
     var isInitialized: Bool
     var negotiatedProtocolVersion: String?
+    var isClientTransportSession: Bool
+    var lastClientActivityUptimeNanoseconds: UInt64
+    var activeClientRequestCount: Int
+    var activeEventStreamCount: Int
 }
 
 final class SessionRegistry: Sendable {
@@ -18,43 +22,131 @@ final class SessionRegistry: Sendable {
     private let config: ProxyRuntimeConfiguration
     private let notificationSink: (@Sendable (_ sessionID: String, _ data: Data) -> Void)?
     private let sessionClosedSink: (@Sendable (_ sessionID: String) -> Void)?
+    private let nowUptimeNanoseconds: @Sendable () -> UInt64
 
     init(
         configuration: ProxyRuntimeConfiguration,
         notificationSink: (@Sendable (_ sessionID: String, _ data: Data) -> Void)? = nil,
-        sessionClosedSink: (@Sendable (_ sessionID: String) -> Void)? = nil
+        sessionClosedSink: (@Sendable (_ sessionID: String) -> Void)? = nil,
+        nowUptimeNanoseconds: @escaping @Sendable () -> UInt64 = {
+            DispatchTime.now().uptimeNanoseconds
+        }
     ) {
         self.config = configuration
         self.notificationSink = notificationSink
         self.sessionClosedSink = sessionClosedSink
+        self.nowUptimeNanoseconds = nowUptimeNanoseconds
     }
 
     func session(id: String) -> SessionContext {
-        state.withLockedValue { state in
+        let now = nowUptimeNanoseconds()
+        return state.withLockedValue { state in
             if let existing = state.sessions[id] {
                 return existing.context
             }
-            let context: SessionContext
-            if let notificationSink {
-                context = SessionContext(
-                    id: id,
-                    config: config,
-                    notificationSink: { [id] data in
-                        notificationSink(id, data)
-                    }
-                )
-            } else {
-                context = SessionContext(id: id, config: config)
-            }
-            state.nextGeneration &+= 1
-            state.sessions[id] = SessionRecord(
-                context: context,
-                generation: state.nextGeneration,
-                isInitialized: false,
-                negotiatedProtocolVersion: nil
-            )
-            return context
+            let record = makeRecord(id: id, state: &state, nowUptimeNanoseconds: now)
+            state.sessions[id] = record
+            return record.context
         }
+    }
+
+    func sessionStateAndTouch(id: String) -> ProxyRuntimeSessionState {
+        let now = nowUptimeNanoseconds()
+        return state.withLockedValue { state in
+            guard var record = state.sessions[id] else { return .missing }
+            record.isClientTransportSession = true
+            record.lastClientActivityUptimeNanoseconds = now
+            state.sessions[id] = record
+            guard record.isInitialized else { return .uninitialized }
+            return .initialized(protocolVersion: record.negotiatedProtocolVersion)
+        }
+    }
+
+    @discardableResult
+    func beginClientRequest(id: String, createIfMissing: Bool) -> Bool {
+        let now = nowUptimeNanoseconds()
+        return state.withLockedValue { state in
+            var record: SessionRecord
+            if let existing = state.sessions[id] {
+                record = existing
+            } else {
+                guard createIfMissing else { return false }
+                record = makeRecord(id: id, state: &state, nowUptimeNanoseconds: now)
+            }
+            record.isClientTransportSession = true
+            record.activeClientRequestCount += 1
+            record.lastClientActivityUptimeNanoseconds = now
+            state.sessions[id] = record
+            return true
+        }
+    }
+
+    func endClientRequest(id: String) {
+        let now = nowUptimeNanoseconds()
+        state.withLockedValue { state in
+            guard var record = state.sessions[id] else { return }
+            precondition(
+                record.activeClientRequestCount > 0,
+                "client request activity ended without a matching begin"
+            )
+            record.activeClientRequestCount -= 1
+            record.lastClientActivityUptimeNanoseconds = now
+            state.sessions[id] = record
+        }
+    }
+
+    @discardableResult
+    func openEventStream(id: String) -> Bool {
+        let now = nowUptimeNanoseconds()
+        return state.withLockedValue { state in
+            guard var record = state.sessions[id] else { return false }
+            record.isClientTransportSession = true
+            record.activeEventStreamCount += 1
+            record.lastClientActivityUptimeNanoseconds = now
+            state.sessions[id] = record
+            return true
+        }
+    }
+
+    func closeEventStream(id: String) {
+        let now = nowUptimeNanoseconds()
+        state.withLockedValue { state in
+            guard var record = state.sessions[id] else { return }
+            precondition(
+                record.activeEventStreamCount > 0,
+                "event stream activity ended without a matching open"
+            )
+            record.activeEventStreamCount -= 1
+            record.lastClientActivityUptimeNanoseconds = now
+            state.sessions[id] = record
+        }
+    }
+
+    func removeInactiveSessions(inactiveForNanoseconds: UInt64) -> [String] {
+        precondition(inactiveForNanoseconds > 0)
+        let now = nowUptimeNanoseconds()
+        let removedSessionIDs = state.withLockedValue { state -> [String] in
+            let expiredSessionIDs = state.sessions.compactMap { entry -> String? in
+                let (sessionID, record) = entry
+                guard record.isClientTransportSession,
+                    record.activeClientRequestCount == 0,
+                    record.activeEventStreamCount == 0,
+                    now >= record.lastClientActivityUptimeNanoseconds,
+                    now - record.lastClientActivityUptimeNanoseconds >= inactiveForNanoseconds
+                else {
+                    return nil
+                }
+                return sessionID
+            }.sorted()
+            for sessionID in expiredSessionIDs {
+                state.sessions.removeValue(forKey: sessionID)
+            }
+            return expiredSessionIDs
+        }
+        for sessionID in removedSessionIDs {
+            sessionClosedSink?(sessionID)
+        }
+        return removedSessionIDs
     }
 
     func hasSession(id: String) -> Bool {
@@ -144,5 +236,35 @@ final class SessionRegistry: Sendable {
                 generation: record.generation
             )
         }
+    }
+
+    private func makeRecord(
+        id: String,
+        state: inout State,
+        nowUptimeNanoseconds: UInt64
+    ) -> SessionRecord {
+        let context: SessionContext
+        if let notificationSink {
+            context = SessionContext(
+                id: id,
+                config: config,
+                notificationSink: { [id] data in
+                    notificationSink(id, data)
+                }
+            )
+        } else {
+            context = SessionContext(id: id, config: config)
+        }
+        state.nextGeneration &+= 1
+        return SessionRecord(
+            context: context,
+            generation: state.nextGeneration,
+            isInitialized: false,
+            negotiatedProtocolVersion: nil,
+            isClientTransportSession: false,
+            lastClientActivityUptimeNanoseconds: nowUptimeNanoseconds,
+            activeClientRequestCount: 0,
+            activeEventStreamCount: 0
+        )
     }
 }

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -766,7 +766,7 @@ private final class StartupInventoryRuntime: @unchecked Sendable, ProxyRuntimeSe
     func beginRequest(
         _ message: ProxyRuntimeRequest,
         in sessionID: ProxySessionID?
-    ) -> any ProxyRuntimeRequestOperating {
+    ) -> (any ProxyRuntimeRequestOperating)? {
         fatalError("startup lifecycle test does not admit requests")
     }
 

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -770,9 +770,17 @@ private final class StartupInventoryRuntime: @unchecked Sendable, ProxyRuntimeSe
         fatalError("startup lifecycle test does not admit requests")
     }
 
+    func clientRequestFinished(_: ProxySessionID) {}
+
     func sessionState(_ id: ProxySessionID) -> ProxyRuntimeSessionState {
         .missing
     }
+
+    func clientEventStreamOpened(_: ProxySessionID) -> Bool { false }
+
+    func clientEventStreamClosed(_: ProxySessionID) {}
+
+    func expireInactiveSessions(inactiveFor _: TimeAmount) {}
 
     func removeSession(_ id: ProxySessionID) {}
 

--- a/Tests/XcodeMCPCoreTests/RequestInspectorTests.swift
+++ b/Tests/XcodeMCPCoreTests/RequestInspectorTests.swift
@@ -60,6 +60,44 @@ struct RequestInspectorTests {
         #expect(mapped == false)
     }
 
+    @Test func requestInspectorRewritesProgressTokenWhenMapperIsProvided() async throws {
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": [
+                "name": "Example",
+                "arguments": [String: Any](),
+                "_meta": ["progressToken": 42],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let transform = try RequestInspector.transform(
+            data,
+            sessionID: "s1",
+            mapProgressToken: { token in
+                #expect(token == .number(.int(42)))
+                return "proxy-progress-token"
+            },
+            mapID: { _, _ in 7 }
+        )
+
+        #expect(
+            transform.progressTokenMapping
+                == ProgressTokenMapping(
+                    clientToken: .number(.int(42)),
+                    upstreamToken: "proxy-progress-token"
+                )
+        )
+        let upstream = try #require(
+            try JSONSerialization.jsonObject(with: transform.upstreamData) as? [String: Any]
+        )
+        let params = try #require(upstream["params"] as? [String: Any])
+        let meta = try #require(params["_meta"] as? [String: Any])
+        #expect(meta["progressToken"] as? String == "proxy-progress-token")
+    }
+
     @Test func requestInspectorDoesNotMapJSONRPCResponseIDs() async throws {
         let payload: [String: Any] = [
             "jsonrpc": "2.0",

--- a/Tests/XcodeMCPProxyHTTPTests/HTTPEventDeliveryStoreTests.swift
+++ b/Tests/XcodeMCPProxyHTTPTests/HTTPEventDeliveryStoreTests.swift
@@ -23,6 +23,7 @@ struct HTTPEventDeliveryStoreTests {
         }
         try activate(firstChannel, port: 1)
         try activate(secondChannel, port: 2)
+        openSession(sessionID, in: store)
 
         store.receive(.notification(sessionID: sessionID, data: buffered))
         store.open(sessionID: sessionID, channel: firstChannel)
@@ -52,6 +53,7 @@ struct HTTPEventDeliveryStoreTests {
             _ = try? channel.finish()
         }
         try activate(channel, port: 3)
+        openSession(sessionID, in: store)
 
         store.receive(.notification(sessionID: sessionID, data: first))
         store.receive(.notification(sessionID: sessionID, data: second))
@@ -75,6 +77,7 @@ struct HTTPEventDeliveryStoreTests {
         )
         defer { store.closeAll() }
         let sessionID = ProxySessionID(rawValue: "session-overflow-warning")
+        openSession(sessionID, in: store)
 
         store.receive(
             .notification(
@@ -134,6 +137,8 @@ struct HTTPEventDeliveryStoreTests {
         defer { store.closeAll() }
         let firstSessionID = ProxySessionID(rawValue: "session-overflow-a")
         let secondSessionID = ProxySessionID(rawValue: "session-overflow-b")
+        openSession(firstSessionID, in: store)
+        openSession(secondSessionID, in: store)
 
         store.receive(
             .notification(
@@ -156,6 +161,14 @@ struct HTTPEventDeliveryStoreTests {
         #expect(warnings.map(\.droppedNotificationCount) == [1, 1])
 
         store.receive(.sessionClosed(sessionID: firstSessionID))
+        store.receive(
+            .notification(
+                sessionID: firstSessionID,
+                data: notification(method: "notifications/a-late")
+            ))
+        #expect(state.warnings.count == 2)
+
+        openSession(firstSessionID, in: store)
         store.receive(
             .notification(
                 sessionID: firstSessionID,
@@ -183,6 +196,7 @@ struct HTTPEventDeliveryStoreTests {
         )
         defer { store.closeAll() }
         let sessionID = ProxySessionID(rawValue: "session-overflow-method-cardinality")
+        openSession(sessionID, in: store)
 
         store.receive(
             .notification(
@@ -243,6 +257,7 @@ struct HTTPEventDeliveryStoreTests {
         }
         try activate(disconnectedChannel, port: 4)
         try activate(reconnectedChannel, port: 5)
+        openSession(sessionID, in: store)
 
         store.open(sessionID: sessionID, channel: disconnectedChannel)
         try disconnectedChannel.close().wait()
@@ -268,6 +283,7 @@ struct HTTPEventDeliveryStoreTests {
         }
         try activate(disconnectedChannel, port: 6)
         try activate(reconnectedChannel, port: 7)
+        openSession(sessionID, in: store)
 
         store.open(sessionID: sessionID, channel: disconnectedChannel)
         store.receive(.notification(sessionID: sessionID, data: notification))
@@ -293,6 +309,7 @@ struct HTTPEventDeliveryStoreTests {
             _ = try? channel.finish()
         }
         try activate(channel, port: 8)
+        openSession(sessionID, in: store)
 
         store.receive(.notification(sessionID: sessionID, data: first))
         store.receive(.notification(sessionID: sessionID, data: second))
@@ -316,12 +333,38 @@ struct HTTPEventDeliveryStoreTests {
             _ = try? channel.finish()
         }
         try activate(channel, port: 9)
+        openSession(sessionID, in: store)
         store.open(sessionID: sessionID, channel: channel)
 
         store.receive(.sessionClosed(sessionID: sessionID))
         channel.embeddedEventLoop.run()
 
         #expect(channel.isActive == false)
+    }
+
+    @Test func lateNotificationDoesNotRecreateClosedSessionDelivery() throws {
+        let store = HTTPEventDeliveryStore()
+        let sessionID = ProxySessionID(rawValue: "session-late-notification")
+        let channel = EmbeddedChannel()
+        defer {
+            store.closeAll()
+            _ = try? channel.finish()
+        }
+        try activate(channel, port: 10)
+        openSession(sessionID, in: store)
+
+        store.receive(.sessionClosed(sessionID: sessionID))
+        store.receive(
+            .notification(
+                sessionID: sessionID,
+                data: notification(method: "notifications/late")
+            ))
+
+        #expect(store.open(sessionID: sessionID, channel: channel) == false)
+        openSession(sessionID, in: store)
+        #expect(store.open(sessionID: sessionID, channel: channel))
+        channel.embeddedEventLoop.run()
+        #expect(try drainSSEBodies(from: channel).isEmpty)
     }
 }
 
@@ -343,6 +386,10 @@ private func drainSSEBodies(from channel: EmbeddedChannel) throws -> [String] {
 
 private func notification(method: String) -> Data {
     Data(#"{"jsonrpc":"2.0","method":"\#(method)"}"#.utf8)
+}
+
+private func openSession(_ sessionID: ProxySessionID, in store: HTTPEventDeliveryStore) {
+    store.receive(.sessionOpened(sessionID: sessionID))
 }
 
 private final class HTTPDeliveryTestState: @unchecked Sendable {

--- a/Tests/XcodeMCPProxyHTTPTests/HTTPEventDeliveryStoreTests.swift
+++ b/Tests/XcodeMCPProxyHTTPTests/HTTPEventDeliveryStoreTests.swift
@@ -65,6 +65,171 @@ struct HTTPEventDeliveryStoreTests {
         #expect(bodies[1].contains(String(decoding: third, as: UTF8.self)))
     }
 
+    @Test func overflowWarningsAreRateLimitedAndDescribeEvictedNotifications() throws {
+        let state = HTTPDeliveryTestState()
+        let store = HTTPEventDeliveryStore(
+            bufferLimit: 1,
+            notificationOverflowWarningInterval: .seconds(30),
+            uptimeNanoseconds: { state.uptimeNanoseconds },
+            overflowWarningSink: { state.record($0) }
+        )
+        defer { store.closeAll() }
+        let sessionID = ProxySessionID(rawValue: "session-overflow-warning")
+
+        store.receive(
+            .notification(
+                sessionID: sessionID,
+                data: notification(method: "notifications/first")
+            ))
+        store.receive(
+            .notification(
+                sessionID: sessionID,
+                data: notification(method: "notifications/second")
+            ))
+        store.receive(
+            .notification(
+                sessionID: sessionID,
+                data: notification(method: "notifications/third")
+            ))
+
+        var warnings = state.warnings
+        #expect(warnings.count == 1)
+        let firstWarning = try #require(warnings.first)
+        #expect(firstWarning.droppedNotificationCount == 1)
+        #expect(firstWarning.droppedSinceLastWarning == 1)
+        #expect(
+            firstWarning.droppedMethodsSinceLastWarning
+                == ["notifications/first": 1]
+        )
+
+        state.uptimeNanoseconds = 30_000_000_000
+        store.receive(
+            .notification(
+                sessionID: sessionID,
+                data: notification(method: "notifications/fourth")
+            ))
+
+        warnings = state.warnings
+        #expect(warnings.count == 2)
+        let secondWarning = try #require(warnings.last)
+        #expect(secondWarning.droppedNotificationCount == 3)
+        #expect(secondWarning.droppedSinceLastWarning == 2)
+        #expect(
+            secondWarning.droppedMethodsSinceLastWarning
+                == [
+                    "notifications/second": 1,
+                    "notifications/third": 1,
+                ]
+        )
+    }
+
+    @Test func overflowAccountingIsPerSessionAndResetsWhenSessionCloses() throws {
+        let state = HTTPDeliveryTestState()
+        let store = HTTPEventDeliveryStore(
+            bufferLimit: 0,
+            notificationOverflowWarningInterval: .seconds(30),
+            uptimeNanoseconds: { state.uptimeNanoseconds },
+            overflowWarningSink: { state.record($0) }
+        )
+        defer { store.closeAll() }
+        let firstSessionID = ProxySessionID(rawValue: "session-overflow-a")
+        let secondSessionID = ProxySessionID(rawValue: "session-overflow-b")
+
+        store.receive(
+            .notification(
+                sessionID: firstSessionID,
+                data: notification(method: "notifications/a-1")
+            ))
+        store.receive(
+            .notification(
+                sessionID: firstSessionID,
+                data: notification(method: "notifications/a-2")
+            ))
+        store.receive(
+            .notification(
+                sessionID: secondSessionID,
+                data: notification(method: "notifications/b-1")
+            ))
+
+        var warnings = state.warnings
+        #expect(warnings.map(\.sessionID) == [firstSessionID, secondSessionID])
+        #expect(warnings.map(\.droppedNotificationCount) == [1, 1])
+
+        store.receive(.sessionClosed(sessionID: firstSessionID))
+        store.receive(
+            .notification(
+                sessionID: firstSessionID,
+                data: notification(method: "notifications/a-new")
+            ))
+
+        warnings = state.warnings
+        #expect(warnings.count == 3)
+        let resetWarning = try #require(warnings.last)
+        #expect(resetWarning.sessionID == firstSessionID)
+        #expect(resetWarning.droppedNotificationCount == 1)
+        #expect(
+            resetWarning.droppedMethodsSinceLastWarning
+                == ["notifications/a-new": 1]
+        )
+    }
+
+    @Test func overflowMethodAggregationHasBoundedCardinality() throws {
+        let state = HTTPDeliveryTestState()
+        let store = HTTPEventDeliveryStore(
+            bufferLimit: 0,
+            notificationOverflowWarningInterval: .seconds(30),
+            uptimeNanoseconds: { state.uptimeNanoseconds },
+            overflowWarningSink: { state.record($0) }
+        )
+        defer { store.closeAll() }
+        let sessionID = ProxySessionID(rawValue: "session-overflow-method-cardinality")
+
+        store.receive(
+            .notification(
+                sessionID: sessionID,
+                data: notification(method: "notifications/initial")
+            ))
+        for index in 1...20 {
+            store.receive(
+                .notification(
+                    sessionID: sessionID,
+                    data: notification(method: "notifications/method-\(index)")
+                ))
+        }
+        state.uptimeNanoseconds = 30_000_000_000
+        store.receive(
+            .notification(
+                sessionID: sessionID,
+                data: notification(method: "notifications/method-21")
+            ))
+
+        let warning = try #require(state.warnings.last)
+        #expect(warning.droppedSinceLastWarning == 21)
+        #expect(warning.droppedMethodsSinceLastWarning.count == 16)
+        #expect(warning.droppedMethodsSinceLastWarning["<additional-methods>"] == 6)
+    }
+
+    @Test func sessionExpirySweepRepeatsUntilCancelled() {
+        let eventLoop = EmbeddedEventLoop()
+        let state = HTTPDeliveryTestState()
+        let sweep = HTTPSessionExpirySweep(interval: .seconds(60)) {
+            state.recordExpirySweep()
+        }
+
+        sweep.start(on: eventLoop)
+        sweep.start(on: eventLoop)
+        eventLoop.advanceTime(by: .seconds(59))
+        #expect(state.expirySweepCount == 0)
+        eventLoop.advanceTime(by: .seconds(1))
+        #expect(state.expirySweepCount == 1)
+        eventLoop.advanceTime(by: .seconds(60))
+        #expect(state.expirySweepCount == 2)
+
+        sweep.cancel()
+        eventLoop.advanceTime(by: .seconds(60))
+        #expect(state.expirySweepCount == 2)
+    }
+
     @Test func notificationBuffersWhileChannelInactiveCallbackIsPending() throws {
         let store = HTTPEventDeliveryStore()
         let sessionID = ProxySessionID(rawValue: "session-inactive-race")
@@ -174,4 +339,36 @@ private func drainSSEBodies(from channel: EmbeddedChannel) throws -> [String] {
         }
     }
     return bodies
+}
+
+private func notification(method: String) -> Data {
+    Data(#"{"jsonrpc":"2.0","method":"\#(method)"}"#.utf8)
+}
+
+private final class HTTPDeliveryTestState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var uptimeNanosecondsStorage: UInt64 = 0
+    private var warningsStorage: [HTTPNotificationOverflowWarning] = []
+    private var expirySweepCountStorage = 0
+
+    var uptimeNanoseconds: UInt64 {
+        get { lock.withLock { uptimeNanosecondsStorage } }
+        set { lock.withLock { uptimeNanosecondsStorage = newValue } }
+    }
+
+    var warnings: [HTTPNotificationOverflowWarning] {
+        lock.withLock { warningsStorage }
+    }
+
+    var expirySweepCount: Int {
+        lock.withLock { expirySweepCountStorage }
+    }
+
+    func record(_ warning: HTTPNotificationOverflowWarning) {
+        lock.withLock { warningsStorage.append(warning) }
+    }
+
+    func recordExpirySweep() {
+        lock.withLock { expirySweepCountStorage += 1 }
+    }
 }

--- a/Tests/XcodeMCPProxyHTTPTests/ProxyHTTPGatewayTests.swift
+++ b/Tests/XcodeMCPProxyHTTPTests/ProxyHTTPGatewayTests.swift
@@ -50,7 +50,7 @@ private final class GatewayTestRuntime: ProxyRuntimeServing, Sendable {
     func beginRequest(
         _: ProxyRuntimeRequest,
         in _: ProxySessionID?
-    ) -> any ProxyRuntimeRequestOperating {
+    ) -> (any ProxyRuntimeRequestOperating)? {
         fatalError("gateway lifecycle test does not admit requests")
     }
 

--- a/Tests/XcodeMCPProxyHTTPTests/ProxyHTTPGatewayTests.swift
+++ b/Tests/XcodeMCPProxyHTTPTests/ProxyHTTPGatewayTests.swift
@@ -54,9 +54,17 @@ private final class GatewayTestRuntime: ProxyRuntimeServing, Sendable {
         fatalError("gateway lifecycle test does not admit requests")
     }
 
+    func clientRequestFinished(_: ProxySessionID) {}
+
     func sessionState(_: ProxySessionID) -> ProxyRuntimeSessionState {
         .missing
     }
+
+    func clientEventStreamOpened(_: ProxySessionID) -> Bool { false }
+
+    func clientEventStreamClosed(_: ProxySessionID) {}
+
+    func expireInactiveSessions(inactiveFor _: TimeAmount) {}
 
     func removeSession(_: ProxySessionID) {}
 

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTestSupport.swift
@@ -189,6 +189,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         var requestLeaseActivationHook: (@Sendable () -> Void)?
         var requeuedLeaseCount = 0
         var rejectNextUpstreamSend = false
+        var removeSessionOnNextClientRequestAdmission = false
         var serverRequestResponseSendResults: [Upstream.SendResult] = []
         var begunClientRequestCount = 0
         var finishedClientRequestCount = 0
@@ -278,6 +279,13 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     func beginClientRequest(id: String, createIfMissing: Bool) -> Bool {
         state.withLockedValue { state in
+            if state.removeSessionOnNextClientRequestAdmission {
+                state.removeSessionOnNextClientRequestAdmission = false
+                state.initializedSessionIDs.remove(id)
+                state.sessionProtocolVersions.removeValue(forKey: id)
+                state.sessions.removeValue(forKey: id)
+                return false
+            }
             if state.sessions[id] == nil {
                 guard createIfMissing else { return false }
                 state.sessions[id] = SessionContext(id: id, config: config)
@@ -1012,6 +1020,10 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     func rejectNextUpstreamSend() {
         state.withLockedValue { $0.rejectNextUpstreamSend = true }
+    }
+
+    func removeSessionOnNextClientRequestAdmission() {
+        state.withLockedValue { $0.removeSessionOnNextClientRequestAdmission = true }
     }
 
     func setAvailableUpstreamIndex(_ value: Int?) {

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTestSupport.swift
@@ -842,7 +842,8 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
-        timeout: TimeAmount?
+        timeout: TimeAmount?,
+        progressTokenMapping: ProgressTokenMapping? = nil
     ) {
         requestLeaseRegistry.activateLease(
             leaseID,
@@ -850,7 +851,8 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             upstreamIndex: upstreamIndex,
             timeoutAt: timeout.map {
                 Date().addingTimeInterval(Double($0.nanoseconds) / 1_000_000_000)
-            }
+            },
+            progressTokenMapping: progressTokenMapping
         )
         state.withLockedValue { $0.requestLeaseActivationHook }?()
     }

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTestSupport.swift
@@ -190,6 +190,8 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         var requeuedLeaseCount = 0
         var rejectNextUpstreamSend = false
         var serverRequestResponseSendResults: [Upstream.SendResult] = []
+        var begunClientRequestCount = 0
+        var finishedClientRequestCount = 0
     }
 
     private let state = NIOLockedValueBox(State())
@@ -266,6 +268,27 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             state.sessionProtocolVersions[id] = MCP.ProtocolVersion.current
             return context
         }
+    }
+
+    var clientRequestActivityCounts: (begun: Int, finished: Int) {
+        state.withLockedValue { state in
+            (state.begunClientRequestCount, state.finishedClientRequestCount)
+        }
+    }
+
+    func beginClientRequest(id: String, createIfMissing: Bool) -> Bool {
+        state.withLockedValue { state in
+            if state.sessions[id] == nil {
+                guard createIfMissing else { return false }
+                state.sessions[id] = SessionContext(id: id, config: config)
+            }
+            state.begunClientRequestCount += 1
+            return true
+        }
+    }
+
+    func endClientRequest(id _: String) {
+        state.withLockedValue { $0.finishedClientRequestCount += 1 }
     }
 
     func uninitializedSession(id: String) -> SessionContext {
@@ -1161,7 +1184,9 @@ func addHTTPHandler(
     sessionManager: any RuntimeCoordinating,
     refreshCodeIssuesCoordinator: RefreshCodeIssues.Coordinator? = nil,
     refreshCodeIssuesTargetResolver: RefreshCodeIssues.TargetResolver = RefreshCodeIssues.TargetResolver(),
-    refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil
+    refreshCodeIssuesDebugState: RefreshCodeIssues.DebugState? = nil,
+    scheduleResponseCompletion:
+        (@Sendable (EventLoop, @escaping @Sendable () -> Void) -> Void)? = nil
 ) throws {
     let completionExecutor = EmbeddedEventLoopCompletionExecutor()
     registerEmbeddedCompletionExecutor(completionExecutor, for: channel)
@@ -1183,7 +1208,7 @@ func addHTTPHandler(
             maxBodyBytes: config.maxBodyBytes
         ),
         controlService: HTTPControlService(runtime: runtime),
-        scheduleResponseCompletion: { _, operation in
+        scheduleResponseCompletion: scheduleResponseCompletion ?? { _, operation in
             completionExecutor.enqueue(operation)
         }
     )

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
@@ -385,6 +385,66 @@ struct HTTPHandlerTests {
         #expect(response.head.headers.first(name: "Mcp-Session-Id")?.isEmpty == false)
     }
 
+    @Test func httpPostKeepsRequestActiveUntilResponseWriteCompletes() async throws {
+        let config = makeHTTPConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        let responseCompletions = NIOLockedValueBox<[@Sendable () -> Void]>([])
+        try addHTTPHandler(
+            to: channel,
+            config: config,
+            sessionManager: sessionManager,
+            scheduleResponseCompletion: { _, completion in
+                responseCompletions.withLockedValue { $0.append(completion) }
+            }
+        )
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        #expect(sessionManager.clientRequestActivityCounts.begun == 1)
+        #expect(sessionManager.clientRequestActivityCounts.finished == 0)
+
+        for _ in 0..<3 where responseCompletions.withLockedValue({ $0.isEmpty }) {
+            drainEmbeddedCompletions(for: channel)
+            channel.embeddedEventLoop.run()
+        }
+
+        #expect(responseCompletions.withLockedValue { $0.count } == 1)
+        #expect(sessionManager.clientRequestActivityCounts.finished == 0)
+
+        let completions = responseCompletions.withLockedValue { completions in
+            let pending = completions
+            completions.removeAll()
+            return pending
+        }
+        for completion in completions {
+            completion()
+        }
+        channel.embeddedEventLoop.run()
+
+        let response = try await collectResponse(from: channel)
+        #expect(response.head.status == .ok)
+        #expect(sessionManager.clientRequestActivityCounts.finished == 1)
+    }
+
     @Test func httpPostRejectsNonJSONContentType() async throws {
         let config = makeHTTPConfig()
         let channel = EmbeddedChannel()

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
@@ -2023,12 +2023,12 @@ struct HTTPHandlerTests {
         let channel = EmbeddedChannel()
         defer { _ = try? channel.finish() }
         let sessionManager = TestRuntimeCoordinator(config: config)
-        _ = sessionManager.session(id: "session-1")
         try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+        let sessionID = try await initializeHTTPChannel(channel)
 
         var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/mcp")
         head.headers.add(name: "Accept", value: "text/event-stream")
-        head.headers.add(name: "Mcp-Session-Id", value: "session-1")
+        head.headers.add(name: "Mcp-Session-Id", value: sessionID)
         head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
         try channel.writeInbound(HTTPServerRequestPart.head(head))
         try channel.writeInbound(HTTPServerRequestPart.end(nil))
@@ -2037,6 +2037,27 @@ struct HTTPHandlerTests {
         #expect(response.head.status == .ok)
         #expect(response.head.headers.first(name: "Content-Type") == "text/event-stream")
         #expect(response.body.contains(": ok"))
+    }
+
+    @Test func httpSSEAdmissionFailureReturnsNotFoundBeforeCommittingStream() async throws {
+        let config = makeHTTPConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        _ = sessionManager.session(id: "session-without-delivery")
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+
+        var head = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "text/event-stream")
+        head.headers.add(name: "Mcp-Session-Id", value: "session-without-delivery")
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try await collectResponse(from: channel)
+        #expect(response.head.status == .notFound)
+        #expect(response.head.headers.first(name: "Content-Type") == "text/plain; charset=utf-8")
+        #expect(response.body == "session not found")
     }
 
     @Test func httpToolsListUsesCachedResultWhenAvailable() async throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
@@ -445,6 +445,40 @@ struct HTTPHandlerTests {
         #expect(sessionManager.clientRequestActivityCounts.finished == 1)
     }
 
+    @Test func httpPostRejectsSessionRemovedAfterValidation() async throws {
+        let config = makeHTTPConfig()
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        try addHTTPHandler(to: channel, config: config, sessionManager: sessionManager)
+        let sessionID = try await initializeHTTPChannel(channel)
+        let activityBeforeRequest = sessionManager.clientRequestActivityCounts
+        sessionManager.removeSessionOnNextClientRequestAdmission()
+
+        let payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": [String: Any](),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        var head = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/mcp")
+        head.headers.add(name: "Accept", value: "application/json, text/event-stream")
+        head.headers.add(name: "Content-Type", value: "application/json")
+        head.headers.add(name: "MCP-Session-Id", value: sessionID)
+        head.headers.add(name: "MCP-Protocol-Version", value: MCP.ProtocolVersion.current)
+        var body = channel.allocator.buffer(capacity: data.count)
+        body.writeBytes(data)
+        try channel.writeInbound(HTTPServerRequestPart.head(head))
+        try channel.writeInbound(HTTPServerRequestPart.body(body))
+        try channel.writeInbound(HTTPServerRequestPart.end(nil))
+
+        let response = try await collectResponse(from: channel)
+        #expect(response.head.status == .notFound)
+        #expect(response.body == "session not found")
+        #expect(sessionManager.clientRequestActivityCounts == activityBeforeRequest)
+    }
+
     @Test func httpPostRejectsNonJSONContentType() async throws {
         let config = makeHTTPConfig()
         let channel = EmbeddedChannel()

--- a/Tests/XcodeMCPProxyRuntimeTests/ProxyUpstreamRequestRuntimeTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ProxyUpstreamRequestRuntimeTests.swift
@@ -49,12 +49,16 @@ struct ProxyUpstreamRequestRuntimeTests {
 
     @Test func startRequestRegistersPendingActivatesLeaseAndSends() throws {
         let port = RecordingUpstreamRuntimePort(chosenUpstreamIndex: 1)
-        let runtime = ProxyUpstreamRequestRuntime(port: port)
+        let runtime = ProxyUpstreamRequestRuntime(
+            port: port,
+            makeUpstreamProgressToken: { "proxy-progress-token" }
+        )
         let requestData = try JSONSerialization.data(
             withJSONObject: [
                 "jsonrpc": "2.0",
                 "id": "client-2",
                 "method": "tools/list",
+                "params": ["_meta": ["progressToken": "client-progress-token"]],
             ],
             options: []
         )
@@ -93,10 +97,21 @@ struct ProxyUpstreamRequestRuntimeTests {
                 leaseID: leaseID,
                 requestIDKey: "client-2",
                 upstreamIndex: 1,
-                timeout: .seconds(3)
+                timeout: .seconds(3),
+                progressTokenMapping: ProgressTokenMapping(
+                    clientToken: .string("client-progress-token"),
+                    upstreamToken: "proxy-progress-token"
+                )
             )
         ])
         #expect(port.sentRequests().map(\.upstreamIndex) == [1])
+        let sentObject = try #require(
+            try JSONSerialization.jsonObject(with: port.sentRequests()[0].data)
+                as? [String: Any]
+        )
+        let sentParams = try #require(sentObject["params"] as? [String: Any])
+        let sentMeta = try #require(sentParams["_meta"] as? [String: Any])
+        #expect(sentMeta["progressToken"] as? String == "proxy-progress-token")
 
         let responseData = try JSONSerialization.data(
             withJSONObject: [
@@ -329,6 +344,7 @@ private final class RecordingUpstreamRuntimePort: ProxyUpstreamRequestRuntimePor
         let requestIDKey: String?
         let upstreamIndex: Int?
         let timeout: TimeAmount?
+        let progressTokenMapping: ProgressTokenMapping?
     }
 
     struct SentRequest: Equatable, Sendable {
@@ -494,7 +510,8 @@ private final class RecordingUpstreamRuntimePort: ProxyUpstreamRequestRuntimePor
         _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
-        timeout: TimeAmount?
+        timeout: TimeAmount?,
+        progressTokenMapping: ProgressTokenMapping?
     ) {
         state.withLockedValue { state in
             state.activations.append(
@@ -502,7 +519,8 @@ private final class RecordingUpstreamRuntimePort: ProxyUpstreamRequestRuntimePor
                     leaseID: leaseID,
                     requestIDKey: requestIDKey,
                     upstreamIndex: upstreamIndex,
-                    timeout: timeout
+                    timeout: timeout,
+                    progressTokenMapping: progressTokenMapping
                 )
             )
         }

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -1946,14 +1946,14 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(handshake.initializeSourceUpstream == 1)
         #expect(handshake.supporterProofs.map(\.slotID.rawValue).sorted() == [0, 1])
         #expect(
-            fixture.manager.processControlPlane.attemptSnapshot(
-                processID: firstTarget.processID
-            )?.phase == .cataloged
+            fixture.manager.processControlPlane.catalog(
+                forProcessID: firstTarget.processID
+            ) != nil
         )
         #expect(
-            fixture.manager.processControlPlane.attemptSnapshot(
-                processID: secondTarget.processID
-            )?.phase == .cataloged
+            fixture.manager.processControlPlane.catalog(
+                forProcessID: secondTarget.processID
+            ) != nil
         )
 
         let canonicalBeforeNonSourceRetirement = handshake.initializeResult

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -4336,6 +4336,26 @@ struct RuntimeCoordinatorInitializationTests {
         _ = firstSession.router.drainBufferedNotifications()
         _ = secondSession.router.drainBufferedNotifications()
 
+        let firstLeaseID = manager.createRequestLease(
+            descriptor: SessionRequestPipeline.Descriptor(
+                sessionID: firstSessionID,
+                label: "tools/call:first-progress-owner",
+                expectsResponse: true,
+                isTopLevelClientRequest: true
+            )
+        )
+        manager.activateRequestLease(
+            firstLeaseID,
+            requestIDKey: "first-progress-owner",
+            upstreamIndex: 0,
+            timeout: .seconds(5),
+            progressTokenMapping: ProgressTokenMapping(
+                clientToken: .string("client-progress-token-a"),
+                upstreamToken: "proxy-progress-token-a"
+            )
+        )
+        defer { manager.completeRequestLease(firstLeaseID) }
+
         let ownerLeaseID = manager.createRequestLease(
             descriptor: SessionRequestPipeline.Descriptor(
                 sessionID: secondSessionID,
@@ -4348,7 +4368,11 @@ struct RuntimeCoordinatorInitializationTests {
             ownerLeaseID,
             requestIDKey: "progress-owner",
             upstreamIndex: 0,
-            timeout: .seconds(5)
+            timeout: .seconds(5),
+            progressTokenMapping: ProgressTokenMapping(
+                clientToken: .string("client-progress-token-b"),
+                upstreamToken: "proxy-progress-token-b"
+            )
         )
         defer { manager.completeRequestLease(ownerLeaseID) }
 
@@ -4357,7 +4381,7 @@ struct RuntimeCoordinatorInitializationTests {
                 "jsonrpc": "2.0",
                 "method": "notifications/progress",
                 "params": [
-                    "progressToken": "progress-token",
+                    "progressToken": "proxy-progress-token-b",
                     "progress": 1,
                     "total": 2,
                 ],
@@ -4367,7 +4391,14 @@ struct RuntimeCoordinatorInitializationTests {
         manager.routeUpstreamMessage(progressNotification, upstreamIndex: 0)
 
         #expect(firstSession.router.drainBufferedNotifications().isEmpty)
-        #expect(secondSession.router.drainBufferedNotifications() == [progressNotification])
+        let routedNotifications = secondSession.router.drainBufferedNotifications()
+        let routedNotification = try #require(routedNotifications.first)
+        #expect(routedNotifications.count == 1)
+        let routedObject = try #require(
+            try JSONSerialization.jsonObject(with: routedNotification) as? [String: Any]
+        )
+        let routedParams = try #require(routedObject["params"] as? [String: Any])
+        #expect(routedParams["progressToken"] as? String == "client-progress-token-b")
     }
 
     @Test func sessionManagerDropsProgressNotificationWithoutActiveOwner() async throws {
@@ -16233,7 +16264,17 @@ struct RuntimeCoordinatorSchedulingTests {
             lease,
             requestIDKey: "refresh-1",
             upstreamIndex: 0,
-            timeoutAt: Date().addingTimeInterval(30)
+            timeoutAt: Date().addingTimeInterval(30),
+            progressTokenMapping: ProgressTokenMapping(
+                clientToken: .string("client-refresh-token"),
+                upstreamToken: "proxy-refresh-token"
+            )
+        )
+        #expect(
+            registry.activeProgressTarget(
+                upstreamIndex: 0,
+                upstreamToken: "proxy-refresh-token"
+            )?.sessionID == "session-requeue"
         )
 
         let releaseAction = try #require(registry.requeueLease(lease))
@@ -16246,6 +16287,12 @@ struct RuntimeCoordinatorSchedulingTests {
         #expect(snapshot.upstreamIndex == nil)
         #expect(snapshot.timeoutAt == nil)
         #expect(snapshot.releaseReason == nil)
+        #expect(
+            registry.activeProgressTarget(
+                upstreamIndex: 0,
+                upstreamToken: "proxy-refresh-token"
+            ) == nil
+        )
     }
 
     @Test func requestLeaseRegistryAbandonActiveLeasesUsesBoundedReleasedHistory()

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -4314,6 +4314,146 @@ struct RuntimeCoordinatorInitializationTests {
         #expect(route.upstreamID.key == "server-request-1")
     }
 
+    @Test func sessionManagerRoutesProgressNotificationOnlyToOwningSession() async throws {
+        let upstream = TestUpstreamClient()
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let firstSessionID = "session-progress-owner-a"
+        let firstSession = manager.session(id: firstSessionID)
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: firstSessionID)
+
+        let secondSessionID = "session-progress-owner-b"
+        let secondSession = manager.session(id: secondSessionID)
+        let secondFuture = fixture.registerInitialize(requestID: 2, sessionID: secondSessionID)
+        _ = try await waitWithTimeout(
+            "waiting for second progress session initialize response",
+            timeout: .seconds(2)
+        ) {
+            try await secondFuture.get()
+        }
+        _ = firstSession.router.drainBufferedNotifications()
+        _ = secondSession.router.drainBufferedNotifications()
+
+        let ownerLeaseID = manager.createRequestLease(
+            descriptor: SessionRequestPipeline.Descriptor(
+                sessionID: secondSessionID,
+                label: "tools/call:progress-owner",
+                expectsResponse: true,
+                isTopLevelClientRequest: true
+            )
+        )
+        manager.activateRequestLease(
+            ownerLeaseID,
+            requestIDKey: "progress-owner",
+            upstreamIndex: 0,
+            timeout: .seconds(5)
+        )
+        defer { manager.completeRequestLease(ownerLeaseID) }
+
+        let progressNotification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/progress",
+                "params": [
+                    "progressToken": "progress-token",
+                    "progress": 1,
+                    "total": 2,
+                ],
+            ],
+            options: []
+        )
+        manager.routeUpstreamMessage(progressNotification, upstreamIndex: 0)
+
+        #expect(firstSession.router.drainBufferedNotifications().isEmpty)
+        #expect(secondSession.router.drainBufferedNotifications() == [progressNotification])
+    }
+
+    @Test func sessionManagerDropsProgressNotificationWithoutActiveOwner() async throws {
+        let upstream = TestUpstreamClient()
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let sessionID = "session-progress-without-owner"
+        let session = manager.session(id: sessionID)
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: sessionID)
+        _ = session.router.drainBufferedNotifications()
+        let droppedBefore = manager.debugSnapshot().upstreams[0]
+            .droppedUnmappedNotificationCount
+
+        let progressNotification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/progress",
+                "params": [
+                    "progressToken": "orphaned-progress-token",
+                    "progress": 1,
+                ],
+            ],
+            options: []
+        )
+        manager.routeUpstreamMessage(progressNotification, upstreamIndex: 0)
+
+        #expect(session.router.drainBufferedNotifications().isEmpty)
+        #expect(
+            manager.debugSnapshot().upstreams[0].droppedUnmappedNotificationCount
+                == droppedBefore + 1
+        )
+    }
+
+    @Test func sessionManagerBroadcastsGlobalNotificationWithActiveOwner() async throws {
+        let upstream = TestUpstreamClient()
+        let fixture = RuntimeCoordinatorFixture(upstreams: [upstream])
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+
+        let firstSessionID = "session-global-notification-a"
+        let firstSession = manager.session(id: firstSessionID)
+        _ = try await fixture.initializePrimary(on: upstream, sessionID: firstSessionID)
+
+        let secondSessionID = "session-global-notification-b"
+        let secondSession = manager.session(id: secondSessionID)
+        let secondFuture = fixture.registerInitialize(requestID: 2, sessionID: secondSessionID)
+        _ = try await waitWithTimeout(
+            "waiting for second global notification session initialize response",
+            timeout: .seconds(2)
+        ) {
+            try await secondFuture.get()
+        }
+        _ = firstSession.router.drainBufferedNotifications()
+        _ = secondSession.router.drainBufferedNotifications()
+
+        let ownerLeaseID = manager.createRequestLease(
+            descriptor: SessionRequestPipeline.Descriptor(
+                sessionID: secondSessionID,
+                label: "tools/call:global-notification-owner",
+                expectsResponse: true,
+                isTopLevelClientRequest: true
+            )
+        )
+        manager.activateRequestLease(
+            ownerLeaseID,
+            requestIDKey: "global-notification-owner",
+            upstreamIndex: 0,
+            timeout: .seconds(5)
+        )
+        defer { manager.completeRequestLease(ownerLeaseID) }
+
+        let globalNotification = try JSONSerialization.data(
+            withJSONObject: [
+                "jsonrpc": "2.0",
+                "method": "notifications/tools/list_changed",
+            ],
+            options: []
+        )
+        manager.routeUpstreamMessage(globalNotification, upstreamIndex: 0)
+
+        #expect(firstSession.router.drainBufferedNotifications() == [globalNotification])
+        #expect(secondSession.router.drainBufferedNotifications() == [globalNotification])
+    }
+
     @Test func sessionManagerRestoresPendingInitializeWhenInitializedNotificationOverloads()
         async throws
     {

--- a/Tests/XcodeMCPProxyRuntimeTests/SessionRegistryTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/SessionRegistryTests.swift
@@ -1,0 +1,131 @@
+import NIOConcurrencyHelpers
+import Testing
+
+@testable import XcodeMCPProxyRuntime
+
+@Suite
+struct SessionRegistryTests {
+    @Test func idleSessionExpiresAtGraceBoundaryAndReportsClosure() {
+        let clock = NIOLockedValueBox<UInt64>(0)
+        let closedSessionIDs = NIOLockedValueBox<[String]>([])
+        let registry = SessionRegistry(
+            configuration: makeConfig(requestTimeout: 5),
+            sessionClosedSink: { sessionID in
+                closedSessionIDs.withLockedValue { $0.append(sessionID) }
+            },
+            nowUptimeNanoseconds: { clock.withLockedValue { $0 } }
+        )
+        _ = registry.session(id: "idle")
+        #expect(registry.sessionStateAndTouch(id: "idle") == .uninitialized)
+
+        clock.withLockedValue { $0 = 99 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100).isEmpty)
+        #expect(registry.hasSession(id: "idle"))
+
+        clock.withLockedValue { $0 = 100 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100) == ["idle"])
+        #expect(registry.hasSession(id: "idle") == false)
+        #expect(closedSessionIDs.withLockedValue { $0 } == ["idle"])
+    }
+
+    @Test func clientActivityRestartsTheInactivityGracePeriod() {
+        let clock = NIOLockedValueBox<UInt64>(0)
+        let registry = SessionRegistry(
+            configuration: makeConfig(requestTimeout: 5),
+            nowUptimeNanoseconds: { clock.withLockedValue { $0 } }
+        )
+        _ = registry.session(id: "reconnecting")
+        registry.markInitialized(
+            id: "reconnecting",
+            negotiatedProtocolVersion: "2025-06-18"
+        )
+
+        clock.withLockedValue { $0 = 99 }
+        #expect(
+            registry.sessionStateAndTouch(id: "reconnecting")
+                == .initialized(protocolVersion: "2025-06-18")
+        )
+
+        clock.withLockedValue { $0 = 198 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100).isEmpty)
+        clock.withLockedValue { $0 = 199 }
+        #expect(
+            registry.removeInactiveSessions(inactiveForNanoseconds: 100)
+                == ["reconnecting"]
+        )
+    }
+
+    @Test func inFlightRequestPreventsExpiryUntilCompletion() {
+        let clock = NIOLockedValueBox<UInt64>(0)
+        let registry = SessionRegistry(
+            configuration: makeConfig(requestTimeout: 5),
+            nowUptimeNanoseconds: { clock.withLockedValue { $0 } }
+        )
+
+        #expect(registry.beginClientRequest(id: "request", createIfMissing: true))
+        clock.withLockedValue { $0 = 500 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100).isEmpty)
+
+        registry.endClientRequest(id: "request")
+        clock.withLockedValue { $0 = 599 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100).isEmpty)
+        clock.withLockedValue { $0 = 600 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100) == ["request"])
+    }
+
+    @Test func everyOpenEventStreamMustCloseBeforeExpiry() {
+        let clock = NIOLockedValueBox<UInt64>(0)
+        let registry = SessionRegistry(
+            configuration: makeConfig(requestTimeout: 5),
+            nowUptimeNanoseconds: { clock.withLockedValue { $0 } }
+        )
+        _ = registry.session(id: "streams")
+        #expect(registry.openEventStream(id: "streams"))
+        #expect(registry.openEventStream(id: "streams"))
+
+        clock.withLockedValue { $0 = 200 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100).isEmpty)
+        registry.closeEventStream(id: "streams")
+
+        clock.withLockedValue { $0 = 400 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100).isEmpty)
+        registry.closeEventStream(id: "streams")
+
+        clock.withLockedValue { $0 = 499 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100).isEmpty)
+        clock.withLockedValue { $0 = 500 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100) == ["streams"])
+    }
+
+    @Test func outboundTargetEnumerationDoesNotExtendSessionLifetime() {
+        let clock = NIOLockedValueBox<UInt64>(0)
+        let registry = SessionRegistry(
+            configuration: makeConfig(requestTimeout: 5),
+            nowUptimeNanoseconds: { clock.withLockedValue { $0 } }
+        )
+        _ = registry.session(id: "outbound-only")
+        #expect(registry.sessionStateAndTouch(id: "outbound-only") == .uninitialized)
+        registry.markInitialized(id: "outbound-only", negotiatedProtocolVersion: nil)
+
+        clock.withLockedValue { $0 = 99 }
+        #expect(registry.initializedNotificationTargets().map(\.id) == ["outbound-only"])
+        clock.withLockedValue { $0 = 100 }
+        #expect(
+            registry.removeInactiveSessions(inactiveForNanoseconds: 100)
+                == ["outbound-only"]
+        )
+    }
+
+    @Test func internalRuntimeSessionDoesNotParticipateInClientInactivityExpiry() {
+        let clock = NIOLockedValueBox<UInt64>(0)
+        let registry = SessionRegistry(
+            configuration: makeConfig(requestTimeout: 5),
+            nowUptimeNanoseconds: { clock.withLockedValue { $0 } }
+        )
+        _ = registry.session(id: "internal-control-plane")
+
+        clock.withLockedValue { $0 = 1_000 }
+        #expect(registry.removeInactiveSessions(inactiveForNanoseconds: 100).isEmpty)
+        #expect(registry.hasSession(id: "internal-control-plane"))
+    }
+}

--- a/Tests/XcodeMCPProxyRuntimeTests/ToolSurfaceTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ToolSurfaceTests.swift
@@ -480,7 +480,8 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
         _ leaseID: LeaseManager.ID,
         requestIDKey: String?,
         upstreamIndex: Int?,
-        timeout: TimeAmount?
+        timeout: TimeAmount?,
+        progressTokenMapping: ProgressTokenMapping?
     ) {}
 
     func completeRequestLease(_ leaseID: LeaseManager.ID) {}


### PR DESCRIPTION
## Purpose

Prevent SSE notification buffer overflows caused by progress notifications being fanned out to unrelated or abandoned sessions. The warning represented real notification eviction, although stale-session fan-out amplified it.

## Changes

- Route `notifications/progress` only to the client session that owns the active operation.
- Track HTTP request and SSE activity and expire inactive client transport sessions after a five-minute grace period.
- Exclude internal runtime sessions and active requests or SSE streams from expiry.
- Keep request activity active until the HTTP response write completes.
- Move overflow accounting to the delivery store and rate-limit per-session warnings while reporting cumulative and delta drop counts and the actual evicted notification methods.
- Document the routing, expiry, and recovery behavior and add regression coverage.

## User impact

Active clients receive progress only for their own operations, abandoned sessions no longer accumulate indefinitely, and overflow warnings now contain enough information to distinguish real client backpressure from stale-session amplification.

## Testing

- `swift test --no-parallel -Xswiftc -strict-concurrency=minimal` — 981 tests in 64 suites passed
- `env XCODE_MCP_RUN_PROCESS_TESTS=1 swift test --no-parallel --filter XcodeMCPProcessRuntimeTests -Xswiftc -strict-concurrency=minimal` — 24 tests passed
- `env XCODE_MCP_RUN_PROCESS_TESTS=1 swift test --no-parallel --filter ProxyStdioAdapterTests -Xswiftc -strict-concurrency=minimal` — 13 tests passed
- `git diff --check`
- Codex self-review completed with no actionable findings