### PR TITLE
Cancel timed-out upstream requests before retry

### DIFF
--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
@@ -27,6 +27,14 @@ final class UpstreamHealthManager: Sendable {
         var upstreamIndex: Int { upstreamID.rawValue }
     }
 
+    struct ClearedUpstreamState: Sendable {
+        let timeout: RuntimeScheduledTimeout?
+        let initUpstreamID: Int64?
+        let didReceiveInitializeResponse: Bool
+        let didSendInitialized: Bool
+        let initializeOwner: InitializeClaimOwner?
+    }
+
     struct BridgeAttachmentVerification: Sendable {
         let recovery: ProcessBridgeRecovery
         let initializeParticipant: CanonicalHandshakeState.InitializeParticipantLease
@@ -624,12 +632,7 @@ final class UpstreamHealthManager: Sendable {
         commit: () -> Bool
     ) -> (
         recovery: ProcessBridgePoolRecovery,
-        cleared: (
-            timeout: RuntimeScheduledTimeout?,
-            initUpstreamID: Int64?,
-            didReceiveInitializeResponse: Bool,
-            didSendInitialized: Bool
-        )?
+        cleared: ClearedUpstreamState?
     )? {
         state.withLockedValue { state in
             guard case .processBridgeAttachment(let verification) = request.purpose else {
@@ -750,23 +753,26 @@ final class UpstreamHealthManager: Sendable {
         owner: InitializeClaimOwner = .regular
     ) -> InitializeClaim? {
         state.withLockedValue { state in
-            guard Self.isActive(upstreamIndex, state: state) else { return nil }
-            if state.upstreamStates[upstreamIndex].isInitialized || state.upstreamStates[upstreamIndex].initInFlight {
-                return nil
-            }
-            state.nextInitializeClaimGeneration &+= 1
-            let claim = InitializeClaim(
-                upstreamID: UpstreamSlotID(rawValue: upstreamIndex),
-                generation: state.nextInitializeClaimGeneration,
+            let upstreamID = UpstreamSlotID(rawValue: upstreamIndex)
+            guard let proof = state.topology?.proof(upstreamID) else { return nil }
+            return Self.claimWarmInitialize(
+                proof: proof,
                 owner: owner,
-                topologyProof: state.topology?.proof(
-                    UpstreamSlotID(rawValue: upstreamIndex)
-                )
+                state: &state
             )
-            state.upstreamStates[upstreamIndex].initInFlight = true
-            state.upstreamStates[upstreamIndex].initializeClaim = claim
-            state.upstreamStates[upstreamIndex].initializeClaimPhase = .reserved
-            return claim
+        }
+    }
+
+    func claimWarmInitialize(
+        topologyProof: UpstreamTopologyProof,
+        owner: InitializeClaimOwner = .regular
+    ) -> InitializeClaim? {
+        state.withLockedValue { state in
+            Self.claimWarmInitialize(
+                proof: topologyProof,
+                owner: owner,
+                state: &state
+            )
         }
     }
 
@@ -842,12 +848,7 @@ final class UpstreamHealthManager: Sendable {
 
     func clearInitializeClaim(
         _ claim: InitializeClaim
-    ) -> (
-        timeout: RuntimeScheduledTimeout?,
-        initUpstreamID: Int64?,
-        didReceiveInitializeResponse: Bool,
-        didSendInitialized: Bool
-    )? {
+    ) -> ClearedUpstreamState? {
         state.withLockedValue { state in
             guard Self.owns(claim, state: state) else { return nil }
             return Self.clearUpstreamState(at: claim.upstreamIndex, state: &state)
@@ -871,12 +872,7 @@ final class UpstreamHealthManager: Sendable {
     func clearUpstreamState(
         _ proof: UpstreamTopologyProof,
         expectedUpstreamID: Int64? = nil
-    ) -> (
-        timeout: RuntimeScheduledTimeout?,
-        initUpstreamID: Int64?,
-        didReceiveInitializeResponse: Bool,
-        didSendInitialized: Bool
-    )? {
+    ) -> ClearedUpstreamState? {
         state.withLockedValue { state in
             guard Self.isActive(proof, state: state) else { return nil }
             let upstreamIndex = proof.slotID.rawValue
@@ -1212,6 +1208,31 @@ final class UpstreamHealthManager: Sendable {
         }
     }
 
+    private static func claimWarmInitialize(
+        proof: UpstreamTopologyProof,
+        owner: InitializeClaimOwner,
+        state: inout State
+    ) -> InitializeClaim? {
+        guard isActive(proof, state: state) else { return nil }
+        let upstreamIndex = proof.slotID.rawValue
+        if state.upstreamStates[upstreamIndex].isInitialized
+            || state.upstreamStates[upstreamIndex].initInFlight
+        {
+            return nil
+        }
+        state.nextInitializeClaimGeneration &+= 1
+        let claim = InitializeClaim(
+            upstreamID: proof.slotID,
+            generation: state.nextInitializeClaimGeneration,
+            owner: owner,
+            topologyProof: proof
+        )
+        state.upstreamStates[upstreamIndex].initInFlight = true
+        state.upstreamStates[upstreamIndex].initializeClaim = claim
+        state.upstreamStates[upstreamIndex].initializeClaimPhase = .reserved
+        return claim
+    }
+
     private static func matches(_ claim: InitializeClaim, state: State) -> Bool {
         let upstreamIndex = claim.upstreamIndex
         guard isActive(upstreamIndex, state: state),
@@ -1233,25 +1254,22 @@ final class UpstreamHealthManager: Sendable {
     private static func clearUpstreamState(
         at upstreamIndex: Int,
         state: inout State
-    ) -> (
-        timeout: RuntimeScheduledTimeout?,
-        initUpstreamID: Int64?,
-        didReceiveInitializeResponse: Bool,
-        didSendInitialized: Bool
-    ) {
+    ) -> ClearedUpstreamState {
         let timeout = state.upstreamStates[upstreamIndex].initTimeout
         let initUpstreamID = state.upstreamStates[upstreamIndex].initUpstreamID
         let didReceiveInitializeResponse =
             state.upstreamStates[upstreamIndex].didReceiveInitializeResponse
         let didSendInitialized = state.upstreamStates[upstreamIndex].didSendInitialized
+        let initializeOwner = state.upstreamStates[upstreamIndex].initializeClaim?.owner
         let nextProbeGeneration = state.upstreamStates[upstreamIndex].healthProbeGeneration &+ 1
         state.upstreamStates[upstreamIndex] = UpstreamState()
         state.upstreamStates[upstreamIndex].healthProbeGeneration = nextProbeGeneration
-        return (
-            timeout,
-            initUpstreamID,
-            didReceiveInitializeResponse,
-            didSendInitialized
+        return ClearedUpstreamState(
+            timeout: timeout,
+            initUpstreamID: initUpstreamID,
+            didReceiveInitializeResponse: didReceiveInitializeResponse,
+            didSendInitialized: didSendInitialized,
+            initializeOwner: initializeOwner
         )
     }
 

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
@@ -1051,22 +1051,18 @@ final class UpstreamHealthManager: Sendable {
         }
     }
 
-    func timeoutCatalogActivation(
+    func timeoutCatalogRequest(
         _ claim: InitializeClaim,
         commit: (InitializeClaim) -> Bool
-    ) -> (
-        timeout: RuntimeScheduledTimeout?,
-        initUpstreamID: Int64?,
-        didReceiveInitializeResponse: Bool,
-        didSendInitialized: Bool
-    )? {
+    ) -> Bool {
         state.withLockedValue { state in
             guard Self.owns(claim, state: state),
                   state.upstreamStates[claim.upstreamIndex].isInitialized,
                   state.upstreamStates[claim.upstreamIndex].initializeClaimPhase
                     == .initializedAwaitingCatalog,
-                  commit(claim) else { return nil }
-            return Self.clearUpstreamState(at: claim.upstreamIndex, state: &state)
+                  commit(claim) else { return false }
+            state.upstreamStates[claim.upstreamIndex].initTimeout = nil
+            return true
         }
     }
 

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Bridge/UpstreamHealthManager.swift
@@ -855,6 +855,21 @@ final class UpstreamHealthManager: Sendable {
         }
     }
 
+    func timeoutInitializeClaim(
+        _ claim: InitializeClaim
+    ) -> ClearedUpstreamState? {
+        state.withLockedValue { state in
+            guard Self.owns(claim, state: state),
+                  let phase = state.upstreamStates[claim.upstreamIndex]
+                    .initializeClaimPhase,
+                  [.reserved, .sending, .responseReceived].contains(phase)
+            else {
+                return nil
+            }
+            return Self.clearUpstreamState(at: claim.upstreamIndex, state: &state)
+        }
+    }
+
     func replaceInitTimeout(
         _ timeout: RuntimeScheduledTimeout,
         for claim: InitializeClaim
@@ -995,23 +1010,6 @@ final class UpstreamHealthManager: Sendable {
         }
     }
 
-    func replaceCatalogTimeout(
-        _ timeout: RuntimeScheduledTimeout,
-        for claim: InitializeClaim
-    ) -> TimeoutAttachment {
-        state.withLockedValue { state in
-            guard Self.owns(claim, state: state),
-                  state.upstreamStates[claim.upstreamIndex].isInitialized,
-                  state.upstreamStates[claim.upstreamIndex].initializeClaimPhase
-                    == .initializedAwaitingCatalog else {
-                return TimeoutAttachment(accepted: false, replaced: nil)
-            }
-            let replaced = state.upstreamStates[claim.upstreamIndex].initTimeout
-            state.upstreamStates[claim.upstreamIndex].initTimeout = timeout
-            return TimeoutAttachment(accepted: true, replaced: replaced)
-        }
-    }
-
     func currentCatalogActivationClaim(
         upstreamIndex: Int
     ) -> InitializeClaim? {
@@ -1057,7 +1055,6 @@ final class UpstreamHealthManager: Sendable {
                   state.upstreamStates[claim.upstreamIndex].initializeClaimPhase
                     == .initializedAwaitingCatalog,
                   commit(claim) else { return false }
-            state.upstreamStates[claim.upstreamIndex].initTimeout = nil
             return true
         }
     }

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/BridgeRuntime/MCPBridgeRuntime.swift
@@ -66,13 +66,7 @@ enum MCPBridgeRuntime {
         } else {
             upstreams.reserveCapacity(upstreamCount)
             for _ in 0..<upstreamCount {
-                let upstreamConfig = makeDefaultUpstreamConfig(
-                    config: config,
-                    xcodeTarget: nil
-                )
-                upstreams.append(
-                    ManagedUpstreamSlot(factory: UpstreamProcess(configuration: upstreamConfig))
-                )
+                upstreams.append(makeUnboundUpstreamSlot(config: config))
             }
         }
 
@@ -101,6 +95,19 @@ enum MCPBridgeRuntime {
                 )
             )
         }
+    }
+
+    static func makeUnboundUpstreamSlot(
+        config: Configuration
+    ) -> ManagedUpstreamSlot {
+        ManagedUpstreamSlot(
+            factory: UpstreamProcess(
+                configuration: makeDefaultUpstreamConfig(
+                    config: config,
+                    xcodeTarget: nil
+                )
+            )
+        )
     }
 
     static func supportsProcessBoundRouting(config: Configuration) -> Bool {

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/BridgeRuntime/UpstreamTopologyAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/BridgeRuntime/UpstreamTopologyAuthority.swift
@@ -9,9 +9,20 @@ struct UpstreamTopologyProof: Sendable, Hashable {
 struct UpstreamOperationLease: Sendable {
     let proof: UpstreamTopologyProof
     let slot: any UpstreamSlotControlling
+    let predecessorStopCompletion: AsyncTerminalSignal?
 
     var upstreamID: UpstreamSlotID { proof.slotID }
     var upstreamIndex: Int { upstreamID.rawValue }
+
+    init(
+        proof: UpstreamTopologyProof,
+        slot: any UpstreamSlotControlling,
+        predecessorStopCompletion: AsyncTerminalSignal? = nil
+    ) {
+        self.proof = proof
+        self.slot = slot
+        self.predecessorStopCompletion = predecessorStopCompletion
+    }
 }
 
 final class UpstreamTopologyAuthority: Sendable {
@@ -19,11 +30,25 @@ final class UpstreamTopologyAuthority: Sendable {
         let id: UpstreamSlotID
         let generation: UInt64
         let slot: any UpstreamSlotControlling
+        let predecessorStopCompletion: AsyncTerminalSignal?
+
+        init(
+            id: UpstreamSlotID,
+            generation: UInt64,
+            slot: any UpstreamSlotControlling,
+            predecessorStopCompletion: AsyncTerminalSignal? = nil
+        ) {
+            self.id = id
+            self.generation = generation
+            self.slot = slot
+            self.predecessorStopCompletion = predecessorStopCompletion
+        }
 
         var operationLease: UpstreamOperationLease {
             UpstreamOperationLease(
                 proof: UpstreamTopologyProof(slotID: id, slotGeneration: generation),
-                slot: slot
+                slot: slot,
+                predecessorStopCompletion: predecessorStopCompletion
             )
         }
     }
@@ -104,7 +129,8 @@ final class UpstreamTopologyAuthority: Sendable {
 
     func replace(
         _ proof: UpstreamTopologyProof,
-        with slot: any UpstreamSlotControlling
+        with slot: any UpstreamSlotControlling,
+        predecessorStopCompletion: AsyncTerminalSignal? = nil
     ) -> Transition? {
         state.withLockedValue { state -> Transition? in
             guard let previous = state.entriesByID[proof.slotID],
@@ -112,7 +138,8 @@ final class UpstreamTopologyAuthority: Sendable {
             state.entriesByID[proof.slotID] = Entry(
                 id: proof.slotID,
                 generation: previous.generation &+ 1,
-                slot: slot
+                slot: slot,
+                predecessorStopCompletion: predecessorStopCompletion
             )
             state.topologyEpoch &+= 1
             return Transition(
@@ -124,6 +151,22 @@ final class UpstreamTopologyAuthority: Sendable {
         }
     }
 
+    func clearPredecessorStopCompletion(
+        _ completion: AsyncTerminalSignal,
+        for proof: UpstreamTopologyProof
+    ) {
+        state.withLockedValue { state in
+            guard let current = state.entriesByID[proof.slotID],
+                  current.generation == proof.slotGeneration,
+                  current.predecessorStopCompletion === completion else { return }
+            state.entriesByID[proof.slotID] = Entry(
+                id: current.id,
+                generation: current.generation,
+                slot: current.slot
+            )
+        }
+    }
+
     func retire(_ ids: Set<UpstreamSlotID>) -> Transition {
         state.withLockedValue { state in
             let retired = state.order.compactMap { id in
@@ -131,6 +174,23 @@ final class UpstreamTopologyAuthority: Sendable {
             }
             if retired.isEmpty == false {
                 state.order.removeAll { ids.contains($0) }
+                state.topologyEpoch &+= 1
+            }
+            return Transition(
+                snapshot: Self.snapshot(state),
+                addedIDs: [],
+                retired: retired,
+                replaced: nil
+            )
+        }
+    }
+
+    func retireAll() -> Transition {
+        state.withLockedValue { state in
+            let retired = state.order.compactMap { state.entriesByID[$0] }
+            if retired.isEmpty == false {
+                state.entriesByID.removeAll()
+                state.order.removeAll()
                 state.topologyEpoch &+= 1
             }
             return Transition(
@@ -172,7 +232,11 @@ final class UpstreamTopologyAuthority: Sendable {
         state.withLockedValue { state in
             guard let entry = state.entriesByID[proof.slotID],
                   entry.generation == proof.slotGeneration else { return nil }
-            return UpstreamOperationLease(proof: proof, slot: entry.slot)
+            return UpstreamOperationLease(
+                proof: proof,
+                slot: entry.slot,
+                predecessorStopCompletion: entry.predecessorStopCompletion
+            )
         }
     }
 
@@ -184,7 +248,8 @@ final class UpstreamTopologyAuthority: Sendable {
                     slotID: id,
                     slotGeneration: entry.generation
                 ),
-                slot: entry.slot
+                slot: entry.slot,
+                predecessorStopCompletion: entry.predecessorStopCompletion
             )
         }
     }

--- a/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/ProxyUpstreamRequestRuntime.swift
+++ b/Sources/XcodeMCPProxyRuntime/RuntimeCore/Broker/ProxyUpstreamRequestRuntime.swift
@@ -1,6 +1,50 @@
 import Foundation
 import NIO
+import NIOConcurrencyHelpers
 import XcodeMCPKit
+
+final class UpstreamRequestSendCompletion: @unchecked Sendable {
+    enum Outcome: Sendable, Equatable {
+        case accepted
+        case notSent
+    }
+
+    private struct State {
+        var outcome: Outcome?
+        var waiters: [CheckedContinuation<Outcome, Never>] = []
+    }
+
+    private let state = NIOLockedValueBox(State())
+
+    func complete(_ outcome: Outcome) {
+        let waiters = state.withLockedValue {
+            state -> [CheckedContinuation<Outcome, Never>] in
+            guard state.outcome == nil else { return [] }
+            state.outcome = outcome
+            let waiters = state.waiters
+            state.waiters.removeAll()
+            return waiters
+        }
+        for waiter in waiters {
+            waiter.resume(returning: outcome)
+        }
+    }
+
+    func wait() async -> Outcome {
+        await withCheckedContinuation { continuation in
+            let outcome = state.withLockedValue { state -> Outcome? in
+                if let outcome = state.outcome {
+                    return outcome
+                }
+                state.waiters.append(continuation)
+                return nil
+            }
+            if let outcome {
+                continuation.resume(returning: outcome)
+            }
+        }
+    }
+}
 
 protocol ProxyUpstreamRequestRuntimePort: Sendable {
     func chooseUpstreamOperationLease() -> UpstreamOperationLease?
@@ -35,6 +79,7 @@ protocol ProxyUpstreamRequestRuntimePort: Sendable {
         operationLease: UpstreamOperationLease,
         ensureRunning: Bool,
         admission: RouteForwardingAdmission?,
+        requestSendCompletion: UpstreamRequestSendCompletion?,
         onRejected: @escaping @Sendable () -> Void
     ) -> Bool
     func activateRequestLease(
@@ -68,7 +113,26 @@ extension ProxyUpstreamRequestRuntimePort {
             operationLease: operationLease,
             ensureRunning: ensureRunning,
             admission: admission,
+            requestSendCompletion: nil,
             onRejected: {}
+        )
+    }
+
+    @discardableResult
+    func sendUpstream(
+        _ data: Data,
+        operationLease: UpstreamOperationLease,
+        ensureRunning: Bool,
+        admission: RouteForwardingAdmission?,
+        onRejected: @escaping @Sendable () -> Void
+    ) -> Bool {
+        sendUpstream(
+            data,
+            operationLease: operationLease,
+            ensureRunning: ensureRunning,
+            admission: admission,
+            requestSendCompletion: nil,
+            onRejected: onRejected
         )
     }
 
@@ -99,12 +163,18 @@ struct ProxyUpstreamRequestRuntime: Sendable {
     struct StartedRegistration: Sendable {
         let operationLease: UpstreamOperationLease
         let routerPendingToken: UUID
+        let requestSendCompletion: UpstreamRequestSendCompletion
 
         var upstreamIndex: Int { operationLease.upstreamIndex }
 
-        init(operationLease: UpstreamOperationLease, routerPendingToken: UUID) {
+        init(
+            operationLease: UpstreamOperationLease,
+            routerPendingToken: UUID,
+            requestSendCompletion: UpstreamRequestSendCompletion
+        ) {
             self.operationLease = operationLease
             self.routerPendingToken = routerPendingToken
+            self.requestSendCompletion = requestSendCompletion
         }
     }
 
@@ -204,16 +274,25 @@ struct ProxyUpstreamRequestRuntime: Sendable {
         requestTimeout: TimeAmount?,
         leaseID: LeaseManager.ID? = nil,
         onRegistered: (@Sendable (StartedRegistration) throws -> Void)? = nil,
-        onTimeout: (@Sendable () -> Void)? = nil
+        onTimeout: (@Sendable (UpstreamRequestSendCompletion) -> Void)? = nil
     ) throws -> StartedRequest {
         guard let idKey = prepared.transform.idKey else {
             throw Error.missingRequestID
+        }
+        let requestSendCompletion = UpstreamRequestSendCompletion()
+        let timeoutHandler: (@Sendable () -> Void)?
+        if let onTimeout {
+            timeoutHandler = {
+                onTimeout(requestSendCompletion)
+            }
+        } else {
+            timeoutHandler = nil
         }
         let registration = router.registerRequestPending(
             idKey: idKey,
             on: eventLoop,
             timeout: requestTimeout,
-            onTimeout: onTimeout
+            onTimeout: timeoutHandler
         )
 
         if let leaseID {
@@ -244,10 +323,12 @@ struct ProxyUpstreamRequestRuntime: Sendable {
             try onRegistered?(
                 StartedRegistration(
                     operationLease: prepared.operationLease,
-                    routerPendingToken: registration.token
+                    routerPendingToken: registration.token,
+                    requestSendCompletion: requestSendCompletion
                 )
             )
         } catch {
+            requestSendCompletion.complete(.notSent)
             if router.failPending(token: registration.token, error: error),
                 let responseID = prepared.transform.responseID
             {
@@ -264,9 +345,11 @@ struct ProxyUpstreamRequestRuntime: Sendable {
             operationLease: prepared.operationLease,
             ensureRunning: false,
             admission: prepared.admission,
+            requestSendCompletion: requestSendCompletion,
             onRejected: reject
         )
         guard sent else {
+            requestSendCompletion.complete(.notSent)
             reject()
             throw Error.staleUpstreamTopology
         }

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/MCP/MCPForwardingService.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/MCP/MCPForwardingService.swift
@@ -48,7 +48,7 @@ struct MCPForwardingService: Sendable {
         requestTimeoutOverride: TimeAmount? = nil,
         leaseID: LeaseManager.ID? = nil,
         cancellationHandle: ClientMCPRequestExecutor.CancellationHandle? = nil,
-        onTimeout: (@Sendable () -> Void)? = nil
+        onTimeout: (@Sendable (UpstreamRequestSendCompletion) -> Void)? = nil
     ) throws -> StartedRequest {
         let requestTimeout =
             requestTimeoutOverride
@@ -66,7 +66,8 @@ struct MCPForwardingService: Sendable {
                 guard let cancellationHandle else { return }
                 guard cancellationHandle.bindStartedRegistration(
                     operationLease: registration.operationLease,
-                    routerPendingToken: registration.routerPendingToken
+                    routerPendingToken: registration.routerPendingToken,
+                    requestSendCompletion: registration.requestSendCompletion
                 ) else {
                     throw CancellationError()
                 }
@@ -215,6 +216,11 @@ struct MCPForwardingService: Sendable {
             sessionID: sessionID,
             requestIDKeys: []
         )
+        if let cancellationHandle,
+           cancellationHandle.bindChildHandle(internalCancellationHandle) == false {
+            internalCancellationHandle.cancel(using: sessionManager)
+            return .cancelled
+        }
         let session = sessionManager.session(id: sessionID)
 
         let resolution: ResponseResolution
@@ -246,12 +252,6 @@ struct MCPForwardingService: Sendable {
                     internalCancellationHandle.bindRequestIDKeys(
                         prepared.transform.responseID.map { [$0.key] } ?? []
                     )
-                    if let cancellationHandle,
-                        cancellationHandle.bindChildHandle(internalCancellationHandle) == false
-                    {
-                        internalCancellationHandle.cancel(using: sessionManager)
-                        return eventLoop.makeFailedFuture(CancellationError())
-                    }
                 } catch is CancellationError {
                     return eventLoop.makeFailedFuture(CancellationError())
                 } catch ProxyUpstreamRequestRuntime.Error.staleUpstreamTopology {
@@ -269,12 +269,13 @@ struct MCPForwardingService: Sendable {
                         requestTimeoutOverride: requestTimeoutOverride,
                         leaseID: leaseID,
                         cancellationHandle: internalCancellationHandle,
-                        onTimeout: {
+                        onTimeout: { requestSendCompletion in
                             self.sessionManager.handleRequestLeaseTimeout(
                                 leaseID,
                                 sessionID: sessionID,
                                 requestIDKeys: prepared.transform.responseID.map { [$0.key] } ?? [],
-                                operationLease: prepared.operationLease
+                                operationLease: prepared.operationLease,
+                                after: requestSendCompletion
                             )
                         }
                     )
@@ -299,7 +300,8 @@ struct MCPForwardingService: Sendable {
                     return self.resolveResponse(
                         .failure(error),
                         started: started,
-                        sessionID: sessionID
+                        sessionID: sessionID,
+                        accountTimeout: false
                     )
                 }
             }.get()

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/MCP/MCPForwardingService.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/MCP/MCPForwardingService.swift
@@ -30,15 +30,36 @@ struct MCPForwardingService: Sendable {
         parsedRequestJSON: Any,
         sessionID: String,
         operationLeaseOverride: UpstreamOperationLease? = nil,
-        admission: RouteForwardingAdmission? = nil
+        admission: RouteForwardingAdmission? = nil,
+        cancellationHandle: ClientMCPRequestExecutor.CancellationHandle? = nil
     ) throws -> PreparedRequest? {
-        try upstreamRuntime.prepareRequest(
+        guard let prepared = try upstreamRuntime.prepareRequest(
             bodyData: bodyData,
             parsedRequestJSON: parsedRequestJSON,
             sessionID: sessionID,
             operationLeaseOverride: operationLeaseOverride,
             admission: admission
-        )
+        ) else {
+            return nil
+        }
+        guard let cancellationHandle else {
+            return prepared
+        }
+        let requestIDKeys = prepared.transform.responseID.map { [$0.key] } ?? []
+        guard cancellationHandle.bindPreparedRequest(
+            operationLease: prepared.operationLease,
+            requestIDKeys: requestIDKeys
+        ) else {
+            for requestIDKey in requestIDKeys {
+                sessionManager.removeUpstreamIDMapping(
+                    sessionID: sessionID,
+                    requestIDKey: requestIDKey,
+                    operationLease: prepared.operationLease
+                )
+            }
+            throw CancellationError()
+        }
+        return prepared
     }
 
     func startRequest(
@@ -244,14 +265,12 @@ struct MCPForwardingService: Sendable {
                         parsedRequestJSON: parsedRequestJSON,
                         sessionID: sessionID,
                         operationLeaseOverride: selectedOperationLease,
-                        admission: admission
+                        admission: admission,
+                        cancellationHandle: internalCancellationHandle
                     ) else {
                         return eventLoop.makeSucceededFuture(.invalidUpstreamResponse)
                     }
                     prepared = candidate
-                    internalCancellationHandle.bindRequestIDKeys(
-                        prepared.transform.responseID.map { [$0.key] } ?? []
-                    )
                 } catch is CancellationError {
                     return eventLoop.makeFailedFuture(CancellationError())
                 } catch ProxyUpstreamRequestRuntime.Error.staleUpstreamTopology {

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+ForwardExecutor.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+ForwardExecutor.swift
@@ -76,7 +76,8 @@ extension ClientMCPRequestExecutor {
                 parsedRequestJSON: requestObject,
                 sessionID: sessionID,
                 operationLeaseOverride: operationLease,
-                admission: admission
+                admission: admission,
+                cancellationHandle: cancellationHandle
             ) else {
                 return makeImmediateLeaseResolution(
                     Self.makeUpstreamUnavailableResolution(
@@ -90,6 +91,8 @@ extension ClientMCPRequestExecutor {
                 )
             }
             prepared = candidate
+        } catch is CancellationError {
+            return eventLoop.makeFailedFuture(CancellationError())
         } catch ProxyUpstreamRequestRuntime.Error.staleUpstreamTopology {
             return eventLoop.makeFailedFuture(
                 ProxyUpstreamRequestRuntime.Error.staleUpstreamTopology

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+ForwardExecutor.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+ForwardExecutor.swift
@@ -157,12 +157,13 @@ extension ClientMCPRequestExecutor {
                 requestTimeoutOverride: effectiveTimeout,
                 leaseID: leaseID,
                 cancellationHandle: cancellationHandle,
-                onTimeout: {
+                onTimeout: { requestSendCompletion in
                     self.sessionManager.handleRequestLeaseTimeout(
                         leaseID,
                         sessionID: sessionID,
                         requestIDKeys: prepared.transform.responseID.map { [$0.key] } ?? [],
-                        operationLease: prepared.operationLease
+                        operationLease: prepared.operationLease,
+                        after: requestSendCompletion
                     )
                 }
             )

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+RefreshSupport.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+RefreshSupport.swift
@@ -95,13 +95,16 @@ extension ClientMCPRequestExecutor {
                         parsedRequestJSON: attemptRequestObject,
                         sessionID: sessionID,
                         operationLeaseOverride: selectedOperationLease,
-                        admission: admission
+                        admission: admission,
+                        cancellationHandle: cancellationHandle
                     ) else {
                         return eventLoop.makeSucceededFuture(
                             MCPForwardingService.ResponseResolution.invalidUpstreamResponse
                         )
                     }
                     prepared = candidate
+                } catch is CancellationError {
+                    return eventLoop.makeFailedFuture(CancellationError())
                 } catch ProxyUpstreamRequestRuntime.Error.staleUpstreamTopology {
                     return eventLoop.makeSucceededFuture(
                         MCPForwardingService.ResponseResolution.upstreamUnavailable

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+RefreshSupport.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestExecutor+RefreshSupport.swift
@@ -121,12 +121,13 @@ extension ClientMCPRequestExecutor {
                         requestTimeoutOverride: requestTimeoutOverride,
                         leaseID: leaseID,
                         cancellationHandle: cancellationHandle,
-                        onTimeout: {
+                        onTimeout: { requestSendCompletion in
                             self.sessionManager.handleRequestLeaseTimeout(
                                 leaseID,
                                 sessionID: sessionID,
                                 requestIDKeys: [responseID.key],
-                                operationLease: prepared.operationLease
+                                operationLease: prepared.operationLease,
+                                after: requestSendCompletion
                             )
                         }
                     )

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestTypes.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestTypes.swift
@@ -70,10 +70,46 @@ extension ClientMCPRequestExecutor {
     }
 
     final class CancellationHandle: @unchecked Sendable {
+        private enum ActiveRequest: Sendable {
+            case selected(UpstreamOperationLease)
+            case sendRegistered(
+                operationLease: UpstreamOperationLease,
+                routerPendingToken: UUID,
+                requestSendCompletion: UpstreamRequestSendCompletion
+            )
+
+            var routerPendingToken: UUID? {
+                guard case .sendRegistered(_, let routerPendingToken, _) = self else {
+                    return nil
+                }
+                return routerPendingToken
+            }
+
+            var cancellationOperationLease: UpstreamOperationLease? {
+                guard case .sendRegistered(let operationLease, _, _) = self else {
+                    return nil
+                }
+                return operationLease
+            }
+
+            var requestSendCompletion: UpstreamRequestSendCompletion? {
+                guard case .sendRegistered(_, _, let requestSendCompletion) = self else {
+                    return nil
+                }
+                return requestSendCompletion
+            }
+        }
+
+        private struct CancellationSnapshot: Sendable {
+            let activeRequest: ActiveRequest?
+            let refreshTask: Task<Void, Never>?
+            let childHandles: [ClientMCPRequestExecutor.CancellationHandle]
+            let requestIDKeys: [String]
+        }
+
         private struct State: Sendable {
             var requestIDKeys: [String]
-            var operationLease: UpstreamOperationLease?
-            var routerPendingToken: UUID?
+            var activeRequest: ActiveRequest?
             var refreshTask: Task<Void, Never>?
             var childHandles: [ClientMCPRequestExecutor.CancellationHandle] = []
             var isTerminal = false
@@ -106,19 +142,25 @@ extension ClientMCPRequestExecutor {
         func activate(operationLease: UpstreamOperationLease) -> Bool {
             state.withLockedValue { state in
                 guard !state.isTerminal else { return false }
-                state.operationLease = operationLease
+                state.activeRequest = .selected(operationLease)
                 return true
             }
         }
 
         func bindStartedRegistration(
             operationLease: UpstreamOperationLease,
-            routerPendingToken: UUID
+            routerPendingToken: UUID,
+            requestSendCompletion: UpstreamRequestSendCompletion
         ) -> Bool {
             state.withLockedValue { state in
-                guard !state.isTerminal else { return false }
-                state.operationLease = operationLease
-                state.routerPendingToken = routerPendingToken
+                guard !state.isTerminal,
+                      case .selected(let selected) = state.activeRequest,
+                      selected.proof == operationLease.proof else { return false }
+                state.activeRequest = .sendRegistered(
+                    operationLease: operationLease,
+                    routerPendingToken: routerPendingToken,
+                    requestSendCompletion: requestSendCompletion
+                )
                 return true
             }
         }
@@ -160,36 +202,34 @@ extension ClientMCPRequestExecutor {
 
         func cancel(using runtime: any RuntimeSessionRegistryPort & RuntimeRequestLeasePort) {
             let snapshot = state.withLockedValue {
-                state -> (
-                    UpstreamOperationLease?, UUID?, Task<Void, Never>?, [ClientMCPRequestExecutor.CancellationHandle], [String]
-                )?
-                in
+                state -> CancellationSnapshot? in
                 guard !state.isTerminal else { return nil }
                 state.isTerminal = true
-                let snapshot = (
-                    state.operationLease,
-                    state.routerPendingToken,
-                    state.refreshTask,
-                    state.childHandles,
-                    state.requestIDKeys
+                let snapshot = CancellationSnapshot(
+                    activeRequest: state.activeRequest,
+                    refreshTask: state.refreshTask,
+                    childHandles: state.childHandles,
+                    requestIDKeys: state.requestIDKeys
                 )
                 state.refreshTask = nil
                 state.childHandles = []
                 return snapshot
             }
             guard let snapshot else { return }
-            snapshot.2?.cancel()
-            for childHandle in snapshot.3 {
+            snapshot.refreshTask?.cancel()
+            for childHandle in snapshot.childHandles {
                 childHandle.cancel(using: runtime)
             }
-            if let routerPendingToken = snapshot.1, runtime.hasSession(id: sessionID) {
+            if let routerPendingToken = snapshot.activeRequest?.routerPendingToken,
+               runtime.hasSession(id: sessionID) {
                 _ = runtime.session(id: sessionID).router.cancelPending(token: routerPendingToken)
             }
             runtime.abandonRequestLease(
                 leaseID,
                 sessionID: sessionID,
-                requestIDKeys: snapshot.4,
-                operationLease: snapshot.0
+                requestIDKeys: snapshot.requestIDKeys,
+                operationLease: snapshot.activeRequest?.cancellationOperationLease,
+                after: snapshot.activeRequest?.requestSendCompletion
             )
         }
     }

--- a/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestTypes.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ClientRequestExecution/Post/ClientMCPRequestTypes.swift
@@ -72,6 +72,7 @@ extension ClientMCPRequestExecutor {
     final class CancellationHandle: @unchecked Sendable {
         private enum ActiveRequest: Sendable {
             case selected(UpstreamOperationLease)
+            case prepared(UpstreamOperationLease)
             case sendRegistered(
                 operationLease: UpstreamOperationLease,
                 routerPendingToken: UUID,
@@ -87,6 +88,13 @@ extension ClientMCPRequestExecutor {
 
             var cancellationOperationLease: UpstreamOperationLease? {
                 guard case .sendRegistered(let operationLease, _, _) = self else {
+                    return nil
+                }
+                return operationLease
+            }
+
+            var preparedOperationLease: UpstreamOperationLease? {
+                guard case .prepared(let operationLease) = self else {
                     return nil
                 }
                 return operationLease
@@ -147,6 +155,20 @@ extension ClientMCPRequestExecutor {
             }
         }
 
+        func bindPreparedRequest(
+            operationLease: UpstreamOperationLease,
+            requestIDKeys: [String]
+        ) -> Bool {
+            state.withLockedValue { state in
+                guard !state.isTerminal,
+                      case .selected(let selected) = state.activeRequest,
+                      selected.proof == operationLease.proof else { return false }
+                state.requestIDKeys = requestIDKeys
+                state.activeRequest = .prepared(operationLease)
+                return true
+            }
+        }
+
         func bindStartedRegistration(
             operationLease: UpstreamOperationLease,
             routerPendingToken: UUID,
@@ -154,21 +176,14 @@ extension ClientMCPRequestExecutor {
         ) -> Bool {
             state.withLockedValue { state in
                 guard !state.isTerminal,
-                      case .selected(let selected) = state.activeRequest,
-                      selected.proof == operationLease.proof else { return false }
+                      case .prepared(let prepared) = state.activeRequest,
+                      prepared.proof == operationLease.proof else { return false }
                 state.activeRequest = .sendRegistered(
                     operationLease: operationLease,
                     routerPendingToken: routerPendingToken,
                     requestSendCompletion: requestSendCompletion
                 )
                 return true
-            }
-        }
-
-        func bindRequestIDKeys(_ requestIDKeys: [String]) {
-            state.withLockedValue { state in
-                guard !state.isTerminal else { return }
-                state.requestIDKeys = requestIDKeys
             }
         }
 
@@ -200,7 +215,12 @@ extension ClientMCPRequestExecutor {
             }
         }
 
-        func cancel(using runtime: any RuntimeSessionRegistryPort & RuntimeRequestLeasePort) {
+        func cancel(
+            using runtime:
+                any RuntimeSessionRegistryPort
+                    & RuntimeRequestLeasePort
+                    & ProxyUpstreamRequestRuntimePort
+        ) {
             let snapshot = state.withLockedValue {
                 state -> CancellationSnapshot? in
                 guard !state.isTerminal else { return nil }
@@ -223,6 +243,15 @@ extension ClientMCPRequestExecutor {
             if let routerPendingToken = snapshot.activeRequest?.routerPendingToken,
                runtime.hasSession(id: sessionID) {
                 _ = runtime.session(id: sessionID).router.cancelPending(token: routerPendingToken)
+            }
+            if let operationLease = snapshot.activeRequest?.preparedOperationLease {
+                for requestIDKey in snapshot.requestIDKeys {
+                    runtime.removeUpstreamIDMapping(
+                        sessionID: sessionID,
+                        requestIDKey: requestIDKey,
+                        operationLease: operationLease
+                    )
+                }
             }
             runtime.abandonRequestLease(
                 leaseID,

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
@@ -161,7 +161,7 @@ extension ControlPlane {
         let registrationToken: UUID?
         let operationLease: UpstreamOperationLease?
         let requestIDKey: String?
-        let requestSendCompletion: AsyncTerminalSignal?
+        let requestSendCompletion: UpstreamRequestSendCompletion?
         let cause: RPCCancellationCause
 
         var upstreamIndex: Int? { operationLease?.upstreamIndex }
@@ -170,7 +170,7 @@ extension ControlPlane {
             registrationToken: UUID?,
             operationLease: UpstreamOperationLease?,
             requestIDKey: String?,
-            requestSendCompletion: AsyncTerminalSignal?,
+            requestSendCompletion: UpstreamRequestSendCompletion?,
             cause: RPCCancellationCause
         ) {
             self.registrationToken = registrationToken
@@ -239,7 +239,7 @@ extension ControlPlane {
                 registrationToken: UUID,
                 operationLease: UpstreamOperationLease,
                 requestIDKey: String,
-                requestSendCompletion: AsyncTerminalSignal
+                requestSendCompletion: UpstreamRequestSendCompletion
             )
             case finished
             case cancelled(ControlPlane.RPCCancelSnapshot)
@@ -326,7 +326,7 @@ extension ControlPlane {
                     else {
                         return false
                     }
-                    let requestSendCompletion = AsyncTerminalSignal()
+                    let requestSendCompletion = UpstreamRequestSendCompletion()
                     state.state = .assigned(
                         registrationToken: registrationToken,
                         operationLease: operationLease,
@@ -351,7 +351,7 @@ extension ControlPlane {
             }
         }
 
-        func requestSendCompletion() -> AsyncTerminalSignal? {
+        func requestSendCompletion() -> UpstreamRequestSendCompletion? {
             state.withLockedValue { state in
                 switch state.state {
                 case .assigned(_, _, _, let requestSendCompletion):
@@ -397,10 +397,10 @@ extension ControlPlane {
                         requestSendCompletion: nil,
                         cause: cause
                     )
-                case .registered(let registrationToken, let operationLease):
+                case .registered(let registrationToken, _):
                     snapshot = ControlPlane.RPCCancelSnapshot(
                         registrationToken: registrationToken,
-                        operationLease: operationLease,
+                        operationLease: nil,
                         requestIDKey: nil,
                         requestSendCompletion: nil,
                         cause: cause

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
@@ -161,6 +161,7 @@ extension ControlPlane {
         let registrationToken: UUID?
         let operationLease: UpstreamOperationLease?
         let requestIDKey: String?
+        let requestSendCompletion: AsyncTerminalSignal?
         let cause: RPCCancellationCause
 
         var upstreamIndex: Int? { operationLease?.upstreamIndex }
@@ -169,12 +170,62 @@ extension ControlPlane {
             registrationToken: UUID?,
             operationLease: UpstreamOperationLease?,
             requestIDKey: String?,
+            requestSendCompletion: AsyncTerminalSignal?,
             cause: RPCCancellationCause
         ) {
             self.registrationToken = registrationToken
             self.operationLease = operationLease
             self.requestIDKey = requestIDKey
+            self.requestSendCompletion = requestSendCompletion
             self.cause = cause
+        }
+    }
+
+    final class RPCCancellationDelivery: @unchecked Sendable {
+        enum Result: Sendable, Equatable {
+            case delivered
+            case noLongerApplicable
+            case rejected
+
+            var permitsSameSlotReuse: Bool {
+                self == .delivered
+            }
+        }
+
+        private struct DeliveryState {
+            var result: Result?
+            var waiters: [CheckedContinuation<Result, Never>] = []
+        }
+
+        private let state = NIOLockedValueBox(DeliveryState())
+
+        func complete(_ result: Result) {
+            let waiters = state.withLockedValue {
+                state -> [CheckedContinuation<Result, Never>] in
+                guard state.result == nil else { return [] }
+                state.result = result
+                let waiters = state.waiters
+                state.waiters.removeAll()
+                return waiters
+            }
+            for waiter in waiters {
+                waiter.resume(returning: result)
+            }
+        }
+
+        func wait() async -> Result {
+            await withCheckedContinuation { continuation in
+                let result = state.withLockedValue { state -> Result? in
+                    if let result = state.result {
+                        return result
+                    }
+                    state.waiters.append(continuation)
+                    return nil
+                }
+                if let result {
+                    continuation.resume(returning: result)
+                }
+            }
         }
     }
 }
@@ -187,7 +238,8 @@ extension ControlPlane {
             case assigned(
                 registrationToken: UUID,
                 operationLease: UpstreamOperationLease,
-                requestIDKey: String
+                requestIDKey: String,
+                requestSendCompletion: AsyncTerminalSignal
             )
             case finished
             case cancelled(ControlPlane.RPCCancelSnapshot)
@@ -198,10 +250,10 @@ extension ControlPlane {
             var onCancel: (
                 @Sendable (
                     ControlPlane.RPCCancelSnapshot,
-                    AsyncTerminalSignal
+                    ControlPlane.RPCCancellationDelivery
                 ) -> Void
             )?
-            var cancellationDelivery: AsyncTerminalSignal?
+            var cancellationDelivery: ControlPlane.RPCCancellationDelivery?
         }
 
         private let state = NIOLockedValueBox(HandleState())
@@ -213,21 +265,26 @@ extension ControlPlane {
         ) {
             installCancelWithDelivery { snapshot, delivery in
                 onCancel(snapshot)
-                delivery.signal()
+                delivery.complete(.noLongerApplicable)
             }
         }
 
         func installCancelWithDelivery(
             _ onCancel: @escaping @Sendable (
                 ControlPlane.RPCCancelSnapshot,
-                AsyncTerminalSignal
+                ControlPlane.RPCCancellationDelivery
             ) -> Void
         ) {
             let pendingCancellation = state.withLockedValue {
-                state -> (ControlPlane.RPCCancelSnapshot, AsyncTerminalSignal)? in
+                state -> (
+                    ControlPlane.RPCCancelSnapshot,
+                    ControlPlane.RPCCancellationDelivery
+                )? in
                 state.onCancel = onCancel
                 if case .cancelled(let snapshot) = state.state {
-                    let delivery = state.cancellationDelivery ?? AsyncTerminalSignal()
+                    let delivery =
+                        state.cancellationDelivery
+                        ?? ControlPlane.RPCCancellationDelivery()
                     state.cancellationDelivery = delivery
                     return (snapshot, delivery)
                 }
@@ -269,10 +326,12 @@ extension ControlPlane {
                     else {
                         return false
                     }
+                    let requestSendCompletion = AsyncTerminalSignal()
                     state.state = .assigned(
                         registrationToken: registrationToken,
                         operationLease: operationLease,
-                        requestIDKey: requestIDKey
+                        requestIDKey: requestIDKey,
+                        requestSendCompletion: requestSendCompletion
                     )
                     return true
                 case .queued, .assigned, .cancelled, .finished:
@@ -292,16 +351,29 @@ extension ControlPlane {
             }
         }
 
+        func requestSendCompletion() -> AsyncTerminalSignal? {
+            state.withLockedValue { state in
+                switch state.state {
+                case .assigned(_, _, _, let requestSendCompletion):
+                    return requestSendCompletion
+                case .cancelled(let snapshot):
+                    return snapshot.requestSendCompletion
+                case .queued, .registered, .finished:
+                    return nil
+                }
+            }
+        }
+
         @discardableResult
         func cancel(
             cause: ControlPlane.RPCCancellationCause = .cancelled
-        ) -> AsyncTerminalSignal? {
+        ) -> ControlPlane.RPCCancellationDelivery? {
             let cancellation = state.withLockedValue { state -> (
-                delivery: AsyncTerminalSignal,
+                delivery: ControlPlane.RPCCancellationDelivery,
                 onCancel: (
                     @Sendable (
                         ControlPlane.RPCCancelSnapshot,
-                        AsyncTerminalSignal
+                        ControlPlane.RPCCancellationDelivery
                     ) -> Void
                 )?,
                 snapshot: ControlPlane.RPCCancelSnapshot?
@@ -322,6 +394,7 @@ extension ControlPlane {
                         registrationToken: nil,
                         operationLease: nil,
                         requestIDKey: nil,
+                        requestSendCompletion: nil,
                         cause: cause
                     )
                 case .registered(let registrationToken, let operationLease):
@@ -329,17 +402,24 @@ extension ControlPlane {
                         registrationToken: registrationToken,
                         operationLease: operationLease,
                         requestIDKey: nil,
+                        requestSendCompletion: nil,
                         cause: cause
                     )
-                case .assigned(let registrationToken, let operationLease, let requestIDKey):
+                case .assigned(
+                    let registrationToken,
+                    let operationLease,
+                    let requestIDKey,
+                    let requestSendCompletion
+                ):
                     snapshot = ControlPlane.RPCCancelSnapshot(
                         registrationToken: registrationToken,
                         operationLease: operationLease,
                         requestIDKey: requestIDKey,
+                        requestSendCompletion: requestSendCompletion,
                         cause: cause
                     )
                 }
-                let delivery = AsyncTerminalSignal()
+                let delivery = ControlPlane.RPCCancellationDelivery()
                 state.state = .cancelled(snapshot)
                 state.cancellationDelivery = delivery
                 return (delivery, state.onCancel, snapshot)
@@ -365,7 +445,7 @@ extension ControlPlane {
             state.withLockedValue { state in
                 switch state.state {
                 case .registered(_, let operationLease),
-                     .assigned(_, let operationLease, _):
+                     .assigned(_, let operationLease, _, _):
                     return operationLease.proof == proof
                 case .cancelled(let snapshot):
                     return snapshot.operationLease?.proof == proof

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
@@ -152,21 +152,29 @@ extension ControlPlane {
 }
 
 extension ControlPlane {
+    enum RPCCancellationCause: Sendable, Equatable {
+        case cancelled
+        case timedOut
+    }
+
     struct RPCCancelSnapshot: Sendable {
         let registrationToken: UUID?
         let operationLease: UpstreamOperationLease?
         let requestIDKey: String?
+        let cause: RPCCancellationCause
 
         var upstreamIndex: Int? { operationLease?.upstreamIndex }
 
         init(
             registrationToken: UUID?,
             operationLease: UpstreamOperationLease?,
-            requestIDKey: String?
+            requestIDKey: String?,
+            cause: RPCCancellationCause
         ) {
             self.registrationToken = registrationToken
             self.operationLease = operationLease
             self.requestIDKey = requestIDKey
+            self.cause = cause
         }
     }
 }
@@ -187,7 +195,13 @@ extension ControlPlane {
 
         private struct HandleState: Sendable {
             var state: State = .queued
-            var onCancel: (@Sendable (ControlPlane.RPCCancelSnapshot) -> Void)?
+            var onCancel: (
+                @Sendable (
+                    ControlPlane.RPCCancelSnapshot,
+                    AsyncTerminalSignal
+                ) -> Void
+            )?
+            var cancellationDelivery: AsyncTerminalSignal?
         }
 
         private let state = NIOLockedValueBox(HandleState())
@@ -197,15 +211,30 @@ extension ControlPlane {
         func installCancel(
             _ onCancel: @escaping @Sendable (ControlPlane.RPCCancelSnapshot) -> Void
         ) {
-            let snapshot = state.withLockedValue { state -> ControlPlane.RPCCancelSnapshot? in
+            installCancelWithDelivery { snapshot, delivery in
+                onCancel(snapshot)
+                delivery.signal()
+            }
+        }
+
+        func installCancelWithDelivery(
+            _ onCancel: @escaping @Sendable (
+                ControlPlane.RPCCancelSnapshot,
+                AsyncTerminalSignal
+            ) -> Void
+        ) {
+            let pendingCancellation = state.withLockedValue {
+                state -> (ControlPlane.RPCCancelSnapshot, AsyncTerminalSignal)? in
                 state.onCancel = onCancel
                 if case .cancelled(let snapshot) = state.state {
-                    return snapshot
+                    let delivery = state.cancellationDelivery ?? AsyncTerminalSignal()
+                    state.cancellationDelivery = delivery
+                    return (snapshot, delivery)
                 }
                 return nil
             }
-            if let snapshot {
-                onCancel(snapshot)
+            if let (snapshot, delivery) = pendingCancellation {
+                onCancel(snapshot, delivery)
             }
         }
 
@@ -263,44 +292,64 @@ extension ControlPlane {
             }
         }
 
-        func cancel() {
-            let cancellation = state.withLockedValue {
-                state -> (
-                    (@Sendable (ControlPlane.RPCCancelSnapshot) -> Void),
-                    ControlPlane.RPCCancelSnapshot
-                )? in
+        @discardableResult
+        func cancel(
+            cause: ControlPlane.RPCCancellationCause = .cancelled
+        ) -> AsyncTerminalSignal? {
+            let cancellation = state.withLockedValue { state -> (
+                delivery: AsyncTerminalSignal,
+                onCancel: (
+                    @Sendable (
+                        ControlPlane.RPCCancelSnapshot,
+                        AsyncTerminalSignal
+                    ) -> Void
+                )?,
+                snapshot: ControlPlane.RPCCancelSnapshot?
+            )? in
                 let snapshot: ControlPlane.RPCCancelSnapshot
                 switch state.state {
-                case .finished, .cancelled:
+                case .finished:
                     return nil
+                case .cancelled:
+                    guard let delivery = state.cancellationDelivery else {
+                        preconditionFailure(
+                            "cancelled RPC handle must own its cancellation delivery"
+                        )
+                    }
+                    return (delivery, nil, nil)
                 case .queued:
                     snapshot = ControlPlane.RPCCancelSnapshot(
                         registrationToken: nil,
                         operationLease: nil,
-                        requestIDKey: nil
+                        requestIDKey: nil,
+                        cause: cause
                     )
                 case .registered(let registrationToken, let operationLease):
                     snapshot = ControlPlane.RPCCancelSnapshot(
                         registrationToken: registrationToken,
                         operationLease: operationLease,
-                        requestIDKey: nil
+                        requestIDKey: nil,
+                        cause: cause
                     )
                 case .assigned(let registrationToken, let operationLease, let requestIDKey):
                     snapshot = ControlPlane.RPCCancelSnapshot(
                         registrationToken: registrationToken,
                         operationLease: operationLease,
-                        requestIDKey: requestIDKey
+                        requestIDKey: requestIDKey,
+                        cause: cause
                     )
                 }
+                let delivery = AsyncTerminalSignal()
                 state.state = .cancelled(snapshot)
-                guard let onCancel = state.onCancel else {
-                    return nil
-                }
-                return (onCancel, snapshot)
+                state.cancellationDelivery = delivery
+                return (delivery, state.onCancel, snapshot)
             }
-            if let (onCancel, snapshot) = cancellation {
-                onCancel(snapshot)
+            guard let cancellation else { return nil }
+            if let onCancel = cancellation.onCancel,
+               let snapshot = cancellation.snapshot {
+                onCancel(snapshot, cancellation.delivery)
             }
+            return cancellation.delivery
         }
 
         func isCancelled() -> Bool {

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
@@ -232,66 +232,63 @@ extension ControlPlane {
 
 extension ControlPlane {
     final class RPCHandle: Sendable {
-        enum State: Sendable {
-            case queued
-            case registered(registrationToken: UUID, operationLease: UpstreamOperationLease)
+        typealias CancellationHandler = @Sendable (
+            ControlPlane.RPCCancelSnapshot,
+            ControlPlane.RPCCancellationDelivery
+        ) -> Void
+
+        private enum State: Sendable {
+            case idle
+            case armed(CancellationHandler)
+            case registered(
+                onCancel: CancellationHandler,
+                registrationToken: UUID,
+                operationLease: UpstreamOperationLease
+            )
             case assigned(
+                onCancel: CancellationHandler,
                 registrationToken: UUID,
                 operationLease: UpstreamOperationLease,
                 requestIDKey: String,
                 requestSendCompletion: UpstreamRequestSendCompletion
             )
             case finished
-            case cancelled(ControlPlane.RPCCancelSnapshot)
+            case cancelled(
+                snapshot: ControlPlane.RPCCancelSnapshot,
+                delivery: ControlPlane.RPCCancellationDelivery
+            )
         }
 
-        private struct HandleState: Sendable {
-            var state: State = .queued
-            var onCancel: (
-                @Sendable (
-                    ControlPlane.RPCCancelSnapshot,
-                    ControlPlane.RPCCancellationDelivery
-                ) -> Void
-            )?
-            var cancellationDelivery: ControlPlane.RPCCancellationDelivery?
-        }
-
-        private let state = NIOLockedValueBox(HandleState())
+        private let state = NIOLockedValueBox<State>(.idle)
 
         init() {}
 
+        @discardableResult
         func installCancel(
             _ onCancel: @escaping @Sendable (ControlPlane.RPCCancelSnapshot) -> Void
-        ) {
+        ) -> Bool {
             installCancelWithDelivery { snapshot, delivery in
                 onCancel(snapshot)
                 delivery.complete(.noLongerApplicable)
             }
         }
 
+        @discardableResult
         func installCancelWithDelivery(
-            _ onCancel: @escaping @Sendable (
-                ControlPlane.RPCCancelSnapshot,
-                ControlPlane.RPCCancellationDelivery
-            ) -> Void
-        ) {
-            let pendingCancellation = state.withLockedValue {
-                state -> (
-                    ControlPlane.RPCCancelSnapshot,
-                    ControlPlane.RPCCancellationDelivery
-                )? in
-                state.onCancel = onCancel
-                if case .cancelled(let snapshot) = state.state {
-                    let delivery =
-                        state.cancellationDelivery
-                        ?? ControlPlane.RPCCancellationDelivery()
-                    state.cancellationDelivery = delivery
-                    return (snapshot, delivery)
+            _ onCancel: @escaping CancellationHandler
+        ) -> Bool {
+            state.withLockedValue { state in
+                switch state {
+                case .idle:
+                    state = .armed(onCancel)
+                    return true
+                case .cancelled, .finished:
+                    return false
+                case .armed, .registered, .assigned:
+                    preconditionFailure(
+                        "RPC handle cancellation handler may only be installed once"
+                    )
                 }
-                return nil
-            }
-            if let (snapshot, delivery) = pendingCancellation {
-                onCancel(snapshot, delivery)
             }
         }
 
@@ -300,14 +297,15 @@ extension ControlPlane {
             operationLease: UpstreamOperationLease
         ) -> Bool {
             state.withLockedValue { state in
-                switch state.state {
-                case .queued:
-                    state.state = .registered(
+                switch state {
+                case .armed(let onCancel):
+                    state = .registered(
+                        onCancel: onCancel,
                         registrationToken: registrationToken,
                         operationLease: operationLease
                     )
                     return true
-                case .cancelled, .finished, .registered, .assigned:
+                case .idle, .cancelled, .finished, .registered, .assigned:
                     return false
                 }
             }
@@ -319,22 +317,27 @@ extension ControlPlane {
             requestIDKey: String
         ) -> Bool {
             state.withLockedValue { state in
-                switch state.state {
-                case .registered(let token, let registeredOperationLease):
+                switch state {
+                case .registered(
+                    let onCancel,
+                    let token,
+                    let registeredOperationLease
+                ):
                     guard token == registrationToken,
                           registeredOperationLease.proof == operationLease.proof
                     else {
                         return false
                     }
                     let requestSendCompletion = UpstreamRequestSendCompletion()
-                    state.state = .assigned(
+                    state = .assigned(
+                        onCancel: onCancel,
                         registrationToken: registrationToken,
                         operationLease: operationLease,
                         requestIDKey: requestIDKey,
                         requestSendCompletion: requestSendCompletion
                     )
                     return true
-                case .queued, .assigned, .cancelled, .finished:
+                case .idle, .armed, .assigned, .cancelled, .finished:
                     return false
                 }
             }
@@ -342,9 +345,9 @@ extension ControlPlane {
 
         func markFinished() {
             state.withLockedValue { state in
-                switch state.state {
-                case .queued, .registered, .assigned:
-                    state.state = .finished
+                switch state {
+                case .idle, .armed, .registered, .assigned:
+                    state = .finished
                 case .finished, .cancelled:
                     return
                 }
@@ -353,12 +356,12 @@ extension ControlPlane {
 
         func requestSendCompletion() -> UpstreamRequestSendCompletion? {
             state.withLockedValue { state in
-                switch state.state {
-                case .assigned(_, _, _, let requestSendCompletion):
+                switch state {
+                case .assigned(_, _, _, _, let requestSendCompletion):
                     return requestSendCompletion
-                case .cancelled(let snapshot):
+                case .cancelled(let snapshot, _):
                     return snapshot.requestSendCompletion
-                case .queued, .registered, .finished:
+                case .idle, .armed, .registered, .finished:
                     return nil
                 }
             }
@@ -370,26 +373,19 @@ extension ControlPlane {
         ) -> ControlPlane.RPCCancellationDelivery? {
             let cancellation = state.withLockedValue { state -> (
                 delivery: ControlPlane.RPCCancellationDelivery,
-                onCancel: (
-                    @Sendable (
-                        ControlPlane.RPCCancelSnapshot,
-                        ControlPlane.RPCCancellationDelivery
-                    ) -> Void
-                )?,
-                snapshot: ControlPlane.RPCCancelSnapshot?
+                onCancel: CancellationHandler?,
+                snapshot: ControlPlane.RPCCancelSnapshot,
+                completesImmediately: Bool
             )? in
                 let snapshot: ControlPlane.RPCCancelSnapshot
-                switch state.state {
+                let onCancel: CancellationHandler?
+                let completesImmediately: Bool
+                switch state {
                 case .finished:
                     return nil
-                case .cancelled:
-                    guard let delivery = state.cancellationDelivery else {
-                        preconditionFailure(
-                            "cancelled RPC handle must own its cancellation delivery"
-                        )
-                    }
-                    return (delivery, nil, nil)
-                case .queued:
+                case .cancelled(let snapshot, let delivery):
+                    return (delivery, nil, snapshot, false)
+                case .idle:
                     snapshot = ControlPlane.RPCCancelSnapshot(
                         registrationToken: nil,
                         operationLease: nil,
@@ -397,7 +393,19 @@ extension ControlPlane {
                         requestSendCompletion: nil,
                         cause: cause
                     )
-                case .registered(let registrationToken, _):
+                    onCancel = nil
+                    completesImmediately = true
+                case .armed(let handler):
+                    snapshot = ControlPlane.RPCCancelSnapshot(
+                        registrationToken: nil,
+                        operationLease: nil,
+                        requestIDKey: nil,
+                        requestSendCompletion: nil,
+                        cause: cause
+                    )
+                    onCancel = handler
+                    completesImmediately = false
+                case .registered(let handler, let registrationToken, _):
                     snapshot = ControlPlane.RPCCancelSnapshot(
                         registrationToken: registrationToken,
                         operationLease: nil,
@@ -405,7 +413,10 @@ extension ControlPlane {
                         requestSendCompletion: nil,
                         cause: cause
                     )
+                    onCancel = handler
+                    completesImmediately = false
                 case .assigned(
+                    let handler,
                     let registrationToken,
                     let operationLease,
                     let requestIDKey,
@@ -418,23 +429,25 @@ extension ControlPlane {
                         requestSendCompletion: requestSendCompletion,
                         cause: cause
                     )
+                    onCancel = handler
+                    completesImmediately = false
                 }
                 let delivery = ControlPlane.RPCCancellationDelivery()
-                state.state = .cancelled(snapshot)
-                state.cancellationDelivery = delivery
-                return (delivery, state.onCancel, snapshot)
+                state = .cancelled(snapshot: snapshot, delivery: delivery)
+                return (delivery, onCancel, snapshot, completesImmediately)
             }
             guard let cancellation else { return nil }
-            if let onCancel = cancellation.onCancel,
-               let snapshot = cancellation.snapshot {
-                onCancel(snapshot, cancellation.delivery)
+            if let onCancel = cancellation.onCancel {
+                onCancel(cancellation.snapshot, cancellation.delivery)
+            } else if cancellation.completesImmediately {
+                cancellation.delivery.complete(.noLongerApplicable)
             }
             return cancellation.delivery
         }
 
         func isCancelled() -> Bool {
             state.withLockedValue { state in
-                if case .cancelled = state.state {
+                if case .cancelled = state {
                     return true
                 }
                 return false
@@ -443,13 +456,13 @@ extension ControlPlane {
 
         func isBound(to proof: UpstreamTopologyProof) -> Bool {
             state.withLockedValue { state in
-                switch state.state {
-                case .registered(_, let operationLease),
-                     .assigned(_, let operationLease, _, _):
+                switch state {
+                case .registered(_, _, let operationLease),
+                     .assigned(_, _, let operationLease, _, _):
                     return operationLease.proof == proof
-                case .cancelled(let snapshot):
+                case .cancelled(let snapshot, _):
                     return snapshot.operationLease?.proof == proof
-                case .queued, .finished:
+                case .idle, .armed, .finished:
                     return false
                 }
             }

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ControlPlaneSupport.swift
@@ -187,8 +187,8 @@ extension ControlPlane {
             case noLongerApplicable
             case rejected
 
-            var permitsSameSlotReuse: Bool {
-                self == .delivered
+            var allowsRetryScheduling: Bool {
+                self != .rejected
             }
         }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/InitializeManager.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/InitializeManager.swift
@@ -177,6 +177,15 @@ final class InitializeManager: Sendable {
         }
     }
 
+    @discardableResult
+    func performIfRunning(_ operation: () -> Void) -> Bool {
+        state.withLockedValue { state in
+            guard state.isShuttingDown == false else { return false }
+            operation()
+            return true
+        }
+    }
+
     func removePendingInitializes(sessionID: String) -> PendingRemovalResult {
         state.withLockedValue { state in
             let removed = state.initPending.filter { $0.sessionID == sessionID }

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -470,6 +470,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         var catalogEligibilityEstablished: Bool
         var bridgeRecovery: BridgeRecoveryState
         var nextAttemptID: Int
+        var catalogRetryCount: Int
         var attempt: Attempt?
 
         func cooldown(_ scope: CooldownScope) -> Cooldown {
@@ -1479,6 +1480,9 @@ final class ProcessControlPlaneAuthority: Sendable {
                     )
                 )
             }
+            if record.attempt?.phase == .backoff {
+                return nil
+            }
             let effects = record.attempt?.detachedEffects() ?? []
             record.nextAttemptID &+= 1
             var attempt = Attempt(
@@ -1688,6 +1692,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                     state.processIDByUpstreamID[UpstreamSlotID(rawValue: upstreamIndex)] =
                         record.route.target.processID
                 }
+                record.catalogRetryCount = 0
                 effects.append(contentsOf: record.clearAllCooldowns().effects)
                 attempt.phase = .cataloged
                 effects.append(contentsOf: Self.takeBridgePoolRecoveryEffects(owner: &record))
@@ -1971,6 +1976,7 @@ final class ProcessControlPlaneAuthority: Sendable {
             attempt.readinessToken = nil
             attempt.phase = .backoff
             var updated = record
+            updated.catalogRetryCount &+= 1
             updated.attempt = attempt
             state.recordsByKey[key] = updated
             return (
@@ -1980,7 +1986,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                     routeID: lease.routeID,
                     catalogEpoch: state.catalogEpoch
                 ),
-                Self.retry(forAttempt: attempt.id.rawValue),
+                Self.retry(forAttempt: updated.catalogRetryCount),
                 ProcessControlPlaneTransition(
                     addedRoutes: [],
                     retiredRoutes: [],
@@ -2096,6 +2102,7 @@ final class ProcessControlPlaneAuthority: Sendable {
             attempt.retryKind = .catalog
             attempt.loads.removeAll()
             attempt.phase = .backoff
+            record.catalogRetryCount &+= 1
             record.attempt = attempt
             state.recordsByKey[key] = record
             return CatalogRequestTimeout(
@@ -2105,7 +2112,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                     effects: effects,
                     publishesToolsListChanged: false
                 ),
-                retry: Self.retry(forAttempt: attempt.id.rawValue),
+                retry: Self.retry(forAttempt: record.catalogRetryCount),
                 catalogLease: Self.lease(
                     for: attempt,
                     loadID: loadID,
@@ -2330,6 +2337,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                 pendingUpstreamIDs: Self.secondaryUpstreamIDs(in: route)
             ),
             nextAttemptID: 0,
+            catalogRetryCount: 0,
             attempt: nil
         )
         if state.order.contains(key) == false { state.order.append(key) }

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -369,18 +369,30 @@ final class ProcessControlPlaneAuthority: Sendable {
 
     private struct Attempt: Sendable {
         struct Load: Sendable {
-            struct CatalogTimeout: Sendable {
-                let generation: UInt64
-                var scheduled: RuntimeScheduledTimeout?
+            enum CatalogTimeout: Sendable {
+                case reserved(generation: UInt64)
+                case attached(generation: UInt64, RuntimeScheduledTimeout)
+
+                var generation: UInt64 {
+                    switch self {
+                    case .reserved(let generation), .attached(let generation, _):
+                        return generation
+                    }
+                }
+
+                var cancellationEffect: ProcessControlPlaneEffect? {
+                    guard case .attached(_, let timeout) = self else {
+                        return nil
+                    }
+                    return .cancelTimeout(timeout)
+                }
             }
 
             var catalogTimeout: CatalogTimeout? = nil
             var rpcHandles: [ControlPlane.RPCHandle] = []
 
             func detachedEffects() -> [ProcessControlPlaneEffect] {
-                var effects = catalogTimeout?.scheduled.map {
-                    [ProcessControlPlaneEffect.cancelTimeout($0)]
-                } ?? []
+                var effects = catalogTimeout?.cancellationEffect.map { [$0] } ?? []
                 effects.append(contentsOf: rpcHandles.map(ProcessControlPlaneEffect.cancelRPC))
                 return effects
             }
@@ -1668,10 +1680,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                 catalogLease: lease,
                 generation: state.nextCatalogTimeoutGeneration
             )
-            load.catalogTimeout = Attempt.Load.CatalogTimeout(
-                generation: reservation.generation,
-                scheduled: nil
-            )
+            load.catalogTimeout = .reserved(generation: reservation.generation)
             attempt.loads[lease.loadID] = load
             record.attempt = attempt
             state.recordsByKey[key] = record
@@ -1691,9 +1700,9 @@ final class ProcessControlPlaneAuthority: Sendable {
                   Self.matches(lease: lease, attempt: attempt, state: state),
                   attempt.phase == .loadingCatalog,
                   var load = attempt.loads[lease.loadID],
-                  var catalogTimeout = load.catalogTimeout,
+                  let catalogTimeout = load.catalogTimeout,
                   catalogTimeout.generation == reservation.generation,
-                  catalogTimeout.scheduled == nil else {
+                  case .reserved = catalogTimeout else {
                 return ProcessControlPlaneTransition(
                     addedRoutes: [],
                     retiredRoutes: [],
@@ -1701,8 +1710,10 @@ final class ProcessControlPlaneAuthority: Sendable {
                     publishesToolsListChanged: false
                 )
             }
-            catalogTimeout.scheduled = timeout
-            load.catalogTimeout = catalogTimeout
+            load.catalogTimeout = .attached(
+                generation: reservation.generation,
+                timeout
+            )
             attempt.loads[lease.loadID] = load
             record.attempt = attempt
             state.recordsByKey[key] = record
@@ -2189,8 +2200,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                   Self.matches(lease: lease, attempt: attempt, state: state),
                   attempt.phase == .loadingCatalog,
                   let catalogTimeout = attempt.loads[lease.loadID]?.catalogTimeout,
-                  catalogTimeout.generation == reservation.generation,
-                  catalogTimeout.scheduled != nil else {
+                  catalogTimeout.generation == reservation.generation else {
                 return nil
             }
             let effects = attempt.loads.removeValue(forKey: lease.loadID)?

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -33,6 +33,13 @@ struct CatalogLease: Sendable, Hashable {
     }
 }
 
+struct CatalogTimeoutReservation: Sendable, Hashable {
+    fileprivate let catalogLease: CatalogLease
+    fileprivate let generation: UInt64
+
+    var lease: CatalogLease { catalogLease }
+}
+
 struct ActivationLease: Sendable, Hashable {
     let routeID: ProcessRouteID
     let attemptID: CatalogAttemptID
@@ -279,6 +286,7 @@ final class ProcessControlPlaneAuthority: Sendable {
     struct ChannelInitializedAttempt: Sendable {
         let attempt: Int
         let shouldStartCatalogLoad: Bool
+        let activeCatalogLeases: [CatalogLease]
     }
 
     struct Retry: Sendable {
@@ -293,10 +301,21 @@ final class ProcessControlPlaneAuthority: Sendable {
         let activationLease: ActivationLease
     }
 
-    struct CatalogRequestTimeout: Sendable {
-        let transition: ProcessControlPlaneTransition
-        let retry: Retry
-        let catalogLease: CatalogLease
+    enum CatalogRequestTimeout: Sendable {
+        case loadTimedOut(ProcessControlPlaneTransition)
+        case retryRequired(
+            transition: ProcessControlPlaneTransition,
+            retry: Retry,
+            catalogLease: CatalogLease
+        )
+
+        var transition: ProcessControlPlaneTransition {
+            switch self {
+            case .loadTimedOut(let transition),
+                 .retryRequired(let transition, _, _):
+                return transition
+            }
+        }
     }
 
     enum RejectedCancellationRecovery: Sendable {
@@ -350,10 +369,20 @@ final class ProcessControlPlaneAuthority: Sendable {
 
     private struct Attempt: Sendable {
         struct Load: Sendable {
+            struct CatalogTimeout: Sendable {
+                let generation: UInt64
+                var scheduled: RuntimeScheduledTimeout?
+            }
+
+            var catalogTimeout: CatalogTimeout? = nil
             var rpcHandles: [ControlPlane.RPCHandle] = []
 
             func detachedEffects() -> [ProcessControlPlaneEffect] {
-                rpcHandles.map(ProcessControlPlaneEffect.cancelRPC)
+                var effects = catalogTimeout?.scheduled.map {
+                    [ProcessControlPlaneEffect.cancelTimeout($0)]
+                } ?? []
+                effects.append(contentsOf: rpcHandles.map(ProcessControlPlaneEffect.cancelRPC))
+                return effects
             }
         }
 
@@ -558,6 +587,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         var canonicalToolsCatalogRaw: JSONValue?
         var canonicalSourceProof: UpstreamTopologyProof?
         var nextUnboundAttemptID: Int = 0
+        var nextCatalogTimeoutGeneration: UInt64 = 0
         var unboundAttempt: Attempt?
         var unboundCatalogRaw: JSONValue?
         var unboundCatalogSource: UpstreamTopologyProof?
@@ -1432,7 +1462,17 @@ final class ProcessControlPlaneAuthority: Sendable {
             state.recordsByKey[key] = record
             return ChannelInitializedAttempt(
                 attempt: attempt.id.rawValue,
-                shouldStartCatalogLoad: shouldStartCatalogLoad
+                shouldStartCatalogLoad: shouldStartCatalogLoad,
+                activeCatalogLeases: attempt.loads.keys.sorted {
+                    $0.rawValue < $1.rawValue
+                }.map {
+                    Self.lease(
+                        for: attempt,
+                        loadID: $0,
+                        routeID: routeID,
+                        catalogEpoch: state.catalogEpoch
+                    )
+                }
             )
         }
     }
@@ -1606,6 +1646,67 @@ final class ProcessControlPlaneAuthority: Sendable {
                 addedRoutes: [], retiredRoutes: [], effects: effects,
                 publishesToolsListChanged: false
             )
+        }
+    }
+
+    func reserveCatalogTimeout(
+        for lease: CatalogLease
+    ) -> CatalogTimeoutReservation? {
+        state.withLockedValue { state in
+            guard lease.routeID != Self.unboundRouteID,
+                  let key = Self.key(routeID: lease.routeID, in: state),
+                  var record = state.recordsByKey[key],
+                  var attempt = record.attempt,
+                  Self.matches(lease: lease, attempt: attempt, state: state),
+                  attempt.phase == .loadingCatalog,
+                  var load = attempt.loads[lease.loadID],
+                  load.catalogTimeout == nil else {
+                return nil
+            }
+            state.nextCatalogTimeoutGeneration &+= 1
+            let reservation = CatalogTimeoutReservation(
+                catalogLease: lease,
+                generation: state.nextCatalogTimeoutGeneration
+            )
+            load.catalogTimeout = Attempt.Load.CatalogTimeout(
+                generation: reservation.generation,
+                scheduled: nil
+            )
+            attempt.loads[lease.loadID] = load
+            record.attempt = attempt
+            state.recordsByKey[key] = record
+            return reservation
+        }
+    }
+
+    func attachCatalogTimeout(
+        _ timeout: RuntimeScheduledTimeout,
+        to reservation: CatalogTimeoutReservation
+    ) -> ProcessControlPlaneTransition {
+        state.withLockedValue { state in
+            let lease = reservation.catalogLease
+            guard let key = Self.key(routeID: lease.routeID, in: state),
+                  var record = state.recordsByKey[key],
+                  var attempt = record.attempt,
+                  Self.matches(lease: lease, attempt: attempt, state: state),
+                  attempt.phase == .loadingCatalog,
+                  var load = attempt.loads[lease.loadID],
+                  var catalogTimeout = load.catalogTimeout,
+                  catalogTimeout.generation == reservation.generation,
+                  catalogTimeout.scheduled == nil else {
+                return ProcessControlPlaneTransition(
+                    addedRoutes: [],
+                    retiredRoutes: [],
+                    effects: [.cancelTimeout(timeout)],
+                    publishesToolsListChanged: false
+                )
+            }
+            catalogTimeout.scheduled = timeout
+            load.catalogTimeout = catalogTimeout
+            attempt.loads[lease.loadID] = load
+            record.attempt = attempt
+            state.recordsByKey[key] = record
+            return .none
         }
     }
 
@@ -2075,32 +2176,45 @@ final class ProcessControlPlaneAuthority: Sendable {
     }
 
     func handleCatalogRequestTimeout(
-        routeID: ProcessRouteID,
-        upstreamProof: UpstreamTopologyProof,
+        _ reservation: CatalogTimeoutReservation,
         nowUptimeNs: UInt64
     ) -> CatalogRequestTimeout? {
         state.withLockedValue { state in
+            let lease = reservation.catalogLease
             state.nowUptimeNs = max(state.nowUptimeNs, nowUptimeNs)
-            guard let key = Self.key(routeID: routeID, in: state),
+            guard lease.catalogEpoch == state.catalogEpoch,
+                  let key = Self.key(routeID: lease.routeID, in: state),
                   var record = state.recordsByKey[key],
                   var attempt = record.attempt,
-                  attempt.upstreamProof == upstreamProof,
+                  Self.matches(lease: lease, attempt: attempt, state: state),
                   attempt.phase == .loadingCatalog,
-                  let loadID = attempt.loads.keys.min(by: {
-                      $0.rawValue < $1.rawValue
-                  }) else {
+                  let catalogTimeout = attempt.loads[lease.loadID]?.catalogTimeout,
+                  catalogTimeout.generation == reservation.generation,
+                  catalogTimeout.scheduled != nil else {
                 return nil
             }
-            let effects = attempt.detachedEffects()
+            let effects = attempt.loads.removeValue(forKey: lease.loadID)?
+                .detachedEffects() ?? []
+            if attempt.loads.isEmpty == false {
+                record.attempt = attempt
+                state.recordsByKey[key] = record
+                return .loadTimedOut(
+                    ProcessControlPlaneTransition(
+                        addedRoutes: [],
+                        retiredRoutes: [],
+                        effects: effects,
+                        publishesToolsListChanged: false
+                    )
+                )
+            }
             attempt.readinessToken = nil
             attempt.retryTimeout = nil
             attempt.retryKind = .catalog
-            attempt.loads.removeAll()
             attempt.phase = .backoff
             record.catalogRetryCount &+= 1
             record.attempt = attempt
             state.recordsByKey[key] = record
-            return CatalogRequestTimeout(
+            return .retryRequired(
                 transition: ProcessControlPlaneTransition(
                     addedRoutes: [],
                     retiredRoutes: [],
@@ -2108,12 +2222,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                     publishesToolsListChanged: false
                 ),
                 retry: Self.retry(forAttempt: record.catalogRetryCount),
-                catalogLease: Self.lease(
-                    for: attempt,
-                    loadID: loadID,
-                    routeID: routeID,
-                    catalogEpoch: state.catalogEpoch
-                )
+                catalogLease: lease
             )
         }
     }

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -299,6 +299,12 @@ final class ProcessControlPlaneAuthority: Sendable {
         let catalogLease: CatalogLease
     }
 
+    enum RejectedCancellationRecovery: Sendable {
+        case preserved(ProcessControlPlaneTransition)
+        case bridgeRecovery(ProcessBridgeRecoveryRetry)
+        case freshActivation(ActivationLease, Retry, ProcessControlPlaneTransition)
+    }
+
     struct CooldownLease: Sendable, Hashable {
         let routeID: ProcessRouteID
         let scope: CooldownScope
@@ -615,16 +621,10 @@ final class ProcessControlPlaneAuthority: Sendable {
             else {
                 return .none
             }
-            switch owner.bridgeRecovery.phase {
-            case .attempting(let current) where current.upstreamID == upstreamID:
-                return .none
-            case .waitingRetry(let current, _) where current.upstreamID == upstreamID:
-                return .none
-            case .idle, .attempting, .waitingRetry:
-                break
-            }
-            owner.bridgeRecovery.pendingUpstreamIDs.insert(upstreamID)
-            let effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
+            let effects = Self.requestBridgePoolRecoveryEffects(
+                upstreamID: upstreamID,
+                owner: &owner
+            )
             state.recordsByKey[key] = owner
             return ProcessControlPlaneTransition(
                 addedRoutes: [], retiredRoutes: [], effects: effects,
@@ -681,17 +681,12 @@ final class ProcessControlPlaneAuthority: Sendable {
         state.withLockedValue { state in
             guard let key = Self.key(routeID: recovery.routeID, in: state),
                   var owner = state.recordsByKey[key],
-                  case .attempting(let current) = owner.bridgeRecovery.phase,
-                  current == recovery else { return nil }
-            owner.bridgeRecovery.consecutiveFailureCount += 1
-            owner.bridgeRecovery.phase = .waitingRetry(recovery, nil)
+                  let retry = Self.prepareBridgeRecoveryRetry(
+                      recovery,
+                      owner: &owner
+                  ) else { return nil }
             state.recordsByKey[key] = owner
-            return ProcessBridgeRecoveryRetry(
-                reservation: recovery,
-                delay: owner.bridgeRecovery.consecutiveFailureCount == 1
-                    ? .seconds(1)
-                    : .seconds(10)
-            )
+            return retry
         }
     }
 
@@ -2154,6 +2149,100 @@ final class ProcessControlPlaneAuthority: Sendable {
         }
     }
 
+    /// Commits rejected-cancellation recovery against the current process owner.
+    ///
+    /// The rejected bridge reservation is evidence only: a newer attempt, catalog,
+    /// or bridge recovery that won the race is preserved by this same transaction.
+    func recoverAfterRejectedCancellation(
+        routeID: ProcessRouteID,
+        failedProof: UpstreamTopologyProof,
+        replacementProof: UpstreamTopologyProof,
+        rejectedBridgeRecovery: ProcessBridgePoolRecovery?,
+        nowUptimeNs: UInt64
+    ) -> RejectedCancellationRecovery? {
+        state.withLockedValue { state in
+            state.nowUptimeNs = max(state.nowUptimeNs, nowUptimeNs)
+            guard failedProof != replacementProof,
+                  failedProof.slotID == replacementProof.slotID,
+                  replacementProof.slotGeneration == failedProof.slotGeneration &+ 1,
+                  let key = Self.key(routeID: routeID, in: state),
+                  var record = state.recordsByKey[key],
+                  record.route.upstreamIndices.contains(replacementProof.slotID.rawValue) else {
+                return nil
+            }
+
+            if let rejectedBridgeRecovery,
+               rejectedBridgeRecovery.routeID == routeID,
+               rejectedBridgeRecovery.upstreamID == failedProof.slotID,
+               let retry = Self.prepareBridgeRecoveryRetry(
+                   rejectedBridgeRecovery,
+                   owner: &record
+               ) {
+                state.recordsByKey[key] = record
+                return .bridgeRecovery(retry)
+            }
+
+            switch record.bridgeRecovery.phase {
+            case .attempting(let current)
+                where current.upstreamID == replacementProof.slotID:
+                return .preserved(.none)
+            case .waitingRetry(let current, _)
+                where current.upstreamID == replacementProof.slotID:
+                return .preserved(.none)
+            case .idle, .attempting, .waitingRetry:
+                break
+            }
+
+            if let catalog = state.catalogsByProcessID[record.route.target.processID] {
+                if catalog.upstreamProof.slotID == failedProof.slotID,
+                   catalog.upstreamProof != failedProof {
+                    return .preserved(.none)
+                }
+                let effects = Self.requestBridgePoolRecoveryEffects(
+                    upstreamID: replacementProof.slotID,
+                    owner: &record
+                )
+                state.recordsByKey[key] = record
+                return .preserved(ProcessControlPlaneTransition(
+                    addedRoutes: [],
+                    retiredRoutes: [],
+                    effects: effects,
+                    publishesToolsListChanged: false
+                ))
+            }
+
+            if let attempt = record.attempt, attempt.phase != .abandoned {
+                if attempt.upstreamProof == replacementProof {
+                    return .preserved(.none)
+                }
+                if attempt.upstreamProof.slotID != failedProof.slotID {
+                    let effects = Self.requestBridgePoolRecoveryEffects(
+                        upstreamID: replacementProof.slotID,
+                        owner: &record
+                    )
+                    state.recordsByKey[key] = record
+                    return .preserved(ProcessControlPlaneTransition(
+                        addedRoutes: [],
+                        retiredRoutes: [],
+                        effects: effects,
+                        publishesToolsListChanged: false
+                    ))
+                }
+                if attempt.upstreamProof != failedProof {
+                    return .preserved(.none)
+                }
+            }
+
+            let fresh = Self.prepareFreshActivationRetry(
+                upstreamProof: replacementProof,
+                nowUptimeNs: nowUptimeNs,
+                owner: &record
+            )
+            state.recordsByKey[key] = record
+            return .freshActivation(fresh.0, fresh.1, fresh.2)
+        }
+    }
+
     func prepareFreshActivationRetry(
         routeID: ProcessRouteID,
         upstreamProof: UpstreamTopologyProof,
@@ -2166,34 +2255,13 @@ final class ProcessControlPlaneAuthority: Sendable {
                   record.route.upstreamIndices.contains(upstreamProof.slotID.rawValue) else {
                 return nil
             }
-            let effects = record.attempt?.detachedEffects() ?? []
-            let retryOrdinal = max(1, record.nextAttemptID)
-            record.nextAttemptID &+= 1
-            let attempt = Attempt(
-                id: CatalogAttemptID(rawValue: record.nextAttemptID),
+            let fresh = Self.prepareFreshActivationRetry(
                 upstreamProof: upstreamProof,
-                startedAtUptimeNs: nowUptimeNs,
-                phase: .backoff,
-                readinessToken: nil,
-                retryTimeout: nil,
-                retryKind: .activation,
-                nextLoadID: 0,
-                loads: [:]
+                nowUptimeNs: nowUptimeNs,
+                owner: &record
             )
-            record.attempt = attempt
             state.recordsByKey[key] = record
-            return (
-                ActivationLease(
-                    routeID: routeID,
-                    attemptID: attempt.id,
-                    upstreamProof: attempt.upstreamProof
-                ),
-                Self.retry(forAttempt: retryOrdinal),
-                ProcessControlPlaneTransition(
-                    addedRoutes: [], retiredRoutes: [], effects: effects,
-                    publishesToolsListChanged: false
-                )
-            )
+            return fresh
         }
     }
 
@@ -2410,6 +2478,38 @@ final class ProcessControlPlaneAuthority: Sendable {
         return state.recordsByKey[key]
     }
 
+    private static func prepareBridgeRecoveryRetry(
+        _ recovery: ProcessBridgePoolRecovery,
+        owner: inout XcodeProcessOwner
+    ) -> ProcessBridgeRecoveryRetry? {
+        guard case .attempting(let current) = owner.bridgeRecovery.phase,
+              current == recovery else { return nil }
+        owner.bridgeRecovery.consecutiveFailureCount += 1
+        owner.bridgeRecovery.phase = .waitingRetry(recovery, nil)
+        return ProcessBridgeRecoveryRetry(
+            reservation: recovery,
+            delay: owner.bridgeRecovery.consecutiveFailureCount == 1
+                ? .seconds(1)
+                : .seconds(10)
+        )
+    }
+
+    private static func requestBridgePoolRecoveryEffects(
+        upstreamID: UpstreamSlotID,
+        owner: inout XcodeProcessOwner
+    ) -> [ProcessControlPlaneEffect] {
+        switch owner.bridgeRecovery.phase {
+        case .attempting(let current) where current.upstreamID == upstreamID:
+            return []
+        case .waitingRetry(let current, _) where current.upstreamID == upstreamID:
+            return []
+        case .idle, .attempting, .waitingRetry:
+            break
+        }
+        owner.bridgeRecovery.pendingUpstreamIDs.insert(upstreamID)
+        return takeBridgePoolRecoveryEffects(owner: &owner)
+    }
+
     private static func takeBridgePoolRecoveryEffects(
         owner: inout XcodeProcessOwner
     ) -> [ProcessControlPlaneEffect] {
@@ -2428,6 +2528,42 @@ final class ProcessControlPlaneAuthority: Sendable {
         return [
             .restoreBridgePool(recovery)
         ]
+    }
+
+    private static func prepareFreshActivationRetry(
+        upstreamProof: UpstreamTopologyProof,
+        nowUptimeNs: UInt64,
+        owner: inout XcodeProcessOwner
+    ) -> (ActivationLease, Retry, ProcessControlPlaneTransition) {
+        let effects = owner.attempt?.detachedEffects() ?? []
+        let retryOrdinal = max(1, owner.nextAttemptID)
+        owner.nextAttemptID &+= 1
+        let attempt = Attempt(
+            id: CatalogAttemptID(rawValue: owner.nextAttemptID),
+            upstreamProof: upstreamProof,
+            startedAtUptimeNs: nowUptimeNs,
+            phase: .backoff,
+            readinessToken: nil,
+            retryTimeout: nil,
+            retryKind: .activation,
+            nextLoadID: 0,
+            loads: [:]
+        )
+        owner.attempt = attempt
+        return (
+            ActivationLease(
+                routeID: owner.route.id,
+                attemptID: attempt.id,
+                upstreamProof: attempt.upstreamProof
+            ),
+            retry(forAttempt: retryOrdinal),
+            ProcessControlPlaneTransition(
+                addedRoutes: [],
+                retiredRoutes: [],
+                effects: effects,
+                publishesToolsListChanged: false
+            )
+        )
     }
 
     private static func routingSnapshot(

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -293,6 +293,12 @@ final class ProcessControlPlaneAuthority: Sendable {
         let activationLease: ActivationLease
     }
 
+    struct CatalogRequestTimeout: Sendable {
+        let transition: ProcessControlPlaneTransition
+        let retry: Retry
+        let catalogLease: CatalogLease
+    }
+
     struct CooldownLease: Sendable, Hashable {
         let routeID: ProcessRouteID
         let scope: CooldownScope
@@ -308,7 +314,6 @@ final class ProcessControlPlaneAuthority: Sendable {
 
     struct SupportEligibilityResult: Sendable {
         let transition: ProcessControlPlaneTransition
-        let catalogTimeout: AttemptTimeout?
     }
 
     private enum RouteState: String, Sendable {
@@ -794,8 +799,7 @@ final class ProcessControlPlaneAuthority: Sendable {
     func applySupportEligibility(
         usability: UpstreamUsabilitySnapshot,
         newlyIneligibleProofs: Set<UpstreamTopologyProof>,
-        nowUptimeNs: UInt64,
-        catalogTimeoutProof: UpstreamTopologyProof? = nil
+        nowUptimeNs: UInt64
     ) -> SupportEligibilityResult {
         state.withLockedValue { state in
             state.nowUptimeNs = max(state.nowUptimeNs, nowUptimeNs)
@@ -852,17 +856,6 @@ final class ProcessControlPlaneAuthority: Sendable {
                     state.unboundCatalogSource = nil
                 }
             }
-            // Invalidate the timed-out channel's old proof-bound attempt and
-            // catalog first. The timeout transition then creates the fresh
-            // backoff attempt that owns retry; eligibility invalidation must
-            // not immediately abandon that replacement attempt.
-            let catalogTimeout = catalogTimeoutProof.flatMap {
-                Self.handleCatalogChannelTimeout(
-                    upstreamProof: $0,
-                    nowUptimeNs: nowUptimeNs,
-                    state: &state
-                )
-            }
             let projectionChanged = Self.recomputeCanonicalProjection(in: &state)
             return SupportEligibilityResult(
                 transition: ProcessControlPlaneTransition(
@@ -870,8 +863,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                     retiredRoutes: [],
                     effects: effects,
                     publishesToolsListChanged: projectionChanged
-                ),
-                catalogTimeout: catalogTimeout
+                )
             )
         }
     }
@@ -2081,64 +2073,47 @@ final class ProcessControlPlaneAuthority: Sendable {
         )
     }
 
-    private static func handleCatalogChannelTimeout(
+    func handleCatalogRequestTimeout(
+        routeID: ProcessRouteID,
         upstreamProof: UpstreamTopologyProof,
-        nowUptimeNs: UInt64,
-        state: inout State
-    ) -> AttemptTimeout? {
-        state.nowUptimeNs = max(state.nowUptimeNs, nowUptimeNs)
-        let upstreamIndex = upstreamProof.slotID.rawValue
-        guard let key = activeKey(upstreamIndex: upstreamIndex, in: state),
-              var record = state.recordsByKey[key] else { return nil }
-
-        let effects: [ProcessControlPlaneEffect]
-        let retryOrdinal: Int
-        let attempt: Attempt
-        if var current = record.attempt,
-           current.upstreamProof == upstreamProof,
-           [.pending, .attaching, .initialized, .loadingCatalog, .backoff]
-            .contains(current.phase) {
-            effects = current.detachedEffects()
-            retryOrdinal = current.id.rawValue
-            current.readinessToken = nil
-            current.retryTimeout = nil
-            current.retryKind = .activation
-            current.loads.removeAll()
-            current.phase = .backoff
-            attempt = current
-        } else {
-            effects = record.attempt?.detachedEffects() ?? []
-            retryOrdinal = max(1, record.nextAttemptID)
-            record.nextAttemptID &+= 1
-            attempt = Attempt(
-                id: CatalogAttemptID(rawValue: record.nextAttemptID),
-                upstreamProof: upstreamProof,
-                startedAtUptimeNs: nowUptimeNs,
-                phase: .backoff,
-                readinessToken: nil,
-                retryTimeout: nil,
-                retryKind: .activation,
-                nextLoadID: 0,
-                loads: [:]
+        nowUptimeNs: UInt64
+    ) -> CatalogRequestTimeout? {
+        state.withLockedValue { state in
+            state.nowUptimeNs = max(state.nowUptimeNs, nowUptimeNs)
+            guard let key = Self.key(routeID: routeID, in: state),
+                  var record = state.recordsByKey[key],
+                  var attempt = record.attempt,
+                  attempt.upstreamProof == upstreamProof,
+                  attempt.phase == .loadingCatalog,
+                  let loadID = attempt.loads.keys.min(by: {
+                      $0.rawValue < $1.rawValue
+                  }) else {
+                return nil
+            }
+            let effects = attempt.detachedEffects()
+            attempt.readinessToken = nil
+            attempt.retryTimeout = nil
+            attempt.retryKind = .catalog
+            attempt.loads.removeAll()
+            attempt.phase = .backoff
+            record.attempt = attempt
+            state.recordsByKey[key] = record
+            return CatalogRequestTimeout(
+                transition: ProcessControlPlaneTransition(
+                    addedRoutes: [],
+                    retiredRoutes: [],
+                    effects: effects,
+                    publishesToolsListChanged: false
+                ),
+                retry: Self.retry(forAttempt: attempt.id.rawValue),
+                catalogLease: Self.lease(
+                    for: attempt,
+                    loadID: loadID,
+                    routeID: routeID,
+                    catalogEpoch: state.catalogEpoch
+                )
             )
         }
-        record.attempt = attempt
-        state.recordsByKey[key] = record
-        let lease = ActivationLease(
-            routeID: record.route.id,
-            attemptID: attempt.id,
-            upstreamProof: attempt.upstreamProof
-        )
-        return AttemptTimeout(
-            transition: ProcessControlPlaneTransition(
-                addedRoutes: [],
-                retiredRoutes: [],
-                effects: effects,
-                publishesToolsListChanged: false
-            ),
-            retry: retry(forAttempt: retryOrdinal),
-            activationLease: lease
-        )
     }
 
     func handleRetryFired(_ lease: CatalogLease) -> Bool {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -555,14 +555,9 @@ extension RuntimeCoordinator {
         guard cancellationDeliveries.isEmpty else {
             addRuntimeTask { [weak self] in
                 var rejected = false
-                var permitsSameSlotReuse = true
                 for delivery in cancellationDeliveries {
                     let result = await delivery.wait()
-                    guard result.permitsSameSlotReuse else {
-                        permitsSameSlotReuse = false
-                        rejected = rejected || result == .rejected
-                        continue
-                    }
+                    rejected = rejected || result.allowsRetryScheduling == false
                 }
                 guard let self else { return }
                 guard rejected == false else {
@@ -572,7 +567,6 @@ extension RuntimeCoordinator {
                     )
                     return
                 }
-                guard permitsSameSlotReuse else { return }
                 self.armMissingProcessToolsCatalogRetry(
                     processID: processID,
                     lease: lease,
@@ -699,7 +693,7 @@ extension RuntimeCoordinator {
                     "upstream": .string("\(sourceUpstream)"),
                 ]
             )
-            applyCatalogCommit(
+            let cancellationDeliveries = applyCatalogCommit(
                 commitProcessCatalog(
                     .unusable,
                     lease: route.lease,
@@ -709,6 +703,7 @@ extension RuntimeCoordinator {
             scheduleMissingProcessToolsCatalogRetry(
                 processID: route.target.processID,
                 lease: route.lease,
+                after: cancellationDeliveries,
                 reason: "empty_process_catalog"
             )
             return currentCatalogResult(

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -272,7 +272,10 @@ extension RuntimeCoordinator {
         exposedProcessIDs: Set<pid_t>,
         returnAfterFirstSuccess: Bool = true
     ) async throws -> CanonicalToolsCatalogLoadResult {
-        try await withThrowingTaskGroup(
+        for route in routes {
+            scheduleProcessRouteActivationCatalogTimeoutIfNeeded(lease: route.lease)
+        }
+        return try await withThrowingTaskGroup(
             of: AvailableToolsCatalogOutcome.self,
             returning: CanonicalToolsCatalogLoadResult.self
         ) { group in

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -231,10 +231,9 @@ extension RuntimeCoordinator {
         let routes = uncachedExposures.compactMap { exposure -> AvailableToolsCatalogRoute? in
             guard let preferred = exposure.usableUpstreamIDs.first,
                   let preferredProof = upstreamTopology.operationLease(for: preferred)?.proof,
-                  let (lease, transition) = processControlPlane.beginCatalogAttempt(
+                  let (lease, transition) = beginProcessCatalogAttemptIfRunning(
                       routeID: exposure.route.id,
-                      preferredUpstreamProof: preferredProof,
-                      nowUptimeNanoseconds: nowUptimeNanoseconds()
+                      preferredUpstreamProof: preferredProof
                   ) else { return nil }
             applyProcessControlPlaneTransition(transition)
             return AvailableToolsCatalogRoute(
@@ -413,6 +412,7 @@ extension RuntimeCoordinator {
         reason: String,
         processIDs requestedProcessIDs: Set<pid_t>? = nil
     ) {
+        guard initializeManager.snapshot().isShuttingDown == false else { return }
         guard processRoutingEnabled else {
             return
         }
@@ -434,10 +434,9 @@ extension RuntimeCoordinator {
         let missingRoutes = missingExposures.compactMap { exposure -> AvailableToolsCatalogRoute? in
             guard let preferred = exposure.usableUpstreamIDs.first,
                   let preferredProof = upstreamTopology.operationLease(for: preferred)?.proof,
-                  let (lease, transition) = processControlPlane.beginCatalogAttempt(
+                  let (lease, transition) = beginProcessCatalogAttemptIfRunning(
                       routeID: exposure.route.id,
-                      preferredUpstreamProof: preferredProof,
-                      nowUptimeNanoseconds: nowUptimeNanoseconds()
+                      preferredUpstreamProof: preferredProof
                   ) else { return nil }
             applyProcessControlPlaneTransition(transition)
             return AvailableToolsCatalogRoute(
@@ -458,10 +457,9 @@ extension RuntimeCoordinator {
         guard processRoutingEnabled,
               isInitialized(),
               processControlPlane.catalog(forProcessID: route.target.processID) == nil,
-              let (lease, transition) = processControlPlane.beginCatalogAttempt(
+              let (lease, transition) = beginProcessCatalogAttemptIfRunning(
                   routeID: route.id,
-                  preferredUpstreamProof: upstreamProof,
-                  nowUptimeNanoseconds: nowUptimeNanoseconds()
+                  preferredUpstreamProof: upstreamProof
               ) else { return }
         applyProcessControlPlaneTransition(transition)
         refreshProcessToolsCatalogs(
@@ -475,6 +473,24 @@ extension RuntimeCoordinator {
             ],
             reason: reason
         )
+    }
+
+    func beginProcessCatalogAttemptIfRunning(
+        routeID: ProcessRouteID,
+        preferredUpstreamProof: UpstreamTopologyProof
+    ) -> (CatalogLease, ProcessControlPlaneTransition)? {
+        let nowUptimeNanoseconds = nowUptimeNanoseconds()
+        var attempt: (CatalogLease, ProcessControlPlaneTransition)?
+        guard initializeManager.performIfRunning({
+            attempt = processControlPlane.beginCatalogAttempt(
+                routeID: routeID,
+                preferredUpstreamProof: preferredUpstreamProof,
+                nowUptimeNanoseconds: nowUptimeNanoseconds
+            )
+        }) else {
+            return nil
+        }
+        return attempt
     }
 
     private func refreshProcessToolsCatalogs(
@@ -532,7 +548,14 @@ extension RuntimeCoordinator {
         after cancellationDeliveries: [ControlPlane.RPCCancellationDelivery] = [],
         reason: String
     ) {
-        guard let scheduled = processControlPlane.scheduleRetry(lease: lease) else { return }
+        var scheduled: (
+            lease: CatalogLease,
+            retry: ProcessControlPlaneAuthority.Retry,
+            transition: ProcessControlPlaneTransition
+        )?
+        guard initializeManager.performIfRunning({
+            scheduled = processControlPlane.scheduleRetry(lease: lease)
+        }), let scheduled else { return }
         let retryCancellationDeliveries = applyProcessControlPlaneTransition(
             scheduled.transition
         )
@@ -561,10 +584,6 @@ extension RuntimeCoordinator {
                 }
                 guard let self else { return }
                 guard rejected == false else {
-                    self.recoverProcessCatalogAfterRejectedCancellation(
-                        lease: lease,
-                        reason: reason
-                    )
                     return
                 }
                 self.armMissingProcessToolsCatalogRetry(
@@ -581,31 +600,6 @@ extension RuntimeCoordinator {
             lease: lease,
             retry: retry,
             reason: reason
-        )
-    }
-
-    private func recoverProcessCatalogAfterRejectedCancellation(
-        lease: CatalogLease,
-        reason: String
-    ) {
-        logger.warning(
-            "Process catalog cancellation was rejected; replacing its upstream channel",
-            metadata: [
-                "pid": .string("\(lease.processID)"),
-                "upstream": .string("\(lease.upstreamIndex)"),
-                "reason": .string(reason),
-            ]
-        )
-        guard clearUpstreamState(
-            proof: lease.topologyProof,
-            resetsProcessRouteActivation: false
-        ) else {
-            return
-        }
-        _ = replaceOrRetireInitializeChannel(
-            lease.topologyProof,
-            expectedRouteID: lease.routeIdentity,
-            requestsBridgePoolRecovery: false
         )
     }
 
@@ -640,9 +634,14 @@ extension RuntimeCoordinator {
                 processIDs: [processID]
             )
         }
-        applyProcessControlPlaneTransition(
-            processControlPlane.attach(.retryTimeout(timeout), to: lease)
-        )
+        var transition = ProcessControlPlaneTransition.none
+        guard initializeManager.performIfRunning({
+            transition = processControlPlane.attach(.retryTimeout(timeout), to: lease)
+        }) else {
+            timeout.cancel()
+            return
+        }
+        applyProcessControlPlaneTransition(transition)
     }
 
     private func availableToolsCatalogSurfaceResult(
@@ -986,6 +985,7 @@ extension RuntimeCoordinator {
         guard let originalID = JSONRPC.Message.Inspector.requestID(from: requestObject) else {
             throw ControlPlane.Error.invalidResponse("missing request id")
         }
+        let rpcHandle = rpcHandle ?? ControlPlane.RPCHandle()
         let requestTemplate = requestObject.reduce(into: [String: JSONValue]()) { partial, entry in
             if entry.key == "id" { return }
             if let value = JSONValue(any: entry.value) {
@@ -1006,7 +1006,7 @@ extension RuntimeCoordinator {
             case .pinnedUpstream(let upstreamIndex):
                 upstreamIndex
             }
-        rpcHandle?.installCancelWithDelivery {
+        rpcHandle.installCancelWithDelivery {
             [self, router] snapshot, cancellationDelivery in
             if let registrationToken = snapshot.registrationToken {
                 _ = router.cancelPending(token: registrationToken)
@@ -1042,7 +1042,7 @@ extension RuntimeCoordinator {
                 cancellationDelivery.complete(.rejected)
             }
         }
-        if rpcHandle?.isCancelled() == true {
+        if rpcHandle.isCancelled() {
             throw CancellationError()
         }
 
@@ -1055,7 +1055,7 @@ extension RuntimeCoordinator {
                 preferredUpstreamIndex: preferredUpstreamIndex
             ) { [self, requestTemplate, originalID] selectedOperationLease in
                 let selectedUpstreamIndex = selectedOperationLease.upstreamIndex
-                if rpcHandle?.isCancelled() == true {
+                if rpcHandle.isCancelled() {
                     return self.eventLoop.makeFailedFuture(CancellationError())
                 }
                 let upstreamRequestTimeout = self.timeAmount(until: requestDeadlineUptimeNs)
@@ -1078,19 +1078,10 @@ extension RuntimeCoordinator {
                     on: self.eventLoop,
                     timeout: upstreamRequestTimeout,
                     onTimeout: {
-                        if let rpcHandle {
-                            rpcHandle.cancel(cause: .timedOut)
-                        } else {
-                            self.handleRequestLeaseTimeout(
-                                leaseID,
-                                sessionID: internalSessionID,
-                                requestIDKeys: [originalID.key],
-                                operationLease: selectedOperationLease
-                            )
-                        }
+                        rpcHandle.cancel(cause: .timedOut)
                     }
                 )
-                if rpcHandle?.markRegistered(
+                if rpcHandle.markRegistered(
                     registrationToken: registration.token,
                     operationLease: selectedOperationLease
                 ) == false {
@@ -1125,7 +1116,8 @@ extension RuntimeCoordinator {
                         UpstreamSlotScheduler.AcquisitionError.unavailable
                     )
                 }
-                if rpcHandle?.markAssigned(
+                self.testHooks.controlPlaneRPCAssignedUpstreamID?()
+                if rpcHandle.markAssigned(
                     registrationToken: registration.token,
                     operationLease: selectedOperationLease,
                     requestIDKey: originalID.key
@@ -1144,12 +1136,20 @@ extension RuntimeCoordinator {
                     )
                     return self.eventLoop.makeFailedFuture(CancellationError())
                 }
-                let requestSendCompletion = rpcHandle?.requestSendCompletion()
+                guard let requestSendCompletion = rpcHandle.requestSendCompletion() else {
+                    preconditionFailure("assigned RPC must own request send completion")
+                }
                 var upstreamObject = requestTemplate.mapValues(\.foundationObject)
                 upstreamObject["id"] = upstreamID
                 guard let requestData = try? JSONRPC.Wire.data(from: upstreamObject)
                 else {
-                    requestSendCompletion?.signal()
+                    requestSendCompletion.complete(.notSent)
+                    _ = session.router.cancelPending(token: registration.token)
+                    self.removeUpstreamIDMapping(
+                        sessionID: internalSessionID,
+                        requestIDKey: originalID.key,
+                        operationLease: selectedOperationLease
+                    )
                     self.failRequestLease(
                         leaseID,
                         terminalState: .failed,
@@ -1165,8 +1165,8 @@ extension RuntimeCoordinator {
                         )
                     )
                 }
-                if rpcHandle?.isCancelled() == true {
-                    requestSendCompletion?.signal()
+                if rpcHandle.isCancelled() {
+                    requestSendCompletion.complete(.notSent)
                     _ = session.router.cancelPending(token: registration.token)
                     self.removeUpstreamIDMapping(
                         sessionID: internalSessionID,
@@ -1190,6 +1190,11 @@ extension RuntimeCoordinator {
                     requestSendCompletion: requestSendCompletion,
                     onRejected: {
                         _ = session.router.cancelPending(token: registration.token)
+                        self.removeUpstreamIDMapping(
+                            sessionID: internalSessionID,
+                            requestIDKey: originalID.key,
+                            operationLease: selectedOperationLease
+                        )
                     }
                 )
                 guard sent else {
@@ -1198,7 +1203,8 @@ extension RuntimeCoordinator {
                         leaseID,
                         sessionID: internalSessionID,
                         requestIDKeys: [originalID.key],
-                        operationLease: selectedOperationLease
+                        operationLease: selectedOperationLease,
+                        after: requestSendCompletion
                     )
                     return self.eventLoop.makeFailedFuture(
                         UpstreamSlotScheduler.AcquisitionError.unavailable
@@ -1221,7 +1227,7 @@ extension RuntimeCoordinator {
                     )
                 }
             }
-            if rpcHandle?.isCancelled() == true {
+            if rpcHandle.isCancelled() {
                 abandonRequestLease(
                     leaseID,
                     sessionID: internalSessionID,
@@ -1234,11 +1240,11 @@ extension RuntimeCoordinator {
                     future,
                     deadlineUptimeNs: requestDeadlineUptimeNs,
                     onTimeout: {
-                        rpcHandle?.cancel(cause: .timedOut)
+                        rpcHandle.cancel(cause: .timedOut)
                     }
                 )
             } onCancel: {
-                rpcHandle?.cancel()
+                rpcHandle.cancel()
             }
             let responseObject = try extractJSONRPCResponseObject(from: response.responseData)
             let isProxyUpstreamFailure = responseIsProxyUpstreamFailure(responseObject)
@@ -1267,7 +1273,7 @@ extension RuntimeCoordinator {
             } else {
                 responseData = response.responseData
             }
-            rpcHandle?.markFinished()
+            rpcHandle.markFinished()
             if !isProxyUpstreamFailure {
                 markRequestSucceeded(response.operationLease)
             }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -812,14 +812,14 @@ extension RuntimeCoordinator {
     ) async throws -> CanonicalToolsCatalogLoadResult {
         var lastFailure: (upstreamIndex: Int, error: any Error)?
         for upstreamIndex in route.upstreamIndices {
-            let rpcHandle = ControlPlane.RPCHandle()
-            applyProcessControlPlaneTransition(
-                processControlPlane.attach(.rpc(rpcHandle), to: route.lease)
-            )
             let routeTimeout = timeAmount(until: deadlineUptimeNs) ?? requestTimeout
             if routeTimeout?.nanoseconds == 0 {
                 throw TimeoutError()
             }
+            let rpcHandle = ControlPlane.RPCHandle()
+            applyProcessControlPlaneTransition(
+                processControlPlane.attach(.rpc(rpcHandle), to: route.lease)
+            )
             do {
                 // First-success catalog loads cancel sibling routes; the route-level
                 // handle must release queued or in-flight fallback RPCs.
@@ -1009,7 +1009,7 @@ extension RuntimeCoordinator {
             case .pinnedUpstream(let upstreamIndex):
                 upstreamIndex
             }
-        rpcHandle.installCancelWithDelivery {
+        let installedCancellationHandler = rpcHandle.installCancelWithDelivery {
             [self, router] snapshot, cancellationDelivery in
             if let registrationToken = snapshot.registrationToken {
                 _ = router.cancelPending(token: registrationToken)
@@ -1044,6 +1044,15 @@ extension RuntimeCoordinator {
             if scheduled == false {
                 cancellationDelivery.complete(.rejected)
             }
+        }
+        guard installedCancellationHandler else {
+            abandonRequestLease(
+                leaseID,
+                sessionID: internalSessionID,
+                requestIDKeys: [originalID.key],
+                operationLease: nil
+            )
+            throw CancellationError()
         }
         if rpcHandle.isCancelled() {
             throw CancellationError()

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -325,11 +325,19 @@ extension RuntimeCoordinator {
                             }
                             return .stale
                         }
-                        self.applyCatalogCommit(self.commitProcessCatalog(
-                            .failed,
+                        let cancellationDeliveries = self.applyCatalogCommit(
+                            self.commitProcessCatalog(
+                                .unusable,
+                                lease: route.lease,
+                                nowUptimeNanoseconds: self.nowUptimeNanoseconds()
+                            )
+                        )
+                        self.scheduleMissingProcessToolsCatalogRetry(
+                            processID: route.target.processID,
                             lease: route.lease,
-                            nowUptimeNanoseconds: self.nowUptimeNanoseconds()
-                        ))
+                            after: cancellationDeliveries,
+                            reason: "process_catalog_timeout"
+                        )
                         throw TimeoutError()
                     } catch {
                         let commit = self.commitProcessCatalog(
@@ -521,25 +529,72 @@ extension RuntimeCoordinator {
     func scheduleMissingProcessToolsCatalogRetry(
         processID: pid_t,
         lease: CatalogLease,
+        after cancellationDeliveries: [AsyncTerminalSignal] = [],
         reason: String
     ) {
         guard let scheduled = processControlPlane.scheduleRetry(lease: lease) else { return }
-        applyProcessControlPlaneTransition(scheduled.transition)
-        let delay = scheduled.retry.delay
+        let retryCancellationDeliveries = applyProcessControlPlaneTransition(
+            scheduled.transition
+        )
+        scheduleMissingProcessToolsCatalogRetry(
+            processID: processID,
+            lease: scheduled.lease,
+            retry: scheduled.retry,
+            after: cancellationDeliveries + retryCancellationDeliveries,
+            reason: reason
+        )
+    }
+
+    func scheduleMissingProcessToolsCatalogRetry(
+        processID: pid_t,
+        lease: CatalogLease,
+        retry: ProcessControlPlaneAuthority.Retry,
+        after cancellationDeliveries: [AsyncTerminalSignal],
+        reason: String
+    ) {
+        guard cancellationDeliveries.isEmpty else {
+            addRuntimeTask { [weak self] in
+                for delivery in cancellationDeliveries {
+                    await delivery.wait()
+                }
+                self?.armMissingProcessToolsCatalogRetry(
+                    processID: processID,
+                    lease: lease,
+                    retry: retry,
+                    reason: reason
+                )
+            }
+            return
+        }
+        armMissingProcessToolsCatalogRetry(
+            processID: processID,
+            lease: lease,
+            retry: retry,
+            reason: reason
+        )
+    }
+
+    private func armMissingProcessToolsCatalogRetry(
+        processID: pid_t,
+        lease: CatalogLease,
+        retry: ProcessControlPlaneAuthority.Retry,
+        reason: String
+    ) {
+        let delay = retry.delay
         logger.debug(
             "Scheduling missing process tools/list catalog retry",
             metadata: [
                 "pid": .string("\(processID)"),
-                "delay_ms": .string("\(scheduled.retry.delayMilliseconds)"),
+                "delay_ms": .string("\(retry.delayMilliseconds)"),
                 "reason": .string(reason),
             ]
         )
         let timeout = scheduleRuntimeTimeout(delay) { [weak self] in
             guard let self else { return }
-            guard self.processControlPlane.handleRetryFired(scheduled.lease),
+            guard self.processControlPlane.handleRetryFired(lease),
                   self.processRoutingEnabled,
                   self.xcodeProcessRoutes.contains(where: {
-                      $0.id == scheduled.lease.routeIdentity
+                      $0.id == lease.routeIdentity
                   }),
                   self.processControlPlane.catalog(forProcessID: processID) == nil
             else {
@@ -551,7 +606,7 @@ extension RuntimeCoordinator {
             )
         }
         applyProcessControlPlaneTransition(
-            processControlPlane.attach(.retryTimeout(timeout), to: scheduled.lease)
+            processControlPlane.attach(.retryTimeout(timeout), to: lease)
         )
     }
 
@@ -915,25 +970,39 @@ extension RuntimeCoordinator {
             case .pinnedUpstream(let upstreamIndex):
                 upstreamIndex
             }
-        rpcHandle?.installCancel { [self, router] snapshot in
+        rpcHandle?.installCancelWithDelivery {
+            [self, router] snapshot, cancellationDelivery in
             if let registrationToken = snapshot.registrationToken {
                 _ = router.cancelPending(token: registrationToken)
             }
             let requestIDKeys = snapshot.requestIDKey.map { [$0] } ?? [originalID.key]
-            if let operationLease = snapshot.operationLease {
-                self.abandonRequestLease(
+            let upstreamDelivery: AsyncTerminalSignal?
+            switch snapshot.cause {
+            case .cancelled:
+                upstreamDelivery = self.abandonRequestLeaseWithCancellationDelivery(
                     leaseID,
                     sessionID: internalSessionID,
                     requestIDKeys: requestIDKeys,
-                    operationLease: operationLease
+                    operationLease: snapshot.operationLease
                 )
-            } else {
-                self.abandonRequestLease(
+            case .timedOut:
+                upstreamDelivery = self.handleRequestLeaseTimeoutWithCancellationDelivery(
                     leaseID,
                     sessionID: internalSessionID,
                     requestIDKeys: requestIDKeys,
-                    operationLease: nil
+                    operationLease: snapshot.operationLease
                 )
+            }
+            guard let upstreamDelivery else {
+                cancellationDelivery.signal()
+                return
+            }
+            let scheduled = self.addRuntimeTask {
+                await upstreamDelivery.wait()
+                cancellationDelivery.signal()
+            }
+            if scheduled == false {
+                cancellationDelivery.signal()
             }
         }
         if rpcHandle?.isCancelled() == true {
@@ -972,12 +1041,16 @@ extension RuntimeCoordinator {
                     on: self.eventLoop,
                     timeout: upstreamRequestTimeout,
                     onTimeout: {
-                        self.handleRequestLeaseTimeout(
-                            leaseID,
-                            sessionID: internalSessionID,
-                            requestIDKeys: [originalID.key],
-                            operationLease: selectedOperationLease
-                        )
+                        if let rpcHandle {
+                            rpcHandle.cancel(cause: .timedOut)
+                        } else {
+                            self.handleRequestLeaseTimeout(
+                                leaseID,
+                                sessionID: internalSessionID,
+                                requestIDKeys: [originalID.key],
+                                operationLease: selectedOperationLease
+                            )
+                        }
                     }
                 )
                 if rpcHandle?.markRegistered(
@@ -1120,7 +1193,7 @@ extension RuntimeCoordinator {
                     future,
                     deadlineUptimeNs: requestDeadlineUptimeNs,
                     onTimeout: {
-                        rpcHandle?.cancel()
+                        rpcHandle?.cancel(cause: .timedOut)
                     }
                 )
             } onCancel: {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+ControlPlane.swift
@@ -529,7 +529,7 @@ extension RuntimeCoordinator {
     func scheduleMissingProcessToolsCatalogRetry(
         processID: pid_t,
         lease: CatalogLease,
-        after cancellationDeliveries: [AsyncTerminalSignal] = [],
+        after cancellationDeliveries: [ControlPlane.RPCCancellationDelivery] = [],
         reason: String
     ) {
         guard let scheduled = processControlPlane.scheduleRetry(lease: lease) else { return }
@@ -549,15 +549,31 @@ extension RuntimeCoordinator {
         processID: pid_t,
         lease: CatalogLease,
         retry: ProcessControlPlaneAuthority.Retry,
-        after cancellationDeliveries: [AsyncTerminalSignal],
+        after cancellationDeliveries: [ControlPlane.RPCCancellationDelivery],
         reason: String
     ) {
         guard cancellationDeliveries.isEmpty else {
             addRuntimeTask { [weak self] in
+                var rejected = false
+                var permitsSameSlotReuse = true
                 for delivery in cancellationDeliveries {
-                    await delivery.wait()
+                    let result = await delivery.wait()
+                    guard result.permitsSameSlotReuse else {
+                        permitsSameSlotReuse = false
+                        rejected = rejected || result == .rejected
+                        continue
+                    }
                 }
-                self?.armMissingProcessToolsCatalogRetry(
+                guard let self else { return }
+                guard rejected == false else {
+                    self.recoverProcessCatalogAfterRejectedCancellation(
+                        lease: lease,
+                        reason: reason
+                    )
+                    return
+                }
+                guard permitsSameSlotReuse else { return }
+                self.armMissingProcessToolsCatalogRetry(
                     processID: processID,
                     lease: lease,
                     retry: retry,
@@ -571,6 +587,31 @@ extension RuntimeCoordinator {
             lease: lease,
             retry: retry,
             reason: reason
+        )
+    }
+
+    private func recoverProcessCatalogAfterRejectedCancellation(
+        lease: CatalogLease,
+        reason: String
+    ) {
+        logger.warning(
+            "Process catalog cancellation was rejected; replacing its upstream channel",
+            metadata: [
+                "pid": .string("\(lease.processID)"),
+                "upstream": .string("\(lease.upstreamIndex)"),
+                "reason": .string(reason),
+            ]
+        )
+        guard clearUpstreamState(
+            proof: lease.topologyProof,
+            resetsProcessRouteActivation: false
+        ) else {
+            return
+        }
+        _ = replaceOrRetireInitializeChannel(
+            lease.topologyProof,
+            expectedRouteID: lease.routeIdentity,
+            requestsBridgePoolRecovery: false
         )
     }
 
@@ -976,33 +1017,34 @@ extension RuntimeCoordinator {
                 _ = router.cancelPending(token: registrationToken)
             }
             let requestIDKeys = snapshot.requestIDKey.map { [$0] } ?? [originalID.key]
-            let upstreamDelivery: AsyncTerminalSignal?
+            let upstreamDelivery: ControlPlane.RPCCancellationDelivery?
             switch snapshot.cause {
             case .cancelled:
                 upstreamDelivery = self.abandonRequestLeaseWithCancellationDelivery(
                     leaseID,
                     sessionID: internalSessionID,
                     requestIDKeys: requestIDKeys,
-                    operationLease: snapshot.operationLease
+                    operationLease: snapshot.operationLease,
+                    after: snapshot.requestSendCompletion
                 )
             case .timedOut:
                 upstreamDelivery = self.handleRequestLeaseTimeoutWithCancellationDelivery(
                     leaseID,
                     sessionID: internalSessionID,
                     requestIDKeys: requestIDKeys,
-                    operationLease: snapshot.operationLease
+                    operationLease: snapshot.operationLease,
+                    after: snapshot.requestSendCompletion
                 )
             }
             guard let upstreamDelivery else {
-                cancellationDelivery.signal()
+                cancellationDelivery.complete(.noLongerApplicable)
                 return
             }
             let scheduled = self.addRuntimeTask {
-                await upstreamDelivery.wait()
-                cancellationDelivery.signal()
+                cancellationDelivery.complete(await upstreamDelivery.wait())
             }
             if scheduled == false {
-                cancellationDelivery.signal()
+                cancellationDelivery.complete(.rejected)
             }
         }
         if rpcHandle?.isCancelled() == true {
@@ -1107,10 +1149,12 @@ extension RuntimeCoordinator {
                     )
                     return self.eventLoop.makeFailedFuture(CancellationError())
                 }
+                let requestSendCompletion = rpcHandle?.requestSendCompletion()
                 var upstreamObject = requestTemplate.mapValues(\.foundationObject)
                 upstreamObject["id"] = upstreamID
                 guard let requestData = try? JSONRPC.Wire.data(from: upstreamObject)
                 else {
+                    requestSendCompletion?.signal()
                     self.failRequestLease(
                         leaseID,
                         terminalState: .failed,
@@ -1127,6 +1171,7 @@ extension RuntimeCoordinator {
                     )
                 }
                 if rpcHandle?.isCancelled() == true {
+                    requestSendCompletion?.signal()
                     _ = session.router.cancelPending(token: registration.token)
                     self.removeUpstreamIDMapping(
                         sessionID: internalSessionID,
@@ -1147,6 +1192,7 @@ extension RuntimeCoordinator {
                     operationLease: selectedOperationLease,
                     ensureRunning: false,
                     admission: nil,
+                    requestSendCompletion: requestSendCompletion,
                     onRejected: {
                         _ = session.router.cancelPending(token: registration.token)
                     }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -319,12 +319,7 @@ extension RuntimeCoordinator {
         let proof = probe.topologyProof
         var verification: (
             recovery: ProcessBridgePoolRecovery,
-            cleared: (
-                timeout: RuntimeScheduledTimeout?,
-                initUpstreamID: Int64?,
-                didReceiveInitializeResponse: Bool,
-                didSendInitialized: Bool
-            )?
+            cleared: UpstreamHealthManager.ClearedUpstreamState?
         )?
         var bridgeCompletion: ProcessControlPlaneTransition?
         var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
@@ -418,12 +413,7 @@ extension RuntimeCoordinator {
         let proof = probe.topologyProof
         var verification: (
             recovery: ProcessBridgePoolRecovery,
-            cleared: (
-                timeout: RuntimeScheduledTimeout?,
-                initUpstreamID: Int64?,
-                didReceiveInitializeResponse: Bool,
-                didSendInitialized: Bool
-            )?
+            cleared: UpstreamHealthManager.ClearedUpstreamState?
         )?
         var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
         let eligibility = initializeManager.finishSupportEligibilityUpdate {
@@ -670,6 +660,7 @@ extension RuntimeCoordinator {
         applyBackoff: Bool = false,
         mode: WarmInitializeMode = .regular
     ) {
+        guard initializeManager.snapshot().isShuttingDown == false else { return }
         guard isActiveProcessBoundUpstream(upstreamIndex) else { return }
         runWhenUpstreamReady(
             reason: "warm_initialize_\(upstreamIndex)",
@@ -687,7 +678,23 @@ extension RuntimeCoordinator {
         upstreamIndex: Int,
         mode: WarmInitializeMode
     ) {
+        guard initializeManager.snapshot().isShuttingDown == false else { return }
         guard isActiveProcessBoundUpstream(upstreamIndex) else { return }
+        guard let operationLease = upstreamTopology.operationLease(
+            for: UpstreamSlotID(rawValue: upstreamIndex)
+        ) else { return }
+        if deferInitializeUntilUpstreamActivatable(
+            operationLease,
+            resume: { [weak self] in
+                self?.startUpstreamWarmInitializeWhenReady(
+                    upstreamIndex: upstreamIndex,
+                    mode: mode
+                )
+            }
+        ) {
+            return
+        }
+        let proof = operationLease.proof
         if case .processBridgeRecovery(let recovery) = mode {
             guard processControlPlane.validateBridgeRecovery(recovery.reservation),
                   recovery.topologyProof.slotID.rawValue == upstreamIndex,
@@ -717,10 +724,16 @@ extension RuntimeCoordinator {
             )
             return
         }
-        guard let initializeClaim = upstreamHealthManager.claimWarmInitialize(
-            upstreamIndex: upstreamIndex,
-            owner: mode.claimOwner
-        ) else {
+        var initializeClaim: UpstreamHealthManager.InitializeClaim?
+        guard initializeManager.performIfRunning({
+            initializeClaim = upstreamHealthManager.claimWarmInitialize(
+                topologyProof: proof,
+                owner: mode.claimOwner
+            )
+        }) else {
+            return
+        }
+        guard let initializeClaim else {
             if let activationStart {
                 applyProcessControlPlaneTransition(
                     processControlPlane.cancelActivation(activationStart)
@@ -734,9 +747,7 @@ extension RuntimeCoordinator {
             }
             return
         }
-        guard let proof = initializeClaim.topologyProof,
-              let operationLease = upstreamTopology.operationLease(for: proof),
-              let upstreamID = upstreamRouter.assignInitialize(proof: proof) else {
+        guard let upstreamID = upstreamRouter.assignInitialize(proof: proof) else {
             handleWarmInitializeStartFailure(
                 mode: mode,
                 initializeClaim: initializeClaim,
@@ -895,11 +906,13 @@ extension RuntimeCoordinator {
                 return
             }
         }
-        let attachment = upstreamHealthManager.replaceInitTimeout(
-            timeout,
-            for: initializeClaim
-        )
-        guard attachment.accepted else {
+        var attachment: UpstreamHealthManager.TimeoutAttachment?
+        guard initializeManager.performIfRunning({
+            attachment = upstreamHealthManager.replaceInitTimeout(
+                timeout,
+                for: initializeClaim
+            )
+        }), let attachment, attachment.accepted else {
             timeout.cancel()
             return
         }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -934,7 +934,7 @@ extension RuntimeCoordinator {
     func handleUpstreamInitTimeout(
         initializeClaim: UpstreamHealthManager.InitializeClaim
     ) {
-        guard clearUpstreamState(initializeClaim: initializeClaim) else { return }
+        guard timeoutUpstreamInitialize(initializeClaim: initializeClaim) else { return }
         let upstreamIndex = initializeClaim.upstreamIndex
 
         if isCurrentPrimaryInitializeUpstream(upstreamIndex) {
@@ -955,10 +955,10 @@ extension RuntimeCoordinator {
         guard case .processBridgeRecovery(let claimedRecovery) = initializeClaim.owner,
               claimedRecovery == recovery,
               initializeClaim.topologyProof == recovery.topologyProof,
-              clearUpstreamState(
-                initializeClaim: initializeClaim,
-                resetsProcessRouteActivation: false,
-                replacesInitializedChannel: false
+              timeoutUpstreamInitialize(
+                  initializeClaim: initializeClaim,
+                  resetsProcessRouteActivation: false,
+                  replacesInitializedChannel: false
               )
         else { return }
         logger.info(

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -1119,7 +1119,6 @@ extension RuntimeCoordinator {
     func commitSupportEligibilityAfterHealthMutation(
         topologySnapshot: UpstreamTopologyAuthority.Snapshot,
         detachedProof: UpstreamTopologyProof?,
-        catalogTimeoutProof: UpstreamTopologyProof? = nil,
         processEligibility: inout ProcessControlPlaneAuthority.SupportEligibilityResult?
     ) -> CanonicalHandshakeState.SupportEligibilityUpdate {
         let authoritativeProofs = Set(topologySnapshot.entries.map { $0.operationLease.proof })
@@ -1146,8 +1145,7 @@ extension RuntimeCoordinator {
                     recoveryAwareUsableUpstreamIDs: usableIDs
                 ),
                 newlyIneligibleProofs: update.newlyIneligibleProofs,
-                nowUptimeNs: nowUptimeNanoseconds(),
-                catalogTimeoutProof: catalogTimeoutProof
+                nowUptimeNs: nowUptimeNanoseconds()
             )
             return update
         }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -103,10 +103,21 @@ extension RuntimeCoordinator {
             )
             return
         }
+        guard let operationLease = upstreamTopology.operationLease(
+            for: UpstreamSlotID(rawValue: upstreamIndex)
+        ) else { return }
+        if deferInitializeUntilUpstreamActivatable(
+            operationLease,
+            resume: { [weak self] in
+                self?.sendPrimaryInitializeRequestIfStillPending()
+            }
+        ) {
+            return
+        }
+        let proof = operationLease.proof
         guard let initializeClaim = upstreamHealthManager.claimWarmInitialize(
-            upstreamIndex: upstreamIndex
-        ), let proof = initializeClaim.topologyProof,
-           let operationLease = upstreamTopology.operationLease(for: proof),
+            topologyProof: proof
+        ),
            let upstreamID = upstreamRouter.assignInitialize(proof: proof) else {
             return
         }
@@ -1003,12 +1014,19 @@ extension RuntimeCoordinator {
         expectedUpstreamID: Int64? = nil,
         resetsProcessRouteActivation: Bool = true
     ) -> Bool {
-        var cleared: (
-            timeout: RuntimeScheduledTimeout?,
-            initUpstreamID: Int64?,
-            didReceiveInitializeResponse: Bool,
-            didSendInitialized: Bool
-        )?
+        clearUpstreamStateReturningDetachedState(
+            proof: proof,
+            expectedUpstreamID: expectedUpstreamID,
+            resetsProcessRouteActivation: resetsProcessRouteActivation
+        ) != nil
+    }
+
+    func clearUpstreamStateReturningDetachedState(
+        proof: UpstreamTopologyProof,
+        expectedUpstreamID: Int64? = nil,
+        resetsProcessRouteActivation: Bool = true
+    ) -> UpstreamHealthManager.ClearedUpstreamState? {
+        var cleared: UpstreamHealthManager.ClearedUpstreamState?
         var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
         let eligibility = initializeManager.finishSupportEligibilityUpdate {
             var update: CanonicalHandshakeState.SupportEligibilityUpdate?
@@ -1027,7 +1045,7 @@ extension RuntimeCoordinator {
             }) == true else { return nil }
             return update
         }
-        guard let cleared, let eligibility, let processEligibility else { return false }
+        guard let cleared, let eligibility, let processEligibility else { return nil }
         applyProcessControlPlaneTransition(processEligibility.transition)
         applySupportEligibilityCompletion(eligibility)
         finishClearingUpstreamState(
@@ -1035,7 +1053,7 @@ extension RuntimeCoordinator {
             cleared: cleared,
             resetsProcessRouteActivation: resetsProcessRouteActivation
         )
-        return true
+        return cleared
     }
 
     @discardableResult
@@ -1045,12 +1063,7 @@ extension RuntimeCoordinator {
         replacesInitializedChannel: Bool = true
     ) -> Bool {
         guard let proof = initializeClaim.topologyProof else { return false }
-        var cleared: (
-            timeout: RuntimeScheduledTimeout?,
-            initUpstreamID: Int64?,
-            didReceiveInitializeResponse: Bool,
-            didSendInitialized: Bool
-        )?
+        var cleared: UpstreamHealthManager.ClearedUpstreamState?
         var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
         let eligibility = initializeManager.finishSupportEligibilityUpdate {
             var update: CanonicalHandshakeState.SupportEligibilityUpdate?
@@ -1091,12 +1104,7 @@ extension RuntimeCoordinator {
 
     func finishClearingUpstreamState(
         proof: UpstreamTopologyProof,
-        cleared: (
-            timeout: RuntimeScheduledTimeout?,
-            initUpstreamID: Int64?,
-            didReceiveInitializeResponse: Bool,
-            didSendInitialized: Bool
-        ),
+        cleared: UpstreamHealthManager.ClearedUpstreamState,
         resetsProcessRouteActivation: Bool
     ) {
         let upstreamIndex = proof.slotID.rawValue

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Initialization.swift
@@ -1062,14 +1062,42 @@ extension RuntimeCoordinator {
         resetsProcessRouteActivation: Bool = true,
         replacesInitializedChannel: Bool = true
     ) -> Bool {
+        clearUpstreamState(
+            initializeClaim: initializeClaim,
+            resetsProcessRouteActivation: resetsProcessRouteActivation,
+            replacesInitializedChannel: replacesInitializedChannel,
+            clearClaim: upstreamHealthManager.clearInitializeClaim
+        )
+    }
+
+    @discardableResult
+    func timeoutUpstreamInitialize(
+        initializeClaim: UpstreamHealthManager.InitializeClaim,
+        resetsProcessRouteActivation: Bool = true,
+        replacesInitializedChannel: Bool = true
+    ) -> Bool {
+        clearUpstreamState(
+            initializeClaim: initializeClaim,
+            resetsProcessRouteActivation: resetsProcessRouteActivation,
+            replacesInitializedChannel: replacesInitializedChannel,
+            clearClaim: upstreamHealthManager.timeoutInitializeClaim
+        )
+    }
+
+    private func clearUpstreamState(
+        initializeClaim: UpstreamHealthManager.InitializeClaim,
+        resetsProcessRouteActivation: Bool,
+        replacesInitializedChannel: Bool,
+        clearClaim: (UpstreamHealthManager.InitializeClaim)
+            -> UpstreamHealthManager.ClearedUpstreamState?
+    ) -> Bool {
         guard let proof = initializeClaim.topologyProof else { return false }
         var cleared: UpstreamHealthManager.ClearedUpstreamState?
         var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
         let eligibility = initializeManager.finishSupportEligibilityUpdate {
             var update: CanonicalHandshakeState.SupportEligibilityUpdate?
             guard upstreamTopology.withValidatedSnapshot(proof, { topologySnapshot in
-                guard let result = upstreamHealthManager.clearInitializeClaim(initializeClaim)
-                else { return false }
+                guard let result = clearClaim(initializeClaim) else { return false }
                 cleared = result
                 update = commitSupportEligibilityAfterHealthMutation(
                     topologySnapshot: topologySnapshot,

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Readiness.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Readiness.swift
@@ -29,11 +29,7 @@ extension RuntimeCoordinator {
     func startAllUpstreamSlots() {
         let snapshot = upstreamTopology.snapshot()
         for entry in snapshot.entries {
-            guard let proof = snapshot.proof(entry.id) else { continue }
-            addRuntimeTask { [weak self, entry, proof] in
-                guard let self, self.upstreamTopology.validate(proof) else { return }
-                await entry.slot.start()
-            }
+            startUpstreamSlot(entry.operationLease)
         }
     }
 
@@ -42,12 +38,57 @@ extension RuntimeCoordinator {
     }
 
     func startUpstreamSlot(_ upstreamIndex: Int) {
-        guard let context = upstreamSlotContext(upstreamIndex) else { return }
-        addRuntimeTask { [weak self, context] in
-            guard let self, self.upstreamTopology.validate(context.proof) else { return }
-            let upstream = context.slot
-            await upstream.start()
+        guard let operationLease = upstreamTopology.operationLease(
+            for: UpstreamSlotID(rawValue: upstreamIndex)
+        ) else { return }
+        startUpstreamSlot(operationLease)
+    }
+
+    private func startUpstreamSlot(_ operationLease: UpstreamOperationLease) {
+        addRuntimeTask { [weak self, operationLease] in
+            guard let self,
+                  await self.waitUntilUpstreamOperationActivatable(operationLease)
+            else { return }
+            await operationLease.slot.start()
         }
+    }
+
+    func retireUpstreamSlot(
+        _ slot: any UpstreamSlotControlling,
+        onStopped: @escaping @Sendable () -> Void = {}
+    ) {
+        let retirement: @Sendable () async -> Void = {
+            await slot.stop()
+            onStopped()
+        }
+        if upstreamRetirementTasks.run(retirement) == false {
+            Task.detached(operation: retirement)
+        }
+    }
+
+    func waitUntilUpstreamOperationActivatable(
+        _ operationLease: UpstreamOperationLease
+    ) async -> Bool {
+        if let completion = operationLease.predecessorStopCompletion {
+            await completion.wait()
+        }
+        guard Task.isCancelled == false else { return false }
+        return upstreamTopology.validate(operationLease)
+    }
+
+    func deferInitializeUntilUpstreamActivatable(
+        _ operationLease: UpstreamOperationLease,
+        resume: @escaping @Sendable () -> Void
+    ) -> Bool {
+        guard operationLease.predecessorStopCompletion != nil else { return false }
+        addRuntimeTask { [weak self, operationLease] in
+            guard let self,
+                  await self.waitUntilUpstreamOperationActivatable(operationLease),
+                  self.initializeManager.snapshot().isShuttingDown == false
+            else { return }
+            resume()
+        }
+        return true
     }
 
     func noteUpstreamInitializationSucceeded() {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -331,8 +331,9 @@ extension RuntimeCoordinator {
     private func cancelUpstreamRequest(
         sessionID: String,
         requestIDKey: String,
-        operationLease: UpstreamOperationLease
-    ) -> AsyncTerminalSignal? {
+        operationLease: UpstreamOperationLease,
+        after requestSendCompletion: AsyncTerminalSignal? = nil
+    ) -> ControlPlane.RPCCancellationDelivery? {
         guard let upstreamID = upstreamRouter.remove(
             proof: operationLease.proof,
             sessionID: sessionID,
@@ -347,44 +348,68 @@ extension RuntimeCoordinator {
         ) else {
             return nil
         }
-        let delivery = AsyncTerminalSignal()
-        let scheduled = addRuntimeTask { [weak self, operationLease] in
+        let delivery = ControlPlane.RPCCancellationDelivery()
+        let scheduled = addRuntimeTask {
+            [weak self, operationLease, requestSendCompletion] in
+            await requestSendCompletion?.wait()
             guard let self else {
-                delivery.signal()
+                delivery.complete(.noLongerApplicable)
                 return
             }
-            defer { delivery.signal() }
-            guard self.upstreamTopology.validate(operationLease) else { return }
+            guard self.upstreamTopology.validate(operationLease) else {
+                delivery.complete(.noLongerApplicable)
+                return
+            }
             let result = await operationLease.slot.send(data)
-            guard self.upstreamTopology.validate(operationLease) else { return }
-            if case .accepted = result {
+            guard self.upstreamTopology.validate(operationLease) else {
+                delivery.complete(.noLongerApplicable)
+                return
+            }
+            switch result {
+            case .accepted:
                 self.recordTraffic(
                     upstreamIndex: operationLease.upstreamIndex,
                     direction: "outbound",
                     data: data
                 )
+                delivery.complete(.delivered)
+            case .backpressure:
+                self.markUpstreamOverloaded(operationLease.proof)
+                delivery.complete(.rejected)
+            case .unavailable(let reason):
+                self.handleUnavailableUpstreamSend(
+                    operationLease: operationLease,
+                    reason: reason
+                )
+                delivery.complete(.noLongerApplicable)
             }
         }
         if scheduled == false {
-            delivery.signal()
+            delivery.complete(.rejected)
         }
         return delivery
     }
 
     private func cancellationDelivery(
-        waitingFor deliveries: [AsyncTerminalSignal]
-    ) -> AsyncTerminalSignal? {
+        waitingFor deliveries: [ControlPlane.RPCCancellationDelivery]
+    ) -> ControlPlane.RPCCancellationDelivery? {
         guard deliveries.isEmpty == false else { return nil }
         guard deliveries.count > 1 else { return deliveries[0] }
-        let aggregate = AsyncTerminalSignal()
+        let aggregate = ControlPlane.RPCCancellationDelivery()
         let scheduled = addRuntimeTask {
+            var result = ControlPlane.RPCCancellationDelivery.Result.delivered
             for delivery in deliveries {
-                await delivery.wait()
+                let next = await delivery.wait()
+                if next == .rejected {
+                    result = .rejected
+                } else if next == .noLongerApplicable, result == .delivered {
+                    result = .noLongerApplicable
+                }
             }
-            aggregate.signal()
+            aggregate.complete(result)
         }
         if scheduled == false {
-            aggregate.signal()
+            aggregate.complete(.rejected)
         }
         return aggregate
     }
@@ -420,19 +445,42 @@ extension RuntimeCoordinator {
         admission: RouteForwardingAdmission?,
         onRejected: @escaping @Sendable () -> Void
     ) -> Bool {
+        sendUpstream(
+            data,
+            operationLease: operationLease,
+            ensureRunning: ensureRunning,
+            admission: admission,
+            requestSendCompletion: nil,
+            onRejected: onRejected
+        )
+    }
+
+    @discardableResult
+    func sendUpstream(
+        _ data: Data,
+        operationLease: UpstreamOperationLease,
+        ensureRunning: Bool,
+        admission: RouteForwardingAdmission?,
+        requestSendCompletion: AsyncTerminalSignal?,
+        onRejected: @escaping @Sendable () -> Void
+    ) -> Bool {
         let upstreamIndex = operationLease.upstreamIndex
         guard upstreamTopology.validate(operationLease) else {
             onRejected()
+            requestSendCompletion?.signal()
             return false
         }
         if let admission {
             guard processControlPlane.validate(admission.route),
                   admission.proof(for: upstreamIndex) == operationLease.proof else {
                 onRejected()
+                requestSendCompletion?.signal()
                 return false
             }
         }
-        let scheduled = addRuntimeTask { [weak self, operationLease, admission, onRejected] in
+        let scheduled = addRuntimeTask {
+            [weak self, operationLease, admission, requestSendCompletion, onRejected] in
+            defer { requestSendCompletion?.signal() }
             guard let self else { return }
             if ensureRunning {
                 await operationLease.slot.start()
@@ -483,6 +531,7 @@ extension RuntimeCoordinator {
         }
         if scheduled == false {
             onRejected()
+            requestSendCompletion?.signal()
         }
         return scheduled
     }
@@ -728,14 +777,16 @@ extension RuntimeCoordinator {
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease?
-    ) -> AsyncTerminalSignal? {
-        var cancellationDeliveries: [AsyncTerminalSignal] = []
+        operationLease: UpstreamOperationLease?,
+        after requestSendCompletion: AsyncTerminalSignal? = nil
+    ) -> ControlPlane.RPCCancellationDelivery? {
+        var cancellationDeliveries: [ControlPlane.RPCCancellationDelivery] = []
         if let operationLease, let first = requestIDKeys.first {
             if let delivery = cancelUpstreamRequest(
                 sessionID: sessionID,
                 requestIDKey: first,
-                operationLease: operationLease
+                operationLease: operationLease,
+                after: requestSendCompletion
             ) {
                 cancellationDeliveries.append(delivery)
             }
@@ -743,7 +794,8 @@ extension RuntimeCoordinator {
                 if let delivery = cancelUpstreamRequest(
                     sessionID: sessionID,
                     requestIDKey: requestIDKey,
-                    operationLease: operationLease
+                    operationLease: operationLease,
+                    after: requestSendCompletion
                 ) {
                     cancellationDeliveries.append(delivery)
                 }
@@ -773,15 +825,17 @@ extension RuntimeCoordinator {
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease?
-    ) -> AsyncTerminalSignal? {
-        var deliveries: [AsyncTerminalSignal] = []
+        operationLease: UpstreamOperationLease?,
+        after requestSendCompletion: AsyncTerminalSignal? = nil
+    ) -> ControlPlane.RPCCancellationDelivery? {
+        var deliveries: [ControlPlane.RPCCancellationDelivery] = []
         if let operationLease {
             for requestIDKey in requestIDKeys {
                 if let delivery = cancelUpstreamRequest(
                     sessionID: sessionID,
                     requestIDKey: requestIDKey,
-                    operationLease: operationLease
+                    operationLease: operationLease,
+                    after: requestSendCompletion
                 ) {
                     deliveries.append(delivery)
                 }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -332,7 +332,7 @@ extension RuntimeCoordinator {
         sessionID: String,
         requestIDKey: String,
         operationLease: UpstreamOperationLease,
-        after requestSendCompletion: AsyncTerminalSignal? = nil
+        after requestSendCompletion: UpstreamRequestSendCompletion? = nil
     ) -> ControlPlane.RPCCancellationDelivery? {
         guard let upstreamID = upstreamRouter.remove(
             proof: operationLease.proof,
@@ -351,7 +351,11 @@ extension RuntimeCoordinator {
         let delivery = ControlPlane.RPCCancellationDelivery()
         let scheduled = addRuntimeTask {
             [weak self, operationLease, requestSendCompletion] in
-            await requestSendCompletion?.wait()
+            if let requestSendCompletion,
+               await requestSendCompletion.wait() == .notSent {
+                delivery.complete(.noLongerApplicable)
+                return
+            }
             guard let self else {
                 delivery.complete(.noLongerApplicable)
                 return
@@ -374,7 +378,10 @@ extension RuntimeCoordinator {
                 )
                 delivery.complete(.delivered)
             case .backpressure:
-                self.markUpstreamOverloaded(operationLease.proof)
+                await self.recoverUpstreamAfterRejectedCancellation(
+                    operationLease,
+                    reason: "cancellation_backpressure"
+                )
                 delivery.complete(.rejected)
             case .unavailable(let reason):
                 self.handleUnavailableUpstreamSend(
@@ -388,6 +395,90 @@ extension RuntimeCoordinator {
             delivery.complete(.rejected)
         }
         return delivery
+    }
+
+    private func recoverUpstreamAfterRejectedCancellation(
+        _ operationLease: UpstreamOperationLease,
+        reason: String
+    ) async {
+        let proof = operationLease.proof
+        let route = xcodeProcessRoute(forUpstreamIndex: operationLease.upstreamIndex)
+        logger.warning(
+            "Upstream cancellation was rejected; replacing its channel",
+            metadata: [
+                "upstream": .string("\(operationLease.upstreamIndex)"),
+                "reason": .string(reason),
+            ]
+        )
+        guard let cleared = clearUpstreamStateReturningDetachedState(
+            proof: proof,
+            resetsProcessRouteActivation: false
+        ) else {
+            return
+        }
+        let rejectedBridgeRecovery: ProcessBridgePoolRecovery?
+        if case .processBridgeRecovery(let recovery) = cleared.initializeOwner {
+            rejectedBridgeRecovery = recovery.reservation
+        } else {
+            rejectedBridgeRecovery = nil
+        }
+        guard let replacement = replaceOrRetireInitializeChannel(
+            proof,
+            expectedRouteID: route?.id,
+            requestsBridgePoolRecovery: false
+        ) else {
+            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+            return
+        }
+        guard await waitUntilUpstreamOperationActivatable(replacement.operationLease) else {
+            if initializeManager.snapshot().isShuttingDown == false {
+                failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+            }
+            return
+        }
+        guard initializeManager.snapshot().isShuttingDown == false else {
+            return
+        }
+        guard upstreamTopology.validate(replacement.proof) else {
+            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+            return
+        }
+        let replacementProof = replacement.proof
+        guard let route else {
+            startUpstreamWarmInitialize(
+                upstreamIndex: replacementProof.slotID.rawValue,
+                applyBackoff: true
+            )
+            return
+        }
+        var recovery: ProcessControlPlaneAuthority.RejectedCancellationRecovery?
+        guard initializeManager.performIfRunning({
+            recovery = processControlPlane.recoverAfterRejectedCancellation(
+                routeID: route.id,
+                failedProof: proof,
+                replacementProof: replacementProof,
+                rejectedBridgeRecovery: rejectedBridgeRecovery,
+                nowUptimeNs: nowUptimeNanoseconds()
+            )
+        }), let recovery else {
+            failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
+            return
+        }
+        switch recovery {
+        case .preserved(let transition):
+            applyProcessControlPlaneTransition(transition)
+        case .bridgeRecovery(let retry):
+            schedulePreparedProcessBridgeRecoveryRetry(retry, reason: reason)
+        case .freshActivation(let lease, let retry, let transition):
+            applyProcessControlPlaneTransition(transition)
+            scheduleProcessRouteActivationRetry(
+                processID: route.target.processID,
+                retry: retry,
+                lease: lease,
+                reason: reason
+            )
+        }
+        failQueuedRequestsIfNoHealthyOrRecoveringUpstream()
     }
 
     private func cancellationDelivery(
@@ -461,77 +552,96 @@ extension RuntimeCoordinator {
         operationLease: UpstreamOperationLease,
         ensureRunning: Bool,
         admission: RouteForwardingAdmission?,
-        requestSendCompletion: AsyncTerminalSignal?,
+        requestSendCompletion: UpstreamRequestSendCompletion?,
         onRejected: @escaping @Sendable () -> Void
     ) -> Bool {
         let upstreamIndex = operationLease.upstreamIndex
         guard upstreamTopology.validate(operationLease) else {
             onRejected()
-            requestSendCompletion?.signal()
+            requestSendCompletion?.complete(.notSent)
             return false
         }
         if let admission {
             guard processControlPlane.validate(admission.route),
                   admission.proof(for: upstreamIndex) == operationLease.proof else {
                 onRejected()
-                requestSendCompletion?.signal()
+                requestSendCompletion?.complete(.notSent)
                 return false
             }
         }
-        let scheduled = addRuntimeTask {
-            [weak self, operationLease, admission, requestSendCompletion, onRejected] in
-            defer { requestSendCompletion?.signal() }
-            guard let self else { return }
-            if ensureRunning {
-                await operationLease.slot.start()
-            }
-            guard self.upstreamTopology.validate(operationLease) else {
-                onRejected()
-                return
-            }
-            if let admission {
-                guard self.processControlPlane.validate(admission.route),
-                      admission.proof(for: upstreamIndex) == operationLease.proof else {
+        var scheduled = false
+        guard initializeManager.performIfRunning({
+            scheduled = addRuntimeTask {
+                [weak self, operationLease, admission, requestSendCompletion, onRejected] in
+                guard let self else {
+                    requestSendCompletion?.complete(.notSent)
+                    return
+                }
+                guard await self.waitUntilUpstreamOperationActivatable(operationLease) else {
+                    requestSendCompletion?.complete(.notSent)
                     onRejected()
                     return
                 }
+                if ensureRunning {
+                    await operationLease.slot.start()
+                }
+                guard self.upstreamTopology.validate(operationLease) else {
+                    requestSendCompletion?.complete(.notSent)
+                    onRejected()
+                    return
+                }
+                if let admission {
+                    guard self.processControlPlane.validate(admission.route),
+                          admission.proof(for: upstreamIndex) == operationLease.proof else {
+                        requestSendCompletion?.complete(.notSent)
+                        onRejected()
+                        return
+                    }
+                }
+                let result = await operationLease.slot.send(data)
+                requestSendCompletion?.complete(
+                    result == .accepted ? .accepted : .notSent
+                )
+                guard self.upstreamTopology.validate(operationLease) else {
+                    onRejected()
+                    return
+                }
+                switch result {
+                case .accepted:
+                    self.recordTraffic(
+                        upstreamIndex: upstreamIndex,
+                        direction: "outbound",
+                        data: data
+                    )
+                case .backpressure:
+                    self.markUpstreamOverloaded(operationLease.proof)
+                    self.failPendingSend(
+                        originalRequestData: data,
+                        proof: operationLease.proof,
+                        code: -32002,
+                        message: "upstream overloaded"
+                    )
+                case .unavailable(let reason):
+                    self.failPendingSend(
+                        originalRequestData: data,
+                        proof: operationLease.proof,
+                        code: -32001,
+                        message: "upstream unavailable"
+                    )
+                    self.handleUnavailableUpstreamSend(
+                        operationLease: operationLease,
+                        reason: reason
+                    )
+                }
             }
-            let result = await operationLease.slot.send(data)
-            guard self.upstreamTopology.validate(operationLease) else {
-                onRejected()
-                return
-            }
-            switch result {
-            case .accepted:
-                self.recordTraffic(
-                    upstreamIndex: upstreamIndex,
-                    direction: "outbound",
-                    data: data
-                )
-            case .backpressure:
-                self.markUpstreamOverloaded(operationLease.proof)
-                self.failPendingSend(
-                    originalRequestData: data,
-                    proof: operationLease.proof,
-                    code: -32002,
-                    message: "upstream overloaded"
-                )
-            case .unavailable(let reason):
-                self.failPendingSend(
-                    originalRequestData: data,
-                    proof: operationLease.proof,
-                    code: -32001,
-                    message: "upstream unavailable"
-                )
-                self.handleUnavailableUpstreamSend(
-                    operationLease: operationLease,
-                    reason: reason
-                )
-            }
+        }) else {
+            onRejected()
+            requestSendCompletion?.complete(.notSent)
+            return false
         }
         if scheduled == false {
             onRejected()
-            requestSendCompletion?.signal()
+            requestSendCompletion?.complete(.notSent)
         }
         return scheduled
     }
@@ -763,13 +873,15 @@ extension RuntimeCoordinator {
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease
+        operationLease: UpstreamOperationLease,
+        after requestSendCompletion: UpstreamRequestSendCompletion?
     ) {
         _ = handleRequestLeaseTimeoutWithCancellationDelivery(
             leaseID,
             sessionID: sessionID,
             requestIDKeys: requestIDKeys,
-            operationLease: operationLease
+            operationLease: operationLease,
+            after: requestSendCompletion
         )
     }
 
@@ -778,7 +890,7 @@ extension RuntimeCoordinator {
         sessionID: String,
         requestIDKeys: [String],
         operationLease: UpstreamOperationLease?,
-        after requestSendCompletion: AsyncTerminalSignal? = nil
+        after requestSendCompletion: UpstreamRequestSendCompletion? = nil
     ) -> ControlPlane.RPCCancellationDelivery? {
         var cancellationDeliveries: [ControlPlane.RPCCancellationDelivery] = []
         if let operationLease, let first = requestIDKeys.first {
@@ -803,21 +915,27 @@ extension RuntimeCoordinator {
             markRequestTimedOut(operationLease)
         }
         upstreamSlotScheduler.cancelQueuedRequest(leaseID: leaseID)
-        releaseLeases([leaseManager.timeoutLease(leaseID)].compactMap { $0 })
-        return cancellationDelivery(waitingFor: cancellationDeliveries)
+        let cancellationDelivery = cancellationDelivery(waitingFor: cancellationDeliveries)
+        settleRequestLease(
+            leaseManager.timeoutLease(leaseID),
+            after: cancellationDelivery
+        )
+        return cancellationDelivery
     }
 
     func abandonRequestLease(
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease?
+        operationLease: UpstreamOperationLease?,
+        after requestSendCompletion: UpstreamRequestSendCompletion?
     ) {
         _ = abandonRequestLeaseWithCancellationDelivery(
             leaseID,
             sessionID: sessionID,
             requestIDKeys: requestIDKeys,
-            operationLease: operationLease
+            operationLease: operationLease,
+            after: requestSendCompletion
         )
     }
 
@@ -826,7 +944,7 @@ extension RuntimeCoordinator {
         sessionID: String,
         requestIDKeys: [String],
         operationLease: UpstreamOperationLease?,
-        after requestSendCompletion: AsyncTerminalSignal? = nil
+        after requestSendCompletion: UpstreamRequestSendCompletion? = nil
     ) -> ControlPlane.RPCCancellationDelivery? {
         var deliveries: [ControlPlane.RPCCancellationDelivery] = []
         if let operationLease {
@@ -842,15 +960,16 @@ extension RuntimeCoordinator {
             }
         }
         upstreamSlotScheduler.cancelQueuedRequest(leaseID: leaseID)
-        upstreamSlotScheduler.releaseUpstreamSlot(leaseID: leaseID)
-        releaseLeases(
-            [leaseManager.failLease(
+        let cancellationDelivery = cancellationDelivery(waitingFor: deliveries)
+        settleRequestLease(
+            leaseManager.failLease(
                 leaseID,
                 terminalState: .abandoned,
                 reason: .clientDisconnected
-            )].compactMap { $0 }
+            ),
+            after: cancellationDelivery
         )
-        return cancellationDelivery(waitingFor: deliveries)
+        return cancellationDelivery
     }
 
     func testStateSnapshot() -> TestSnapshot {
@@ -1266,12 +1385,35 @@ extension RuntimeCoordinator {
 
     func releaseLeases(_ actions: [LeaseManager.ReleaseAction]) {
         for action in actions {
-            upstreamSlotScheduler.releaseUpstreamSlot(
-                upstreamIndex: action.upstreamIndex,
-                leaseID: action.leaseID
-            )
+            releaseUpstreamSlot(for: action)
             failPendingRequestIfNeeded(for: action)
         }
+    }
+
+    private func settleRequestLease(
+        _ action: LeaseManager.ReleaseAction?,
+        after cancellationDelivery: ControlPlane.RPCCancellationDelivery?
+    ) {
+        guard let action else { return }
+        failPendingRequestIfNeeded(for: action)
+        guard let cancellationDelivery else {
+            releaseUpstreamSlot(for: action)
+            return
+        }
+        let scheduled = addRuntimeTask { [weak self] in
+            _ = await cancellationDelivery.wait()
+            self?.releaseUpstreamSlot(for: action)
+        }
+        if scheduled == false {
+            releaseUpstreamSlot(for: action)
+        }
+    }
+
+    private func releaseUpstreamSlot(for action: LeaseManager.ReleaseAction) {
+        upstreamSlotScheduler.releaseUpstreamSlot(
+            upstreamIndex: action.upstreamIndex,
+            leaseID: action.leaseID
+        )
     }
 
     private func failPendingRequestIfNeeded(for action: LeaseManager.ReleaseAction) {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+UpstreamRouting.swift
@@ -328,12 +328,73 @@ extension RuntimeCoordinator {
         )
     }
 
+    private func cancelUpstreamRequest(
+        sessionID: String,
+        requestIDKey: String,
+        operationLease: UpstreamOperationLease
+    ) -> AsyncTerminalSignal? {
+        guard let upstreamID = upstreamRouter.remove(
+            proof: operationLease.proof,
+            sessionID: sessionID,
+            requestIDKey: requestIDKey
+        ), let data = try? JSONRPC.Wire.data(
+            from: JSONRPC.Wire.notificationObject(
+                method: "notifications/cancelled",
+                params: .object([
+                    "requestId": .number(.int(upstreamID))
+                ])
+            )
+        ) else {
+            return nil
+        }
+        let delivery = AsyncTerminalSignal()
+        let scheduled = addRuntimeTask { [weak self, operationLease] in
+            guard let self else {
+                delivery.signal()
+                return
+            }
+            defer { delivery.signal() }
+            guard self.upstreamTopology.validate(operationLease) else { return }
+            let result = await operationLease.slot.send(data)
+            guard self.upstreamTopology.validate(operationLease) else { return }
+            if case .accepted = result {
+                self.recordTraffic(
+                    upstreamIndex: operationLease.upstreamIndex,
+                    direction: "outbound",
+                    data: data
+                )
+            }
+        }
+        if scheduled == false {
+            delivery.signal()
+        }
+        return delivery
+    }
+
+    private func cancellationDelivery(
+        waitingFor deliveries: [AsyncTerminalSignal]
+    ) -> AsyncTerminalSignal? {
+        guard deliveries.isEmpty == false else { return nil }
+        guard deliveries.count > 1 else { return deliveries[0] }
+        let aggregate = AsyncTerminalSignal()
+        let scheduled = addRuntimeTask {
+            for delivery in deliveries {
+                await delivery.wait()
+            }
+            aggregate.signal()
+        }
+        if scheduled == false {
+            aggregate.signal()
+        }
+        return aggregate
+    }
+
     func onRequestTimeout(
         sessionID: String,
         requestIDKey: String,
         operationLease: UpstreamOperationLease
     ) {
-        removeUpstreamIDMapping(
+        _ = cancelUpstreamRequest(
             sessionID: sessionID,
             requestIDKey: requestIDKey,
             operationLease: operationLease
@@ -655,21 +716,43 @@ extension RuntimeCoordinator {
         requestIDKeys: [String],
         operationLease: UpstreamOperationLease
     ) {
-        if let first = requestIDKeys.first {
-            onRequestTimeout(
+        _ = handleRequestLeaseTimeoutWithCancellationDelivery(
+            leaseID,
+            sessionID: sessionID,
+            requestIDKeys: requestIDKeys,
+            operationLease: operationLease
+        )
+    }
+
+    func handleRequestLeaseTimeoutWithCancellationDelivery(
+        _ leaseID: LeaseManager.ID,
+        sessionID: String,
+        requestIDKeys: [String],
+        operationLease: UpstreamOperationLease?
+    ) -> AsyncTerminalSignal? {
+        var cancellationDeliveries: [AsyncTerminalSignal] = []
+        if let operationLease, let first = requestIDKeys.first {
+            if let delivery = cancelUpstreamRequest(
                 sessionID: sessionID,
                 requestIDKey: first,
                 operationLease: operationLease
-            )
+            ) {
+                cancellationDeliveries.append(delivery)
+            }
             for requestIDKey in requestIDKeys.dropFirst() {
-                removeUpstreamIDMapping(
+                if let delivery = cancelUpstreamRequest(
                     sessionID: sessionID,
                     requestIDKey: requestIDKey,
                     operationLease: operationLease
-                )
+                ) {
+                    cancellationDeliveries.append(delivery)
+                }
             }
+            markRequestTimedOut(operationLease)
         }
+        upstreamSlotScheduler.cancelQueuedRequest(leaseID: leaseID)
         releaseLeases([leaseManager.timeoutLease(leaseID)].compactMap { $0 })
+        return cancellationDelivery(waitingFor: cancellationDeliveries)
     }
 
     func abandonRequestLease(
@@ -678,13 +761,30 @@ extension RuntimeCoordinator {
         requestIDKeys: [String],
         operationLease: UpstreamOperationLease?
     ) {
+        _ = abandonRequestLeaseWithCancellationDelivery(
+            leaseID,
+            sessionID: sessionID,
+            requestIDKeys: requestIDKeys,
+            operationLease: operationLease
+        )
+    }
+
+    func abandonRequestLeaseWithCancellationDelivery(
+        _ leaseID: LeaseManager.ID,
+        sessionID: String,
+        requestIDKeys: [String],
+        operationLease: UpstreamOperationLease?
+    ) -> AsyncTerminalSignal? {
+        var deliveries: [AsyncTerminalSignal] = []
         if let operationLease {
             for requestIDKey in requestIDKeys {
-                removeUpstreamIDMapping(
+                if let delivery = cancelUpstreamRequest(
                     sessionID: sessionID,
                     requestIDKey: requestIDKey,
                     operationLease: operationLease
-                )
+                ) {
+                    deliveries.append(delivery)
+                }
             }
         }
         upstreamSlotScheduler.cancelQueuedRequest(leaseID: leaseID)
@@ -696,6 +796,7 @@ extension RuntimeCoordinator {
                 reason: .clientDisconnected
             )].compactMap { $0 }
         )
+        return cancellationDelivery(waitingFor: deliveries)
     }
 
     func testStateSnapshot() -> TestSnapshot {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -84,23 +84,28 @@ extension RuntimeCoordinator {
     ) {
         guard processRoutingEnabled else { return }
         defer { testHooks.xcodeProcessReconcileCompleted?(reason) }
-        let existingRoutes = processControlPlane.activeRoutes()
-        let observedRoutes = MCPBridgeRuntime.orderedXcodeTargets(targets).map { target in
-            existingRoutes.first(where: {
-                $0.target == target && $0.upstreamIndices.isEmpty == false
-            })
-                ?? appendProcessBoundRoute(for: target)
+        var result: ProcessControlPlaneTransition?
+        guard initializeManager.performIfRunning({
+            let existingRoutes = processControlPlane.activeRoutes()
+            let observedRoutes = MCPBridgeRuntime.orderedXcodeTargets(targets).map { target in
+                existingRoutes.first(where: {
+                    $0.target == target && $0.upstreamIndices.isEmpty == false
+                })
+                    ?? appendProcessBoundRouteWhileRunning(for: target)
+            }
+            let usability = processRouteUpstreamUsabilitySnapshot(
+                policy: .toolsCatalog,
+                nowUptimeNs: nowUptimeNanoseconds()
+            )
+            result = processControlPlane.reconcileRoutes(
+                observedRoutes,
+                reason: reason,
+                nowUptimeNs: nowUptimeNanoseconds(),
+                usability: usability
+            )
+        }), let result else {
+            return
         }
-        let usability = processRouteUpstreamUsabilitySnapshot(
-            policy: .toolsCatalog,
-            nowUptimeNs: nowUptimeNanoseconds()
-        )
-        let result = processControlPlane.reconcileRoutes(
-            observedRoutes,
-            reason: reason,
-            nowUptimeNs: nowUptimeNanoseconds(),
-            usability: usability
-        )
         applyProcessControlPlaneTransition(result)
         guard result.didChangeRoutes else {
             retryPendingProcessRouteReadiness(reason: reason)
@@ -118,7 +123,7 @@ extension RuntimeCoordinator {
         retryPendingProcessRouteReadiness(reason: reason)
     }
 
-    private func appendProcessBoundRoute(
+    private func appendProcessBoundRouteWhileRunning(
         for target: XcodeProcessTarget
     ) -> XcodeProcessRoute {
         let slots = dynamicUpstreamFactory?(target) ?? []
@@ -133,8 +138,9 @@ extension RuntimeCoordinator {
             return XcodeProcessRoute(target: target, upstreamIndices: [])
         }
 
-        let transition = upstreamTopology.append(slots)
-        publishUpstreamTopology(transition.snapshot)
+        let transition = commitUpstreamTopologyMutation {
+            upstreamTopology.append(slots)
+        }
         let upstreamIndices = transition.addedIDs.map(\.rawValue)
         for id in transition.addedIDs {
             guard let operationLease = transition.snapshot.operationLease(id) else { continue }
@@ -168,10 +174,15 @@ extension RuntimeCoordinator {
                 reason: reason
             )
         }
-        let topologyTransition = upstreamTopology.retire(
-            Set(route.upstreamIndices.map(UpstreamSlotID.init(rawValue:)))
-        )
-        publishUpstreamTopology(topologyTransition.snapshot)
+        testHooks.processRouteRetirementWillDetach?()
+        let topologyTransition = commitUpstreamTopologyMutation {
+            upstreamTopology.retire(
+                Set(route.upstreamIndices.map(UpstreamSlotID.init(rawValue:)))
+            )
+        }
+        for retired in topologyTransition.retired {
+            retireUpstreamSlot(retired.slot)
+        }
 
         let resetInitialize = hadGlobalInitialize
             && canonicalHandshakeState.initializeResult() == nil
@@ -212,10 +223,6 @@ extension RuntimeCoordinator {
                 reason: .upstreamExit
             )
         )
-        addRuntimeTask {
-            await operationLease.slot.stop()
-        }
-
         let retiredPrimaryInitialize =
             globalInit?.wasInFlight == true
             && globalInit?.primaryInitUpstreamIndex == upstreamIndex
@@ -304,9 +311,11 @@ extension RuntimeCoordinator {
         }
         guard isInitialized() else { return }
         for route in activeRoutes where pendingProcessIDs.contains(route.target.processID) {
-            applyProcessControlPlaneTransition(
-                processControlPlane.beginBridgePoolRecovery(routeID: route.id)
-            )
+            var transition = ProcessControlPlaneTransition.none
+            guard initializeManager.performIfRunning({
+                transition = processControlPlane.beginBridgePoolRecovery(routeID: route.id)
+            }) else { return }
+            applyProcessControlPlaneTransition(transition)
         }
         refreshMissingProcessToolsCatalogsIfNeeded(
             reason: "pending_process_route_\(reason)",
@@ -315,6 +324,7 @@ extension RuntimeCoordinator {
     }
 
     func restoreProcessBridgePool(_ recovery: ProcessBridgePoolRecovery) {
+        guard initializeManager.snapshot().isShuttingDown == false else { return }
         guard let route = xcodeProcessRoutes.first(where: { $0.id == recovery.routeID }) else {
             return
         }
@@ -364,14 +374,24 @@ extension RuntimeCoordinator {
         _ recovery: ProcessBridgePoolRecovery,
         reason: String
     ) {
-        guard let retry = processControlPlane.prepareBridgeRecoveryRetry(recovery) else {
+        var retry: ProcessBridgeRecoveryRetry?
+        guard initializeManager.performIfRunning({
+            retry = processControlPlane.prepareBridgeRecoveryRetry(recovery)
+        }), let retry else {
             return
         }
+        schedulePreparedProcessBridgeRecoveryRetry(retry, reason: reason)
+    }
+
+    func schedulePreparedProcessBridgeRecoveryRetry(
+        _ retry: ProcessBridgeRecoveryRetry,
+        reason: String
+    ) {
         logger.info(
             "bridge_pool_recovery_retry_scheduled",
             metadata: [
-                "pid": .string("\(recovery.routeID.processID)"),
-                "upstream": .string("\(recovery.upstreamID.rawValue)"),
+                "pid": .string("\(retry.reservation.routeID.processID)"),
+                "upstream": .string("\(retry.reservation.upstreamID.rawValue)"),
                 "reason": .string(reason),
                 "delay_ms": .string("\(retry.delay.nanoseconds / 1_000_000)"),
             ]
@@ -384,27 +404,47 @@ extension RuntimeCoordinator {
                 )
             )
         }
-        applyProcessControlPlaneTransition(
-            processControlPlane.attachBridgeRecoveryRetryTimeout(
+        var transition = ProcessControlPlaneTransition.none
+        guard initializeManager.performIfRunning({
+            transition = processControlPlane.attachBridgeRecoveryRetryTimeout(
                 timeout,
                 to: retry.reservation
             )
-        )
+        }) else {
+            timeout.cancel()
+            return
+        }
+        applyProcessControlPlaneTransition(transition)
     }
 
     func replaceProcessBridgeRecoveryChannelAndScheduleRetry(
         _ recovery: ProcessBridgeRecovery,
         reason: String
     ) {
-        _ = replaceOrRetireInitializeChannel(
+        let replacement = replaceOrRetireInitializeChannel(
             recovery.topologyProof,
             expectedRouteID: recovery.routeID,
             requestsBridgePoolRecovery: false
         )
-        scheduleProcessBridgeRecoveryRetry(
-            recovery.reservation,
-            reason: reason
-        )
+        var retry: ProcessBridgeRecoveryRetry?
+        guard initializeManager.performIfRunning({
+            retry = processControlPlane.prepareBridgeRecoveryRetry(
+                recovery.reservation
+            )
+        }), let retry else { return }
+        guard let replacement else {
+            schedulePreparedProcessBridgeRecoveryRetry(retry, reason: reason)
+            return
+        }
+        addRuntimeTask { [weak self, replacement] in
+            guard let self,
+                  await self.waitUntilUpstreamOperationActivatable(
+                    replacement.operationLease
+                  ),
+                  self.initializeManager.snapshot().isShuttingDown == false
+            else { return }
+            self.schedulePreparedProcessBridgeRecoveryRetry(retry, reason: reason)
+        }
     }
 
     func refreshPendingProcessToolsCatalogAfterWarmInitialize(upstreamIndex: Int) {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -3,6 +3,11 @@ import NIO
 import XcodeMCPKit
 
 extension RuntimeCoordinator {
+    private struct ProcessRouteReconcileCommit: Sendable {
+        let transition: ProcessControlPlaneTransition
+        let healthEffects: [UpstreamHealthManager.Effect]
+    }
+
     func triggerXcodeProcessReconcile(reason: String) {
         guard processRoutingEnabled, let xcodeTargetDiscovery else {
             return
@@ -84,7 +89,7 @@ extension RuntimeCoordinator {
     ) {
         guard processRoutingEnabled else { return }
         defer { testHooks.xcodeProcessReconcileCompleted?(reason) }
-        var result: ProcessControlPlaneTransition?
+        var commit: ProcessRouteReconcileCommit?
         guard initializeManager.performIfRunning({
             let existingRoutes = processControlPlane.activeRoutes()
             let observedRoutes = MCPBridgeRuntime.orderedXcodeTargets(targets).map { target in
@@ -93,31 +98,36 @@ extension RuntimeCoordinator {
                 })
                     ?? appendProcessBoundRouteWhileRunning(for: target)
             }
-            let usability = processRouteUpstreamUsabilitySnapshot(
+            let nowUptimeNs = nowUptimeNanoseconds()
+            let usability = evaluateProcessRouteUpstreamUsability(
                 policy: .toolsCatalog,
-                nowUptimeNs: nowUptimeNanoseconds()
+                nowUptimeNs: nowUptimeNs
             )
-            result = processControlPlane.reconcileRoutes(
-                observedRoutes,
-                reason: reason,
-                nowUptimeNs: nowUptimeNanoseconds(),
-                usability: usability
+            commit = ProcessRouteReconcileCommit(
+                transition: processControlPlane.reconcileRoutes(
+                    observedRoutes,
+                    reason: reason,
+                    nowUptimeNs: nowUptimeNs,
+                    usability: usability.snapshot
+                ),
+                healthEffects: usability.effects
             )
-        }), let result else {
+        }), let commit else {
             return
         }
-        applyProcessControlPlaneTransition(result)
-        guard result.didChangeRoutes else {
+        applyProcessControlPlaneTransition(commit.transition)
+        applyHealthEffects(commit.healthEffects)
+        guard commit.transition.didChangeRoutes else {
             retryPendingProcessRouteReadiness(reason: reason)
             return
         }
 
-        for route in result.retiredRoutes {
+        for route in commit.transition.retiredRoutes {
             retireProcessBoundRoute(route, reason: reason)
         }
 
-        if result.addedRoutes.isEmpty == false {
-            startInitializationForAddedProcessRoutes(result.addedRoutes)
+        if commit.transition.addedRoutes.isEmpty == false {
+            startInitializationForAddedProcessRoutes(commit.transition.addedRoutes)
         }
 
         retryPendingProcessRouteReadiness(reason: reason)

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -253,6 +253,12 @@ extension RuntimeCoordinator {
                 ),
             ]
         )
+        for lease in initialized.activeCatalogLeases {
+            scheduleProcessRouteActivationCatalogTimeout(
+                lease: lease,
+                initializeClaim: initializeClaim
+            )
+        }
         if let existingCatalog = processControlPlane.catalog(
             forProcessID: route.target.processID
         ) {
@@ -272,12 +278,6 @@ extension RuntimeCoordinator {
             }
             return
         }
-        scheduleProcessRouteActivationCatalogTimeout(
-            processID: route.target.processID,
-            upstreamIndex: upstreamIndex,
-            attempt: initialized.attempt,
-            initializeClaim: initializeClaim
-        )
         guard initialized.shouldStartCatalogLoad else { return }
         refreshProcessRouteToolsCatalog(
             route: route,
@@ -396,34 +396,50 @@ extension RuntimeCoordinator {
         applyProcessControlPlaneTransition(transition)
     }
 
+    func scheduleProcessRouteActivationCatalogTimeoutIfNeeded(
+        lease: CatalogLease
+    ) {
+        guard let initializeClaim = upstreamHealthManager.currentCatalogActivationClaim(
+            upstreamIndex: lease.upstreamIndex
+        ), initializeClaim.topologyProof == lease.topologyProof else {
+            return
+        }
+        scheduleProcessRouteActivationCatalogTimeout(
+            lease: lease,
+            initializeClaim: initializeClaim
+        )
+    }
+
     private func scheduleProcessRouteActivationCatalogTimeout(
-        processID: pid_t,
-        upstreamIndex: Int,
-        attempt: Int,
+        lease: CatalogLease,
         initializeClaim: UpstreamHealthManager.InitializeClaim
     ) {
         guard let timeoutAmount = processRouteActivationCatalogTimeoutAmount() else {
             return
         }
+        var reservation: CatalogTimeoutReservation?
+        guard initializeManager.performIfRunning({
+            reservation = processControlPlane.reserveCatalogTimeout(for: lease)
+        }), let reservation else {
+            return
+        }
         let timeout = scheduleRuntimeTimeout(timeoutAmount) { [weak self] in
             self?.handleProcessRouteActivationCatalogTimeout(
-                processID: processID,
-                upstreamIndex: upstreamIndex,
-                attempt: attempt,
+                reservation: reservation,
                 initializeClaim: initializeClaim
             )
         }
-        var attachment: UpstreamHealthManager.TimeoutAttachment?
+        var transition = ProcessControlPlaneTransition.none
         guard initializeManager.performIfRunning({
-            attachment = upstreamHealthManager.replaceCatalogTimeout(
+            transition = processControlPlane.attachCatalogTimeout(
                 timeout,
-                for: initializeClaim
+                to: reservation
             )
-        }), let attachment, attachment.accepted else {
+        }) else {
             timeout.cancel()
             return
         }
-        attachment.replaced?.cancel()
+        applyProcessControlPlaneTransition(transition)
     }
 
     private func processRouteActivationCatalogTimeoutAmount() -> TimeAmount? {
@@ -432,14 +448,14 @@ extension RuntimeCoordinator {
     }
 
     private func handleProcessRouteActivationCatalogTimeout(
-        processID: pid_t,
-        upstreamIndex: Int,
-        attempt: Int,
+        reservation: CatalogTimeoutReservation,
         initializeClaim: UpstreamHealthManager.InitializeClaim
     ) {
+        let lease = reservation.lease
         guard let proof = initializeClaim.topologyProof,
-              let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
-              route.target.processID == processID else { return }
+              proof == lease.topologyProof,
+              let route = xcodeProcessRoute(forUpstreamIndex: lease.upstreamIndex),
+              route.id == lease.routeIdentity else { return }
         var timeout: ProcessControlPlaneAuthority.CatalogRequestTimeout?
         var didTimeoutCatalogRequest = false
         guard upstreamTopology.withValidated(proof, {
@@ -447,8 +463,7 @@ extension RuntimeCoordinator {
                 initializeClaim,
                 commit: { _ in
                     timeout = processControlPlane.handleCatalogRequestTimeout(
-                        routeID: route.id,
-                        upstreamProof: proof,
+                        reservation,
                         nowUptimeNs: nowUptimeNanoseconds()
                     )
                     return timeout != nil
@@ -456,25 +471,32 @@ extension RuntimeCoordinator {
             )
         }) != nil, didTimeoutCatalogRequest, let timeout else { return }
         let cancellationDeliveries = applyProcessControlPlaneTransition(timeout.transition)
+        guard case .retryRequired(
+            _,
+            let retry,
+            let retryLease
+        ) = timeout else {
+            return
+        }
 
         logger.info(
             "route_activation_timeout",
             metadata: [
-                "pid": .string("\(processID)"),
-                "upstream": .string("\(upstreamIndex)"),
-                "attempt": .string("\(attempt)"),
+                "pid": .string("\(lease.processID)"),
+                "upstream": .string("\(lease.upstreamIndex)"),
+                "attempt": .string("\(lease.attempt)"),
                 "phase": .string("catalog"),
                 "timeout_ms": .string(
                     processRouteActivationCatalogTimeoutMillisecondsDescription()
                 ),
-                "retry_delay_ms": .string("\(timeout.retry.delayMilliseconds)"),
+                "retry_delay_ms": .string("\(retry.delayMilliseconds)"),
             ]
         )
 
         scheduleMissingProcessToolsCatalogRetry(
-            processID: processID,
-            lease: timeout.catalogLease,
-            retry: timeout.retry,
+            processID: lease.processID,
+            lease: retryLease,
+            retry: retry,
             after: cancellationDeliveries,
             reason: "catalog_timeout"
         )
@@ -490,7 +512,7 @@ extension RuntimeCoordinator {
         lease: ActivationLease,
         initializeClaim: UpstreamHealthManager.InitializeClaim
     ) {
-        guard clearUpstreamState(
+        guard timeoutUpstreamInitialize(
             initializeClaim: initializeClaim,
             resetsProcessRouteActivation: false,
             replacesInitializedChannel: false

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -4,6 +4,12 @@ import NIO
 import XcodeMCPKit
 
 extension RuntimeCoordinator {
+    struct InitializeChannelReplacement: Sendable {
+        let operationLease: UpstreamOperationLease
+
+        var proof: UpstreamTopologyProof { operationLease.proof }
+    }
+
     @discardableResult
     func applyCatalogCommit(
         _ commit: CatalogCommit
@@ -94,6 +100,7 @@ extension RuntimeCoordinator {
     }
 
     func startProcessRouteActivation(for route: XcodeProcessRoute) {
+        guard initializeManager.snapshot().isShuttingDown == false else { return }
         guard unavailableXcodeProcessIDs().contains(route.target.processID) == false else {
             return
         }
@@ -109,12 +116,18 @@ extension RuntimeCoordinator {
             for: UpstreamSlotID(rawValue: upstreamIndex)
         )?.proof else { return }
         let readinessToken = UpstreamReadinessWaiterToken()
-        guard let (reservation, transition) = processControlPlane.reserveActivation(
-            routeID: route.id,
-            upstreamProof: upstreamProof,
-            nowUptimeNs: nowUptimeNanoseconds(),
-            readinessToken: readinessToken
-        ) else {
+        var activation: (
+            ProcessControlPlaneAuthority.ActivationReservation,
+            ProcessControlPlaneTransition
+        )?
+        guard initializeManager.performIfRunning({
+            activation = processControlPlane.reserveActivation(
+                routeID: route.id,
+                upstreamProof: upstreamProof,
+                nowUptimeNs: nowUptimeNanoseconds(),
+                readinessToken: readinessToken
+            )
+        }), let (reservation, transition) = activation else {
             return
         }
         applyProcessControlPlaneTransition(transition)
@@ -243,10 +256,9 @@ extension RuntimeCoordinator {
         if let existingCatalog = processControlPlane.catalog(
             forProcessID: route.target.processID
         ) {
-            guard let (lease, transition) = processControlPlane.beginCatalogAttempt(
+            guard let (lease, transition) = beginProcessCatalogAttemptIfRunning(
                 routeID: route.id,
-                preferredUpstreamProof: upstreamProof,
-                nowUptimeNanoseconds: nowUptimeNanoseconds()
+                preferredUpstreamProof: upstreamProof
             ) else { return }
             applyProcessControlPlaneTransition(transition)
             let commit = commitProcessCatalog(
@@ -374,9 +386,14 @@ extension RuntimeCoordinator {
             }
             self.startProcessRouteActivation(for: route)
         }
-        applyProcessControlPlaneTransition(
-            processControlPlane.attachRetryTimeout(timeout, to: lease)
-        )
+        var transition = ProcessControlPlaneTransition.none
+        guard initializeManager.performIfRunning({
+            transition = processControlPlane.attachRetryTimeout(timeout, to: lease)
+        }) else {
+            timeout.cancel()
+            return
+        }
+        applyProcessControlPlaneTransition(transition)
     }
 
     private func scheduleProcessRouteActivationCatalogTimeout(
@@ -396,11 +413,13 @@ extension RuntimeCoordinator {
                 initializeClaim: initializeClaim
             )
         }
-        let attachment = upstreamHealthManager.replaceCatalogTimeout(
-            timeout,
-            for: initializeClaim
-        )
-        guard attachment.accepted else {
+        var attachment: UpstreamHealthManager.TimeoutAttachment?
+        guard initializeManager.performIfRunning({
+            attachment = upstreamHealthManager.replaceCatalogTimeout(
+                timeout,
+                for: initializeClaim
+            )
+        }), let attachment, attachment.accepted else {
             timeout.cancel()
             return
         }
@@ -478,15 +497,16 @@ extension RuntimeCoordinator {
         ) else {
             return
         }
-        guard replaceOrRetireInitializeChannel(initializeClaim) else { return }
+        guard let replacement = replaceOrRetireInitializeChannel(initializeClaim) else { return }
         let timeout = processControlPlane.handleChannelInitializeTimeout(lease)
         if let timeout,
            xcodeProcessRoutes.contains(where: { $0.id == timeout.activationLease.routeID }) {
             applyProcessControlPlaneTransition(timeout.transition)
-            scheduleProcessRouteActivationRetry(
+            scheduleProcessRouteActivationRetryAfterChannelStop(
                 processID: lease.processID,
                 retry: timeout.retry,
                 lease: timeout.activationLease,
+                replacement: replacement,
                 reason: "channel_initialize_timeout"
             )
             return
@@ -494,29 +514,66 @@ extension RuntimeCoordinator {
         if let timeout {
             applyProcessControlPlaneTransition(timeout.transition)
         }
-        guard let route = xcodeProcessRoute(forUpstreamIndex: initializeClaim.upstreamIndex),
-              let replacementProof = upstreamTopology.operationLease(
-                for: UpstreamSlotID(rawValue: initializeClaim.upstreamIndex)
-              )?.proof,
-              let fresh = processControlPlane.prepareFreshActivationRetry(
-                  routeID: route.id,
-                  upstreamProof: replacementProof,
-                  nowUptimeNs: nowUptimeNanoseconds()
-              ) else { return }
+        guard let route = xcodeProcessRoute(forUpstreamIndex: initializeClaim.upstreamIndex) else {
+            return
+        }
+        var fresh: (
+            ActivationLease,
+            ProcessControlPlaneAuthority.Retry,
+            ProcessControlPlaneTransition
+        )?
+        guard initializeManager.performIfRunning({
+            fresh = processControlPlane.prepareFreshActivationRetry(
+                routeID: route.id,
+                upstreamProof: replacement.proof,
+                nowUptimeNs: nowUptimeNanoseconds()
+            )
+        }), let fresh else {
+            return
+        }
         applyProcessControlPlaneTransition(fresh.2)
-        scheduleProcessRouteActivationRetry(
+        scheduleProcessRouteActivationRetryAfterChannelStop(
             processID: route.target.processID,
             retry: fresh.1,
             lease: fresh.0,
+            replacement: replacement,
             reason: "channel_initialize_timeout"
         )
+    }
+
+    private func scheduleProcessRouteActivationRetryAfterChannelStop(
+        processID: pid_t,
+        retry: ProcessControlPlaneAuthority.Retry,
+        lease: ActivationLease,
+        replacement: InitializeChannelReplacement,
+        reason: String
+    ) {
+        let scheduled = addRuntimeTask { [weak self, replacement] in
+            guard let self,
+                  await self.waitUntilUpstreamOperationActivatable(
+                    replacement.operationLease
+                  ),
+                  self.initializeManager.snapshot().isShuttingDown == false
+            else { return }
+            self.scheduleProcessRouteActivationRetry(
+                processID: processID,
+                retry: retry,
+                lease: lease,
+                reason: reason
+            )
+        }
+        if scheduled == false {
+            applyProcessControlPlaneTransition(
+                processControlPlane.resetAttempt(processID: processID)
+            )
+        }
     }
 
     @discardableResult
     func replaceOrRetireInitializeChannel(
         _ initializeClaim: UpstreamHealthManager.InitializeClaim
-    ) -> Bool {
-        guard let proof = initializeClaim.topologyProof else { return false }
+    ) -> InitializeChannelReplacement? {
+        guard let proof = initializeClaim.topologyProof else { return nil }
         let requestsBridgePoolRecovery: Bool
         if initializeClaim.owner == .regular {
             requestsBridgePoolRecovery = true
@@ -527,7 +584,7 @@ extension RuntimeCoordinator {
             proof,
             expectedRouteID: nil,
             requestsBridgePoolRecovery: requestsBridgePoolRecovery
-        ) != nil
+        )
     }
 
     @discardableResult
@@ -535,42 +592,99 @@ extension RuntimeCoordinator {
         _ proof: UpstreamTopologyProof,
         expectedRouteID: ProcessRouteID?,
         requestsBridgePoolRecovery: Bool
-    ) -> UpstreamTopologyProof? {
+    ) -> InitializeChannelReplacement? {
+        var replacement: InitializeChannelReplacement?
+        guard initializeManager.performIfRunning({
+            replacement = replaceOrRetireInitializeChannelWhileRunning(
+                proof,
+                expectedRouteID: expectedRouteID,
+                requestsBridgePoolRecovery: requestsBridgePoolRecovery
+            )
+        }) else {
+            return nil
+        }
+        return replacement
+    }
+
+    private func replaceOrRetireInitializeChannelWhileRunning(
+        _ proof: UpstreamTopologyProof,
+        expectedRouteID: ProcessRouteID?,
+        requestsBridgePoolRecovery: Bool
+    ) -> InitializeChannelReplacement? {
         let upstreamIndex = proof.slotID.rawValue
         let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex)
         if let expectedRouteID, route?.id != expectedRouteID {
             return nil
         }
+        let replacements: [any UpstreamSlotControlling]
         if let route {
-            let replacements = dynamicUpstreamFactory?(route.target) ?? []
-            if let replacement = replacements.first,
-               let transition = upstreamTopology.replace(proof, with: replacement),
-               let previous = transition.replaced?.slot,
-               let replacementLease = transition.snapshot.operationLease(proof.slotID) {
-                publishUpstreamTopology(transition.snapshot)
+            replacements = dynamicUpstreamFactory?(route.target) ?? []
+        } else if processRoutingEnabled == false, let unboundUpstreamFactory {
+            replacements = [unboundUpstreamFactory()]
+        } else {
+            replacements = []
+        }
+        if let replacement = replacements.first {
+            let previousStopCompletion = AsyncTerminalSignal()
+            if let transition = commitUpstreamTopologyMutation({
+                upstreamTopology.replace(
+                    proof,
+                    with: replacement,
+                    predecessorStopCompletion: previousStopCompletion
+                )
+            }),
+                let previous = transition.replaced?.slot,
+                let replacementLease = transition.snapshot.operationLease(proof.slotID) {
                 observeUpstreamEvents(replacementLease)
-                addRuntimeTask { await previous.stop() }
+                let replacementProof = replacementLease.proof
+                let upstreamTopology = upstreamTopology
+                let finishPreviousStop: @Sendable () -> Void = {
+                    upstreamTopology.clearPredecessorStopCompletion(
+                        previousStopCompletion,
+                        for: replacementProof
+                    )
+                    previousStopCompletion.signal()
+                }
+                retireUpstreamSlot(previous, onStopped: finishPreviousStop)
                 for unused in replacements.dropFirst() {
-                    addRuntimeTask { await unused.stop() }
+                    retireUpstreamSlot(unused)
                 }
                 if requestsBridgePoolRecovery {
-                    applyProcessControlPlaneTransition(
-                        processControlPlane.requestBridgePoolRecovery(
-                            routeID: route.id,
-                            upstreamID: replacementLease.proof.slotID
-                        )
-                    )
+                    addRuntimeTask { [weak self, replacementLease] in
+                        guard let self,
+                              await self.waitUntilUpstreamOperationActivatable(replacementLease),
+                              self.initializeManager.snapshot().isShuttingDown == false
+                        else { return }
+                        if let route {
+                            var transition = ProcessControlPlaneTransition.none
+                            guard self.initializeManager.performIfRunning({
+                                transition = self.processControlPlane.requestBridgePoolRecovery(
+                                    routeID: route.id,
+                                    upstreamID: replacementLease.proof.slotID
+                                )
+                            }) else { return }
+                            self.applyProcessControlPlaneTransition(transition)
+                        } else if self.processRoutingEnabled == false {
+                            self.startUpstreamWarmInitialize(
+                                upstreamIndex: replacementLease.upstreamIndex,
+                                applyBackoff: true
+                            )
+                        }
+                    }
                 }
-                return replacementLease.proof
-            }
-            for unused in replacements {
-                addRuntimeTask { await unused.stop() }
+                return InitializeChannelReplacement(
+                    operationLease: replacementLease
+                )
             }
         }
-        guard let transition = upstreamTopology.retire(proof) else { return nil }
-        publishUpstreamTopology(transition.snapshot)
+        for unused in replacements {
+            retireUpstreamSlot(unused)
+        }
+        guard let transition = commitUpstreamTopologyMutation({
+            upstreamTopology.retire(proof)
+        }) else { return nil }
         for retired in transition.retired {
-            addRuntimeTask { await retired.slot.stop() }
+            retireUpstreamSlot(retired.slot)
         }
         if let route {
             applyProcessControlPlaneTransition(processControlPlane.retireRoute(

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -5,7 +5,9 @@ import XcodeMCPKit
 
 extension RuntimeCoordinator {
     @discardableResult
-    func applyCatalogCommit(_ commit: CatalogCommit) -> [AsyncTerminalSignal] {
+    func applyCatalogCommit(
+        _ commit: CatalogCommit
+    ) -> [ControlPlane.RPCCancellationDelivery] {
         switch commit {
         case .accepted(_, let transition), .discarded(_, let transition):
             return applyProcessControlPlaneTransition(transition)

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -4,10 +4,11 @@ import NIO
 import XcodeMCPKit
 
 extension RuntimeCoordinator {
-    func applyCatalogCommit(_ commit: CatalogCommit) {
+    @discardableResult
+    func applyCatalogCommit(_ commit: CatalogCommit) -> [AsyncTerminalSignal] {
         switch commit {
         case .accepted(_, let transition), .discarded(_, let transition):
-            applyProcessControlPlaneTransition(transition)
+            return applyProcessControlPlaneTransition(transition)
         }
     }
 
@@ -415,46 +416,25 @@ extension RuntimeCoordinator {
         attempt: Int,
         initializeClaim: UpstreamHealthManager.InitializeClaim
     ) {
-        guard let proof = initializeClaim.topologyProof else { return }
-        var cleared: (
-            timeout: RuntimeScheduledTimeout?,
-            initUpstreamID: Int64?,
-            didReceiveInitializeResponse: Bool,
-            didSendInitialized: Bool
-        )?
-        var processEligibility: ProcessControlPlaneAuthority.SupportEligibilityResult?
-        let eligibility = initializeManager.finishSupportEligibilityUpdate {
-            var update: CanonicalHandshakeState.SupportEligibilityUpdate?
-            guard upstreamTopology.withValidatedSnapshot(proof, { topologySnapshot in
-                cleared = upstreamHealthManager.timeoutCatalogActivation(
-                    initializeClaim,
-                    commit: { _ in true }
-                )
-                guard cleared != nil else { return false }
-                update = commitSupportEligibilityAfterHealthMutation(
-                    topologySnapshot: topologySnapshot,
-                    detachedProof: proof,
-                    catalogTimeoutProof: proof,
-                    processEligibility: &processEligibility
-                )
-                return true
-            }) == true else { return nil }
-            return update
-        }
-        guard let eligibility, let cleared, let processEligibility else { return }
-        let timeout = processEligibility.catalogTimeout
-        if let timeout {
-            applyProcessControlPlaneTransition(timeout.transition)
-        }
-        applyProcessControlPlaneTransition(processEligibility.transition)
-        applySupportEligibilityCompletion(eligibility)
-        finishClearingUpstreamState(
-            proof: proof,
-            cleared: cleared,
-            resetsProcessRouteActivation: false
-        )
-        guard replaceOrRetireInitializeChannel(initializeClaim) else { return }
-        guard let timeout else { return }
+        guard let proof = initializeClaim.topologyProof,
+              let route = xcodeProcessRoute(forUpstreamIndex: upstreamIndex),
+              route.target.processID == processID else { return }
+        var timeout: ProcessControlPlaneAuthority.CatalogRequestTimeout?
+        var didTimeoutCatalogRequest = false
+        guard upstreamTopology.withValidated(proof, {
+            didTimeoutCatalogRequest = upstreamHealthManager.timeoutCatalogRequest(
+                initializeClaim,
+                commit: { _ in
+                    timeout = processControlPlane.handleCatalogRequestTimeout(
+                        routeID: route.id,
+                        upstreamProof: proof,
+                        nowUptimeNs: nowUptimeNanoseconds()
+                    )
+                    return timeout != nil
+                }
+            )
+        }) != nil, didTimeoutCatalogRequest, let timeout else { return }
+        let cancellationDeliveries = applyProcessControlPlaneTransition(timeout.transition)
 
         logger.info(
             "route_activation_timeout",
@@ -470,10 +450,11 @@ extension RuntimeCoordinator {
             ]
         )
 
-        scheduleProcessRouteActivationRetry(
-            processID: timeout.activationLease.processID,
+        scheduleMissingProcessToolsCatalogRetry(
+            processID: processID,
+            lease: timeout.catalogLease,
             retry: timeout.retry,
-            lease: timeout.activationLease,
+            after: cancellationDeliveries,
             reason: "catalog_timeout"
         )
     }

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -458,18 +458,27 @@ extension RuntimeCoordinator {
               route.id == lease.routeIdentity else { return }
         var timeout: ProcessControlPlaneAuthority.CatalogRequestTimeout?
         var didTimeoutCatalogRequest = false
-        guard upstreamTopology.withValidated(proof, {
-            didTimeoutCatalogRequest = upstreamHealthManager.timeoutCatalogRequest(
-                initializeClaim,
-                commit: { _ in
-                    timeout = processControlPlane.handleCatalogRequestTimeout(
-                        reservation,
-                        nowUptimeNs: nowUptimeNanoseconds()
-                    )
-                    return timeout != nil
-                }
-            )
-        }) != nil, didTimeoutCatalogRequest, let timeout else { return }
+        var validatedTopology = false
+        guard initializeManager.performIfRunning({
+            validatedTopology = upstreamTopology.withValidated(proof, {
+                didTimeoutCatalogRequest = upstreamHealthManager.timeoutCatalogRequest(
+                    initializeClaim,
+                    commit: { _ in
+                        timeout = processControlPlane.handleCatalogRequestTimeout(
+                            reservation,
+                            nowUptimeNs: nowUptimeNanoseconds()
+                        )
+                        return timeout != nil
+                    }
+                )
+            }) != nil
+        }),
+            validatedTopology,
+            didTimeoutCatalogRequest,
+            let timeout
+        else {
+            return
+        }
         let cancellationDeliveries = applyProcessControlPlaneTransition(timeout.transition)
         guard case .retryRequired(
             _,

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouting.swift
@@ -4,6 +4,11 @@ import NIOCore
 import XcodeMCPKit
 
 extension RuntimeCoordinator {
+    struct ProcessRouteUsabilityEvaluation: Sendable {
+        let snapshot: ProcessControlPlaneAuthority.UpstreamUsabilitySnapshot
+        let effects: [UpstreamHealthManager.Effect]
+    }
+
     private static let xcodeProcessRouteUnavailableCooldownNanoseconds: UInt64 =
         2_000_000_000
     private static let xcodeProcessRouteCatalogUnavailableCooldownNanoseconds: UInt64 =
@@ -402,20 +407,23 @@ extension RuntimeCoordinator {
         policy: ProcessControlPlaneAuthority.ExposurePolicy
     ) -> ProcessControlPlaneAuthority.RoutingSnapshot {
         let nowUptimeNs = nowUptimeNanoseconds()
-        let upstreamUsability = processRouteUpstreamUsabilitySnapshot(
+        let upstreamUsability = evaluateProcessRouteUpstreamUsability(
             policy: policy,
             nowUptimeNs: nowUptimeNs
         )
-        applyProcessControlPlaneTransition(
-            processControlPlane.updateUsability(upstreamUsability, nowUptimeNs: nowUptimeNs)
+        let transition = processControlPlane.updateUsability(
+            upstreamUsability.snapshot,
+            nowUptimeNs: nowUptimeNs
         )
+        applyProcessControlPlaneTransition(transition)
+        applyHealthEffects(upstreamUsability.effects)
         return processControlPlane.routingSnapshot(policy: policy, nowUptimeNs: nowUptimeNs)
     }
 
-    func processRouteUpstreamUsabilitySnapshot(
+    func evaluateProcessRouteUpstreamUsability(
         policy: ProcessControlPlaneAuthority.ExposurePolicy,
         nowUptimeNs: UInt64
-    ) -> ProcessControlPlaneAuthority.UpstreamUsabilitySnapshot {
+    ) -> ProcessRouteUsabilityEvaluation {
         let states = upstreamHealthManager.activeStatesSnapshot()
         let snapshotUsable = Set(states.compactMap { upstreamID, state -> Int? in
             guard state.initPhase.isUsableInitialized else {
@@ -430,9 +438,9 @@ extension RuntimeCoordinator {
         })
 
         var recoveryAwareUsable = snapshotUsable
+        var effects: [UpstreamHealthManager.Effect] = []
         switch policy {
         case .toolsCatalog:
-            var effects: [UpstreamHealthManager.Effect] = []
             recoveryAwareUsable = Set(states.compactMap { upstreamID, _ -> Int? in
                 let evaluation = upstreamHealthManager.evaluateUsableInitialized(
                     index: upstreamID.rawValue,
@@ -441,16 +449,20 @@ extension RuntimeCoordinator {
                 effects.append(contentsOf: evaluation.effects)
                 return evaluation.isUsable ? upstreamID.rawValue : nil
             })
-            applyHealthEffects(effects)
         case .ownerRouting, .windowDiscovery, .initialization:
             break
         }
 
-        return ProcessControlPlaneAuthority.UpstreamUsabilitySnapshot(
-            snapshotUsableUpstreamIDs: Set(snapshotUsable.map(UpstreamSlotID.init(rawValue:))),
-            recoveryAwareUsableUpstreamIDs: Set(
-                recoveryAwareUsable.map(UpstreamSlotID.init(rawValue:))
-            )
+        return ProcessRouteUsabilityEvaluation(
+            snapshot: ProcessControlPlaneAuthority.UpstreamUsabilitySnapshot(
+                snapshotUsableUpstreamIDs: Set(
+                    snapshotUsable.map(UpstreamSlotID.init(rawValue:))
+                ),
+                recoveryAwareUsableUpstreamIDs: Set(
+                    recoveryAwareUsable.map(UpstreamSlotID.init(rawValue:))
+                )
+            ),
+            effects: effects
         )
     }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
@@ -1142,13 +1142,19 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             ?? processControlPlane.canonicalToolsCatalogRaw()
     }
 
-    func applyProcessControlPlaneTransition(_ transition: ProcessControlPlaneTransition) {
+    @discardableResult
+    func applyProcessControlPlaneTransition(
+        _ transition: ProcessControlPlaneTransition
+    ) -> [AsyncTerminalSignal] {
+        var cancellationDeliveries: [AsyncTerminalSignal] = []
         for effect in transition.effects {
             switch effect {
             case .cancelTimeout(let timeout):
                 timeout.cancel()
             case .cancelRPC(let handle):
-                handle.cancel()
+                if let delivery = handle.cancel() {
+                    cancellationDeliveries.append(delivery)
+                }
             case .cancelReadinessWaiter(let token):
                 cancelUpstreamReadinessWaiter(token)
             case .restoreBridgePool(let recovery):
@@ -1158,6 +1164,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         if transition.publishesToolsListChanged {
             publishToolsListChangedNotification()
         }
+        return cancellationDeliveries
     }
 
     func publishUpstreamTopology(_ snapshot: UpstreamTopologyAuthority.Snapshot) {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
@@ -1145,8 +1145,8 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     @discardableResult
     func applyProcessControlPlaneTransition(
         _ transition: ProcessControlPlaneTransition
-    ) -> [AsyncTerminalSignal] {
-        var cancellationDeliveries: [AsyncTerminalSignal] = []
+    ) -> [ControlPlane.RPCCancellationDelivery] {
+        var cancellationDeliveries: [ControlPlane.RPCCancellationDelivery] = []
         for effect in transition.effects {
             switch effect {
             case .cancelTimeout(let timeout):

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator.swift
@@ -54,7 +54,9 @@ struct RuntimeCoordinatorTestHooks: Sendable {
     var processRouteCatalogCommitted:
         (@Sendable (_ processID: pid_t, _ upstreamIndex: Int) -> Void)?
     var xcodeProcessReconcileCompleted: (@Sendable (_ reason: String) -> Void)?
+    var processRouteRetirementWillDetach: (@Sendable () -> Void)?
     var controlPlaneRPCWillEnqueue: (@Sendable () -> Void)?
+    var controlPlaneRPCAssignedUpstreamID: (@Sendable () -> Void)?
     var upstreamRequestQueued:
         (
             @Sendable (
@@ -82,7 +84,9 @@ struct RuntimeCoordinatorTestHooks: Sendable {
         processRouteCatalogCommitted:
             (@Sendable (_ processID: pid_t, _ upstreamIndex: Int) -> Void)? = nil,
         xcodeProcessReconcileCompleted: (@Sendable (_ reason: String) -> Void)? = nil,
+        processRouteRetirementWillDetach: (@Sendable () -> Void)? = nil,
         controlPlaneRPCWillEnqueue: (@Sendable () -> Void)? = nil,
+        controlPlaneRPCAssignedUpstreamID: (@Sendable () -> Void)? = nil,
         upstreamRequestQueued:
             (
                 @Sendable (
@@ -108,7 +112,9 @@ struct RuntimeCoordinatorTestHooks: Sendable {
         self.upstreamInitialized = upstreamInitialized
         self.processRouteCatalogCommitted = processRouteCatalogCommitted
         self.xcodeProcessReconcileCompleted = xcodeProcessReconcileCompleted
+        self.processRouteRetirementWillDetach = processRouteRetirementWillDetach
         self.controlPlaneRPCWillEnqueue = controlPlaneRPCWillEnqueue
+        self.controlPlaneRPCAssignedUpstreamID = controlPlaneRPCAssignedUpstreamID
         self.upstreamRequestQueued = upstreamRequestQueued
         self.upstreamRequestWillStart = upstreamRequestWillStart
         self.primaryInitializeFailureCleanupCompleted = primaryInitializeFailureCleanupCompleted
@@ -136,6 +142,8 @@ struct DocumentationProviderDiscoveryState: Sendable {
 
 typealias XcodeProcessUpstreamFactory =
     @Sendable (_ target: XcodeProcessTarget) -> [any UpstreamSlotControlling]
+typealias UnboundUpstreamFactory =
+    @Sendable () -> any UpstreamSlotControlling
 
 /// The single routing decision for a DocumentationSearch tools/call:
 /// either the provider produced the response, or proxy-managed
@@ -259,14 +267,48 @@ protocol RuntimeRequestLeasePort: Sendable {
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease
+        operationLease: UpstreamOperationLease,
+        after requestSendCompletion: UpstreamRequestSendCompletion?
     )
     func abandonRequestLease(
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease?
+        operationLease: UpstreamOperationLease?,
+        after requestSendCompletion: UpstreamRequestSendCompletion?
     )
+}
+
+extension RuntimeRequestLeasePort {
+    func handleRequestLeaseTimeout(
+        _ leaseID: LeaseManager.ID,
+        sessionID: String,
+        requestIDKeys: [String],
+        operationLease: UpstreamOperationLease
+    ) {
+        handleRequestLeaseTimeout(
+            leaseID,
+            sessionID: sessionID,
+            requestIDKeys: requestIDKeys,
+            operationLease: operationLease,
+            after: nil
+        )
+    }
+
+    func abandonRequestLease(
+        _ leaseID: LeaseManager.ID,
+        sessionID: String,
+        requestIDKeys: [String],
+        operationLease: UpstreamOperationLease?
+    ) {
+        abandonRequestLease(
+            leaseID,
+            sessionID: sessionID,
+            requestIDKeys: requestIDKeys,
+            operationLease: operationLease,
+            after: nil
+        )
+    }
 }
 
 protocol RuntimeClientLocalMCPResponderPort:
@@ -452,7 +494,9 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let sessionRegistry: SessionRegistry
     let initializeManager: InitializeManager
     let upstreamEventTasks = AsyncTaskSupervisor()
+    let upstreamRetirementTasks = AsyncTaskSupervisor()
     let runtimeTasks = AsyncTaskSupervisor()
+    let upstreamTopologyCommitLock = NIOLock()
     let upstreamStderrLogLimiter = UpstreamStderrLogLimiter()
     let primaryInitializeReadinessTokenBox =
         NIOLockedValueBox<UpstreamReadinessWaiterToken?>(nil)
@@ -494,6 +538,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
     let xcodeProcessEventMonitor: (any XcodeProcessEventMonitoring)?
     let xcodeTargetDiscovery: (any XcodeTargetDiscovering)?
     let dynamicUpstreamFactory: XcodeProcessUpstreamFactory?
+    let unboundUpstreamFactory: UnboundUpstreamFactory?
     var xcodeProcessRoutes: [XcodeProcessRoute] {
         processControlPlane.activeRoutes()
     }
@@ -559,6 +604,14 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                 )
             }
             : nil
+        let unboundUpstreamFactory: UnboundUpstreamFactory?
+        if xcodeProcessRoutingEnabled {
+            unboundUpstreamFactory = nil
+        } else {
+            unboundUpstreamFactory = {
+                MCPBridgeRuntime.makeUnboundUpstreamSlot(config: bridgeRuntimeConfig)
+            }
+        }
         self.init(
             config: config,
             eventLoop: eventLoop,
@@ -575,6 +628,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
                     xcodeTarget: target
                 )
             },
+            unboundUpstreamFactory: unboundUpstreamFactory,
             documentationProviderManager: documentationProviderManager,
             prewarmDocumentationProviderOnStartup: documentationProviderManager != nil,
             notificationSink: notificationSink,
@@ -629,6 +683,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         xcodeTargetDiscovery: (any XcodeTargetDiscovering)? = nil,
         xcodeProcessEventMonitor: (any XcodeProcessEventMonitoring)? = nil,
         dynamicUpstreamFactory: XcodeProcessUpstreamFactory? = nil,
+        unboundUpstreamFactory: UnboundUpstreamFactory? = nil,
         documentationProviderManager: (any DocumentationProviderManaging)? = nil,
         prewarmDocumentationProviderOnStartup: Bool = false,
         notificationSink: (@Sendable (_ sessionID: String, _ data: Data) -> Void)? = nil,
@@ -698,6 +753,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         self.xcodeTargetDiscovery = xcodeTargetDiscovery
         self.xcodeProcessEventMonitor = xcodeProcessEventMonitor
         self.dynamicUpstreamFactory = dynamicUpstreamFactory
+        self.unboundUpstreamFactory = unboundUpstreamFactory
         self.prewarmDocumentationProviderOnStartup = prewarmDocumentationProviderOnStartup
         self.testHooks = testHooks
         let resolvedReadinessGate =
@@ -1090,10 +1146,13 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
             clearToolsCatalog: true
         )
 
+        let shutdownTopology = commitUpstreamTopologyMutation {
+            upstreamTopology.retireAll()
+        }
         await withTaskGroup(of: Void.self) { group in
-            for upstream in upstreams {
+            for entry in shutdownTopology.retired {
                 group.addTask {
-                    await upstream.stop()
+                    await entry.slot.stop()
                 }
             }
             if let documentationProviderManager {
@@ -1110,6 +1169,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         await upstreamEventTasks.shutdown()
         await controlPlaneDrain.wait()
         await runtimeDrain.wait()
+        await upstreamRetirementTasks.shutdown()
     }
 
     func cancelForDeinit() {
@@ -1127,6 +1187,7 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         applyProcessControlPlaneTransition(processControlPlane.invalidateCatalog(.reset))
         _ = runtimeTasks.beginShutdown()
         _ = upstreamEventTasks.beginShutdown()
+        _ = upstreamRetirementTasks.beginShutdown()
     }
 
     func isInitialized() -> Bool {
@@ -1173,13 +1234,24 @@ final class RuntimeCoordinator: Sendable, RuntimeCoordinating {
         debugRecorder.applyTopology(snapshot)
     }
 
-    func upstreamSlotContext(
-        _ upstreamIndex: Int
-    ) -> (slot: any UpstreamSlotControlling, proof: UpstreamTopologyProof)? {
-        let snapshot = upstreamTopology.snapshot()
-        let id = UpstreamSlotID(rawValue: upstreamIndex)
-        guard let slot = snapshot.slot(id), let proof = snapshot.proof(id) else { return nil }
-        return (slot, proof)
+    func commitUpstreamTopologyMutation(
+        _ mutation: () -> UpstreamTopologyAuthority.Transition
+    ) -> UpstreamTopologyAuthority.Transition {
+        upstreamTopologyCommitLock.withLock {
+            let transition = mutation()
+            publishUpstreamTopology(transition.snapshot)
+            return transition
+        }
+    }
+
+    func commitUpstreamTopologyMutation(
+        _ mutation: () -> UpstreamTopologyAuthority.Transition?
+    ) -> UpstreamTopologyAuthority.Transition? {
+        upstreamTopologyCommitLock.withLock {
+            guard let transition = mutation() else { return nil }
+            publishUpstreamTopology(transition.snapshot)
+            return transition
+        }
     }
 
     func processToolCatalogExposedProcessIDs() -> Set<pid_t> {

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -1453,7 +1453,7 @@ struct ControlPlaneAuthorityTests {
         #expect(session.serverRequestTracker.lookup(clientID: clientID) != nil)
     }
 
-    @Test func catalogActivationSuccessAndTimeoutHaveSingleTerminalWinner() throws {
+    @Test func catalogRequestTimeoutPreservesActivationForRetry() throws {
         let topology = UpstreamTopologyAuthority([TestUpstreamClient()])
         let snapshot = topology.snapshot()
         let proof = try #require(snapshot.proof(UpstreamSlotID(rawValue: 0)))
@@ -1473,29 +1473,20 @@ struct ControlPlaneAuthorityTests {
             commit: { true }
         ))
 
-        let terminalWinners = NIOLockedValueBox<[String]>([])
-        DispatchQueue.concurrentPerform(iterations: 2) { contender in
-            _ = topology.withValidated(proof) {
-                if contender == 0 {
-                    switch health.commitCatalogActivation(
-                        claim,
-                        sourceProof: proof,
-                        commit: { _ in .complete }
-                    ) {
-                    case .completed:
-                        terminalWinners.withLockedValue { $0.append("success") }
-                    case .notOwned, .kept:
-                        break
-                    }
-                    return
-                }
-                if health.timeoutCatalogActivation(claim, commit: { _ in true }) != nil {
-                    terminalWinners.withLockedValue { $0.append("timeout") }
-                }
-            }
+        #expect(topology.withValidated(proof) {
+            health.timeoutCatalogRequest(claim, commit: { _ in true })
+        } == true)
+        let completion = try #require(topology.withValidated(proof) {
+            health.commitCatalogActivation(
+                claim,
+                sourceProof: proof,
+                commit: { _ in .complete }
+            )
+        })
+        guard case .completed = completion else {
+            Issue.record("catalog request timeout must preserve the initialized activation")
+            return
         }
-
-        #expect(terminalWinners.withLockedValue(\.count) == 1)
     }
 
     @Test func forwardingAdmissionRejectsRouteAndTopologyChangesIndependently() throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -210,6 +210,337 @@ struct ControlPlaneAuthorityTests {
         #expect(periodicRetry.delay.nanoseconds == TimeAmount.seconds(10).nanoseconds)
     }
 
+    @Test func rejectedCancellationReplacesFailedAttemptWithFreshActivation() throws {
+        let target = xcodeProcessTarget(processID: 41041, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let failedProof = testTopologyProof(0)
+        let replacementProof = testTopologyProof(0, generation: 2)
+        let (failedLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: failedProof,
+            nowUptimeNanoseconds: 1
+        ))
+        let failedRPC = ControlPlane.RPCHandle()
+        _ = authority.attach(.rpc(failedRPC), to: failedLease)
+
+        let result = try #require(authority.recoverAfterRejectedCancellation(
+            routeID: route.id,
+            failedProof: failedProof,
+            replacementProof: replacementProof,
+            rejectedBridgeRecovery: nil,
+            nowUptimeNs: 2
+        ))
+
+        guard case .freshActivation(let activation, let retry, let transition) = result else {
+            Issue.record("expected a fresh activation on the replacement proof")
+            return
+        }
+        #expect(activation.upstreamProof == replacementProof)
+        #expect(retry.delay == .milliseconds(250))
+        let attempt = try #require(authority.attemptSnapshot(processID: target.processID))
+        #expect(attempt.attemptID == activation.attemptID)
+        #expect(attempt.upstreamProof == replacementProof)
+        #expect(attempt.phase == .backoff)
+        for effect in transition.effects {
+            if case .cancelRPC(let handle) = effect {
+                handle.cancel()
+            }
+        }
+        #expect(failedRPC.isCancelled())
+    }
+
+    @Test func rejectedCancellationPreservesSiblingAttemptAndQueuesReplacementRecovery() throws {
+        let target = xcodeProcessTarget(processID: 41042, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let failedProof = testTopologyProof(0)
+        let replacementProof = testTopologyProof(0, generation: 2)
+        let siblingProof = testTopologyProof(1)
+        let (siblingLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: siblingProof,
+            nowUptimeNanoseconds: 1
+        ))
+
+        let result = try #require(authority.recoverAfterRejectedCancellation(
+            routeID: route.id,
+            failedProof: failedProof,
+            replacementProof: replacementProof,
+            rejectedBridgeRecovery: nil,
+            nowUptimeNs: 2
+        ))
+
+        guard case .preserved(let transition) = result,
+              case .restoreBridgePool(let recovery) = transition.effects.first else {
+            Issue.record("expected the replacement slot to enter bridge recovery")
+            return
+        }
+        #expect(recovery.routeID == route.id)
+        #expect(recovery.upstreamID == replacementProof.slotID)
+        let attempt = try #require(authority.attemptSnapshot(processID: target.processID))
+        #expect(attempt.attemptID.rawValue == siblingLease.attempt)
+        #expect(attempt.upstreamProof == siblingProof)
+        #expect(attempt.phase == .loadingCatalog)
+    }
+
+    @Test func rejectedCancellationPreservesAttemptAlreadyUsingReplacementProof() throws {
+        let target = xcodeProcessTarget(processID: 41043, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let failedProof = testTopologyProof(0)
+        let replacementProof = testTopologyProof(0, generation: 2)
+        let (replacementLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: replacementProof,
+            nowUptimeNanoseconds: 1
+        ))
+
+        let result = try #require(authority.recoverAfterRejectedCancellation(
+            routeID: route.id,
+            failedProof: failedProof,
+            replacementProof: replacementProof,
+            rejectedBridgeRecovery: nil,
+            nowUptimeNs: 2
+        ))
+
+        guard case .preserved(let transition) = result else {
+            Issue.record("expected replacement-proof attempt to survive")
+            return
+        }
+        #expect(transition.effects.isEmpty)
+        let attempt = try #require(authority.attemptSnapshot(processID: target.processID))
+        #expect(attempt.attemptID.rawValue == replacementLease.attempt)
+        #expect(attempt.upstreamProof == replacementProof)
+        guard case .restoreBridgePool(let pendingSibling) = authority
+            .beginBridgePoolRecovery(routeID: route.id).effects.first else {
+            Issue.record("expected only the configured sibling to remain pending")
+            return
+        }
+        #expect(pendingSibling.upstreamID == UpstreamSlotID(rawValue: 1))
+    }
+
+    @Test func staleRejectedCancellationPreservesNewerSameSlotOwners() throws {
+        let attemptTarget = xcodeProcessTarget(processID: 41048, xcodeVersion: "27.0")
+        let attemptAuthority = makeAuthority([(attemptTarget, [0])])
+        let attemptRoute = try #require(
+            attemptAuthority.route(forProcessID: attemptTarget.processID)
+        )
+        let newerProof = testTopologyProof(0, generation: 3)
+        let (newerLease, _) = try #require(attemptAuthority.beginCatalogAttempt(
+            routeID: attemptRoute.id,
+            preferredUpstreamProof: newerProof,
+            nowUptimeNanoseconds: 1
+        ))
+        let attemptResult = try #require(attemptAuthority.recoverAfterRejectedCancellation(
+            routeID: attemptRoute.id,
+            failedProof: testTopologyProof(0),
+            replacementProof: testTopologyProof(0, generation: 2),
+            rejectedBridgeRecovery: nil,
+            nowUptimeNs: 2
+        ))
+        guard case .preserved(let attemptTransition) = attemptResult else {
+            Issue.record("expected the newer same-slot attempt to survive")
+            return
+        }
+        #expect(attemptTransition.effects.isEmpty)
+        #expect(
+            attemptAuthority.attemptSnapshot(processID: attemptTarget.processID)?
+                .attemptID.rawValue == newerLease.attempt
+        )
+
+        let catalogTarget = xcodeProcessTarget(processID: 41049, xcodeVersion: "27.0")
+        let catalogAuthority = makeAuthority([(catalogTarget, [0])])
+        let catalogRoute = try #require(
+            catalogAuthority.route(forProcessID: catalogTarget.processID)
+        )
+        let (catalogLease, _) = try #require(catalogAuthority.beginCatalogAttempt(
+            routeID: catalogRoute.id,
+            preferredUpstreamProof: newerProof,
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted = catalogAuthority.completeCatalog(
+            .usable(catalog("NewerTool"), source: newerProof),
+            lease: catalogLease,
+            nowUptimeNanoseconds: 2
+        ) else {
+            Issue.record("expected newer catalog")
+            return
+        }
+        let catalogResult = try #require(catalogAuthority.recoverAfterRejectedCancellation(
+            routeID: catalogRoute.id,
+            failedProof: testTopologyProof(0),
+            replacementProof: testTopologyProof(0, generation: 2),
+            rejectedBridgeRecovery: nil,
+            nowUptimeNs: 3
+        ))
+        guard case .preserved(let catalogTransition) = catalogResult else {
+            Issue.record("expected the newer same-slot catalog to survive")
+            return
+        }
+        #expect(catalogTransition.effects.isEmpty)
+        #expect(
+            catalogAuthority.catalog(forProcessID: catalogTarget.processID)?
+                .upstreamProof == newerProof
+        )
+    }
+
+    @Test func rejectedCancellationPreservesCatalogAndSerializesReplacementRecovery() throws {
+        let target = xcodeProcessTarget(processID: 41044, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let sourceProof = testTopologyProof(1)
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: sourceProof,
+            nowUptimeNanoseconds: 1
+        ))
+        guard case .accepted(_, let catalogTransition) = authority.completeCatalog(
+            .usable(catalog("BuildProject"), source: sourceProof),
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ), case .restoreBridgePool(let existingRecovery) = catalogTransition.effects.first else {
+            Issue.record("expected the existing sibling recovery")
+            return
+        }
+
+        let replacementProof = testTopologyProof(0, generation: 2)
+        let result = try #require(authority.recoverAfterRejectedCancellation(
+            routeID: route.id,
+            failedProof: testTopologyProof(0),
+            replacementProof: replacementProof,
+            rejectedBridgeRecovery: nil,
+            nowUptimeNs: 3
+        ))
+
+        guard case .preserved(let transition) = result else {
+            Issue.record("expected the usable catalog to survive")
+            return
+        }
+        #expect(transition.effects.isEmpty)
+        #expect(authority.catalog(forProcessID: target.processID)?.upstreamProof == sourceProof)
+        guard case .restoreBridgePool(let replacementRecovery) = authority
+            .completeBridgeRecovery(existingRecovery).effects.first else {
+            Issue.record("expected serialized recovery of the replacement slot")
+            return
+        }
+        #expect(replacementRecovery.upstreamID == replacementProof.slotID)
+    }
+
+    @Test func rejectedBridgeCancellationAtomicallyBecomesRetry() throws {
+        let target = xcodeProcessTarget(processID: 41045, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        guard case .restoreBridgePool(let rejectedRecovery) = authority
+            .beginBridgePoolRecovery(routeID: route.id).effects.first else {
+            Issue.record("expected bridge recovery reservation")
+            return
+        }
+
+        let result = try #require(authority.recoverAfterRejectedCancellation(
+            routeID: route.id,
+            failedProof: testTopologyProof(1),
+            replacementProof: testTopologyProof(1, generation: 2),
+            rejectedBridgeRecovery: rejectedRecovery,
+            nowUptimeNs: 1
+        ))
+
+        guard case .bridgeRecovery(let retry) = result else {
+            Issue.record("expected the rejected reservation to enter retry")
+            return
+        }
+        #expect(retry.reservation == rejectedRecovery)
+        #expect(retry.delay == .seconds(1))
+        #expect(authority.attemptSnapshot(processID: target.processID) == nil)
+        #expect(authority.prepareBridgeRecoveryRetry(rejectedRecovery) == nil)
+        guard case .restoreBridgePool(let retried) = authority
+            .handleBridgeRecoveryRetryFired(retry.reservation).effects.first else {
+            Issue.record("expected the atomic retry to remain schedulable")
+            return
+        }
+        #expect(retried.upstreamID == rejectedRecovery.upstreamID)
+        #expect(retried != rejectedRecovery)
+    }
+
+    @Test func staleRejectedBridgeCancellationPreservesNewerRecoveryState() throws {
+        let target = xcodeProcessTarget(processID: 41046, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        guard case .restoreBridgePool(let staleRecovery) = authority
+            .beginBridgePoolRecovery(routeID: route.id).effects.first else {
+            Issue.record("expected initial bridge recovery")
+            return
+        }
+        let staleRetry = try #require(authority.prepareBridgeRecoveryRetry(staleRecovery))
+        guard case .restoreBridgePool(let currentRecovery) = authority
+            .handleBridgeRecoveryRetryFired(staleRetry.reservation).effects.first else {
+            Issue.record("expected a newer bridge recovery")
+            return
+        }
+
+        let attemptingResult = try #require(authority.recoverAfterRejectedCancellation(
+            routeID: route.id,
+            failedProof: testTopologyProof(1),
+            replacementProof: testTopologyProof(1, generation: 2),
+            rejectedBridgeRecovery: staleRecovery,
+            nowUptimeNs: 1
+        ))
+        guard case .preserved(let attemptingTransition) = attemptingResult else {
+            Issue.record("expected newer attempting recovery to survive")
+            return
+        }
+        #expect(attemptingTransition.effects.isEmpty)
+        #expect(authority.validateBridgeRecovery(currentRecovery))
+
+        let currentRetry = try #require(authority.prepareBridgeRecoveryRetry(currentRecovery))
+        let waitingResult = try #require(authority.recoverAfterRejectedCancellation(
+            routeID: route.id,
+            failedProof: testTopologyProof(1),
+            replacementProof: testTopologyProof(1, generation: 2),
+            rejectedBridgeRecovery: staleRecovery,
+            nowUptimeNs: 2
+        ))
+        guard case .preserved(let waitingTransition) = waitingResult else {
+            Issue.record("expected newer waiting recovery to survive")
+            return
+        }
+        #expect(waitingTransition.effects.isEmpty)
+        guard case .restoreBridgePool(let resumed) = authority
+            .handleBridgeRecoveryRetryFired(currentRetry.reservation).effects.first else {
+            Issue.record("expected preserved waiting recovery to resume")
+            return
+        }
+        #expect(resumed.upstreamID == currentRecovery.upstreamID)
+        #expect(authority.attemptSnapshot(processID: target.processID) == nil)
+    }
+
+    @Test func staleRejectedBridgeEvidenceFallsThroughAfterRecoveryCompleted() throws {
+        let target = xcodeProcessTarget(processID: 41047, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0, 1])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        guard case .restoreBridgePool(let completedRecovery) = authority
+            .beginBridgePoolRecovery(routeID: route.id).effects.first else {
+            Issue.record("expected bridge recovery")
+            return
+        }
+        _ = authority.completeBridgeRecovery(completedRecovery)
+        let replacementProof = testTopologyProof(1, generation: 2)
+
+        let result = try #require(authority.recoverAfterRejectedCancellation(
+            routeID: route.id,
+            failedProof: testTopologyProof(1),
+            replacementProof: replacementProof,
+            rejectedBridgeRecovery: completedRecovery,
+            nowUptimeNs: 1
+        ))
+
+        guard case .freshActivation(let activation, _, _) = result else {
+            Issue.record("expected stale evidence to fall through to route activation")
+            return
+        }
+        #expect(activation.upstreamProof == replacementProof)
+    }
+
     @Test func bridgeVerificationIsNotUsableUntilExactProbeSucceeds() throws {
         let target = xcodeProcessTarget(processID: 41035, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0, 1])])
@@ -1421,6 +1752,7 @@ struct ControlPlaneAuthorityTests {
             processRoutingEnabled: true,
             startImmediately: false
         )
+        defer { manager.shutdownAndWait() }
         let retiredSlot = TestUpstreamClient()
         let currentSlot = TestUpstreamClient()
         let appended = manager.upstreamTopology.append([retiredSlot])
@@ -1440,7 +1772,7 @@ struct ControlPlaneAuthorityTests {
             preview: "{stale"
         )))
         await retiredSlot.stop()
-        await manager.shutdown()
+        await manager.upstreamEventTasks.drainCurrentTasks().wait()
 
         guard case .healthy = manager.upstreamHealthManager.state(
             for: UpstreamSlotID(rawValue: 0)

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -1498,6 +1498,7 @@ struct ControlPlaneAuthorityTests {
 
         #expect(initialized.attempt == catalogLease.attempt)
         #expect(initialized.shouldStartCatalogLoad == false)
+        #expect(initialized.activeCatalogLeases == [catalogLease])
         #expect(authority.validateCatalogLoad(catalogLease))
         #expect(
             authority.attemptSnapshot(processID: target.processID)?.phase
@@ -1515,35 +1516,164 @@ struct ControlPlaneAuthorityTests {
             preferredUpstreamProof: proof,
             nowUptimeNanoseconds: 1
         ))
+        let firstTimeoutReservation = try #require(
+            authority.reserveCatalogTimeout(for: firstLease)
+        )
+        _ = authority.attachCatalogTimeout(
+            RuntimeScheduledTimeout {},
+            to: firstTimeoutReservation
+        )
 
-        let firstTimeout = try #require(authority.handleCatalogRequestTimeout(
-            routeID: route.id,
-            upstreamProof: proof,
-            nowUptimeNs: 2
-        ))
+        guard case .retryRequired(_, let firstRetry, let firstRetryLease) =
+            authority.handleCatalogRequestTimeout(firstTimeoutReservation, nowUptimeNs: 2)
+        else {
+            Issue.record("expected the final load timeout to require retry")
+            return
+        }
 
-        #expect(firstTimeout.catalogLease.attempt == firstLease.attempt)
-        #expect(firstTimeout.retry.delay == .milliseconds(250))
+        #expect(firstRetryLease.attempt == firstLease.attempt)
+        #expect(firstRetry.delay == .milliseconds(250))
         #expect(authority.beginCatalogAttempt(
             routeID: route.id,
             preferredUpstreamProof: proof,
             nowUptimeNanoseconds: 3
         ) == nil)
 
-        #expect(authority.handleRetryFired(firstTimeout.catalogLease))
+        #expect(authority.handleRetryFired(firstRetryLease))
         let (secondLease, _) = try #require(authority.beginCatalogAttempt(
             routeID: route.id,
             preferredUpstreamProof: proof,
             nowUptimeNanoseconds: 4
         ))
-        let secondTimeout = try #require(authority.handleCatalogRequestTimeout(
-            routeID: route.id,
-            upstreamProof: proof,
-            nowUptimeNs: 5
-        ))
+        let secondTimeoutReservation = try #require(
+            authority.reserveCatalogTimeout(for: secondLease)
+        )
+        _ = authority.attachCatalogTimeout(
+            RuntimeScheduledTimeout {},
+            to: secondTimeoutReservation
+        )
+        guard case .retryRequired(_, let secondRetry, _) =
+            authority.handleCatalogRequestTimeout(secondTimeoutReservation, nowUptimeNs: 5)
+        else {
+            Issue.record("expected the retry load timeout to require another retry")
+            return
+        }
 
         #expect(secondLease.attempt == firstLease.attempt)
-        #expect(secondTimeout.retry.delay == .milliseconds(500))
+        #expect(secondRetry.delay == .milliseconds(500))
+    }
+
+    @Test func staleCatalogTimeoutCannotTerminateNewerRetryLoad() throws {
+        let target = xcodeProcessTarget(processID: 41033, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let proof = testTopologyProof(0)
+        let (firstLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: proof,
+            nowUptimeNanoseconds: 1
+        ))
+        let staleTimeoutReservation = try #require(
+            authority.reserveCatalogTimeout(for: firstLease)
+        )
+        _ = authority.attachCatalogTimeout(
+            RuntimeScheduledTimeout {},
+            to: staleTimeoutReservation
+        )
+        guard case .accepted = authority.completeCatalog(
+            .unusable,
+            lease: firstLease,
+            nowUptimeNanoseconds: 2
+        ) else {
+            Issue.record("expected the first load to complete")
+            return
+        }
+        let scheduled = try #require(authority.scheduleRetry(lease: firstLease))
+        #expect(authority.handleRetryFired(scheduled.lease))
+        let (retryLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: proof,
+            nowUptimeNanoseconds: 3
+        ))
+
+        #expect(authority.handleCatalogRequestTimeout(
+            staleTimeoutReservation,
+            nowUptimeNs: 4
+        ) == nil)
+        #expect(authority.validateCatalogLoad(retryLease))
+        #expect(
+            authority.attemptSnapshot(processID: target.processID)?.phase
+                == .loadingCatalog
+        )
+    }
+
+    @Test func catalogLoadTimeoutPreservesSiblingLoad() throws {
+        let target = xcodeProcessTarget(processID: 41034, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let proof = testTopologyProof(0)
+        let (firstLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: proof,
+            nowUptimeNanoseconds: 1
+        ))
+        let (siblingLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: proof,
+            nowUptimeNanoseconds: 2
+        ))
+        let firstTimeoutReservation = try #require(
+            authority.reserveCatalogTimeout(for: firstLease)
+        )
+        let siblingTimeoutReservation = try #require(
+            authority.reserveCatalogTimeout(for: siblingLease)
+        )
+        let firstTimeoutCancelled = NIOLockedValueBox(false)
+        let siblingTimeoutCancelled = NIOLockedValueBox(false)
+        applyEffects(authority.attachCatalogTimeout(
+            RuntimeScheduledTimeout {
+                firstTimeoutCancelled.withLockedValue { $0 = true }
+            },
+            to: firstTimeoutReservation
+        ))
+        applyEffects(authority.attachCatalogTimeout(
+            RuntimeScheduledTimeout {
+                siblingTimeoutCancelled.withLockedValue { $0 = true }
+            },
+            to: siblingTimeoutReservation
+        ))
+        #expect(authority.reserveCatalogTimeout(for: siblingLease) == nil)
+        let firstRPC = ControlPlane.RPCHandle()
+        let siblingRPC = ControlPlane.RPCHandle()
+        _ = authority.attach(.rpc(firstRPC), to: firstLease)
+        _ = authority.attach(.rpc(siblingRPC), to: siblingLease)
+
+        guard case .loadTimedOut(let transition) =
+            authority.handleCatalogRequestTimeout(firstTimeoutReservation, nowUptimeNs: 3)
+        else {
+            Issue.record("a sibling load must suppress retry")
+            return
+        }
+        for effect in transition.effects {
+            switch effect {
+            case .cancelTimeout(let timeout):
+                timeout.cancel()
+            case .cancelRPC(let handle):
+                handle.cancel()
+            case .cancelReadinessWaiter, .restoreBridgePool:
+                break
+            }
+        }
+
+        #expect(firstTimeoutCancelled.withLockedValue { $0 })
+        #expect(firstRPC.isCancelled())
+        #expect(siblingTimeoutCancelled.withLockedValue { $0 } == false)
+        #expect(siblingRPC.isCancelled() == false)
+        #expect(authority.validateCatalogLoad(siblingLease))
+        #expect(
+            authority.attemptSnapshot(processID: target.processID)?.phase
+                == .loadingCatalog
+        )
     }
 
     @Test func windowUpdatesDoNotInvalidateCatalogLease() throws {
@@ -1846,6 +1976,7 @@ struct ControlPlaneAuthorityTests {
             commit: { true }
         ))
 
+        #expect(health.timeoutInitializeClaim(claim) == nil)
         #expect(topology.withValidated(proof) {
             health.timeoutCatalogRequest(claim, commit: { _ in true })
         } == true)

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -1563,6 +1563,38 @@ struct ControlPlaneAuthorityTests {
         #expect(secondRetry.delay == .milliseconds(500))
     }
 
+    @Test func catalogTimeoutFiringBeforeAttachmentConsumesReservation() throws {
+        let target = xcodeProcessTarget(processID: 41035, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let (lease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: testTopologyProof(0),
+            nowUptimeNanoseconds: 1
+        ))
+        let reservation = try #require(
+            authority.reserveCatalogTimeout(for: lease)
+        )
+
+        guard case .retryRequired =
+            authority.handleCatalogRequestTimeout(reservation, nowUptimeNs: 2)
+        else {
+            Issue.record("a reserved timeout must fire before its handle is attached")
+            return
+        }
+
+        let lateTimeoutCancelled = NIOLockedValueBox(false)
+        applyEffects(authority.attachCatalogTimeout(
+            RuntimeScheduledTimeout {
+                lateTimeoutCancelled.withLockedValue { $0 = true }
+            },
+            to: reservation
+        ))
+
+        #expect(lateTimeoutCancelled.withLockedValue { $0 })
+        #expect(authority.validateCatalogLoad(lease) == false)
+    }
+
     @Test func staleCatalogTimeoutCannotTerminateNewerRetryLoad() throws {
         let target = xcodeProcessTarget(processID: 41033, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0])])

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -1174,6 +1174,47 @@ struct ControlPlaneAuthorityTests {
         )
     }
 
+    @Test func catalogTimeoutBackoffBlocksLoadsAndAdvancesRetryOrdinal() throws {
+        let target = xcodeProcessTarget(processID: 41032, xcodeVersion: "27.0")
+        let authority = makeAuthority([(target, [0])])
+        let route = try #require(authority.route(forProcessID: target.processID))
+        let proof = testTopologyProof(0)
+        let (firstLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: proof,
+            nowUptimeNanoseconds: 1
+        ))
+
+        let firstTimeout = try #require(authority.handleCatalogRequestTimeout(
+            routeID: route.id,
+            upstreamProof: proof,
+            nowUptimeNs: 2
+        ))
+
+        #expect(firstTimeout.catalogLease.attempt == firstLease.attempt)
+        #expect(firstTimeout.retry.delay == .milliseconds(250))
+        #expect(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: proof,
+            nowUptimeNanoseconds: 3
+        ) == nil)
+
+        #expect(authority.handleRetryFired(firstTimeout.catalogLease))
+        let (secondLease, _) = try #require(authority.beginCatalogAttempt(
+            routeID: route.id,
+            preferredUpstreamProof: proof,
+            nowUptimeNanoseconds: 4
+        ))
+        let secondTimeout = try #require(authority.handleCatalogRequestTimeout(
+            routeID: route.id,
+            upstreamProof: proof,
+            nowUptimeNs: 5
+        ))
+
+        #expect(secondLease.attempt == firstLease.attempt)
+        #expect(secondTimeout.retry.delay == .milliseconds(500))
+    }
+
     @Test func windowUpdatesDoNotInvalidateCatalogLease() throws {
         let target = xcodeProcessTarget(processID: 41004, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0])])

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -985,6 +985,8 @@ struct ControlPlaneAuthorityTests {
         let fallbackRPC = ControlPlane.RPCHandle()
         _ = authority.attach(.rpc(lostRPC), to: lease)
         _ = authority.attach(.rpc(fallbackRPC), to: lease)
+        #expect(lostRPC.installCancel { _ in })
+        #expect(fallbackRPC.installCancel { _ in })
         #expect(lostRPC.markRegistered(
             registrationToken: UUID(),
             operationLease: testOperationLease(0)

--- a/Tests/XcodeMCPProxyRuntimeTests/DocumentationProviderTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/DocumentationProviderTests.swift
@@ -1963,6 +1963,7 @@ struct DocumentationProviderTests {
         }
         let toolsRequest = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
         #expect(methodName(from: toolsRequest) == "tools/list")
+        let toolsUpstreamID = try extractUpstreamID(from: toolsRequest)
 
         toolsListTask.cancel()
         do {
@@ -1980,6 +1981,15 @@ struct DocumentationProviderTests {
         let toolsListSnapshot = manager.debugSnapshot()
         #expect(toolsListSnapshot.queuedRequestCount == 0)
         #expect(toolsListSnapshot.upstreams[0].activeCorrelatedRequestCount == 0)
+        let toolsCancellation = try await sentValue(
+            from: upstream,
+            at: 1,
+            timeout: .seconds(2)
+        )
+        #expect(
+            try extractCancellationRequestID(from: toolsCancellation)
+                == toolsUpstreamID
+        )
 
         let searchTask = Task {
             try await manager.documentationProviderCall(
@@ -1988,9 +1998,10 @@ struct DocumentationProviderTests {
                 requestTimeout: .seconds(30)
             )
         }
-        let searchRequest = try await sentValue(from: upstream, at: 1, timeout: .seconds(2))
+        let searchRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: searchRequest) == "tools/call")
         #expect(try documentationSearchQuery(in: searchRequest) == "UIView")
+        let searchUpstreamID = try extractUpstreamID(from: searchRequest)
 
         searchTask.cancel()
         do {
@@ -2008,6 +2019,15 @@ struct DocumentationProviderTests {
         let searchSnapshot = manager.debugSnapshot()
         #expect(searchSnapshot.queuedRequestCount == 0)
         #expect(searchSnapshot.upstreams[0].activeCorrelatedRequestCount == 0)
+        let searchCancellation = try await sentValue(
+            from: upstream,
+            at: 3,
+            timeout: .seconds(2)
+        )
+        #expect(
+            try extractCancellationRequestID(from: searchCancellation)
+                == searchUpstreamID
+        )
     }
 
     @Test func runtimeDocumentationTransportFallsBackToDirectCandidateWhenNoUpstreamRouteExists()

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPConcurrencyTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPConcurrencyTests.swift
@@ -240,7 +240,7 @@ struct HTTPConcurrencyTests {
         )
         eventLoop.run()
         await sessionManager.drainRuntimeTasksForTesting()
-        let firstRequestLabels = upstream.recordedRequestLabels(count: 1)
+        let firstRequestLabels = try await waitForUpstreamRequestCount(upstream, count: 1)
         #expect(firstRequestLabels == ["tools/call:ExecuteSnippet"])
 
         let secondOperation = try handlePost(
@@ -264,7 +264,7 @@ struct HTTPConcurrencyTests {
 
         eventLoop.run()
         await sessionManager.drainRuntimeTasksForTesting()
-        let secondRequestLabels = upstream.recordedRequestLabels(count: 2)
+        let secondRequestLabels = try await waitForUpstreamRequestCount(upstream, count: 2)
         #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
             "tools/call:ExecuteSnippet",
@@ -336,7 +336,7 @@ struct HTTPConcurrencyTests {
         )
         firstChannel.embeddedEventLoop.run()
         await sessionManager.drainRuntimeTasksForTesting()
-        let firstRequestLabels = upstream.recordedRequestLabels(count: 1)
+        let firstRequestLabels = try await waitForUpstreamRequestCount(upstream, count: 1)
         #expect(firstRequestLabels == ["tools/call:ExecuteSnippet"])
 
         try postEmbeddedJSON(
@@ -356,7 +356,7 @@ struct HTTPConcurrencyTests {
 
         secondChannel.embeddedEventLoop.run()
         await sessionManager.drainRuntimeTasksForTesting()
-        let secondRequestLabels = upstream.recordedRequestLabels(count: 3)
+        let secondRequestLabels = try await waitForUpstreamRequestCount(upstream, count: 3)
         #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
             "notifications/cancelled",
@@ -964,6 +964,15 @@ private func waitForUpstreamRequestCount(
     }
 }
 
+private func waitForUpstreamRequestCount(
+    _ upstream: EmbeddedControlledUpstreamClient,
+    count: Int
+) async throws -> [String] {
+    try await waitWithTimeout("waiting for \(count) upstream request(s)", timeout: .seconds(2)) {
+        try await upstream.waitForNonInitializeRequestCount(count)
+    }
+}
+
 private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @unchecked Sendable {
     private struct SentRequest: Sendable {
         let label: String
@@ -973,10 +982,13 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
     private struct State {
         var sentRequests: [SentRequest] = []
         var requestHistory: [String] = []
+        var requestLabelBaseline = 0
+        var requestLabelCount = 0
     }
 
     nonisolated let events: AsyncStream<Upstream.Event>
     private let continuation: AsyncStream<Upstream.Event>.Continuation
+    private let requestLabels = LockedRecordedValues<String>()
     private let lock = NSLock()
     private var state = State()
 
@@ -1014,12 +1026,15 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
         withLock {
             $0.sentRequests.removeAll()
             $0.requestHistory.removeAll()
+            $0.requestLabelBaseline = $0.requestLabelCount
         }
     }
 
-    func recordedRequestLabels(count: Int) -> [String] {
+    func waitForNonInitializeRequestCount(_ count: Int) async throws -> [String] {
         guard count > 0 else { return [] }
 
+        let baseline = withLock { $0.requestLabelBaseline }
+        _ = try await requestLabels.nextValue(at: baseline + count - 1)
         return withLock { Array($0.requestHistory.prefix(count)) }
     }
 
@@ -1066,7 +1081,9 @@ private final class EmbeddedControlledUpstreamClient: UpstreamSlotControlling, @
         withLock {
             $0.sentRequests.append(SentRequest(label: label, responseData: responseData))
             $0.requestHistory.append(label)
+            $0.requestLabelCount += 1
         }
+        requestLabels.append(label)
     }
 
     private func withLock<T>(_ body: (inout State) -> T) -> T {

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPConcurrencyTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPConcurrencyTests.swift
@@ -356,9 +356,10 @@ struct HTTPConcurrencyTests {
 
         secondChannel.embeddedEventLoop.run()
         await sessionManager.drainRuntimeTasksForTesting()
-        let secondRequestLabels = upstream.recordedRequestLabels(count: 2)
+        let secondRequestLabels = upstream.recordedRequestLabels(count: 3)
         #expect(secondRequestLabels == [
             "tools/call:ExecuteSnippet",
+            "notifications/cancelled",
             "tools/call:ExecuteSnippet",
         ])
 

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTestSupport.swift
@@ -176,6 +176,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         var availableUpstreamIndex: Int? = 0
         var requestTimeoutNotifications = 0
         var requestSuccessNotifications = 0
+        var abandonedRequestHadOperationLease: [Bool] = []
         var pendingResponses: [PendingResponse] = []
         var sentRequests: [SentRequest] = []
         var sentUpstreamPayloads: [Data] = []
@@ -637,6 +638,7 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         operationLease: UpstreamOperationLease,
         ensureRunning: Bool,
         admission _: RouteForwardingAdmission?,
+        requestSendCompletion: UpstreamRequestSendCompletion?,
         onRejected: @escaping @Sendable () -> Void
     ) -> Bool {
         let upstreamIndex = operationLease.upstreamIndex
@@ -651,9 +653,11 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
             return (true, state.upstreamSendCount)
         }
         guard sendUpdate.accepted else {
+            requestSendCompletion?.complete(.notSent)
             onRejected()
             return false
         }
+        requestSendCompletion?.complete(.accepted)
         sentUpstreamCountRecords.append(sendUpdate.count)
 
         guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
@@ -884,7 +888,8 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease
+        operationLease: UpstreamOperationLease,
+        after _: UpstreamRequestSendCompletion?
     ) {
         _ = leaseID
         if let first = requestIDKeys.first {
@@ -908,8 +913,12 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease?
+        operationLease: UpstreamOperationLease?,
+        after _: UpstreamRequestSendCompletion?
     ) {
+        state.withLockedValue {
+            $0.abandonedRequestHadOperationLease.append(operationLease != nil)
+        }
         if let operationLease {
             for requestIDKey in requestIDKeys {
                 removeUpstreamIDMapping(
@@ -1018,6 +1027,10 @@ final class TestRuntimeCoordinator: RuntimeCoordinating {
 
     func mappedUpstreamRequestCount() -> Int {
         state.withLockedValue { $0.upstreamIDMapping.count }
+    }
+
+    func lastAbandonedRequestHadOperationLease() -> Bool? {
+        state.withLockedValue { $0.abandonedRequestHadOperationLease.last }
     }
 
     func rejectNextUpstreamSend() {

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
@@ -2866,7 +2866,6 @@ struct HTTPHandlerTests {
             requestIDKeys: ["91"]
         )
         #expect(cancellationHandle.activate(operationLease: operationLease))
-        cancellationHandle.cancel(using: sessionManager)
 
         let requestObject = JSONRPC.Wire.requestObject(
             id: 91,
@@ -2881,6 +2880,12 @@ struct HTTPHandlerTests {
                 operationLeaseOverride: operationLease
             )
         )
+        #expect(sessionManager.mappedUpstreamRequestCount() == 1)
+
+        cancellationHandle.cancel(using: sessionManager)
+
+        #expect(sessionManager.lastAbandonedRequestHadOperationLease() == false)
+        #expect(sessionManager.mappedUpstreamRequestCount() == 1)
 
         #expect(throws: CancellationError.self) {
             _ = try forwardingService.startRequest(

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPHandlerTests.swift
@@ -2877,7 +2877,8 @@ struct HTTPHandlerTests {
                 bodyData: requestData,
                 parsedRequestJSON: requestObject,
                 sessionID: sessionID,
-                operationLeaseOverride: operationLease
+                operationLeaseOverride: operationLease,
+                cancellationHandle: cancellationHandle
             )
         )
         #expect(sessionManager.mappedUpstreamRequestCount() == 1)
@@ -2885,7 +2886,7 @@ struct HTTPHandlerTests {
         cancellationHandle.cancel(using: sessionManager)
 
         #expect(sessionManager.lastAbandonedRequestHadOperationLease() == false)
-        #expect(sessionManager.mappedUpstreamRequestCount() == 1)
+        #expect(sessionManager.mappedUpstreamRequestCount() == 0)
 
         #expect(throws: CancellationError.self) {
             _ = try forwardingService.startRequest(
@@ -2898,6 +2899,51 @@ struct HTTPHandlerTests {
         }
         #expect(sessionManager.sentUpstreamCount() == 0)
         #expect(sessionManager.mappedUpstreamRequestCount() == 0)
+    }
+
+    @Test func forwardingServiceCleansMappingWhenCancellationWinsPreparationBinding() throws {
+        let config = makeHTTPConfig()
+        let sessionManager = TestRuntimeCoordinator(config: config)
+        let forwardingService = MCPForwardingService(
+            configuration: config.runtime,
+            sessionManager: sessionManager
+        )
+        let sessionID = "session-cancelled-preparation-binding"
+        let operationLease = try #require(sessionManager.chooseUpstreamOperationLease())
+        let leaseID = sessionManager.createRequestLease(
+            descriptor: SessionRequestPipeline.Descriptor(
+                sessionID: sessionID,
+                label: "resources/list",
+                expectsResponse: true,
+                isTopLevelClientRequest: true
+            )
+        )
+        let cancellationHandle = ClientMCPRequestExecutor.CancellationHandle(
+            leaseID: leaseID,
+            sessionID: sessionID,
+            requestIDKeys: ["92"]
+        )
+        #expect(cancellationHandle.activate(operationLease: operationLease))
+        cancellationHandle.cancel(using: sessionManager)
+
+        let requestObject = JSONRPC.Wire.requestObject(
+            id: 92,
+            method: "resources/list"
+        )
+        let requestData = try JSONRPC.Wire.data(from: requestObject)
+
+        #expect(throws: CancellationError.self) {
+            _ = try forwardingService.prepareRequest(
+                bodyData: requestData,
+                parsedRequestJSON: requestObject,
+                sessionID: sessionID,
+                operationLeaseOverride: operationLease,
+                cancellationHandle: cancellationHandle
+            )
+        }
+        #expect(sessionManager.lastAbandonedRequestHadOperationLease() == false)
+        #expect(sessionManager.mappedUpstreamRequestCount() == 0)
+        #expect(sessionManager.sentUpstreamCount() == 0)
     }
 
     @Test func httpResourceTemplatesListReturnsEmptyArray() async throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/ProxyUpstreamRequestRuntimeTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ProxyUpstreamRequestRuntimeTests.swift
@@ -476,6 +476,7 @@ private final class RecordingUpstreamRuntimePort: ProxyUpstreamRequestRuntimePor
         operationLease: UpstreamOperationLease,
         ensureRunning: Bool,
         admission _: RouteForwardingAdmission?,
+        requestSendCompletion: UpstreamRequestSendCompletion?,
         onRejected: @escaping @Sendable () -> Void
     ) -> Bool {
         let acceptsSend = state.withLockedValue { state in
@@ -491,6 +492,7 @@ private final class RecordingUpstreamRuntimePort: ProxyUpstreamRequestRuntimePor
             }
             return state.acceptsSend
         }
+        requestSendCompletion?.complete(acceptsSend ? .accepted : .notSent)
         if acceptsSend == false {
             onRejected()
         }

--- a/Tests/XcodeMCPProxyRuntimeTests/RefreshCodeIssuesHTTPTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RefreshCodeIssuesHTTPTests.swift
@@ -2459,6 +2459,45 @@ extension HTTPHandlerTests {
         #expect(sessionManager.chooseUpstreamShouldPinValues().isEmpty)
     }
 
+    @Test func forwardingServiceInternalToolTimeoutIsAccountedOnce() async throws {
+        let config = makeHTTPConfig(requestTimeout: 2)
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(eventLoopGroup) }
+        let eventLoop = eventLoopGroup.next()
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamRequestResponder: { _, _, originalID in
+                .manual(try makeToolSuccessResponse(id: originalID, text: "late"))
+            }
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setAvailableUpstreamIndices([0])
+        let forwardingService = MCPForwardingService(
+            configuration: config.runtime,
+            sessionManager: sessionManager
+        )
+
+        let result = await forwardingService.callInternalTool(
+            name: "XcodeListNavigatorIssues",
+            arguments: ["tabIdentifier": "windowtab-timeout-accounting"],
+            sessionID: "session-timeout-accounting",
+            eventLoop: eventLoop,
+            upstreamIndexOverride: 0,
+            requestTimeoutOverride: .milliseconds(20)
+        )
+
+        guard case .timeout = result else {
+            Issue.record("expected internal tool request to time out")
+            return
+        }
+        #expect(sessionManager.requestTimeoutNotificationCount() == 1)
+        #expect(sessionManager.requestSuccessNotificationCount() == 0)
+        #expect(sessionManager.mappedUpstreamRequestCount() == 0)
+        let lease = try #require(sessionManager.leaseDebugSnapshots().first)
+        #expect(lease.state == .timedOut)
+        #expect(lease.releaseReason == "timedOut")
+    }
+
     @Test func forwardingServiceInternalToolRespectsRequestedOverride()
         async throws
     {
@@ -2605,6 +2644,58 @@ extension HTTPHandlerTests {
         }
         #expect(sessionManager.sentUpstreamCount() == 0)
         #expect(sessionManager.mappedUpstreamRequestCount() == 0)
+    }
+
+    @Test func forwardingServiceInternalToolRejectsCancelledParentBeforePreparingRequest()
+        async throws
+    {
+        let config = makeHTTPConfig(requestTimeout: 2)
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { shutdownAndWait(eventLoopGroup) }
+        let eventLoop = eventLoopGroup.next()
+        let sessionManager = TestRuntimeCoordinator(
+            config: config,
+            upstreamPlanResponder: nil
+        )
+        sessionManager.setInitialized(true)
+        sessionManager.setAvailableUpstreamIndices([0])
+
+        let parentLeaseID = sessionManager.createRequestLease(
+            descriptor: .init(
+                sessionID: "session-preparation-cancellation",
+                label: "parent",
+                expectsResponse: true,
+                isTopLevelClientRequest: true
+            )
+        )
+        let parentCancellationHandle = ClientMCPRequestExecutor.CancellationHandle(
+            leaseID: parentLeaseID,
+            sessionID: "session-preparation-cancellation",
+            requestIDKeys: []
+        )
+        parentCancellationHandle.cancel(using: sessionManager)
+
+        let forwardingService = MCPForwardingService(
+            configuration: config.runtime,
+            sessionManager: sessionManager
+        )
+        let result = await forwardingService.callInternalTool(
+            name: "XcodeListNavigatorIssues",
+            arguments: ["tabIdentifier": "windowtab-preparation-cancellation"],
+            sessionID: "session-preparation-cancellation",
+            eventLoop: eventLoop,
+            cancellationHandle: parentCancellationHandle,
+            upstreamIndexOverride: 0
+        )
+
+        guard case .cancelled = result else {
+            Issue.record("expected cancelled parent to reject the internal request")
+            return
+        }
+        #expect(sessionManager.assignedUpstreamIDCount() == 0)
+        #expect(sessionManager.sentUpstreamCount() == 0)
+        #expect(sessionManager.mappedUpstreamRequestCount() == 0)
+        #expect(sessionManager.lastAbandonedRequestHadOperationLease() == false)
     }
 
     @Test func forwardingServiceInternalXcodeListWindowsUsesLiveWindowAggregation()

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
@@ -2460,6 +2460,15 @@ func extractUpstreamID(from data: Data) throws -> Int64 {
     return (object?["id"] as? NSNumber)?.int64Value ?? 0
 }
 
+func extractCancellationRequestID(from data: Data) throws -> Int64 {
+    let object = try #require(
+        JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    )
+    #expect(object["method"] as? String == "notifications/cancelled")
+    let params = try #require(object["params"] as? [String: Any])
+    return try #require((params["requestId"] as? NSNumber)?.int64Value)
+}
+
 func decodeJSON(from buffer: ByteBuffer) throws -> [String: Any] {
     var buffer = buffer
     guard let data = buffer.readData(length: buffer.readableBytes) else {

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTestSupport.swift
@@ -30,12 +30,7 @@ extension UpstreamHealthManager {
     func clearUpstreamState(
         upstreamIndex: Int,
         expectedUpstreamID: Int64? = nil
-    ) -> (
-        timeout: RuntimeScheduledTimeout?,
-        initUpstreamID: Int64?,
-        didReceiveInitializeResponse: Bool,
-        didSendInitialized: Bool
-    )? {
+    ) -> ClearedUpstreamState? {
         guard let proof = topologyProof(for: upstreamIndex) else { return nil }
         return clearUpstreamState(proof, expectedUpstreamID: expectedUpstreamID)
     }
@@ -2353,6 +2348,7 @@ struct RuntimeCoordinatorFixture {
         processRoutingEnabled: Bool? = nil,
         xcodeTargetDiscovery: (any XcodeTargetDiscovering)? = nil,
         dynamicUpstreamFactory: XcodeProcessUpstreamFactory? = nil,
+        unboundUpstreamFactory: UnboundUpstreamFactory? = nil,
         documentationProviderManager: (any DocumentationProviderManaging)? = nil,
         prewarmDocumentationProviderOnStartup: Bool = false,
         testHooks: RuntimeCoordinatorTestHooks = RuntimeCoordinatorTestHooks(),
@@ -2375,6 +2371,7 @@ struct RuntimeCoordinatorFixture {
             processRoutingEnabled: processRoutingEnabled,
             xcodeTargetDiscovery: xcodeTargetDiscovery,
             dynamicUpstreamFactory: dynamicUpstreamFactory,
+            unboundUpstreamFactory: unboundUpstreamFactory,
             documentationProviderManager: documentationProviderManager,
             prewarmDocumentationProviderOnStartup: prewarmDocumentationProviderOnStartup,
             testHooks: testHooks,

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -7248,7 +7248,6 @@ struct RuntimeCoordinatorRecoveryTests {
         await #expect(throws: TimeoutError.self) {
             _ = try await firstTask.value
         }
-        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
         let prewarmCancellation = try await sentValue(
             from: upstream,
             at: 3,
@@ -7258,6 +7257,8 @@ struct RuntimeCoordinatorRecoveryTests {
             try extractCancellationRequestID(from: prewarmCancellation)
                 == extractUpstreamID(from: prewarmRequest)
         )
+        await manager.drainRuntimeTasksForTesting()
+        #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
 
         let secondTask = Task {
             try await manager.sharedToolsList(

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -820,6 +820,74 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 ]))
     }
 
+    @Test func rejectedCatalogCancellationReplacesChannelInsteadOfRetryingIt()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27027, xcodeVersion: "27.0")
+        let initial = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 300),
+            upstreams: [initial],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0])
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return [replacement]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let route = try #require(manager.processControlPlane.route(
+            forProcessID: target.processID
+        ))
+        let proof = try #require(manager.upstreamTopology.operationLease(
+            for: UpstreamSlotID(rawValue: 0)
+        )?.proof)
+        let (lease, transition) = try #require(
+            manager.processControlPlane.beginCatalogAttempt(
+                routeID: route.id,
+                preferredUpstreamProof: proof,
+                nowUptimeNanoseconds: 1
+            )
+        )
+        manager.applyProcessControlPlaneTransition(transition)
+        manager.applyCatalogCommit(manager.processControlPlane.completeCatalog(
+            .unusable,
+            lease: lease,
+            nowUptimeNanoseconds: 2
+        ))
+
+        let cancellation = ControlPlane.RPCCancellationDelivery()
+        manager.scheduleMissingProcessToolsCatalogRetry(
+            processID: target.processID,
+            lease: lease,
+            after: [cancellation],
+            reason: "test_rejected_cancellation"
+        )
+        cancellation.complete(.rejected)
+
+        #expect(
+            try await initial.nextStopCount(timeout: .seconds(2)) == 1
+        )
+        #expect(replacements.withLockedValue(\.count) == 1)
+        #expect(
+            manager.upstreamTopology.operationLease(
+                for: UpstreamSlotID(rawValue: 0)
+            )?.proof != proof
+        )
+        #expect(
+            timeoutScheduler.activeTimeoutIndex(delay: .milliseconds(250)) == nil
+        )
+    }
+
     @Test func processBridgeRecoveryRetriesAttachProbeWithBoundedCadence()
         async throws
     {
@@ -6131,6 +6199,8 @@ struct RuntimeCoordinatorRecoveryTests {
 
         let sessionID = "session-tools-timeout"
         _ = manager.session(id: sessionID)
+        await upstream.blockNextSend(method: "tools/list")
+        await upstream.blockNextCancellation()
 
         let firstTask = Task {
             try await manager.sharedToolsList(
@@ -6141,7 +6211,7 @@ struct RuntimeCoordinatorRecoveryTests {
         try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
         let firstRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: firstRequest) == "tools/list")
-        await upstream.blockNextCancellation()
+        try await upstream.waitForBlockedSend()
         try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
@@ -6150,6 +6220,8 @@ struct RuntimeCoordinatorRecoveryTests {
         await #expect(throws: TimeoutError.self) {
             _ = try await firstTask.value
         }
+        #expect(await upstream.sentCount() == 3)
+        await upstream.releaseBlockedSend()
         try await upstream.waitForBlockedCancellation()
         #expect(await upstream.sentCount() == 4)
         await upstream.releaseBlockedCancellation()
@@ -6762,6 +6834,9 @@ struct RuntimeCoordinatorRecoveryTests {
             try await manager.controlPlaneDebugMirror.waitForSnapshot {
                 $0.waiterCounts.windows == 0 && $0.inFlightControlPlaneRequests.isEmpty
             }
+        }
+        _ = try await waitWithTimeout("waiting for timed-out XcodeListWindows request cleanup") {
+            await manager.drainControlPlaneLoadsForTesting()
         }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
         let firstCancellation = try await sentValue(
@@ -12507,7 +12582,7 @@ struct RuntimeCoordinatorWindowRoutingTests {
 
     @Test func controlPlaneRPCHandlePublishesSharedDeliveryBeforeInvokingCancellation() async {
         let handle = ControlPlane.RPCHandle()
-        let callbackDelivery = NIOLockedValueBox<AsyncTerminalSignal?>(nil)
+        let callbackDelivery = NIOLockedValueBox<ControlPlane.RPCCancellationDelivery?>(nil)
         let callbackCause = NIOLockedValueBox<ControlPlane.RPCCancellationCause?>(nil)
 
         let firstDelivery = handle.cancel(cause: .timedOut)
@@ -12524,8 +12599,8 @@ struct RuntimeCoordinatorWindowRoutingTests {
         #expect(firstDelivery === installedDelivery)
         #expect(callbackCause.withLockedValue { $0 } == .timedOut)
 
-        installedDelivery?.signal()
-        await firstDelivery?.wait()
+        installedDelivery?.complete(.delivered)
+        #expect(await firstDelivery?.wait() == .delivered)
     }
 
     @Test func controlPlaneRPCCancelBetweenPreflightAndEnqueueRemovesQueuedRequest()

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -8989,6 +8989,12 @@ struct RuntimeCoordinatorRecoveryTests {
             #expect(error is TimeoutError)
         }
         #expect(await siblingUpstream.sentCount() == 0)
+        try await waitWithTimeout(
+            "waiting for exhausted sibling deadline retry scheduling",
+            timeout: .seconds(2)
+        ) {
+            await manager.drainRuntimeTasksForTesting()
+        }
     }
 
     @Test func sessionManagerProcessToolsListPropagatesCancellation() async throws {
@@ -13203,27 +13209,91 @@ struct RuntimeCoordinatorWindowRoutingTests {
         #expect(handle.markRegistered(registrationToken: UUID(), operationLease: testOperationLease(0)) == false)
     }
 
+    @Test func controlPlaneRPCHandleCancelBeforeHandlerInstallationTerminatesWithoutReplay() async {
+        let handle = ControlPlane.RPCHandle()
+        let callbackCount = NIOLockedValueBox(0)
+
+        let firstDelivery = handle.cancel(cause: .timedOut)
+        let repeatedDelivery = handle.cancel()
+
+        #expect(firstDelivery === repeatedDelivery)
+        #expect(await firstDelivery?.wait() == .noLongerApplicable)
+        #expect(handle.installCancelWithDelivery { _, _ in
+            callbackCount.withLockedValue { $0 += 1 }
+        } == false)
+        #expect(callbackCount.withLockedValue { $0 } == 0)
+        #expect(
+            handle.markRegistered(
+                registrationToken: UUID(),
+                operationLease: testOperationLease(0)
+            ) == false
+        )
+    }
+
     @Test func controlPlaneRPCHandlePublishesSharedDeliveryBeforeInvokingCancellation() async {
         let handle = ControlPlane.RPCHandle()
         let callbackDelivery = NIOLockedValueBox<ControlPlane.RPCCancellationDelivery?>(nil)
         let callbackCause = NIOLockedValueBox<ControlPlane.RPCCancellationCause?>(nil)
+        let callbackCount = NIOLockedValueBox(0)
+        let reentrantDelivery = NIOLockedValueBox<ControlPlane.RPCCancellationDelivery?>(nil)
 
-        let firstDelivery = handle.cancel(cause: .timedOut)
-        let concurrentDelivery = handle.cancel()
-
-        handle.installCancelWithDelivery { snapshot, delivery in
+        #expect(handle.installCancelWithDelivery { snapshot, delivery in
             callbackCause.withLockedValue { $0 = snapshot.cause }
             callbackDelivery.withLockedValue { $0 = delivery }
-        }
+            callbackCount.withLockedValue { $0 += 1 }
+            reentrantDelivery.withLockedValue { $0 = handle.cancel() }
+        })
 
+        let firstDelivery = handle.cancel(cause: .timedOut)
+        let repeatedDelivery = handle.cancel()
         let installedDelivery = callbackDelivery.withLockedValue { $0 }
 
-        #expect(firstDelivery === concurrentDelivery)
+        #expect(firstDelivery === repeatedDelivery)
         #expect(firstDelivery === installedDelivery)
+        #expect(firstDelivery === reentrantDelivery.withLockedValue { $0 })
         #expect(callbackCause.withLockedValue { $0 } == .timedOut)
+        #expect(callbackCount.withLockedValue { $0 } == 1)
 
         installedDelivery?.complete(.delivered)
         #expect(await firstDelivery?.wait() == .delivered)
+    }
+
+    @Test func controlPlaneRPCRejectsHandleCancelledBeforeInstallationWithoutLeakingLease()
+        async throws
+    {
+        let group = borrowSharedTestEventLoopGroup()
+        defer { shutdownAndWait(group) }
+        let upstream = TestUpstreamClient()
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: group.next(),
+            upstreams: [upstream],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let handle = ControlPlane.RPCHandle()
+
+        #expect(await handle.cancel()?.wait() == .noLongerApplicable)
+        await #expect(throws: CancellationError.self) {
+            try await manager.performControlPlaneRPC(
+                route: .pinnedUpstream(0),
+                purpose: "cancelled-before-handler-installation",
+                label: "cancelled-before-handler-installation",
+                requestObject: JSONRPC.Wire.requestObject(
+                    id: "cancelled-before-handler-installation",
+                    method: "tools/list"
+                ),
+                requestTimeout: .seconds(5),
+                rpcHandle: handle
+            )
+        }
+
+        await manager.drainRuntimeTasksForTesting()
+        #expect(await upstream.sentCount() == 0)
+        let schedulerSnapshot = manager.upstreamSlotScheduler.debugSnapshot()
+        #expect(schedulerSnapshot.queuedRequestCount == 0)
+        #expect(schedulerSnapshot.activeLeaseCountByUpstream.isEmpty)
     }
 
     @Test func controlPlaneRPCCancelBetweenPreflightAndEnqueueRemovesQueuedRequest()

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -3428,6 +3428,126 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(manager.canonicalHandshakeState.initializeSourceUpstream() == 0)
     }
 
+    @Test func processRouteUsabilityEvaluationDefersHealthProbeEffectsOutsideInitializeLock()
+        async throws
+    {
+        let group = borrowSharedTestEventLoopGroup()
+        defer { shutdownAndWait(group) }
+        let upstream = TestUpstreamClient()
+        let target = xcodeProcessTarget(processID: 27015, xcodeVersion: "27.0")
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: group.next(),
+            upstreams: [upstream],
+            nowUptimeNanoseconds: { 16_000_000_000 },
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0])
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let operationLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        for _ in 0..<3 {
+            _ = manager.upstreamHealthManager.markRequestTimedOut(
+                operationLease.proof,
+                nowUptimeNs: 0
+            )
+        }
+
+        var capturedEvaluation: RuntimeCoordinator.ProcessRouteUsabilityEvaluation?
+        #expect(manager.initializeManager.performIfRunning {
+            capturedEvaluation = manager.evaluateProcessRouteUpstreamUsability(
+                policy: .toolsCatalog,
+                nowUptimeNs: 16_000_000_000
+            )
+        })
+
+        let evaluation = try #require(capturedEvaluation)
+        #expect(evaluation.snapshot == .empty)
+        #expect(await upstream.sentCount() == 0)
+        let healthEffect = try #require(evaluation.effects.first)
+        guard case .startHealthProbe = healthEffect else {
+            Issue.record("expired quarantine should produce a deferred health probe")
+            return
+        }
+
+        manager.applyHealthEffects(evaluation.effects)
+        let probe = try await upstream.nextSent(at: 0)
+        #expect(methodName(from: probe) == "tools/list")
+        await upstream.yield(
+            .message(
+                try makeDocumentationToolsListResponse(
+                    id: try extractUpstreamID(from: probe),
+                    tools: []
+                )
+            )
+        )
+        await manager.drainRuntimeTasksForTesting()
+        guard let healthState = manager.testStateSnapshot().upstream(id: 0)?.healthState,
+              case .healthy = healthState
+        else {
+            Issue.record("successful deferred probe should restore healthy state")
+            return
+        }
+    }
+
+    @Test func deferredProcessRouteHealthProbeIsRejectedWhenInitializeShutdownWins()
+        async throws
+    {
+        let group = borrowSharedTestEventLoopGroup()
+        defer { shutdownAndWait(group) }
+        let upstream = TestUpstreamClient()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let eventLoop = group.next()
+        let manager = RuntimeCoordinator(
+            config: makeConfig(requestTimeout: 5),
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            nowUptimeNanoseconds: { 16_000_000_000 },
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(
+                    target: xcodeProcessTarget(processID: 27016, xcodeVersion: "27.0"),
+                    upstreamIndices: [0]
+                )
+            ],
+            startImmediately: false
+        )
+        defer { manager.shutdownAndWait() }
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let operationLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        for _ in 0..<3 {
+            _ = manager.upstreamHealthManager.markRequestTimedOut(
+                operationLease.proof,
+                nowUptimeNs: 0
+            )
+        }
+
+        var capturedEvaluation: RuntimeCoordinator.ProcessRouteUsabilityEvaluation?
+        #expect(manager.initializeManager.performIfRunning {
+            capturedEvaluation = manager.evaluateProcessRouteUpstreamUsability(
+                policy: .toolsCatalog,
+                nowUptimeNs: 16_000_000_000
+            )
+        })
+        let evaluation = try #require(capturedEvaluation)
+        let healthEffect = try #require(evaluation.effects.first)
+        guard case .startHealthProbe = healthEffect else {
+            Issue.record("expired quarantine should produce a deferred health probe")
+            return
+        }
+
+        _ = manager.initializeManager.beginShutdown()
+        manager.applyHealthEffects(evaluation.effects)
+        await manager.drainRuntimeTasksForTesting()
+        try await eventLoop.submit {}.get()
+
+        #expect(await upstream.sentCount() == 0)
+        #expect(timeoutScheduler.scheduledCount() == 1)
+        #expect(timeoutScheduler.isCancelled(at: 0))
+    }
+
     @Test func processRoutingCooldownTimersFollowRouteLifecycle() {
         let uptimeClock = TestUptimeClock()
         let timeoutScheduler = RecordingRuntimeTimeoutScheduler()

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -9308,8 +9308,7 @@ struct RuntimeCoordinatorRecoveryTests {
             [remainingTarget],
             reason: "test_process_route_retired"
         )
-        await manager.drainRuntimeTasksForTesting()
-        #expect(await retiredUpstream.stopCount() == 1)
+        #expect(try await retiredUpstream.nextStopCount() == 1)
 
         #expect(
             toolNames(in: manager.cachedToolsListResult() ?? .null) == [
@@ -9368,8 +9367,7 @@ struct RuntimeCoordinatorRecoveryTests {
             [],
             reason: "test_cataloged_process_route_retired_once"
         )
-        await manager.drainRuntimeTasksForTesting()
-        #expect(await upstream.stopCount() == 1)
+        #expect(try await upstream.nextStopCount() == 1)
 
         let notificationMethods = session.router.drainBufferedNotifications().compactMap {
             methodName(from: $0)
@@ -9676,8 +9674,7 @@ struct RuntimeCoordinatorCatalogTests {
             [remainingTarget],
             reason: "test_uncataloged_process_route_retired"
         )
-        await manager.drainRuntimeTasksForTesting()
-        #expect(await uncatalogedUpstream.stopCount() == 1)
+        #expect(try await uncatalogedUpstream.nextStopCount() == 1)
 
         #expect(
             toolNames(in: manager.cachedToolsListResult() ?? .null) == [

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -645,7 +645,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(timeoutScheduler.isCancelled(at: 0))
     }
 
-    @Test func processRouteActivationCatalogTimeoutStaysBoundedAndReplacesSlot()
+    @Test func processRouteActivationCatalogTimeoutCancelsBeforeRetryingSameSlot()
         async throws
     {
         var config = makeConfig(requestTimeout: 300)
@@ -732,45 +732,45 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(timeoutScheduler.scheduledCount() == 3)
         #expect(timeoutScheduler.delay(at: 1)?.nanoseconds == TimeAmount.seconds(3).nanoseconds)
         #expect(timeoutScheduler.delay(at: 2)?.nanoseconds == TimeAmount.seconds(10).nanoseconds)
+        await firstAttempt.blockNextCancellation()
         #expect(timeoutScheduler.fire(at: 2))
-        #expect(
-            try await waitWithTimeout(
-                "waiting for timed-out activation slot to stop",
-                timeout: .seconds(2)
-            ) {
-                try await firstAttempt.nextStopCount()
-            } == 1)
-        #expect(createdUpstreams.withLockedValue(\.count) == 2)
-
-        let retryAttempt = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
-        let retryTimeoutIndex = try #require(
-            timeoutScheduler.activeTimeoutIndex(
-                delay: .milliseconds(250),
-                startingAt: 3
+        try await firstAttempt.waitForBlockedCancellation()
+        let cancellation = try await waitWithTimeout(
+            "waiting for timed-out catalog cancellation",
+            timeout: .seconds(2)
+        ) {
+            try await firstAttempt.nextSent(
+                startingAt: 3,
+                matching: { methodName(from: $0) == "notifications/cancelled" }
             )
+        }
+        let cancellationObject = try #require(
+            JSONSerialization.jsonObject(with: cancellation, options: []) as? [String: Any]
+        )
+        let cancellationParams = try #require(
+            cancellationObject["params"] as? [String: Any]
+        )
+        let staleToolsUpstreamID = try extractUpstreamID(from: staleToolsRequest)
+        #expect(
+            (cancellationParams["requestId"] as? NSNumber)?.int64Value
+                == staleToolsUpstreamID
+        )
+        #expect(await firstAttempt.stopCount() == 0)
+        #expect(createdUpstreams.withLockedValue(\.count) == 1)
+        #expect(timeoutScheduler.scheduledCount() == 3)
+
+        await firstAttempt.releaseBlockedCancellation()
+        let retryTimeoutIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(250),
+            startingAtEventIndex: 3
         )
         #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
-        let retryInitialize = try await waitWithTimeout(
-            "waiting for activation retry initialize",
-            timeout: .seconds(2)
-        ) {
-            try await retryAttempt.nextSent(at: 0)
-        }
-        await retryAttempt.yield(
-            .message(try makeInitializeResponse(id: try extractUpstreamID(from: retryInitialize)))
-        )
-        _ = try await waitWithTimeout(
-            "waiting for retry activation initialized notification",
-            timeout: .seconds(2)
-        ) {
-            try await retryAttempt.nextSent(at: 1)
-        }
         let retryToolsRequest = try await waitWithTimeout(
-            "waiting for retry activation tools/list",
+            "waiting for catalog retry on the existing activation slot",
             timeout: .seconds(2)
         ) {
-            try await retryAttempt.nextSent(
-                startingAt: 2,
+            try await firstAttempt.nextSent(
+                startingAt: 4,
                 matching: { methodName(from: $0) == "tools/list" }
             )
         }
@@ -787,7 +787,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
         )
         #expect(manager.processControlPlane.catalog(forProcessID: newerTarget.processID) == nil)
 
-        await retryAttempt.yield(
+        await firstAttempt.yield(
             .message(
                 try makeDocumentationToolsListResponse(
                     id: try extractUpstreamID(from: retryToolsRequest),
@@ -3286,33 +3286,36 @@ struct RuntimeCoordinatorProcessRoutingTests {
         let catalogTimeoutIndex = try #require(
             timeoutScheduler.activeTimeoutIndex(delay: .seconds(10))
         )
-        let scheduledBeforeCatalogTimeout = timeoutScheduler.scheduledCount()
+        let scheduledEventsBeforeCatalogTimeout = timeoutScheduler.scheduledEventCount()
         #expect(timeoutScheduler.fire(at: catalogTimeoutIndex))
-        #expect(
-            try await waitWithTimeout(
-                "waiting for timed-out 26 upstream stop",
-                timeout: .seconds(2)
-            ) {
-                try await firstAttempt.nextStopCount()
-            } == 1)
+        _ = try await waitWithTimeout(
+            "waiting for timed-out 26 catalog cancellation",
+            timeout: .seconds(2)
+        ) {
+            try await firstAttempt.nextSent(
+                startingAt: 3,
+                matching: { methodName(from: $0) == "notifications/cancelled" }
+            )
+        }
+        #expect(await firstAttempt.stopCount() == 0)
         #expect(
             manager.unavailableXcodeProcessIDs().contains(
                 relaunched26Target.processID
             ) == false)
-        #expect(createdUpstreams.withLockedValue(\.count) == 2)
-        let retryTimeoutIndex = try #require(
-            timeoutScheduler.activeTimeoutIndex(
-                delay: .milliseconds(250),
-                startingAt: scheduledBeforeCatalogTimeout
-            )
+        #expect(createdUpstreams.withLockedValue(\.count) == 1)
+        let retryTimeoutIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(250),
+            startingAtEventIndex: scheduledEventsBeforeCatalogTimeout
         )
-        let retryAttempt = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
         #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
-        let retryInitialize = try await waitWithTimeout(
-            "waiting for activation-retried relaunched 26 initialize",
+        let retryCatalogRequest = try await waitWithTimeout(
+            "waiting for relaunched 26 catalog retry",
             timeout: .seconds(2)
         ) {
-            try await retryAttempt.nextSent(at: 0)
+            try await firstAttempt.nextSent(
+                startingAt: 4,
+                matching: { methodName(from: $0) == "tools/list" }
+            )
         }
 
         await firstAttempt.yield(
@@ -3331,32 +3334,10 @@ struct RuntimeCoordinatorProcessRoutingTests {
             ) == nil)
 
         let catalogCommitIndex = catalogCommits.count()
-        await retryAttempt.yield(
-            .message(
-                try makeInitializeResponse(
-                    id: try extractUpstreamID(from: retryInitialize),
-                    serverName: "cached-source"
-                ))
-        )
-        _ = try await waitWithTimeout(
-            "waiting for relaunched 26 retry initialized notification",
-            timeout: .seconds(2)
-        ) {
-            try await retryAttempt.nextSent(at: 1)
-        }
-        let readyCatalogRequest = try await waitWithTimeout(
-            "waiting for relaunched 26 retry tools/list",
-            timeout: .seconds(2)
-        ) {
-            try await retryAttempt.nextSent(
-                startingAt: 2,
-                matching: { methodName(from: $0) == "tools/list" }
-            )
-        }
-        await retryAttempt.yield(
+        await firstAttempt.yield(
             .message(
                 try makeDocumentationToolsListResponse(
-                    id: try extractUpstreamID(from: readyCatalogRequest),
+                    id: try extractUpstreamID(from: retryCatalogRequest),
                     tools: [
                         toolDescriptor(name: "Only26Relaunched")
                     ]
@@ -6160,6 +6141,7 @@ struct RuntimeCoordinatorRecoveryTests {
         try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
         let firstRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: firstRequest) == "tools/list")
+        await upstream.blockNextCancellation()
         try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
             uptimeClock: clocks.uptimeClock,
@@ -6168,6 +6150,9 @@ struct RuntimeCoordinatorRecoveryTests {
         await #expect(throws: TimeoutError.self) {
             _ = try await firstTask.value
         }
+        try await upstream.waitForBlockedCancellation()
+        #expect(await upstream.sentCount() == 4)
+        await upstream.releaseBlockedCancellation()
 
         _ = try await waitWithTimeout("waiting for timed-out tools/list load cleanup") {
             try await manager.controlPlaneDebugMirror.waitForSnapshot {
@@ -6178,6 +6163,15 @@ struct RuntimeCoordinatorRecoveryTests {
             await manager.drainControlPlaneLoadsForTesting()
         }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
+        let firstCancellation = try await sentValue(
+            from: upstream,
+            at: 3,
+            timeout: .seconds(2)
+        )
+        #expect(
+            try extractCancellationRequestID(from: firstCancellation)
+                == extractUpstreamID(from: firstRequest)
+        )
 
         let secondTask = Task {
             try await manager.sharedToolsList(
@@ -6185,8 +6179,8 @@ struct RuntimeCoordinatorRecoveryTests {
                 requestTimeoutOverride: .seconds(5)
             )
         }
-        try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
-        let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
+        try await waitForSentCount(upstream, count: 5, timeoutSeconds: 2)
+        let secondRequest = try await sentValue(from: upstream, at: 4, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/list")
         try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
@@ -6304,8 +6298,17 @@ struct RuntimeCoordinatorRecoveryTests {
             )
         }
 
-        try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
-        let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
+        try await waitForSentCount(upstream, count: 5, timeoutSeconds: 2)
+        let firstCancellation = try await sentValue(
+            from: upstream,
+            at: 3,
+            timeout: .seconds(2)
+        )
+        #expect(
+            try extractCancellationRequestID(from: firstCancellation)
+                == extractUpstreamID(from: firstRequest)
+        )
+        let secondRequest = try await sentValue(from: upstream, at: 4, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/list")
 
         firstTask.cancel()
@@ -6575,6 +6578,15 @@ struct RuntimeCoordinatorRecoveryTests {
             _ = try await firstTask.value
         }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
+        let prewarmCancellation = try await sentValue(
+            from: upstream,
+            at: 3,
+            timeout: .seconds(2)
+        )
+        #expect(
+            try extractCancellationRequestID(from: prewarmCancellation)
+                == extractUpstreamID(from: prewarmRequest)
+        )
 
         let secondTask = Task {
             try await manager.sharedToolsList(
@@ -6582,8 +6594,8 @@ struct RuntimeCoordinatorRecoveryTests {
                 requestTimeoutOverride: .seconds(5)
             )
         }
-        try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
-        let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
+        try await waitForSentCount(upstream, count: 5, timeoutSeconds: 2)
+        let secondRequest = try await sentValue(from: upstream, at: 4, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/list")
         try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
@@ -6752,6 +6764,15 @@ struct RuntimeCoordinatorRecoveryTests {
             }
         }
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
+        let firstCancellation = try await sentValue(
+            from: upstream,
+            at: 3,
+            timeout: .seconds(2)
+        )
+        #expect(
+            try extractCancellationRequestID(from: firstCancellation)
+                == extractUpstreamID(from: firstRequest)
+        )
 
         let secondTask = Task {
             try await manager.liveXcodeListWindowsResult(
@@ -6759,8 +6780,8 @@ struct RuntimeCoordinatorRecoveryTests {
                 requestTimeoutOverride: .seconds(5)
             )
         }
-        try await waitForSentCount(upstream, count: 4, timeoutSeconds: 2)
-        let secondRequest = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
+        try await waitForSentCount(upstream, count: 5, timeoutSeconds: 2)
+        let secondRequest = try await sentValue(from: upstream, at: 4, timeout: .seconds(2))
         #expect(methodName(from: secondRequest) == "tools/call")
         try await advanceRuntimeCoordinatorTimeout(
             timeoutClock: clocks.timeoutClock,
@@ -8445,10 +8466,10 @@ struct RuntimeCoordinatorRecoveryTests {
             )
         }
 
-        _ = try await upstream0.nextSent {
+        let request0 = try await upstream0.nextSent {
             methodName(from: $0) == "tools/list"
         }
-        _ = try await upstream1.nextSent {
+        let request1 = try await upstream1.nextSent {
             methodName(from: $0) == "tools/list"
         }
 
@@ -8457,8 +8478,24 @@ struct RuntimeCoordinatorRecoveryTests {
         await #expect(throws: CancellationError.self) {
             _ = try await task.value
         }
-        #expect(await upstream0.sentCount() == 1)
-        #expect(await upstream1.sentCount() == 1)
+        let cancellation0 = try await upstream0.nextSent(
+            startingAt: 1,
+            matching: { methodName(from: $0) == "notifications/cancelled" }
+        )
+        let cancellation1 = try await upstream1.nextSent(
+            startingAt: 1,
+            matching: { methodName(from: $0) == "notifications/cancelled" }
+        )
+        #expect(
+            try extractCancellationRequestID(from: cancellation0)
+                == extractUpstreamID(from: request0)
+        )
+        #expect(
+            try extractCancellationRequestID(from: cancellation1)
+                == extractUpstreamID(from: request1)
+        )
+        #expect(await upstream0.sentCount() == 2)
+        #expect(await upstream1.sentCount() == 2)
     }
 
     @Test func sessionManagerUnavailableUncatalogedRouteRecomputesRemainingProcessSurface()
@@ -12468,6 +12505,29 @@ struct RuntimeCoordinatorWindowRoutingTests {
         #expect(handle.markRegistered(registrationToken: UUID(), operationLease: testOperationLease(0)) == false)
     }
 
+    @Test func controlPlaneRPCHandlePublishesSharedDeliveryBeforeInvokingCancellation() async {
+        let handle = ControlPlane.RPCHandle()
+        let callbackDelivery = NIOLockedValueBox<AsyncTerminalSignal?>(nil)
+        let callbackCause = NIOLockedValueBox<ControlPlane.RPCCancellationCause?>(nil)
+
+        let firstDelivery = handle.cancel(cause: .timedOut)
+        let concurrentDelivery = handle.cancel()
+
+        handle.installCancelWithDelivery { snapshot, delivery in
+            callbackCause.withLockedValue { $0 = snapshot.cause }
+            callbackDelivery.withLockedValue { $0 = delivery }
+        }
+
+        let installedDelivery = callbackDelivery.withLockedValue { $0 }
+
+        #expect(firstDelivery === concurrentDelivery)
+        #expect(firstDelivery === installedDelivery)
+        #expect(callbackCause.withLockedValue { $0 } == .timedOut)
+
+        installedDelivery?.signal()
+        await firstDelivery?.wait()
+    }
+
     @Test func controlPlaneRPCCancelBetweenPreflightAndEnqueueRemovesQueuedRequest()
         async throws
     {
@@ -15542,6 +15602,22 @@ struct RuntimeCoordinatorSchedulingTests {
             requestIDKeys: [originalID.key],
             upstreamIndex: 0
         )
+        let cancellation = try await waitWithTimeout(
+            "waiting for abandoned request cancellation",
+            timeout: .seconds(2)
+        ) {
+            try await upstream.nextSent(
+                startingAt: 0,
+                matching: { methodName(from: $0) == "notifications/cancelled" }
+            )
+        }
+        let cancellationObject = try #require(
+            JSONSerialization.jsonObject(with: cancellation, options: []) as? [String: Any]
+        )
+        let cancellationParams = try #require(
+            cancellationObject["params"] as? [String: Any]
+        )
+        #expect((cancellationParams["requestId"] as? NSNumber)?.int64Value == upstreamID)
 
         let releaseSnapshot = manager.debugSnapshot()
         let releasedLease = try #require(

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -845,6 +845,15 @@ struct RuntimeCoordinatorProcessRoutingTests {
         defer { fixture.shutdownAndWait() }
         let manager = fixture.manager
         manager.markUpstreamInitialized(upstreamIndex: 0)
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+                "serverInfo": ["name": "catalog-cancellation-source"],
+            ]),
+            sourceUpstream: 0
+        )
         let route = try #require(manager.processControlPlane.route(
             forProcessID: target.processID
         ))
@@ -888,14 +897,49 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(timeoutScheduler.isCancelled(at: obsoleteRetryIndex))
 
         let rejectedLease = try prepareRetryLease(at: 3)
-        let cancellation = ControlPlane.RPCCancellationDelivery()
+        let operationLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        let sessionID = "rejected-catalog-cancellation"
+        let originalID = try #require(JSONRPC.ID(any: NSNumber(value: 1)))
+        let requestLeaseID = manager.createRequestLease(
+            descriptor: SessionRequestPipeline.Descriptor(
+                sessionID: sessionID,
+                label: "tools/list",
+                expectsResponse: true,
+                isTopLevelClientRequest: false
+            )
+        )
+        let upstreamID = try #require(manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: originalID,
+            operationLease: operationLease
+        ))
+        manager.activateRequestLease(
+            requestLeaseID,
+            requestIDKey: originalID.key,
+            upstreamIndex: 0,
+            timeout: .seconds(300)
+        )
+        await initial.blockNextCancellation()
+        let cancellation = try #require(
+            manager.handleRequestLeaseTimeoutWithCancellationDelivery(
+                requestLeaseID,
+                sessionID: sessionID,
+                requestIDKeys: [originalID.key],
+                operationLease: operationLease
+            )
+        )
         manager.scheduleMissingProcessToolsCatalogRetry(
             processID: target.processID,
             lease: rejectedLease,
             after: [cancellation],
             reason: "test_rejected_cancellation"
         )
-        cancellation.complete(.rejected)
+        try await initial.waitForBlockedCancellation()
+        let cancellationData = try await initial.nextSent(
+            matching: { methodName(from: $0) == "notifications/cancelled" }
+        )
+        #expect(try extractCancellationRequestID(from: cancellationData) == upstreamID)
+        await initial.releaseBlockedCancellation(.backpressure)
 
         #expect(
             try await initial.nextStopCount(timeout: .seconds(2)) == 1
@@ -906,8 +950,413 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 for: UpstreamSlotID(rawValue: 0)
             )?.proof != proof
         )
-        #expect(
-            timeoutScheduler.activeTimeoutIndex(delay: .milliseconds(500)) == nil
+        let activationRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(500),
+            startingAtEventIndex: obsoleteRetryIndex + 1
+        )
+        #expect(timeoutScheduler.fire(at: activationRetryIndex))
+        let replacement = try #require(replacements.withLockedValue { $0.first })
+        _ = try await replacement.nextSent(
+            matching: { methodName(from: $0) == "initialize" }
+        )
+    }
+
+    @Test func rejectedStaleCatalogCancellationRestartsCurrentAttempt() async throws {
+        let target = xcodeProcessTarget(processID: 27028, xcodeVersion: "27.0")
+        let initial = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 300),
+            upstreams: [initial],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0])
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return [replacement]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+                "serverInfo": ["name": "stale-catalog-cancellation-source"],
+            ]),
+            sourceUpstream: 0
+        )
+        let route = try #require(
+            manager.processControlPlane.route(forProcessID: target.processID)
+        )
+        let operationLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        let proof = operationLease.proof
+        let (staleLease, transition) = try #require(
+            manager.processControlPlane.beginCatalogAttempt(
+                routeID: route.id,
+                preferredUpstreamProof: proof,
+                nowUptimeNanoseconds: 1
+            )
+        )
+        manager.applyProcessControlPlaneTransition(transition)
+        manager.applyCatalogCommit(manager.processControlPlane.completeCatalog(
+            .unusable,
+            lease: staleLease,
+            nowUptimeNanoseconds: 2
+        ))
+
+        let sessionID = "stale-catalog-cancellation"
+        let originalID = try #require(JSONRPC.ID(any: NSNumber(value: 1)))
+        let requestLeaseID = manager.createRequestLease(
+            descriptor: SessionRequestPipeline.Descriptor(
+                sessionID: sessionID,
+                label: "tools/list",
+                expectsResponse: true,
+                isTopLevelClientRequest: false
+            )
+        )
+        _ = try #require(manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: originalID,
+            operationLease: operationLease
+        ))
+        manager.activateRequestLease(
+            requestLeaseID,
+            requestIDKey: originalID.key,
+            upstreamIndex: 0,
+            timeout: .seconds(300)
+        )
+        await initial.blockNextCancellation()
+        let staleCancellation = try #require(
+            manager.handleRequestLeaseTimeoutWithCancellationDelivery(
+                requestLeaseID,
+                sessionID: sessionID,
+                requestIDKeys: [originalID.key],
+                operationLease: operationLease
+            )
+        )
+        manager.scheduleMissingProcessToolsCatalogRetry(
+            processID: target.processID,
+            lease: staleLease,
+            after: [staleCancellation],
+            reason: "test_stale_rejected_cancellation"
+        )
+        try await initial.waitForBlockedCancellation()
+        manager.applyProcessControlPlaneTransition(
+            manager.processControlPlane.resetAttempt(processID: target.processID)
+        )
+        let (currentLease, currentTransition) = try #require(
+            manager.processControlPlane.beginCatalogAttempt(
+                routeID: route.id,
+                preferredUpstreamProof: proof,
+                nowUptimeNanoseconds: 3
+            )
+        )
+        manager.applyProcessControlPlaneTransition(currentTransition)
+
+        await initial.releaseBlockedCancellation(.backpressure)
+
+        #expect(try await initial.nextStopCount(timeout: .seconds(2)) == 1)
+        #expect(manager.processControlPlane.validateCatalogLoad(currentLease) == false)
+        #expect(manager.upstreamTopology.validate(proof) == false)
+        #expect(replacements.withLockedValue(\.count) == 1)
+
+        let activationRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(500),
+            startingAtEventIndex: 0
+        )
+        #expect(timeoutScheduler.fire(at: activationRetryIndex))
+        let replacement = try #require(replacements.withLockedValue { $0.first })
+        _ = try await replacement.nextSent(
+            matching: { methodName(from: $0) == "initialize" }
+        )
+    }
+
+    @Test func rejectedStaleCatalogCancellationPreservesSiblingAttempt() async throws {
+        let target = xcodeProcessTarget(processID: 27029, xcodeVersion: "27.0")
+        let failed = TestUpstreamClient()
+        let sibling = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let replacementFactoryEntered = TestSignal()
+        let allowReplacementFactory = DispatchSemaphore(value: 0)
+        let shouldBlockReplacementFactory = NIOLockedValueBox(true)
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 300),
+            upstreams: [failed, sibling],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0, 1])
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let shouldBlock = shouldBlockReplacementFactory.withLockedValue {
+                    shouldBlock in
+                    let value = shouldBlock
+                    shouldBlock = false
+                    return value
+                }
+                if shouldBlock {
+                    replacementFactoryEntered.signal()
+                    allowReplacementFactory.wait()
+                }
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return [replacement]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        defer { allowReplacementFactory.signal() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        let initializeResult = try jsonValue([
+            "protocolVersion": MCP.ProtocolVersion.current,
+            "capabilities": [String: Any](),
+            "serverInfo": ["name": "sibling-catalog-cancellation-source"],
+        ])
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: initializeResult,
+            sourceUpstream: 0
+        )
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: initializeResult,
+            sourceUpstream: 1
+        )
+        let route = try #require(
+            manager.processControlPlane.route(forProcessID: target.processID)
+        )
+        let failedOperationLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        let siblingProof = manager.operationLeaseForTest(upstreamIndex: 1).proof
+        let (staleLease, staleTransition) = try #require(
+            manager.processControlPlane.beginCatalogAttempt(
+                routeID: route.id,
+                preferredUpstreamProof: failedOperationLease.proof,
+                nowUptimeNanoseconds: 1
+            )
+        )
+        manager.applyProcessControlPlaneTransition(staleTransition)
+        manager.applyCatalogCommit(manager.processControlPlane.completeCatalog(
+            .unusable,
+            lease: staleLease,
+            nowUptimeNanoseconds: 2
+        ))
+
+        let sessionID = "stale-sibling-catalog-cancellation"
+        let originalID = try #require(JSONRPC.ID(any: NSNumber(value: 1)))
+        let requestLeaseID = manager.createRequestLease(
+            descriptor: SessionRequestPipeline.Descriptor(
+                sessionID: sessionID,
+                label: "tools/list",
+                expectsResponse: true,
+                isTopLevelClientRequest: false
+            )
+        )
+        _ = try #require(manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: originalID,
+            operationLease: failedOperationLease
+        ))
+        manager.activateRequestLease(
+            requestLeaseID,
+            requestIDKey: originalID.key,
+            upstreamIndex: 0,
+            timeout: .seconds(300)
+        )
+        await failed.blockNextCancellation()
+        let staleCancellation = try #require(
+            manager.handleRequestLeaseTimeoutWithCancellationDelivery(
+                requestLeaseID,
+                sessionID: sessionID,
+                requestIDKeys: [originalID.key],
+                operationLease: failedOperationLease
+            )
+        )
+        manager.scheduleMissingProcessToolsCatalogRetry(
+            processID: target.processID,
+            lease: staleLease,
+            after: [staleCancellation],
+            reason: "test_stale_sibling_rejected_cancellation"
+        )
+        try await failed.waitForBlockedCancellation()
+
+        await failed.releaseBlockedCancellation(.backpressure)
+        try await replacementFactoryEntered.wait(
+            description: "waiting for rejected cancellation replacement"
+        )
+        manager.applyProcessControlPlaneTransition(
+            manager.processControlPlane.resetAttempt(processID: target.processID)
+        )
+        let (currentLease, currentTransition) = try #require(
+            manager.processControlPlane.beginCatalogAttempt(
+                routeID: route.id,
+                preferredUpstreamProof: siblingProof,
+                nowUptimeNanoseconds: 3
+            )
+        )
+        manager.applyProcessControlPlaneTransition(currentTransition)
+        allowReplacementFactory.signal()
+
+        #expect(try await failed.nextStopCount(timeout: .seconds(2)) == 1)
+        await manager.drainRuntimeTasksForTesting()
+        #expect(manager.processControlPlane.validateCatalogLoad(currentLease))
+        let currentAttempt = try #require(
+            manager.processControlPlane.attemptSnapshot(processID: target.processID)
+        )
+        #expect(currentAttempt.attemptID.rawValue == currentLease.attempt)
+        #expect(currentAttempt.upstreamProof == siblingProof)
+        #expect(manager.upstreamTopology.validate(siblingProof))
+        #expect(manager.upstreamTopology.validate(failedOperationLease) == false)
+        #expect(replacements.withLockedValue(\.count) == 1)
+    }
+
+    @Test
+    func rejectedCancellationReplacementBlocksExistingActivationRetryUntilOldStopCompletes()
+        async throws
+    {
+        let target = xcodeProcessTarget(processID: 27030, xcodeVersion: "27.0")
+        let failed = TestUpstreamClient()
+        let sibling = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 300),
+            upstreams: [failed, sibling],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0, 1])
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return [replacement]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        await failed.blockStop()
+        defer {
+            Task {
+                await failed.releaseBlockedStop()
+            }
+        }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        manager.markUpstreamInitialized(upstreamIndex: 1)
+        let initializeResult = try jsonValue([
+            "protocolVersion": MCP.ProtocolVersion.current,
+            "capabilities": [String: Any](),
+            "serverInfo": ["name": "activation-retry-stop-barrier"],
+        ])
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: initializeResult,
+            sourceUpstream: 0
+        )
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: initializeResult,
+            sourceUpstream: 1
+        )
+
+        let failedOperationLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        let activationStart = try #require(
+            manager.beginProcessRouteAttachingForTesting(
+                processID: target.processID,
+                upstreamIndex: failedOperationLease.upstreamIndex,
+                nowUptimeNs: 1
+            )
+        )
+        let activationTimeout = try #require(
+            manager.processControlPlane.handleChannelInitializeTimeout(
+                activationStart.lease
+            )
+        )
+        manager.applyProcessControlPlaneTransition(activationTimeout.transition)
+        manager.scheduleProcessRouteActivationRetry(
+            processID: target.processID,
+            retry: activationTimeout.retry,
+            lease: activationTimeout.activationLease,
+            reason: "test_existing_activation_retry"
+        )
+        let activationRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: activationTimeout.retry.delay,
+            startingAtEventIndex: 0
+        )
+
+        let sessionID = "rejected-cancellation-activation-retry-stop-barrier"
+        let requestID = try #require(JSONRPC.ID(any: NSNumber(value: 1)))
+        let requestLeaseID = manager.createRequestLease(
+            descriptor: SessionRequestPipeline.Descriptor(
+                sessionID: sessionID,
+                label: "tools/list",
+                expectsResponse: true,
+                isTopLevelClientRequest: false
+            )
+        )
+        _ = try #require(manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: requestID,
+            operationLease: failedOperationLease
+        ))
+        manager.activateRequestLease(
+            requestLeaseID,
+            requestIDKey: requestID.key,
+            upstreamIndex: failedOperationLease.upstreamIndex,
+            timeout: .seconds(300)
+        )
+        await failed.blockNextCancellation()
+        manager.handleRequestLeaseTimeout(
+            requestLeaseID,
+            sessionID: sessionID,
+            requestIDKeys: [requestID.key],
+            operationLease: failedOperationLease
+        )
+        try await failed.waitForBlockedCancellation()
+        await failed.releaseBlockedCancellation(.backpressure)
+
+        try await failed.waitForBlockedStop()
+        let replacement = try await waitWithTimeout(
+            "waiting for rejected cancellation replacement"
+        ) {
+            while true {
+                if let replacement = replacements.withLockedValue({ $0.first }) {
+                    return replacement
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+        let replacementProof = try #require(
+            manager.upstreamTopology.operationLease(
+                for: failedOperationLease.proof.slotID
+            )?.proof
+        )
+        #expect(replacementProof != failedOperationLease.proof)
+        #expect(timeoutScheduler.isCancelled(at: activationRetryIndex) == false)
+        #expect(timeoutScheduler.fire(at: activationRetryIndex))
+
+        let retryAttempt = try #require(
+            manager.processControlPlane.attemptSnapshot(processID: target.processID)
+        )
+        #expect(retryAttempt.upstreamProof == replacementProof)
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+        #expect(await replacement.sentCount() == 0)
+
+        await failed.releaseBlockedStop()
+        #expect(try await failed.nextStopCount(timeout: .seconds(2)) == 1)
+        _ = try await replacement.nextSent(
+            matching: { methodName(from: $0) == "initialize" }
         )
     }
 
@@ -9031,6 +9480,150 @@ struct RuntimeCoordinatorRecoveryTests {
         #expect(manager.cachedToolsListResult() == nil)
     }
 
+    @Test func shutdownRejectsWarmInitializeAndRouteActivationRegeneration() async {
+        let target = xcodeProcessTarget(processID: 80448, xcodeVersion: "27.0")
+        let upstream = TestUpstreamClient()
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let route = XcodeProcessRoute(target: target, upstreamIndices: [0])
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 5),
+            upstreams: [upstream],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [route],
+            processRoutingEnabled: true,
+            startImmediately: false
+        )
+        let manager = fixture.manager
+
+        await manager.shutdown()
+        let scheduledTimeoutCount = timeoutScheduler.scheduledCount()
+
+        manager.startUpstreamWarmInitialize(upstreamIndex: 0)
+        manager.startProcessRouteActivation(for: route)
+
+        #expect(await upstream.sentCount() == 0)
+        #expect(timeoutScheduler.scheduledCount() == scheduledTimeoutCount)
+        #expect(manager.testStateSnapshot().upstream(id: 0) == nil)
+        #expect(manager.processControlPlane.attemptSnapshot(processID: target.processID) == nil)
+    }
+
+    @Test func upstreamSendAdmissionRejectsAfterInitializeShutdownBegins() async throws {
+        let upstream = TestUpstreamClient()
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 5),
+            upstreams: [upstream],
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let operationLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        let rejected = NIOLockedValueBox(false)
+        let requestSendCompletion = UpstreamRequestSendCompletion()
+
+        _ = manager.initializeManager.beginShutdown()
+        let scheduled = manager.sendUpstream(
+            try makeToolListRequest(id: 1),
+            operationLease: operationLease,
+            ensureRunning: false,
+            admission: nil,
+            requestSendCompletion: requestSendCompletion,
+            onRejected: {
+                rejected.withLockedValue { $0 = true }
+            }
+        )
+
+        #expect(scheduled == false)
+        #expect(rejected.withLockedValue { $0 })
+        #expect(await requestSendCompletion.wait() == .notSent)
+        await manager.drainRuntimeTasksForTesting()
+        #expect(await upstream.sentCount() == 0)
+    }
+
+    @Test func processReconcileCannotAppendTopologyAfterInitializeShutdownBegins() async {
+        let upstream = TestUpstreamClient()
+        let lateUpstream = TestUpstreamClient()
+        let factoryCallCount = NIOLockedValueBox(0)
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 5),
+            upstreams: [upstream],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                factoryCallCount.withLockedValue { $0 += 1 }
+                return [lateUpstream]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        let target = xcodeProcessTarget(processID: 80449, xcodeVersion: "27.0")
+
+        _ = manager.initializeManager.beginShutdown()
+        manager.reconcileXcodeProcessTargets(
+            [target],
+            reason: "test_shutdown_append_gate"
+        )
+
+        #expect(factoryCallCount.withLockedValue { $0 } == 0)
+        #expect(manager.processControlPlane.activeRoutes().isEmpty)
+        #expect(manager.upstreamTopology.snapshot().entries.count == 1)
+        #expect(await lateUpstream.startCount() == 0)
+        #expect(await lateUpstream.stopCount() == 0)
+    }
+
+    @Test func shutdownAndRouteRetirementStopEachSlotExactlyOnce() async throws {
+        let target = xcodeProcessTarget(processID: 80450, xcodeVersion: "27.0")
+        let upstream = TestUpstreamClient()
+        let retirementReachedDetach = TestSignal()
+        let allowRetirementDetach = DispatchSemaphore(value: 0)
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 5),
+            upstreams: [upstream],
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0])
+            ],
+            processRoutingEnabled: true,
+            testHooks: RuntimeCoordinatorTestHooks(
+                processRouteRetirementWillDetach: {
+                    retirementReachedDetach.signal()
+                    allowRetirementDetach.wait()
+                }
+            ),
+            startImmediately: false
+        )
+        let manager = fixture.manager
+        await upstream.blockStop()
+        defer {
+            allowRetirementDetach.signal()
+            Task {
+                await upstream.releaseBlockedStop()
+            }
+            fixture.shutdownAndWait()
+        }
+
+        let retirement = Task {
+            manager.reconcileXcodeProcessTargets(
+                [],
+                reason: "test_shutdown_retirement_arbitration"
+            )
+        }
+        try await retirementReachedDetach.wait(
+            description: "waiting for route retirement before topology detach"
+        )
+
+        let shutdown = Task {
+            await manager.shutdown()
+        }
+        try await upstream.waitForBlockedStop()
+        allowRetirementDetach.signal()
+        await upstream.releaseBlockedStop()
+        await retirement.value
+        await shutdown.value
+
+        #expect(await upstream.stopCount() == 1)
+        #expect(manager.upstreamTopology.snapshot().entries.isEmpty)
+    }
+
 }
 
 @Suite(.serialized, .asyncTestCleanup)
@@ -12750,6 +13343,166 @@ struct RuntimeCoordinatorWindowRoutingTests {
         }
     }
 
+    @Test func controlPlaneRPCCancelBetweenIDAssignmentAndSendDoesNotCancelUpstream()
+        async throws
+    {
+        let handle = ControlPlane.RPCHandle()
+        let upstream = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 5),
+            upstreams: [upstream],
+            unboundUpstreamFactory: {
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return replacement
+            },
+            testHooks: RuntimeCoordinatorTestHooks(
+                controlPlaneRPCAssignedUpstreamID: {
+                    handle.cancel()
+                }
+            ),
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let originalLease = manager.operationLeaseForTest(upstreamIndex: 0)
+
+        await #expect(throws: CancellationError.self) {
+            try await waitWithTimeout(
+                "waiting for assigned control-plane RPC cancellation",
+                timeout: .seconds(2)
+            ) {
+                try await manager.performControlPlaneRPC(
+                    route: .pinnedUpstream(0),
+                    purpose: "assigned-cancellation",
+                    label: "assigned-cancellation",
+                    requestObject: JSONRPC.Wire.requestObject(
+                        id: "assigned-cancellation",
+                        method: "tools/list"
+                    ),
+                    requestTimeout: .seconds(5),
+                    rpcHandle: handle
+                )
+            }
+        }
+
+        await manager.drainRuntimeTasksForTesting()
+        #expect(await upstream.sentCount() == 0)
+        #expect(replacements.withLockedValue(\.count) == 0)
+        #expect(manager.upstreamTopology.validate(originalLease))
+        #expect(
+            manager.debugSnapshot().upstreams.first?.activeCorrelatedRequestCount == 0
+        )
+        #expect(
+            manager.upstreamSlotScheduler.debugSnapshot()
+                .activeLeaseCountByUpstream.isEmpty
+        )
+    }
+
+    @Test
+    func controlPlaneRPCTimeoutBeforeBarrieredSendDoesNotCancelUnsentRequestWithoutProvidedHandle()
+        async throws
+    {
+        let initial = TestUpstreamClient()
+        let replacement = TestUpstreamClient()
+        let assignedUpstreamID = TestSignal()
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 5),
+            upstreams: [initial],
+            processRoutingEnabled: false,
+            unboundUpstreamFactory: {
+                replacement
+            },
+            testHooks: RuntimeCoordinatorTestHooks(
+                controlPlaneRPCAssignedUpstreamID: {
+                    assignedUpstreamID.signal()
+                }
+            ),
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let initialLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        await initial.blockStop()
+        defer {
+            Task {
+                await initial.releaseBlockedStop()
+            }
+        }
+
+        let replacementResult = try #require(
+            manager.replaceOrRetireInitializeChannel(
+                initialLease.proof,
+                expectedRouteID: nil,
+                requestsBridgePoolRecovery: false
+            )
+        )
+        try await initial.waitForBlockedStop()
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+
+        let request = Task {
+            try await manager.performControlPlaneRPC(
+                route: .pinnedUpstream(0),
+                purpose: "barriered-timeout-without-provided-handle",
+                label: "barriered-timeout-without-provided-handle",
+                requestObject: JSONRPC.Wire.requestObject(
+                    id: "barriered-timeout-without-provided-handle",
+                    method: "tools/list"
+                ),
+                requestTimeout: .milliseconds(20)
+            )
+        }
+        try await assignedUpstreamID.wait(
+            description: "waiting for barriered control-plane RPC assignment"
+        )
+
+        do {
+            _ = try await waitWithTimeout(
+                "waiting for barriered control-plane RPC timeout",
+                timeout: .seconds(2)
+            ) {
+                try await request.value
+            }
+            Issue.record("barriered control-plane RPC should time out")
+        } catch is TimeoutError {
+        } catch let error as ControlPlane.RequestError {
+            #expect(error.underlying is TimeoutError)
+        } catch {
+            Issue.record("expected control-plane timeout but received \(error)")
+        }
+        #expect(await replacement.sentCount() == 0)
+        #expect(manager.upstreamTopology.validate(replacementResult.operationLease))
+        #expect(
+            manager.upstreamSlotScheduler.debugSnapshot()
+                .activeLeaseCountByUpstream[0] == 1
+        )
+
+        await initial.releaseBlockedStop()
+        let originalRequest = try await sentValue(
+            from: replacement,
+            at: 0,
+            timeout: .seconds(2)
+        )
+        #expect(methodName(from: originalRequest) == "tools/list")
+        let cancellation = try await sentMessage(
+            from: replacement,
+            matching: { methodName(from: $0) == "notifications/cancelled" },
+            timeout: .seconds(2)
+        )
+        #expect(
+            try extractCancellationRequestID(from: cancellation)
+                == extractUpstreamID(from: originalRequest)
+        )
+        await manager.drainRuntimeTasksForTesting()
+        #expect(
+            manager.upstreamSlotScheduler.debugSnapshot()
+                .activeLeaseCountByUpstream.isEmpty
+        )
+    }
+
     @Test func topLevelRequestCancelBeforeLeaseActivationDoesNotSendUpstream()
         async throws
     {
@@ -12852,7 +13605,7 @@ struct RuntimeCoordinatorWindowRoutingTests {
 
         let snapshot = cancellation.withLockedValue { $0 }
         #expect(snapshot?.registrationToken == token)
-        #expect(snapshot?.upstreamIndex == 2)
+        #expect(snapshot?.upstreamIndex == nil)
         #expect(snapshot?.requestIDKey == nil)
         #expect(
             handle.markAssigned(registrationToken: token, operationLease: testOperationLease(2), requestIDKey: "req")
@@ -14891,27 +15644,80 @@ struct RuntimeCoordinatorSchedulingTests {
         }
     }
 
-    @Test func sessionManagerRetiresStaticUpstreamWhenInitializedNotificationSendOverloads()
+    @Test func sessionManagerReplacesStaticUpstreamWhenInitializedNotificationSendOverloads()
         async throws
     {
         let group = borrowSharedTestEventLoopGroup()
         defer { shutdownAndWait(group) }
         let eventLoop = group.next()
-        let upstream = ToggleableOverloadUpstreamClient()
+        let upstream = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
         let config = makeConfig(requestTimeout: 5)
-        let manager = RuntimeCoordinator(config: config, eventLoop: eventLoop, upstreams: [upstream])
+        let manager = RuntimeCoordinator(
+            config: config,
+            eventLoop: eventLoop,
+            upstreams: [upstream],
+            unboundUpstreamFactory: {
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return replacement
+            }
+        )
         defer { manager.shutdownAndWait() }
+        await upstream.blockStop()
+        defer {
+            Task {
+                await upstream.releaseBlockedStop()
+            }
+        }
 
         let initialInitialize = try await sentValue(from: upstream, at: 0, timeout: .seconds(2))
         let initialUpstreamID = try extractUpstreamID(from: initialInitialize)
-        await upstream.overloadNextInitializedNotificationSend()
+        await upstream.blockNextSend(method: "notifications/initialized")
         await upstream.yield(.message(try makeInitializeResponse(id: initialUpstreamID)))
 
-        try await waitForSentCount(upstream, count: 2, timeoutSeconds: 2)
+        try await upstream.waitForBlockedSend()
+        await upstream.releaseBlockedSend(.backpressure)
+        try await upstream.waitForBlockedStop()
+        let replacement = try await waitWithTimeout(
+            "waiting for static initialized-notification replacement"
+        ) {
+            while true {
+                if let replacement = replacements.withLockedValue({ $0.first }) {
+                    return replacement
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+        #expect(await replacement.startCount() == 0)
+        #expect(await replacement.sentCount() == 0)
+
+        await upstream.releaseBlockedStop()
+        #expect(try await upstream.nextStopCount(timeout: .seconds(2)) == 1)
+        let replacementInitialize = try await sentValue(
+            from: replacement,
+            at: 0,
+            timeout: .seconds(2)
+        )
+        await replacement.yield(
+            .message(
+                try makeInitializeResponse(
+                    id: extractUpstreamID(from: replacementInitialize),
+                    serverName: "static-notification-replacement"
+                )
+            )
+        )
+        _ = try await replacement.nextSent(
+            startingAt: 1,
+            matching: { methodName(from: $0) == "notifications/initialized" }
+        )
         await manager.drainRuntimeTasksForTesting()
         #expect(await upstream.sentCount() == 2)
-        #expect(manager.testStateSnapshot().upstream(id: 0)?.isInitialized == nil)
-        #expect(manager.testStateSnapshot().hasInitResult == false)
+        #expect(manager.testStateSnapshot().upstream(id: 0)?.isInitialized == true)
+        #expect(manager.testStateSnapshot().hasInitResult)
     }
 
     @Test func sessionManagerPrimaryInitializedNotificationOverloadClearsSecondaryStateAndToolsCache()
@@ -15739,6 +16545,478 @@ struct RuntimeCoordinatorSchedulingTests {
             lateSnapshot.leases.first(where: { $0.requestIDKey == originalID.key })
         )
         #expect(lateLease.releaseReason == "clientDisconnected")
+    }
+
+    @Test func requestTimeoutKeepsSlotReservedUntilRejectedCancellationRecoversChannel()
+        async throws
+    {
+        try await assertRejectedCancellationRecoversBeforeSlotRelease(.timeout)
+    }
+
+    @Test func requestAbandonKeepsSlotReservedUntilRejectedCancellationRecoversChannel()
+        async throws
+    {
+        try await assertRejectedCancellationRecoversBeforeSlotRelease(.abandon)
+    }
+
+    @Test func rejectedCancellationReplacesAndReinitializesStaticUpstream() async throws {
+        let initial = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 300),
+            upstreams: [initial],
+            processRoutingEnabled: false,
+            unboundUpstreamFactory: {
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return replacement
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        await initial.blockStop()
+        defer {
+            Task {
+                await initial.releaseBlockedStop()
+            }
+        }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+                "serverInfo": ["name": "static-cancellation-source"],
+            ]),
+            sourceUpstream: 0
+        )
+
+        let sessionID = "static-rejected-cancellation"
+        let descriptor = SessionRequestPipeline.Descriptor(
+            sessionID: sessionID,
+            label: "tools/call:DocumentationSearch",
+            expectsResponse: true,
+            isTopLevelClientRequest: true
+        )
+        let leaseID = manager.createRequestLease(descriptor: descriptor)
+        let activePromise = fixture.eventLoop.makePromise(of: Void.self)
+        defer { activePromise.fail(CancellationError()) }
+        let requestID = try #require(JSONRPC.ID(any: NSNumber(value: 1)))
+        _ = try await occupyUpstreamSlot(
+            on: manager,
+            leaseID: leaseID,
+            descriptor: descriptor,
+            eventLoop: fixture.eventLoop,
+            completionPromise: activePromise,
+            requestIDKey: requestID.key
+        )
+        let failedLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        _ = try #require(manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: requestID,
+            operationLease: failedLease
+        ))
+
+        let queuedStarts = LockedRecordedValues<UpstreamTopologyProof>()
+        let queuedLeaseID = manager.createRequestLease(descriptor: descriptor)
+        _ = manager.enqueueOnUpstreamSlot(
+            leaseID: queuedLeaseID,
+            descriptor: descriptor,
+            on: fixture.eventLoop
+        ) { selected in
+            queuedStarts.append(selected.proof)
+            return fixture.eventLoop.makeSucceededFuture(())
+        }
+
+        await initial.blockNextCancellation()
+        manager.handleRequestLeaseTimeout(
+            leaseID,
+            sessionID: sessionID,
+            requestIDKeys: [requestID.key],
+            operationLease: failedLease
+        )
+        try await initial.waitForBlockedCancellation()
+        await initial.releaseBlockedCancellation(.backpressure)
+
+        try await initial.waitForBlockedStop()
+        let replacement = try await waitWithTimeout(
+            "waiting for static replacement channel"
+        ) {
+            while true {
+                if let replacement = replacements.withLockedValue({ $0.first }) {
+                    return replacement
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+        let replacementProof = try #require(
+            manager.upstreamTopology.operationLease(
+                for: UpstreamSlotID(rawValue: 0)
+            )?.proof
+        )
+        #expect(replacementProof != failedLease.proof)
+        manager.startUpstreamWarmInitialize(
+            upstreamIndex: replacementProof.slotID.rawValue,
+            applyBackoff: false
+        )
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+        #expect(await replacement.sentCount() == 0)
+        #expect(
+            manager.upstreamSlotScheduler.debugSnapshot()
+                .activeLeaseCountByUpstream[0] == 1
+        )
+        #expect(queuedStarts.count() == 0)
+
+        await initial.releaseBlockedStop()
+        #expect(try await initial.nextStopCount(timeout: .seconds(2)) == 1)
+        let initialize = try await replacement.nextSent(
+            matching: { methodName(from: $0) == "initialize" }
+        )
+        await replacement.yield(
+            .message(
+                try makeInitializeResponse(
+                    id: extractUpstreamID(from: initialize),
+                    serverName: "static-replacement"
+                )
+            )
+        )
+        _ = try await replacement.nextSent(
+            startingAt: 1,
+            matching: { methodName(from: $0) == "notifications/initialized" }
+        )
+        let queuedProof = try await waitForRecordedValue(
+            queuedStarts,
+            at: 0,
+            description: "waiting for queued request on static replacement"
+        )
+        #expect(queuedProof == replacementProof)
+    }
+
+    @Test func forwardedRequestTimeoutWaitsForOriginalSendBeforeCancellation() async throws {
+        try await assertForwardedCancellationWaitsForOriginalSend(.timeout)
+    }
+
+    @Test func forwardedRequestAbandonWaitsForOriginalSendBeforeCancellation() async throws {
+        try await assertForwardedCancellationWaitsForOriginalSend(.abandon)
+    }
+
+    @Test func forwardedRequestTimeoutDoesNotCancelBackpressuredOriginalSend() async throws {
+        try await assertForwardedCancellationSkipsUnsentRequest(.timeout)
+    }
+
+    @Test func forwardedRequestAbandonDoesNotCancelBackpressuredOriginalSend() async throws {
+        try await assertForwardedCancellationSkipsUnsentRequest(.abandon)
+    }
+
+    private enum RejectedCancellationTrigger: Equatable {
+        case timeout
+        case abandon
+    }
+
+    private func assertRejectedCancellationRecoversBeforeSlotRelease(
+        _ trigger: RejectedCancellationTrigger
+    ) async throws {
+        let initial = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let target = xcodeProcessTarget(processID: 27091, xcodeVersion: "27.0")
+        let timeoutScheduler = RecordingRuntimeTimeoutScheduler()
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 300),
+            upstreams: [initial],
+            scheduleRuntimeTimeout: timeoutScheduler.scheduler(),
+            xcodeProcessRoutes: [
+                XcodeProcessRoute(target: target, upstreamIndices: [0])
+            ],
+            processRoutingEnabled: true,
+            dynamicUpstreamFactory: { _ in
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return [replacement]
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        seedCanonicalInitializeForTesting(
+            on: manager,
+            result: try jsonValue([
+                "protocolVersion": MCP.ProtocolVersion.current,
+                "capabilities": [String: Any](),
+                "serverInfo": ["name": "request-cancellation-source"],
+            ]),
+            sourceUpstream: 0
+        )
+        try seedProcessToolCatalogs(
+            on: manager,
+            entries: [
+                (target, 0, [toolDescriptor(name: "DocumentationSearch")])
+            ]
+        )
+
+        let sessionID = "session-rejected-\(trigger)"
+        let descriptor = SessionRequestPipeline.Descriptor(
+            sessionID: sessionID,
+            label: "tools/call:DocumentationSearch",
+            expectsResponse: true,
+            isTopLevelClientRequest: true
+        )
+        let leaseID = manager.createRequestLease(descriptor: descriptor)
+        let activePromise = fixture.eventLoop.makePromise(of: Void.self)
+        defer { activePromise.fail(CancellationError()) }
+        let requestID = try #require(JSONRPC.ID(any: NSNumber(value: 1)))
+        _ = try await occupyUpstreamSlot(
+            on: manager,
+            leaseID: leaseID,
+            descriptor: descriptor,
+            eventLoop: fixture.eventLoop,
+            completionPromise: activePromise,
+            requestIDKey: requestID.key
+        )
+        let operationLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        _ = try #require(manager.assignUpstreamID(
+            sessionID: sessionID,
+            originalID: requestID,
+            operationLease: operationLease
+        ))
+
+        let queuedStarts = LockedRecordedValues<UpstreamTopologyProof>()
+        let queuedLeaseID = manager.createRequestLease(descriptor: descriptor)
+        _ = manager.enqueueOnUpstreamSlot(
+            leaseID: queuedLeaseID,
+            descriptor: descriptor,
+            on: fixture.eventLoop
+        ) { selected in
+            queuedStarts.append(selected.proof)
+            return fixture.eventLoop.makeSucceededFuture(())
+        }
+        #expect(manager.upstreamSlotScheduler.debugSnapshot().queuedRequestCount == 1)
+
+        await initial.blockNextCancellation()
+        switch trigger {
+        case .timeout:
+            manager.handleRequestLeaseTimeout(
+                leaseID,
+                sessionID: sessionID,
+                requestIDKeys: [requestID.key],
+                operationLease: operationLease
+            )
+        case .abandon:
+            manager.abandonRequestLease(
+                leaseID,
+                sessionID: sessionID,
+                requestIDKeys: [requestID.key],
+                operationLease: operationLease
+            )
+        }
+        try await initial.waitForBlockedCancellation()
+
+        #expect(
+            manager.upstreamSlotScheduler.debugSnapshot()
+                .activeLeaseCountByUpstream[0] == 1
+        )
+        #expect(queuedStarts.count() == 0)
+
+        await initial.releaseBlockedCancellation(.backpressure)
+        #expect(try await initial.nextStopCount(timeout: .seconds(2)) == 1)
+        await manager.drainRuntimeTasksForTesting()
+
+        #expect(queuedStarts.count() == 0)
+        #expect(
+            manager.upstreamSlotScheduler.debugSnapshot()
+                .activeLeaseCountByUpstream.isEmpty
+        )
+        #expect(replacements.withLockedValue(\.count) == 1)
+        #expect(manager.upstreamTopology.validate(operationLease) == false)
+
+        let activationRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(250),
+            startingAtEventIndex: 0
+        )
+        #expect(timeoutScheduler.fire(at: activationRetryIndex))
+        let replacement = try #require(replacements.withLockedValue { $0.first })
+        _ = try await replacement.nextSent(
+            matching: { methodName(from: $0) == "initialize" }
+        )
+        #expect(queuedStarts.count() == 0)
+    }
+
+    private func assertForwardedCancellationWaitsForOriginalSend(
+        _ trigger: RejectedCancellationTrigger
+    ) async throws {
+        let upstream = TestUpstreamClient()
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 300),
+            upstreams: [upstream],
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let sessionID = "session-send-barrier-\(trigger)"
+        let parentCancellationHandle: ClientMCPRequestExecutor.CancellationHandle?
+        switch trigger {
+        case .timeout:
+            parentCancellationHandle = nil
+        case .abandon:
+            let parentLeaseID = manager.createRequestLease(
+                descriptor: SessionRequestPipeline.Descriptor(
+                    sessionID: sessionID,
+                    label: "parent",
+                    expectsResponse: true,
+                    isTopLevelClientRequest: true
+                )
+            )
+            parentCancellationHandle = ClientMCPRequestExecutor.CancellationHandle(
+                leaseID: parentLeaseID,
+                sessionID: sessionID,
+                requestIDKeys: []
+            )
+        }
+        let forwardingService = MCPForwardingService(
+            configuration: makeConfig(requestTimeout: 300),
+            sessionManager: manager
+        )
+        await upstream.blockNextSend(method: "tools/call")
+        let request = Task {
+            let result = await forwardingService.callInternalTool(
+                name: "XcodeListNavigatorIssues",
+                arguments: ["tabIdentifier": "windowtab-send-barrier"],
+                sessionID: sessionID,
+                eventLoop: fixture.eventLoop,
+                cancellationHandle: parentCancellationHandle,
+                upstreamIndexOverride: 0,
+                requestTimeoutOverride: trigger == .timeout ? .milliseconds(20) : .seconds(300)
+            )
+            switch (trigger, result) {
+            case (.timeout, .timeout), (.abandon, .cancelled):
+                return true
+            default:
+                return false
+            }
+        }
+        try await upstream.waitForBlockedSend()
+        parentCancellationHandle?.cancel(using: manager)
+        #expect(try await waitWithTimeout("waiting for forwarded cancellation") {
+            await request.value
+        })
+
+        let beforeOriginalSendCompletion = await upstream.sent()
+        #expect(beforeOriginalSendCompletion.count == 1)
+        let originalRequest = try #require(beforeOriginalSendCompletion.first)
+        #expect(methodName(from: originalRequest) == "tools/call")
+        #expect(
+            beforeOriginalSendCompletion.contains {
+                methodName(from: $0) == "notifications/cancelled"
+            } == false
+        )
+
+        await upstream.releaseBlockedSend()
+        let cancellation = try await upstream.nextSent(
+            matching: { methodName(from: $0) == "notifications/cancelled" }
+        )
+        #expect(
+            try extractCancellationRequestID(from: cancellation)
+                == extractUpstreamID(from: originalRequest)
+        )
+        await manager.drainRuntimeTasksForTesting()
+        #expect(
+            manager.upstreamSlotScheduler.debugSnapshot()
+                .activeLeaseCountByUpstream.isEmpty
+        )
+    }
+
+    private func assertForwardedCancellationSkipsUnsentRequest(
+        _ trigger: RejectedCancellationTrigger
+    ) async throws {
+        let upstream = TestUpstreamClient()
+        let replacements = NIOLockedValueBox<[TestUpstreamClient]>([])
+        let fixture = RuntimeCoordinatorFixture(
+            config: makeConfig(requestTimeout: 300),
+            upstreams: [upstream],
+            unboundUpstreamFactory: {
+                let replacement = TestUpstreamClient()
+                replacements.withLockedValue { $0.append(replacement) }
+                return replacement
+            },
+            startImmediately: false
+        )
+        defer { fixture.shutdownAndWait() }
+        let manager = fixture.manager
+        manager.markUpstreamInitialized(upstreamIndex: 0)
+        let originalLease = manager.operationLeaseForTest(upstreamIndex: 0)
+        let sessionID = "session-unsent-cancellation-\(trigger)"
+        let parentCancellationHandle: ClientMCPRequestExecutor.CancellationHandle?
+        switch trigger {
+        case .timeout:
+            parentCancellationHandle = nil
+        case .abandon:
+            let parentLeaseID = manager.createRequestLease(
+                descriptor: SessionRequestPipeline.Descriptor(
+                    sessionID: sessionID,
+                    label: "parent",
+                    expectsResponse: true,
+                    isTopLevelClientRequest: true
+                )
+            )
+            parentCancellationHandle = ClientMCPRequestExecutor.CancellationHandle(
+                leaseID: parentLeaseID,
+                sessionID: sessionID,
+                requestIDKeys: []
+            )
+        }
+        let forwardingService = MCPForwardingService(
+            configuration: makeConfig(requestTimeout: 300),
+            sessionManager: manager
+        )
+        await upstream.blockNextSend(method: "tools/call")
+        let request = Task {
+            let result = await forwardingService.callInternalTool(
+                name: "XcodeListNavigatorIssues",
+                arguments: ["tabIdentifier": "windowtab-unsent-cancellation"],
+                sessionID: sessionID,
+                eventLoop: fixture.eventLoop,
+                cancellationHandle: parentCancellationHandle,
+                upstreamIndexOverride: 0,
+                requestTimeoutOverride: trigger == .timeout
+                    ? .milliseconds(20)
+                    : .seconds(300)
+            )
+            switch (trigger, result) {
+            case (.timeout, .timeout), (.abandon, .cancelled):
+                return true
+            default:
+                return false
+            }
+        }
+        try await upstream.waitForBlockedSend()
+        parentCancellationHandle?.cancel(using: manager)
+        let matchedExpectedResult = try await waitWithTimeout(
+            "waiting for unsent request cancellation"
+        ) {
+            await request.value
+        }
+        #expect(matchedExpectedResult)
+        await upstream.releaseBlockedSend(.backpressure)
+
+        await manager.drainRuntimeTasksForTesting()
+        let messages = await upstream.sent()
+        #expect(messages.count == 1)
+        #expect(messages.first.map { methodName(from: $0) } == "tools/call")
+        #expect(
+            messages.contains {
+                methodName(from: $0) == "notifications/cancelled"
+            } == false
+        )
+        #expect(replacements.withLockedValue(\.count) == 0)
+        #expect(manager.upstreamTopology.validate(originalLease))
+        #expect(
+            manager.upstreamSlotScheduler.debugSnapshot()
+                .activeLeaseCountByUpstream.isEmpty
+        )
     }
 
     @Test func sessionManagerDoesNotReactivateAbandonedLease() async throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -820,7 +820,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 ]))
     }
 
-    @Test func rejectedCatalogCancellationReplacesChannelInsteadOfRetryingIt()
+    @Test func catalogCancellationOutcomeControlsRetryAndChannelRecovery()
         async throws
     {
         let target = xcodeProcessTarget(processID: 27027, xcodeVersion: "27.0")
@@ -851,24 +851,47 @@ struct RuntimeCoordinatorProcessRoutingTests {
         let proof = try #require(manager.upstreamTopology.operationLease(
             for: UpstreamSlotID(rawValue: 0)
         )?.proof)
-        let (lease, transition) = try #require(
-            manager.processControlPlane.beginCatalogAttempt(
-                routeID: route.id,
-                preferredUpstreamProof: proof,
-                nowUptimeNanoseconds: 1
-            )
-        )
-        manager.applyProcessControlPlaneTransition(transition)
-        manager.applyCatalogCommit(manager.processControlPlane.completeCatalog(
-            .unusable,
-            lease: lease,
-            nowUptimeNanoseconds: 2
-        ))
 
+        func prepareRetryLease(at uptimeNanoseconds: UInt64) throws -> CatalogLease {
+            let (lease, transition) = try #require(
+                manager.processControlPlane.beginCatalogAttempt(
+                    routeID: route.id,
+                    preferredUpstreamProof: proof,
+                    nowUptimeNanoseconds: uptimeNanoseconds
+                )
+            )
+            manager.applyProcessControlPlaneTransition(transition)
+            manager.applyCatalogCommit(manager.processControlPlane.completeCatalog(
+                .unusable,
+                lease: lease,
+                nowUptimeNanoseconds: uptimeNanoseconds &+ 1
+            ))
+            return lease
+        }
+
+        let obsoleteLease = try prepareRetryLease(at: 1)
+        let obsoleteCancellation = ControlPlane.RPCCancellationDelivery()
+        manager.scheduleMissingProcessToolsCatalogRetry(
+            processID: target.processID,
+            lease: obsoleteLease,
+            after: [obsoleteCancellation],
+            reason: "test_obsolete_cancellation"
+        )
+        obsoleteCancellation.complete(.noLongerApplicable)
+        let obsoleteRetryIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(250),
+            startingAtEventIndex: 0
+        )
+        manager.applyProcessControlPlaneTransition(
+            manager.processControlPlane.resetAttempt(processID: target.processID)
+        )
+        #expect(timeoutScheduler.isCancelled(at: obsoleteRetryIndex))
+
+        let rejectedLease = try prepareRetryLease(at: 3)
         let cancellation = ControlPlane.RPCCancellationDelivery()
         manager.scheduleMissingProcessToolsCatalogRetry(
             processID: target.processID,
-            lease: lease,
+            lease: rejectedLease,
             after: [cancellation],
             reason: "test_rejected_cancellation"
         )
@@ -884,7 +907,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
             )?.proof != proof
         )
         #expect(
-            timeoutScheduler.activeTimeoutIndex(delay: .milliseconds(250)) == nil
+            timeoutScheduler.activeTimeoutIndex(delay: .milliseconds(500)) == nil
         )
     }
 

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -556,11 +556,9 @@ struct RuntimeCoordinatorProcessRoutingTests {
 
         let replacement = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
         #expect(try await upstream.nextStopCount() == 1)
-        let retryTimeoutIndex = try #require(
-            timeoutScheduler.activeTimeoutIndex(
-                delay: .milliseconds(250),
-                startingAt: 2
-            )
+        let retryTimeoutIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(250),
+            startingAtEventIndex: 2
         )
         #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
         _ = try await replacement.nextSent(at: 0)
@@ -1629,7 +1627,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(manager.upstreamHealthManager.anyRecoveryInFlight() == false)
     }
 
-    @Test func processRouteActivationEmptyCatalogRetryPreservesCatalogTimeout()
+    @Test func staleCatalogTimeoutCannotTerminateNewerRetryLoad()
         async throws
     {
         var config = makeConfig(requestTimeout: 20)
@@ -1680,7 +1678,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
 
         manager.reconcileXcodeProcessTargets(
             [olderTarget, newerTarget],
-            reason: "test_empty_catalog_retry_preserves_catalog_timeout"
+            reason: "test_stale_catalog_timeout"
         )
 
         let activationUpstream = try #require(createdUpstreams.withLockedValue { $0.first })
@@ -1745,7 +1743,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 == TimeAmount.milliseconds(250).nanoseconds
         )
         #expect(timeoutScheduler.isCancelled(at: retryIndex) == false)
-        #expect(timeoutScheduler.isCancelled(at: catalogTimeoutIndex) == false)
+        #expect(timeoutScheduler.isCancelled(at: catalogTimeoutIndex))
         #expect(createdUpstreams.withLockedValue(\.count) == 1)
         #expect(timeoutScheduler.fire(at: retryIndex))
         let retryToolsRequest = try await waitWithTimeout(
@@ -1757,6 +1755,19 @@ struct RuntimeCoordinatorProcessRoutingTests {
                 matching: { methodName(from: $0) == "tools/list" }
             )
         }
+        let retryCatalogTimeoutIndex = try #require(
+            timeoutScheduler.activeTimeoutIndex(
+                delay: .seconds(10),
+                startingAt: catalogTimeoutIndex + 1
+            )
+        )
+        #expect(timeoutScheduler.fireIgnoringCancellation(at: catalogTimeoutIndex))
+        #expect(timeoutScheduler.isCancelled(at: retryCatalogTimeoutIndex) == false)
+        #expect(
+            manager.processControlPlane.attemptSnapshot(
+                processID: newerTarget.processID
+            )?.phase == .loadingCatalog
+        )
         await activationUpstream.yield(
             .message(
                 try makeDocumentationToolsListResponse(
@@ -1784,7 +1795,7 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(recoveredAttempt.upstreamID.rawValue == 1)
         #expect(recoveredAttempt.attemptID.rawValue == 1)
         #expect(timeoutScheduler.isCancelled(at: catalogTimeoutIndex))
-        #expect(timeoutScheduler.fire(at: catalogTimeoutIndex) == false)
+        #expect(timeoutScheduler.isCancelled(at: retryCatalogTimeoutIndex))
         #expect(
             Set(toolNames(in: manager.cachedToolsListResult() ?? .null))
                 == Set([
@@ -3191,11 +3202,9 @@ struct RuntimeCoordinatorProcessRoutingTests {
             ])
 
         let replacementUpstream = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
-        let retryTimeoutIndex = try #require(
-            timeoutScheduler.activeTimeoutIndex(
-                delay: .milliseconds(250),
-                startingAt: 2
-            )
+        let retryTimeoutIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(250),
+            startingAtEventIndex: 2
         )
         let scheduledBeforeReconcile = timeoutScheduler.scheduledCount()
         manager.reconcileXcodeProcessTargets(
@@ -3284,11 +3293,9 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(manager.testStateSnapshot().hasInitResult == false)
 
         let replacement = try #require(createdUpstreams.withLockedValue { $0.dropFirst().first })
-        let retryTimeoutIndex = try #require(
-            timeoutScheduler.activeTimeoutIndex(
-                delay: .milliseconds(250),
-                startingAt: 2
-            )
+        let retryTimeoutIndex = try await timeoutScheduler.nextActiveTimeoutIndex(
+            delay: .milliseconds(250),
+            startingAtEventIndex: 2
         )
         #expect(timeoutScheduler.fire(at: retryTimeoutIndex))
         let replacementInitialize = try await replacement.nextSent(at: 0)

--- a/Tests/XcodeMCPProxyRuntimeTests/TestUpstreamClient.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/TestUpstreamClient.swift
@@ -10,8 +10,11 @@ actor TestUpstreamClient: UpstreamSlotControlling {
     private let sentMessages = RecordedValues<Data>()
     private let startEvents = RecordedValues<Int>()
     private let stopEvents = RecordedValues<Int>()
+    private let blockedCancellationSignal = TestSignal()
     private var startCountValue = 0
     private var stopCountValue = 0
+    private var shouldBlockNextCancellation = false
+    private var blockedCancellation: CheckedContinuation<Upstream.SendResult, Never>?
 
     init() {
         var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
@@ -29,12 +32,40 @@ actor TestUpstreamClient: UpstreamSlotControlling {
     func stop() async {
         stopCountValue += 1
         await stopEvents.append(stopCountValue)
+        releaseBlockedCancellation()
         continuation.finish()
     }
 
     func send(_ data: Data) async -> Upstream.SendResult {
         await sentMessages.append(data)
-        return .accepted
+        guard shouldBlockNextCancellation,
+              methodName(from: data) == "notifications/cancelled"
+        else {
+            return .accepted
+        }
+        shouldBlockNextCancellation = false
+        blockedCancellationSignal.signal()
+        return await withCheckedContinuation { continuation in
+            blockedCancellation = continuation
+        }
+    }
+
+    func blockNextCancellation() {
+        shouldBlockNextCancellation = true
+    }
+
+    func waitForBlockedCancellation() async throws {
+        if blockedCancellation != nil {
+            return
+        }
+        try await blockedCancellationSignal.wait(
+            description: "waiting for blocked cancellation"
+        )
+    }
+
+    func releaseBlockedCancellation() {
+        blockedCancellation?.resume(returning: .accepted)
+        blockedCancellation = nil
     }
 
     func yield(_ event: Upstream.Event) async {

--- a/Tests/XcodeMCPProxyRuntimeTests/TestUpstreamClient.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/TestUpstreamClient.swift
@@ -11,10 +11,13 @@ actor TestUpstreamClient: UpstreamSlotControlling {
     private let startEvents = RecordedValues<Int>()
     private let stopEvents = RecordedValues<Int>()
     private let blockedCancellationSignal = TestSignal()
+    private let blockedSendSignal = TestSignal()
     private var startCountValue = 0
     private var stopCountValue = 0
     private var shouldBlockNextCancellation = false
     private var blockedCancellation: CheckedContinuation<Upstream.SendResult, Never>?
+    private var blockedMethod: String?
+    private var blockedSend: CheckedContinuation<Upstream.SendResult, Never>?
 
     init() {
         var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
@@ -33,14 +36,23 @@ actor TestUpstreamClient: UpstreamSlotControlling {
         stopCountValue += 1
         await stopEvents.append(stopCountValue)
         releaseBlockedCancellation()
+        releaseBlockedSend(.unavailable(.terminated))
         continuation.finish()
     }
 
     func send(_ data: Data) async -> Upstream.SendResult {
         await sentMessages.append(data)
+        let method = methodName(from: data)
         guard shouldBlockNextCancellation,
-              methodName(from: data) == "notifications/cancelled"
+              method == "notifications/cancelled"
         else {
+            if blockedMethod == method {
+                blockedMethod = nil
+                blockedSendSignal.signal()
+                return await withCheckedContinuation { continuation in
+                    blockedSend = continuation
+                }
+            }
             return .accepted
         }
         shouldBlockNextCancellation = false
@@ -66,6 +78,25 @@ actor TestUpstreamClient: UpstreamSlotControlling {
     func releaseBlockedCancellation() {
         blockedCancellation?.resume(returning: .accepted)
         blockedCancellation = nil
+    }
+
+    func blockNextSend(method: String) {
+        precondition(blockedMethod == nil && blockedSend == nil)
+        blockedMethod = method
+    }
+
+    func waitForBlockedSend() async throws {
+        if blockedSend != nil {
+            return
+        }
+        try await blockedSendSignal.wait(
+            description: "waiting for blocked \(blockedMethod ?? "upstream") send"
+        )
+    }
+
+    func releaseBlockedSend(_ result: Upstream.SendResult = .accepted) {
+        blockedSend?.resume(returning: result)
+        blockedSend = nil
     }
 
     func yield(_ event: Upstream.Event) async {

--- a/Tests/XcodeMCPProxyRuntimeTests/TestUpstreamClient.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/TestUpstreamClient.swift
@@ -12,12 +12,15 @@ actor TestUpstreamClient: UpstreamSlotControlling {
     private let stopEvents = RecordedValues<Int>()
     private let blockedCancellationSignal = TestSignal()
     private let blockedSendSignal = TestSignal()
+    private let blockedStopSignal = TestSignal()
     private var startCountValue = 0
     private var stopCountValue = 0
     private var shouldBlockNextCancellation = false
     private var blockedCancellation: CheckedContinuation<Upstream.SendResult, Never>?
     private var blockedMethod: String?
     private var blockedSend: CheckedContinuation<Upstream.SendResult, Never>?
+    private var shouldBlockStop = false
+    private var blockedStop: CheckedContinuation<Void, Never>?
 
     init() {
         var streamContinuation: AsyncStream<Upstream.Event>.Continuation!
@@ -35,6 +38,13 @@ actor TestUpstreamClient: UpstreamSlotControlling {
     func stop() async {
         stopCountValue += 1
         await stopEvents.append(stopCountValue)
+        if shouldBlockStop {
+            shouldBlockStop = false
+            blockedStopSignal.signal()
+            await withCheckedContinuation { continuation in
+                blockedStop = continuation
+            }
+        }
         releaseBlockedCancellation()
         releaseBlockedSend(.unavailable(.terminated))
         continuation.finish()
@@ -75,8 +85,10 @@ actor TestUpstreamClient: UpstreamSlotControlling {
         )
     }
 
-    func releaseBlockedCancellation() {
-        blockedCancellation?.resume(returning: .accepted)
+    func releaseBlockedCancellation(
+        _ result: Upstream.SendResult = .accepted
+    ) {
+        blockedCancellation?.resume(returning: result)
         blockedCancellation = nil
     }
 
@@ -97,6 +109,24 @@ actor TestUpstreamClient: UpstreamSlotControlling {
     func releaseBlockedSend(_ result: Upstream.SendResult = .accepted) {
         blockedSend?.resume(returning: result)
         blockedSend = nil
+    }
+
+    func blockStop() {
+        precondition(shouldBlockStop == false && blockedStop == nil)
+        shouldBlockStop = true
+    }
+
+    func waitForBlockedStop() async throws {
+        if blockedStop != nil {
+            return
+        }
+        try await blockedStopSignal.wait(description: "waiting for blocked upstream stop")
+    }
+
+    func releaseBlockedStop() {
+        shouldBlockStop = false
+        blockedStop?.resume()
+        blockedStop = nil
     }
 
     func yield(_ event: Upstream.Event) async {

--- a/Tests/XcodeMCPProxyRuntimeTests/ToolSurfaceTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ToolSurfaceTests.swift
@@ -465,8 +465,12 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
         operationLease: UpstreamOperationLease,
         ensureRunning: Bool,
         admission: RouteForwardingAdmission?,
+        requestSendCompletion: UpstreamRequestSendCompletion?,
         onRejected: @escaping @Sendable () -> Void
-    ) -> Bool { false }
+    ) -> Bool {
+        requestSendCompletion?.complete(.notSent)
+        return false
+    }
     func debugSnapshot() -> ProxyDebug.Snapshot { fatalError("unused in ToolSurfaceTests") }
     func debugSnapshot(includeSensitiveDebugPayloads: Bool) -> ProxyDebug.Snapshot {
         fatalError("unused in ToolSurfaceTests")
@@ -497,13 +501,15 @@ private final class ToolSurfaceRuntimeCoordinator: @unchecked Sendable, RuntimeC
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease
+        operationLease: UpstreamOperationLease,
+        after requestSendCompletion: UpstreamRequestSendCompletion?
     ) {}
 
     func abandonRequestLease(
         _ leaseID: LeaseManager.ID,
         sessionID: String,
         requestIDKeys: [String],
-        operationLease: UpstreamOperationLease?
+        operationLease: UpstreamOperationLease?,
+        after requestSendCompletion: UpstreamRequestSendCompletion?
     ) {}
 }


### PR DESCRIPTION
## Purpose

Prevent timed-out or abandoned proxy requests from leaving work active on a degraded Xcode bridge while replacement work starts, which can repeatedly create bridge processes and duplicate Xcode agent attachments.

## Changes

- Give `RPCHandle` one lifecycle state machine for cancellation-handler installation, queue registration, upstream ID assignment, completion, and cancellation.
- Terminalize cancellation that arrives before handler installation, share one delivery across repeated or reentrant cancellation, and release the reserved request lease when late installation is rejected.
- Serialize `notifications/cancelled` after the original request send and preserve exact request identity until cancellation delivery settles.
- Gate catalog-load admission during backoff, scope timeout reservations to the exact catalog load, reject stale timeout and cancellation callbacks, and advance bounded retry cadence independently of activation identity.
- Recover rejected cancellation by replacing the degraded channel and preparing a fresh route activation; apply equivalent recovery to ordinary request timeout and disconnect paths.
- Serialize shutdown admission across initialize, topology, health, and process-control owners so late lifecycle work cannot republish state.
- Separate process-route health evaluation from effect execution so reconciliation commits under the initialize gate and starts probe I/O only after releasing its non-recursive lock.
- Make retirement, cancellation-delivery, and health-probe tests await the task group or event that actually owns completion.
- Add deterministic coverage for cancellation ordering and delivery, pre-install cancellation, stale catalog work, timeout attachment races, retry cadence, rejected recovery, route retirement, health-probe handoff, and shutdown races.

## Testing

- `scripts/check.sh`
  - 1,022 package tests
  - 24 process runtime tests
  - 13 stdio adapter tests
- Process routing, recovery, and catalog suites: 124 passed
- CI-sensitive retirement, cancellation, and health-probe regressions: 20 repeated iterations passed
- `git diff --check`
- Branch-wide `codex-review` against pinned `main`: no findings

## Screenshots

Not applicable; this changes proxy runtime lifecycle behavior.
