### PR TITLE
fix(proxy): explain Xcode MCP access timeouts

### DIFF
--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -8,7 +8,12 @@ If it fails:
 - Confirm `xcrun mcpbridge -h` works in Terminal.
 
 ## `MCP client ... timed out`
-Ensure the proxy server is running. Increase `startup_timeout_sec` in the client config if needed.
+Ensure the proxy server is running. Before increasing any timeout, confirm that
+Xcode MCP access is enabled as described in
+[Set Up Your MCP Client](../README.md#1-enable-xcode-mcp-access). If the proxy
+logs `route_activation_timeout` or `attach_probe_timeout`, follow the dedicated
+section below. Increase `startup_timeout_sec` only when setup is correct and the
+upstream is still starting too slowly.
 
 If you see an error like:
 
@@ -19,6 +24,31 @@ it’s usually because the upstream (`xcrun mcpbridge` / Xcode) was slow on the 
 - `xcode-mcp-proxy-server` prewarms and caches `tools/list` **in memory** once it’s ready, and serves it immediately on subsequent requests.
 - The tool list cache is **not persisted to disk**. It survives repeated Codex restarts as long as the proxy server stays running.
 - `tools/list` is intentionally treated as stable for the lifetime of the proxy process (no background refresh), to avoid upstream churn and surprise Xcode permission dialogs.
+
+## `route_activation_timeout` / `attach_probe_timeout`
+These logs mean `mcpbridge` initialized, but Xcode did not return a usable
+`tools/list` response before the route or bridge-attachment deadline.
+
+First, open your project in Xcode, choose **Xcode > Settings > Intelligence**,
+and turn on **Allow external agents to use Xcode tools** under
+**Model Context Protocol**. This global switch is required by
+[Xcode's external-agent setup][apple-xcode-mcp-access].
+
+`--auto-approve` only handles the per-connection **Allow** dialog; it does not
+enable the global Xcode setting. If the setting is already on:
+
+- Approve any pending Xcode connection dialog.
+- When using `--auto-approve`, allow the app that launched the proxy (for
+  example, Terminal or iTerm) in
+  **System Settings > Privacy & Security > Accessibility**.
+- Wait for the proxy's automatic retry. A recovered route logs
+  `route_activation_cataloged`; a recovered secondary bridge logs
+  `bridge_pool_attach_verification_completed` with `success=true`.
+
+When Xcode does not send a JSON-RPC response for `tools/list`, the proxy cannot
+recover Xcode's internal error from the stdio transport. The timeout log
+therefore includes a `recovery_action` instead of claiming a specific upstream
+failure.
 
 ## Streamable HTTP client cannot connect
 - Ensure `xcode-mcp-proxy-server` is running.
@@ -90,3 +120,5 @@ Ensure the client is using the server-issued `MCP-Session-Id`. Initialize reques
 
 ## `protocol version required` / `protocol version mismatch`
 The proxy only accepts `MCP-Protocol-Version: 2025-06-18` after initialize. Reinitialize the client session if it cached an older protocol version or omitted the header.
+
+[apple-xcode-mcp-access]: https://developer.apple.com/documentation/xcode/giving-external-agents-access-to-xcode

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -11,9 +11,10 @@ If it fails:
 Ensure the proxy server is running. Before increasing any timeout, confirm that
 Xcode MCP access is enabled as described in
 [Set Up Your MCP Client](../README.md#1-enable-xcode-mcp-access). If the proxy
-logs `route_activation_timeout` or `attach_probe_timeout`, follow the dedicated
-section below. Increase `startup_timeout_sec` only when setup is correct and the
-upstream is still starting too slowly.
+logs `route_activation_timeout`, or `bridge_pool_attach_verification_completed`
+with `success=false reason=timeout`, follow the dedicated section below.
+Increase `startup_timeout_sec` only when setup is correct and the upstream is
+still starting too slowly.
 
 If you see an error like:
 
@@ -25,9 +26,11 @@ it’s usually because the upstream (`xcrun mcpbridge` / Xcode) was slow on the 
 - The tool list cache is **not persisted to disk**. It survives repeated Codex restarts as long as the proxy server stays running.
 - `tools/list` is intentionally treated as stable for the lifetime of the proxy process (no background refresh), to avoid upstream churn and surprise Xcode permission dialogs.
 
-## `route_activation_timeout` / `attach_probe_timeout`
-These logs mean `mcpbridge` initialized, but Xcode did not return a usable
-`tools/list` response before the route or bridge-attachment deadline.
+## Xcode tools are unavailable
+`route_activation_timeout`, or `bridge_pool_attach_verification_completed` with
+`success=false reason=timeout`, means `mcpbridge` initialized but Xcode did not
+return a usable `tools/list` response before the route or bridge-attachment
+deadline.
 
 First, open your project in Xcode, choose **Xcode > Settings > Intelligence**,
 and turn on **Allow external agents to use Xcode tools** under
@@ -46,9 +49,10 @@ enable the global Xcode setting. If the setting is already on:
   `bridge_pool_attach_verification_completed` with `success=true`.
 
 When Xcode does not send a JSON-RPC response for `tools/list`, the proxy cannot
-recover Xcode's internal error from the stdio transport. The timeout log
-therefore includes a `recovery_action` instead of claiming a specific upstream
-failure.
+recover Xcode's internal error from the stdio transport. The first timeout
+therefore prints an **Xcode tools are unavailable** warning with recovery steps
+and continues retrying automatically. Later retries keep the structured event
+but do not repeat the warning.
 
 ## Streamable HTTP client cannot connect
 - Ensure `xcode-mcp-proxy-server` is running.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,24 @@ source ~/.zshrc
 
 ## Set Up Your MCP Client
 
-### 1. Start the Proxy Server
+### 1. Enable Xcode MCP Access
+
+Open your project in Xcode, choose **Xcode > Settings > Intelligence**, and turn
+on **Allow external agents to use Xcode tools** under **Model Context Protocol**.
+See [Giving external agents access to Xcode][apple-xcode-mcp-access].
+
+This global Xcode setting is separate from the per-connection **Allow** dialog.
+`--auto-approve` handles the dialog; it does not enable Xcode MCP access.
+
+### 2. Start the Proxy Server
 
 ```bash
 xcode-mcp-proxy-server --auto-approve
 ```
 
-`--auto-approve` clicks the Xcode **Allow** button automatically. It requires macOS Accessibility permission.
+`--auto-approve` clicks the Xcode **Allow** button automatically. In
+**System Settings > Privacy & Security > Accessibility**, allow the app that
+launches the proxy (for example, Terminal or iTerm).
 
 Without Accessibility permission, omit `--auto-approve` and click **Allow** yourself:
 
@@ -71,7 +82,7 @@ Without Accessibility permission, omit `--auto-approve` and click **Allow** your
 xcode-mcp-proxy-server
 ```
 
-### 2. Register the Client
+### 3. Register the Client
 
 Replace `xcrun mcpbridge` with the proxy endpoint.
 
@@ -234,3 +245,5 @@ Edit the draft release notes, then publish the release manually.
 ## License
 
 [LICENSE](LICENSE)
+
+[apple-xcode-mcp-access]: https://developer.apple.com/documentation/xcode/giving-external-agents-access-to-xcode

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -101,6 +101,7 @@ struct ProcessBridgeRecovery: Sendable, Hashable {
 struct ProcessBridgeRecoveryRetry: Sendable {
     let reservation: ProcessBridgePoolRecovery
     let delay: TimeAmount
+    let consecutiveFailureCount: Int
 }
 
 struct ProcessControlPlaneTransition: Sendable {
@@ -2609,7 +2610,8 @@ final class ProcessControlPlaneAuthority: Sendable {
             reservation: recovery,
             delay: owner.bridgeRecovery.consecutiveFailureCount == 1
                 ? .seconds(1)
-                : .seconds(10)
+                : .seconds(10),
+            consecutiveFailureCount: owner.bridgeRecovery.consecutiveFailureCount
         )
     }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/ControlPlane/ProcessControlPlaneAuthority.swift
@@ -98,10 +98,16 @@ struct ProcessBridgeRecovery: Sendable, Hashable {
     var upstreamID: UpstreamSlotID { reservation.upstreamID }
 }
 
+enum ProcessBridgeRecoveryFailure: Sendable, Equatable {
+    case toolsListTimeout
+    case other
+}
+
 struct ProcessBridgeRecoveryRetry: Sendable {
     let reservation: ProcessBridgePoolRecovery
     let delay: TimeAmount
     let consecutiveFailureCount: Int
+    let shouldLogToolsUnavailableWarning: Bool
 }
 
 struct ProcessControlPlaneTransition: Sendable {
@@ -307,13 +313,14 @@ final class ProcessControlPlaneAuthority: Sendable {
         case retryRequired(
             transition: ProcessControlPlaneTransition,
             retry: Retry,
-            catalogLease: CatalogLease
+            catalogLease: CatalogLease,
+            timeoutCount: Int
         )
 
         var transition: ProcessControlPlaneTransition {
             switch self {
             case .loadTimedOut(let transition),
-                 .retryRequired(let transition, _, _):
+                 .retryRequired(let transition, _, _, _):
                 return transition
             }
         }
@@ -407,6 +414,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         var readinessToken: UpstreamReadinessWaiterToken?
         var retryTimeout: RuntimeScheduledTimeout?
         var retryKind: RetryKind?
+        var catalogTimeoutCount: Int
         var nextLoadID: Int
         var loads: [CatalogLoadID: Load]
 
@@ -570,6 +578,7 @@ final class ProcessControlPlaneAuthority: Sendable {
         var phase: Phase = .idle
         var generation: UInt64 = 0
         var consecutiveFailureCount = 0
+        var didLogToolsUnavailableWarning = false
 
         mutating func reset(pendingUpstreamIDs: Set<UpstreamSlotID>)
             -> [ProcessControlPlaneEffect]
@@ -584,6 +593,7 @@ final class ProcessControlPlaneAuthority: Sendable {
             self.pendingUpstreamIDs = pendingUpstreamIDs
             phase = .idle
             consecutiveFailureCount = 0
+            didLogToolsUnavailableWarning = false
             return effects
         }
     }
@@ -694,6 +704,7 @@ final class ProcessControlPlaneAuthority: Sendable {
             let previousOwner = owner
             owner.bridgeRecovery.phase = .idle
             owner.bridgeRecovery.consecutiveFailureCount = 0
+            owner.bridgeRecovery.didLogToolsUnavailableWarning = false
             let effects = Self.takeBridgePoolRecoveryEffects(owner: &owner)
             state.recordsByKey[key] = owner
             guard commit() else {
@@ -719,13 +730,15 @@ final class ProcessControlPlaneAuthority: Sendable {
     }
 
     func prepareBridgeRecoveryRetry(
-        _ recovery: ProcessBridgePoolRecovery
+        _ recovery: ProcessBridgePoolRecovery,
+        failure: ProcessBridgeRecoveryFailure
     ) -> ProcessBridgeRecoveryRetry? {
         state.withLockedValue { state in
             guard let key = Self.key(routeID: recovery.routeID, in: state),
                   var owner = state.recordsByKey[key],
                   let retry = Self.prepareBridgeRecoveryRetry(
                       recovery,
+                      failure: failure,
                       owner: &owner
                   ) else { return nil }
             state.recordsByKey[key] = owner
@@ -1298,6 +1311,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                 readinessToken: readinessToken,
                 retryTimeout: nil,
                 retryKind: nil,
+                catalogTimeoutCount: 0,
                 nextLoadID: 0,
                 loads: [:]
             )
@@ -1541,6 +1555,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                 readinessToken: nil,
                 retryTimeout: nil,
                 retryKind: nil,
+                catalogTimeoutCount: 0,
                 nextLoadID: 0,
                 loads: [:]
             )
@@ -1593,6 +1608,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                 readinessToken: nil,
                 retryTimeout: nil,
                 retryKind: nil,
+                catalogTimeoutCount: 0,
                 nextLoadID: 0,
                 loads: [:]
             )
@@ -2222,6 +2238,7 @@ final class ProcessControlPlaneAuthority: Sendable {
             attempt.retryTimeout = nil
             attempt.retryKind = .catalog
             attempt.phase = .backoff
+            attempt.catalogTimeoutCount &+= 1
             record.catalogRetryCount &+= 1
             record.attempt = attempt
             state.recordsByKey[key] = record
@@ -2233,7 +2250,8 @@ final class ProcessControlPlaneAuthority: Sendable {
                     publishesToolsListChanged: false
                 ),
                 retry: Self.retry(forAttempt: record.catalogRetryCount),
-                catalogLease: lease
+                catalogLease: lease,
+                timeoutCount: attempt.catalogTimeoutCount
             )
         }
     }
@@ -2296,6 +2314,7 @@ final class ProcessControlPlaneAuthority: Sendable {
                rejectedBridgeRecovery.upstreamID == failedProof.slotID,
                let retry = Self.prepareBridgeRecoveryRetry(
                    rejectedBridgeRecovery,
+                   failure: .other,
                    owner: &record
                ) {
                 state.recordsByKey[key] = record
@@ -2600,18 +2619,26 @@ final class ProcessControlPlaneAuthority: Sendable {
 
     private static func prepareBridgeRecoveryRetry(
         _ recovery: ProcessBridgePoolRecovery,
+        failure: ProcessBridgeRecoveryFailure,
         owner: inout XcodeProcessOwner
     ) -> ProcessBridgeRecoveryRetry? {
         guard case .attempting(let current) = owner.bridgeRecovery.phase,
               current == recovery else { return nil }
         owner.bridgeRecovery.consecutiveFailureCount += 1
+        let shouldLogToolsUnavailableWarning =
+            failure == .toolsListTimeout
+            && owner.bridgeRecovery.didLogToolsUnavailableWarning == false
+        if shouldLogToolsUnavailableWarning {
+            owner.bridgeRecovery.didLogToolsUnavailableWarning = true
+        }
         owner.bridgeRecovery.phase = .waitingRetry(recovery, nil)
         return ProcessBridgeRecoveryRetry(
             reservation: recovery,
             delay: owner.bridgeRecovery.consecutiveFailureCount == 1
                 ? .seconds(1)
                 : .seconds(10),
-            consecutiveFailureCount: owner.bridgeRecovery.consecutiveFailureCount
+            consecutiveFailureCount: owner.bridgeRecovery.consecutiveFailureCount,
+            shouldLogToolsUnavailableWarning: shouldLogToolsUnavailableWarning
         )
     }
 
@@ -2667,6 +2694,7 @@ final class ProcessControlPlaneAuthority: Sendable {
             readinessToken: nil,
             retryTimeout: nil,
             retryKind: .activation,
+            catalogTimeoutCount: 0,
             nextLoadID: 0,
             loads: [:]
         )

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -299,21 +299,15 @@ extension RuntimeCoordinator {
               case .processBridgeAttachment(let verification) = probe.purpose else {
             return
         }
-        var metadata: Logger.Metadata = [
-            "pid": .string("\(verification.recovery.routeID.processID)"),
-            "upstream": .string("\(probe.upstreamIndex)"),
-            "success": .string(success ? "true" : "false"),
-            "reason": .string(reason),
-            "method": .string("tools/list"),
-        ]
-        if let recoveryAction = XcodeMCPToolsAvailabilityDiagnostic.action(
-            forAttachProbeFailureReason: reason
-        ) {
-            metadata["recovery_action"] = .string(recoveryAction)
-        }
         logger.info(
             "bridge_pool_attach_verification_completed",
-            metadata: metadata
+            metadata: [
+                "pid": .string("\(verification.recovery.routeID.processID)"),
+                "upstream": .string("\(probe.upstreamIndex)"),
+                "success": .string(success ? "true" : "false"),
+                "reason": .string(reason),
+                "method": .string("tools/list"),
+            ]
         )
     }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+Health.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import NIO
 import NIOFoundationCompat
 import XcodeMCPKit
@@ -298,14 +299,21 @@ extension RuntimeCoordinator {
               case .processBridgeAttachment(let verification) = probe.purpose else {
             return
         }
+        var metadata: Logger.Metadata = [
+            "pid": .string("\(verification.recovery.routeID.processID)"),
+            "upstream": .string("\(probe.upstreamIndex)"),
+            "success": .string(success ? "true" : "false"),
+            "reason": .string(reason),
+            "method": .string("tools/list"),
+        ]
+        if let recoveryAction = XcodeMCPToolsAvailabilityDiagnostic.action(
+            forAttachProbeFailureReason: reason
+        ) {
+            metadata["recovery_action"] = .string(recoveryAction)
+        }
         logger.info(
             "bridge_pool_attach_verification_completed",
-            metadata: [
-                "pid": .string("\(verification.recovery.routeID.processID)"),
-                "upstream": .string("\(probe.upstreamIndex)"),
-                "success": .string(success ? "true" : "false"),
-                "reason": .string(reason),
-            ]
+            metadata: metadata
         )
     }
 

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -386,7 +386,10 @@ extension RuntimeCoordinator {
     ) {
         var retry: ProcessBridgeRecoveryRetry?
         guard initializeManager.performIfRunning({
-            retry = processControlPlane.prepareBridgeRecoveryRetry(recovery)
+            retry = processControlPlane.prepareBridgeRecoveryRetry(
+                recovery,
+                failure: reason == "attach_probe_timeout" ? .toolsListTimeout : .other
+            )
         }), let retry else {
             return
         }
@@ -407,8 +410,7 @@ extension RuntimeCoordinator {
                 "consecutive_failures": .string("\(retry.consecutiveFailureCount)"),
             ]
         )
-        if reason == "attach_probe_timeout",
-           retry.consecutiveFailureCount == 1 {
+        if retry.shouldLogToolsUnavailableWarning {
             XcodeMCPToolsAvailabilityDiagnostic.logTimeout(
                 logger: logger,
                 processID: retry.reservation.routeID.processID,
@@ -449,7 +451,8 @@ extension RuntimeCoordinator {
         var retry: ProcessBridgeRecoveryRetry?
         guard initializeManager.performIfRunning({
             retry = processControlPlane.prepareBridgeRecoveryRetry(
-                recovery.reservation
+                recovery.reservation,
+                failure: reason == "attach_probe_timeout" ? .toolsListTimeout : .other
             )
         }), let retry else { return }
         guard let replacement else {

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessReconciliation.swift
@@ -404,8 +404,18 @@ extension RuntimeCoordinator {
                 "upstream": .string("\(retry.reservation.upstreamID.rawValue)"),
                 "reason": .string(reason),
                 "delay_ms": .string("\(retry.delay.nanoseconds / 1_000_000)"),
+                "consecutive_failures": .string("\(retry.consecutiveFailureCount)"),
             ]
         )
+        if reason == "attach_probe_timeout",
+           retry.consecutiveFailureCount == 1 {
+            XcodeMCPToolsAvailabilityDiagnostic.logTimeout(
+                logger: logger,
+                processID: retry.reservation.routeID.processID,
+                upstreamIndex: retry.reservation.upstreamID.rawValue,
+                retryDelayMilliseconds: retry.delay.nanoseconds / 1_000_000
+            )
+        }
         let timeout = scheduleRuntimeTimeout(retry.delay) { [weak self] in
             guard let self else { return }
             self.applyProcessControlPlaneTransition(

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -499,12 +499,18 @@ extension RuntimeCoordinator {
                 "timeout_ms": .string(
                     processRouteActivationCatalogTimeoutMillisecondsDescription()
                 ),
+                "catalog_timeout_count": .string("\(retry.attempt)"),
                 "retry_delay_ms": .string("\(retry.delayMilliseconds)"),
-                "recovery_action": .string(
-                    XcodeMCPToolsAvailabilityDiagnostic.enableToolsAction
-                ),
             ]
         )
+        if retry.attempt == 1 {
+            XcodeMCPToolsAvailabilityDiagnostic.logTimeout(
+                logger: logger,
+                processID: lease.processID,
+                upstreamIndex: lease.upstreamIndex,
+                retryDelayMilliseconds: retry.delayMilliseconds
+            )
+        }
 
         scheduleMissingProcessToolsCatalogRetry(
             processID: lease.processID,

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -495,10 +495,14 @@ extension RuntimeCoordinator {
                 "upstream": .string("\(lease.upstreamIndex)"),
                 "attempt": .string("\(lease.attempt)"),
                 "phase": .string("catalog"),
+                "method": .string("tools/list"),
                 "timeout_ms": .string(
                     processRouteActivationCatalogTimeoutMillisecondsDescription()
                 ),
                 "retry_delay_ms": .string("\(retry.delayMilliseconds)"),
+                "recovery_action": .string(
+                    XcodeMCPToolsAvailabilityDiagnostic.enableToolsAction
+                ),
             ]
         )
 

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/RuntimeCoordinator+XcodeProcessRouteActivation.swift
@@ -483,7 +483,8 @@ extension RuntimeCoordinator {
         guard case .retryRequired(
             _,
             let retry,
-            let retryLease
+            let retryLease,
+            let catalogTimeoutCount
         ) = timeout else {
             return
         }
@@ -499,11 +500,11 @@ extension RuntimeCoordinator {
                 "timeout_ms": .string(
                     processRouteActivationCatalogTimeoutMillisecondsDescription()
                 ),
-                "catalog_timeout_count": .string("\(retry.attempt)"),
+                "catalog_timeout_count": .string("\(catalogTimeoutCount)"),
                 "retry_delay_ms": .string("\(retry.delayMilliseconds)"),
             ]
         )
-        if retry.attempt == 1 {
+        if catalogTimeoutCount == 1 {
             XcodeMCPToolsAvailabilityDiagnostic.logTimeout(
                 logger: logger,
                 processID: lease.processID,

--- a/Sources/XcodeMCPProxyRuntime/Session/Support/ProxyLogging.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Support/ProxyLogging.swift
@@ -71,11 +71,32 @@ enum LogLevelParser {
 }
 
 enum XcodeMCPToolsAvailabilityDiagnostic {
-    static let enableToolsAction =
-        "Check that \"Allow external agents to use Xcode tools\" is enabled in "
-        + "Xcode > Settings > Intelligence. If Xcode shows a connection dialog, approve it."
+    static let timeoutSummary = """
+        Xcode tools are unavailable
 
-    static func action(forAttachProbeFailureReason reason: String) -> String? {
-        reason == "timeout" ? enableToolsAction : nil
+          The proxy timed out waiting for tools/list.
+          Recovery:
+            1. Open a project in Xcode.
+            2. Check that "Allow external agents to use Xcode tools" is enabled in
+               Xcode > Settings > Intelligence.
+            3. If Xcode shows a connection dialog, approve it.
+          The proxy will retry automatically.
+        """
+
+    static func logTimeout(
+        logger: Logger,
+        processID: pid_t,
+        upstreamIndex: Int,
+        retryDelayMilliseconds: Int64
+    ) {
+        logger.warning(
+            "\(timeoutSummary)",
+            metadata: [
+                "pid": .string("\(processID)"),
+                "upstream": .string("\(upstreamIndex)"),
+                "method": .string("tools/list"),
+                "retry_delay_ms": .string("\(retryDelayMilliseconds)"),
+            ]
+        )
     }
 }

--- a/Sources/XcodeMCPProxyRuntime/Session/Support/ProxyLogging.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Support/ProxyLogging.swift
@@ -69,3 +69,13 @@ enum LogLevelParser {
         }
     }
 }
+
+enum XcodeMCPToolsAvailabilityDiagnostic {
+    static let enableToolsAction =
+        "Check that \"Allow external agents to use Xcode tools\" is enabled in "
+        + "Xcode > Settings > Intelligence. If Xcode shows a connection dialog, approve it."
+
+    static func action(forAttachProbeFailureReason reason: String) -> String? {
+        reason == "timeout" ? enableToolsAction : nil
+    }
+}

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -134,6 +134,7 @@ struct ControlPlaneAuthorityTests {
 
         let firstRetry = try #require(authority.prepareBridgeRecoveryRetry(firstAttempt))
         #expect(firstRetry.delay.nanoseconds == TimeAmount.seconds(1).nanoseconds)
+        #expect(firstRetry.consecutiveFailureCount == 1)
         guard case .restoreBridgePool(let secondAttempt) = authority
             .handleBridgeRecoveryRetryFired(firstRetry.reservation).effects.first else {
             Issue.record("expected early bridge recovery retry")
@@ -160,6 +161,7 @@ struct ControlPlaneAuthorityTests {
 
         let periodicRetry = try #require(authority.prepareBridgeRecoveryRetry(secondAttempt))
         #expect(periodicRetry.delay.nanoseconds == TimeAmount.seconds(10).nanoseconds)
+        #expect(periodicRetry.consecutiveFailureCount == 2)
         guard case .restoreBridgePool(let thirdAttempt) = authority
             .handleBridgeRecoveryRetryFired(periodicRetry.reservation).effects.first else {
             Issue.record("expected periodic bridge recovery retry")
@@ -173,6 +175,7 @@ struct ControlPlaneAuthorityTests {
         #expect(nextSlot.upstreamID == UpstreamSlotID(rawValue: 2))
         let resetRetry = try #require(authority.prepareBridgeRecoveryRetry(nextSlot))
         #expect(resetRetry.delay.nanoseconds == TimeAmount.seconds(1).nanoseconds)
+        #expect(resetRetry.consecutiveFailureCount == 1)
     }
 
     @Test func bridgeRecoveryRetryContinuesWhenCatalogDisappears() throws {
@@ -1534,6 +1537,7 @@ struct ControlPlaneAuthorityTests {
         }
 
         #expect(firstRetryLease.attempt == firstLease.attempt)
+        #expect(firstRetry.attempt == 1)
         #expect(firstRetry.delay == .milliseconds(250))
         #expect(authority.beginCatalogAttempt(
             routeID: route.id,
@@ -1562,6 +1566,7 @@ struct ControlPlaneAuthorityTests {
         }
 
         #expect(secondLease.attempt == firstLease.attempt)
+        #expect(secondRetry.attempt == 2)
         #expect(secondRetry.delay == .milliseconds(500))
     }
 

--- a/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ControlPlaneAuthorityTests.swift
@@ -132,9 +132,13 @@ struct ControlPlaneAuthorityTests {
         }
         #expect(firstAttempt.upstreamID == UpstreamSlotID(rawValue: 1))
 
-        let firstRetry = try #require(authority.prepareBridgeRecoveryRetry(firstAttempt))
+        let firstRetry = try #require(authority.prepareBridgeRecoveryRetry(
+            firstAttempt,
+            failure: .other
+        ))
         #expect(firstRetry.delay.nanoseconds == TimeAmount.seconds(1).nanoseconds)
         #expect(firstRetry.consecutiveFailureCount == 1)
+        #expect(firstRetry.shouldLogToolsUnavailableWarning == false)
         guard case .restoreBridgePool(let secondAttempt) = authority
             .handleBridgeRecoveryRetryFired(firstRetry.reservation).effects.first else {
             Issue.record("expected early bridge recovery retry")
@@ -159,23 +163,41 @@ struct ControlPlaneAuthorityTests {
         #expect(cancelled.withLockedValue { $0 })
         #expect(authority.handleBridgeRecoveryRetryFired(firstRetry.reservation).effects.isEmpty)
 
-        let periodicRetry = try #require(authority.prepareBridgeRecoveryRetry(secondAttempt))
+        let periodicRetry = try #require(authority.prepareBridgeRecoveryRetry(
+            secondAttempt,
+            failure: .toolsListTimeout
+        ))
         #expect(periodicRetry.delay.nanoseconds == TimeAmount.seconds(10).nanoseconds)
         #expect(periodicRetry.consecutiveFailureCount == 2)
+        #expect(periodicRetry.shouldLogToolsUnavailableWarning)
         guard case .restoreBridgePool(let thirdAttempt) = authority
             .handleBridgeRecoveryRetryFired(periodicRetry.reservation).effects.first else {
             Issue.record("expected periodic bridge recovery retry")
             return
         }
+        let repeatedTimeoutRetry = try #require(authority.prepareBridgeRecoveryRetry(
+            thirdAttempt,
+            failure: .toolsListTimeout
+        ))
+        #expect(repeatedTimeoutRetry.shouldLogToolsUnavailableWarning == false)
+        guard case .restoreBridgePool(let recoveredAttempt) = authority
+            .handleBridgeRecoveryRetryFired(repeatedTimeoutRetry.reservation).effects.first else {
+            Issue.record("expected repeated timeout recovery retry")
+            return
+        }
         guard case .restoreBridgePool(let nextSlot) = authority
-            .completeBridgeRecovery(thirdAttempt).effects.first else {
+            .completeBridgeRecovery(recoveredAttempt).effects.first else {
             Issue.record("expected next serialized bridge slot")
             return
         }
         #expect(nextSlot.upstreamID == UpstreamSlotID(rawValue: 2))
-        let resetRetry = try #require(authority.prepareBridgeRecoveryRetry(nextSlot))
+        let resetRetry = try #require(authority.prepareBridgeRecoveryRetry(
+            nextSlot,
+            failure: .toolsListTimeout
+        ))
         #expect(resetRetry.delay.nanoseconds == TimeAmount.seconds(1).nanoseconds)
         #expect(resetRetry.consecutiveFailureCount == 1)
+        #expect(resetRetry.shouldLogToolsUnavailableWarning)
     }
 
     @Test func bridgeRecoveryRetryContinuesWhenCatalogDisappears() throws {
@@ -196,7 +218,10 @@ struct ControlPlaneAuthorityTests {
             Issue.record("expected bridge recovery after catalog commit")
             return
         }
-        let retry = try #require(authority.prepareBridgeRecoveryRetry(firstAttempt))
+        let retry = try #require(authority.prepareBridgeRecoveryRetry(
+            firstAttempt,
+            failure: .other
+        ))
 
         _ = authority.invalidateCatalogSource(
             processID: target.processID,
@@ -209,7 +234,10 @@ struct ControlPlaneAuthorityTests {
             return
         }
         #expect(resumedAttempt.upstreamID == firstAttempt.upstreamID)
-        let periodicRetry = try #require(authority.prepareBridgeRecoveryRetry(resumedAttempt))
+        let periodicRetry = try #require(authority.prepareBridgeRecoveryRetry(
+            resumedAttempt,
+            failure: .other
+        ))
         #expect(periodicRetry.delay.nanoseconds == TimeAmount.seconds(10).nanoseconds)
     }
 
@@ -455,7 +483,10 @@ struct ControlPlaneAuthorityTests {
         #expect(retry.reservation == rejectedRecovery)
         #expect(retry.delay == .seconds(1))
         #expect(authority.attemptSnapshot(processID: target.processID) == nil)
-        #expect(authority.prepareBridgeRecoveryRetry(rejectedRecovery) == nil)
+        #expect(authority.prepareBridgeRecoveryRetry(
+            rejectedRecovery,
+            failure: .other
+        ) == nil)
         guard case .restoreBridgePool(let retried) = authority
             .handleBridgeRecoveryRetryFired(retry.reservation).effects.first else {
             Issue.record("expected the atomic retry to remain schedulable")
@@ -474,7 +505,10 @@ struct ControlPlaneAuthorityTests {
             Issue.record("expected initial bridge recovery")
             return
         }
-        let staleRetry = try #require(authority.prepareBridgeRecoveryRetry(staleRecovery))
+        let staleRetry = try #require(authority.prepareBridgeRecoveryRetry(
+            staleRecovery,
+            failure: .other
+        ))
         guard case .restoreBridgePool(let currentRecovery) = authority
             .handleBridgeRecoveryRetryFired(staleRetry.reservation).effects.first else {
             Issue.record("expected a newer bridge recovery")
@@ -495,7 +529,10 @@ struct ControlPlaneAuthorityTests {
         #expect(attemptingTransition.effects.isEmpty)
         #expect(authority.validateBridgeRecovery(currentRecovery))
 
-        let currentRetry = try #require(authority.prepareBridgeRecoveryRetry(currentRecovery))
+        let currentRetry = try #require(authority.prepareBridgeRecoveryRetry(
+            currentRecovery,
+            failure: .other
+        ))
         let waitingResult = try #require(authority.recoverAfterRejectedCancellation(
             routeID: route.id,
             failedProof: testTopologyProof(1),
@@ -773,7 +810,10 @@ struct ControlPlaneAuthorityTests {
             Issue.record("expected bridge recovery")
             return
         }
-        let retry = try #require(authority.prepareBridgeRecoveryRetry(recovery))
+        let retry = try #require(authority.prepareBridgeRecoveryRetry(
+            recovery,
+            failure: .other
+        ))
         let cancelled = NIOLockedValueBox(false)
         let timeout = RuntimeScheduledTimeout {
             cancelled.withLockedValue { $0 = true }
@@ -1529,7 +1569,7 @@ struct ControlPlaneAuthorityTests {
             to: firstTimeoutReservation
         )
 
-        guard case .retryRequired(_, let firstRetry, let firstRetryLease) =
+        guard case .retryRequired(_, let firstRetry, let firstRetryLease, let firstTimeoutCount) =
             authority.handleCatalogRequestTimeout(firstTimeoutReservation, nowUptimeNs: 2)
         else {
             Issue.record("expected the final load timeout to require retry")
@@ -1539,6 +1579,7 @@ struct ControlPlaneAuthorityTests {
         #expect(firstRetryLease.attempt == firstLease.attempt)
         #expect(firstRetry.attempt == 1)
         #expect(firstRetry.delay == .milliseconds(250))
+        #expect(firstTimeoutCount == 1)
         #expect(authority.beginCatalogAttempt(
             routeID: route.id,
             preferredUpstreamProof: proof,
@@ -1558,7 +1599,7 @@ struct ControlPlaneAuthorityTests {
             RuntimeScheduledTimeout {},
             to: secondTimeoutReservation
         )
-        guard case .retryRequired(_, let secondRetry, _) =
+        guard case .retryRequired(_, let secondRetry, _, let secondTimeoutCount) =
             authority.handleCatalogRequestTimeout(secondTimeoutReservation, nowUptimeNs: 5)
         else {
             Issue.record("expected the retry load timeout to require another retry")
@@ -1568,6 +1609,7 @@ struct ControlPlaneAuthorityTests {
         #expect(secondLease.attempt == firstLease.attempt)
         #expect(secondRetry.attempt == 2)
         #expect(secondRetry.delay == .milliseconds(500))
+        #expect(secondTimeoutCount == 2)
     }
 
     @Test func catalogTimeoutFiringBeforeAttachmentConsumesReservation() throws {
@@ -1602,7 +1644,7 @@ struct ControlPlaneAuthorityTests {
         #expect(authority.validateCatalogLoad(lease) == false)
     }
 
-    @Test func staleCatalogTimeoutCannotTerminateNewerRetryLoad() throws {
+    @Test func catalogTimeoutCountIgnoresNonTimeoutRetryAndRejectsStaleReservation() throws {
         let target = xcodeProcessTarget(processID: 41033, xcodeVersion: "27.0")
         let authority = makeAuthority([(target, [0])])
         let route = try #require(authority.route(forProcessID: target.processID))
@@ -1644,6 +1686,17 @@ struct ControlPlaneAuthorityTests {
             authority.attemptSnapshot(processID: target.processID)?.phase
                 == .loadingCatalog
         )
+        let retryTimeoutReservation = try #require(
+            authority.reserveCatalogTimeout(for: retryLease)
+        )
+        guard case .retryRequired(_, let retry, _, let timeoutCount) =
+            authority.handleCatalogRequestTimeout(retryTimeoutReservation, nowUptimeNs: 5)
+        else {
+            Issue.record("expected the current load timeout to require retry")
+            return
+        }
+        #expect(retry.attempt == 2)
+        #expect(timeoutCount == 1)
     }
 
     @Test func catalogLoadTimeoutPreservesSiblingLoad() throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/HTTPConcurrencyTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/HTTPConcurrencyTests.swift
@@ -354,6 +354,7 @@ struct HTTPConcurrencyTests {
         let firstObject = try jsonObject(from: firstResponse.body)
         #expect((firstObject["error"] as? [String: Any])?["message"] as? String == "upstream timeout")
 
+        await sessionManager.drainRuntimeTasksForTesting()
         secondChannel.embeddedEventLoop.run()
         await sessionManager.drainRuntimeTasksForTesting()
         let secondRequestLabels = try await waitForUpstreamRequestCount(upstream, count: 3)

--- a/Tests/XcodeMCPProxyRuntimeTests/ProxyLoggingTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ProxyLoggingTests.swift
@@ -24,4 +24,20 @@ struct ProxyLoggingTests {
         )
         #expect(level == .error)
     }
+
+    @Test func toolsAvailabilityDiagnosticExplainsAttachTimeout() {
+        let expectedAction =
+            "Check that \"Allow external agents to use Xcode tools\" is enabled in "
+            + "Xcode > Settings > Intelligence. If Xcode shows a connection dialog, approve it."
+        #expect(
+            XcodeMCPToolsAvailabilityDiagnostic.action(
+                forAttachProbeFailureReason: "timeout"
+            ) == expectedAction
+        )
+        #expect(
+            XcodeMCPToolsAvailabilityDiagnostic.action(
+                forAttachProbeFailureReason: "invalid_response"
+            ) == nil
+        )
+    }
 }

--- a/Tests/XcodeMCPProxyRuntimeTests/ProxyLoggingTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/ProxyLoggingTests.swift
@@ -25,19 +25,19 @@ struct ProxyLoggingTests {
         #expect(level == .error)
     }
 
-    @Test func toolsAvailabilityDiagnosticExplainsAttachTimeout() {
-        let expectedAction =
-            "Check that \"Allow external agents to use Xcode tools\" is enabled in "
-            + "Xcode > Settings > Intelligence. If Xcode shows a connection dialog, approve it."
+    @Test func toolsAvailabilityDiagnosticExplainsTimeoutAndRetry() {
         #expect(
-            XcodeMCPToolsAvailabilityDiagnostic.action(
-                forAttachProbeFailureReason: "timeout"
-            ) == expectedAction
-        )
-        #expect(
-            XcodeMCPToolsAvailabilityDiagnostic.action(
-                forAttachProbeFailureReason: "invalid_response"
-            ) == nil
+            XcodeMCPToolsAvailabilityDiagnostic.timeoutSummary == """
+                Xcode tools are unavailable
+
+                  The proxy timed out waiting for tools/list.
+                  Recovery:
+                    1. Open a project in Xcode.
+                    2. Check that "Allow external agents to use Xcode tools" is enabled in
+                       Xcode > Settings > Intelligence.
+                    3. If Xcode shows a connection dialog, approve it.
+                  The proxy will retry automatically.
+                """
         )
     }
 }

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -6808,7 +6808,11 @@ struct RuntimeCoordinatorRecoveryTests {
             )
         }
         try await waitForSentCount(upstream, count: 3, timeoutSeconds: 2)
-        let firstRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        let firstRequest = try await sentValue(
+            from: upstream,
+            at: 2,
+            timeout: .seconds(2)
+        )
         #expect(methodName(from: firstRequest) == "tools/list")
         try await upstream.waitForBlockedSend()
         try await advanceRuntimeCoordinatorTimeout(
@@ -7073,6 +7077,7 @@ struct RuntimeCoordinatorRecoveryTests {
 
         let sessionID = "session-tools-shared-no-starvation"
         _ = manager.session(id: sessionID)
+        await upstream.blockNextCancellation()
 
         let firstTask = Task {
             try await manager.sharedToolsList(
@@ -7080,7 +7085,8 @@ struct RuntimeCoordinatorRecoveryTests {
                 requestTimeoutOverride: .seconds(5)
             )
         }
-        _ = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        let firstRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
+        #expect(methodName(from: firstRequest) == "tools/list")
 
         uptimeClock.advance(by: .nanoseconds(120_000_001))
 
@@ -7090,7 +7096,16 @@ struct RuntimeCoordinatorRecoveryTests {
                 requestTimeoutOverride: .seconds(5)
             )
         }
-        _ = try await sentValue(from: upstream, at: 3, timeout: .seconds(2))
+        try await upstream.waitForBlockedCancellation()
+        let firstCancellation = try await sentValue(
+            from: upstream,
+            at: 3,
+            timeout: .seconds(2)
+        )
+        #expect(
+            try extractCancellationRequestID(from: firstCancellation)
+                == extractUpstreamID(from: firstRequest)
+        )
 
         uptimeClock.advance(by: .nanoseconds(120_000_001))
 
@@ -7106,7 +7121,9 @@ struct RuntimeCoordinatorRecoveryTests {
                 $0.waiterCounts.toolsCatalog == 3
             }
         }
-        #expect(await upstream.sentCount() == 4)
+        let sentCount = await upstream.sentCount()
+        #expect(sentCount == 4)
+        await upstream.releaseBlockedCancellation()
 
         firstTask.cancel()
         secondTask.cancel()
@@ -7224,6 +7241,7 @@ struct RuntimeCoordinatorRecoveryTests {
         manager.refreshToolsListIfNeeded()
         let prewarmRequest = try await sentValue(from: upstream, at: 2, timeout: .seconds(2))
         #expect(methodName(from: prewarmRequest) == "tools/list")
+        await upstream.blockNextCancellation()
 
         let sessionID = "session-tools-prewarm-timeout"
         _ = manager.session(id: sessionID)
@@ -7248,6 +7266,7 @@ struct RuntimeCoordinatorRecoveryTests {
         await #expect(throws: TimeoutError.self) {
             _ = try await firstTask.value
         }
+        try await upstream.waitForBlockedCancellation()
         let prewarmCancellation = try await sentValue(
             from: upstream,
             at: 3,
@@ -7257,6 +7276,7 @@ struct RuntimeCoordinatorRecoveryTests {
             try extractCancellationRequestID(from: prewarmCancellation)
                 == extractUpstreamID(from: prewarmRequest)
         )
+        await upstream.releaseBlockedCancellation()
         await manager.drainRuntimeTasksForTesting()
         #expect(manager.debugSnapshot().upstreams[0].activeCorrelatedRequestCount == 0)
 


### PR DESCRIPTION
## Purpose

Xcode can initialize `mcpbridge` without returning `tools/list` when the global external-agent access setting is disabled. The proxy previously surfaced only repeated route or attachment timeout lines, making a live Xcode process look unattached without a readable next step.

## Changes

- Add the required **Xcode > Settings > Intelligence > Allow external agents to use Xcode tools** step to the README, with the official Apple documentation.
- Explain the distinction between the global Xcode setting, the per-connection **Allow** dialog, `--auto-approve`, and macOS Accessibility permission.
- Document the actual `route_activation_timeout` and `bridge_pool_attach_verification_completed success=false reason=timeout` events.
- Keep structured retry events concise and emit a multiline **Xcode tools are unavailable** warning only for the first `tools/list` timeout in each recovery incident.
- Track catalog timeout counts and bridge timeout-warning state independently from general retry failures in the process control-plane owner.
- Drive the queued-request event loop only after timeout settlement tasks become idle, removing a race from the affected CI test.
- Hold cancellation delivery at the test upstream boundary while asserting shared-load promotion and timeout cleanup, removing two additional scheduling races from the recovery shard.
- Keep production timeout and retry semantics unchanged.

## Validation

- `scripts/check.sh`
  - 1,023 tests in the standard suite
  - 24 process runtime tests
  - 13 STDIO adapter tests
- GitHub Actions `remaining` shard command: 425 tests passed.
- GitHub Actions `RuntimeCoordinatorRecoveryTests` shard command: 45 tests passed.
- `swift test --filter 'ControlPlaneAuthorityTests|httpRequestLeaseTimeoutReleasesSessionAndStartsNextQueuedRequest' -Xswiftc -strict-concurrency=minimal`: 50 tests passed.
- Each affected recovery test passed 100 consecutive targeted repetitions.
- Branch-wide audit against pinned `main` (`3c1278ad...`): no P0-P3 findings.
- `git diff --check`
