### PR TITLE
Honor auto-approval for headless Xcode connections

### DIFF
--- a/Docs/xcode-27-headless-mcp-design.md
+++ b/Docs/xcode-27-headless-mcp-design.md
@@ -109,6 +109,10 @@ Xcode 27 developer directory in `DEVELOPER_DIR`:
 8. With headless access enabled and Xcode Service stopped, launching an unbound
    `mcpbridge` starts Xcode Service and completes `initialize`. XcodeMCPKit does
    not need to call `mcp-server start`.
+9. With `unsafeAlwaysAllowAllAgents` enabled, headless `DocumentationSearch`
+   can still present a connection approval dialog in GUI Xcode. The proxy's
+   automatic approval policy therefore applies independently of routing mode;
+   the existing dialog matcher limits approval to the proxy's own connections.
 
 The preview CLI may return valid status JSON together with a nonzero status or
 warning when its live service query times out. A valid JSON payload is the
@@ -170,8 +174,9 @@ resolved mode.
 - GUI mode preserves process-bound discovery, `MCP_XCODE_PID`, per-Xcode pools,
   AX permission automation, and the proxy DocumentationSearch provider.
 - Headless mode launches the configured stock bridge without
-  `MCP_XCODE_PID`. It does not wait for a GUI Xcode process and does not run AX
-  permission automation.
+  `MCP_XCODE_PID`. It does not wait for a GUI Xcode process. When automatic
+  approval is requested, the existing process monitor supplies dialog owners
+  to AX permission automation without enabling GUI process routing.
 - Headless mode forwards the upstream DocumentationSearch and workspace tools;
   it does not create a second workspace or documentation source of truth.
 - Proxy shutdown closes and awaits its bridge/runtime/HTTP resources. It does
@@ -257,7 +262,8 @@ that behavior is observed.
   cancellation.
 - CLI/config tests for all modes and custom-upstream conflicts.
 - Runtime tests proving GUI mode remains process-bound and headless mode is
-  unbound with no GUI readiness launch.
+  unbound with no GUI readiness launch, while honoring the approval policy for
+  Xcode connection dialogs.
 - Startup-summary and exact multiline notice tests.
 - Public product contract compile test for `xcodeMode`.
 - Device-affinity owner and routing tests, including both key spellings,

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ For GUI routing, open your project in Xcode, choose
 See [Giving external agents access to Xcode][apple-xcode-mcp-access].
 
 This global Xcode setting is separate from the per-connection **Allow** dialog.
-`--auto-approve` handles the GUI dialog; it does not enable headless MCP access.
+`--auto-approve` handles Xcode connection dialogs, including those that appear
+while using headless routing; it does not enable headless MCP access.
 The first headless `XcodeOpenWorkspace` call can separately ask you to approve
 the agent and containing folder. Review that request in Xcode Service and
 approve it manually; XcodeMCPKit does not broaden headless permissions.
@@ -90,7 +91,8 @@ approve it manually; XcodeMCPKit does not broaden headless permissions.
 xcode-mcp-proxy-server --auto-approve
 ```
 
-In GUI mode, `--auto-approve` clicks the Xcode **Allow** button automatically. In
+`--auto-approve` clicks the Xcode **Allow** button for the proxy's own connections
+in both GUI and headless modes. In
 **System Settings > Privacy & Security > Accessibility**, allow the app that
 launches the proxy (for example, Terminal or iTerm).
 
@@ -157,7 +159,7 @@ xcode-mcp-proxy --help
 |----------|-------------|
 | `LISTEN` | Listen address, for example `127.0.0.1:8765`. |
 | `HOST` / `PORT` | Listen host and port when `LISTEN` is unset. |
-| `MCP_XCODE_PID` | Set by the proxy on GUI process-bound upstream `mcpbridge` children. Headless routing leaves the stock bridge unbound. An inherited value is only passed through when process-bound Xcode routing is not active. |
+| `MCP_XCODE_PID` | Set by the proxy on GUI process-bound upstream `mcpbridge` children. Headless routing removes inherited values to leave the stock bridge unbound. Custom and GUI fallback upstreams pass inherited values through. |
 | `MCP_XCODE_SESSION_ID` | Optional explicit upstream Xcode MCP session ID. |
 | `MCP_XCODE_CONFIG` | TOML config path. `--config` takes precedence. |
 | `MCP_XCODE_REFRESH_CODE_ISSUES_MODE` | `proxy` or `upstream`. |

--- a/Sources/XcodeMCPProxyKit/Internal/Configuration/ProxyConfig.swift
+++ b/Sources/XcodeMCPProxyKit/Internal/Configuration/ProxyConfig.swift
@@ -180,7 +180,7 @@ package struct ProxyConfig: Sendable {
             maxMessageBytes: maxBodyBytes,
             requestTimeout: requestTimeout,
             prewarmToolsList: prewarmToolsList,
-            usesPermissionDialogAutomation: autoApproveXcodeDialog && xcodeMode != .headless,
+            usesPermissionDialogAutomation: autoApproveXcodeDialog,
             refreshCodeIssuesMode: effectiveRefreshCodeIssuesMode,
             disabledToolNames: disabledToolNames,
             initializeParamsOverride: initializeParamsOverride.map(

--- a/Sources/XcodeMCPProxyKit/README.md
+++ b/Sources/XcodeMCPProxyKit/README.md
@@ -68,13 +68,14 @@ a new instance after shutdown.
   service and otherwise preserves GUI routing.
 
 Headless mode does not require a workspace to be open in the Xcode app. It
-forwards workspace lifecycle and DocumentationSearch tools to Xcode Service,
-does not run GUI permission automation, and never enables, approves, or stops
-the shared service. If headless access is disabled, enable it separately with
+forwards workspace lifecycle and DocumentationSearch tools to Xcode Service
+and never enables, approves, or stops the shared service. If headless access is
+disabled, enable it separately with
 `sudo xcrun mcp-server enable`; explicit `.headless` fails startup instead of
 silently falling back. Xcode Service can request manual agent and folder
-approval on the first `XcodeOpenWorkspace` call; `approvalPolicy: .automatic`
-applies only to GUI Xcode dialogs.
+approval on the first `XcodeOpenWorkspace` call. `approvalPolicy: .automatic`
+handles Xcode connection dialogs for the proxy's own connections in either
+routing mode. It does not grant headless agent or folder permissions.
 
 Custom upstream commands keep their existing unbound behavior and require
 `xcodeMode: .automatic`.

--- a/Sources/XcodeMCPProxyRuntime/Session/Runtime/ProxyRuntimeAPI.swift
+++ b/Sources/XcodeMCPProxyRuntime/Session/Runtime/ProxyRuntimeAPI.swift
@@ -356,7 +356,8 @@ package final class ProxyRuntime: ProxyRuntimeServing, Sendable {
         let eventLoop = group.next()
         let eventSource = ProxyRuntimeEventSource()
         let processEventMonitor: XcodeProcessEventMonitor? =
-            config.xcodeMode == .headless ? nil : XcodeProcessEventMonitor()
+            config.xcodeMode != .headless || config.usesPermissionDialogAutomation
+            ? XcodeProcessEventMonitor() : nil
         let coordinator = RuntimeCoordinator(
             config: config,
             eventLoop: eventLoop,

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerBuildInfoTests.swift
@@ -80,7 +80,7 @@ struct XcodeMCPProxyServerBuildInfoTests {
         Server
           URL: http://localhost:8765/mcp
           Upstream processes: 1
-          Auto approve: disabled
+          Auto approve: enabled
 
         Xcode
           Mode: headless

--- a/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
+++ b/Tests/ProxyIntegrationTests/XcodeMCPProxyServerTests.swift
@@ -296,16 +296,20 @@ struct XcodeMCPProxyServerTests {
         try await server.shutdown()
     }
 
-    @Test func automaticEnabledHeadlessSkipsGUIAutomationAndUsesUnboundFeatures() async throws {
+    @Test(arguments: [false, true])
+    func automaticEnabledHeadlessHonorsApprovalPolicyAndUsesUnboundFeatures(
+        autoApprove: Bool
+    ) async throws {
         let availabilityQueries = NIOLockedValueBox(0)
         let autoApproverCreations = NIOLockedValueBox(0)
+        let autoApprover = RecordingAutoApprover()
         let runtimeConfiguration = NIOLockedValueBox<ProxyRuntimeConfiguration?>(nil)
         let runtime = StartupInventoryRuntime()
         let server = XcodeMCPProxyServer(
             configuration: .init(
                 bindAddress: .init(host: "127.0.0.1", port: 0),
                 discovery: .disabled,
-                approvalPolicy: .automatic,
+                approvalPolicy: autoApprove ? .automatic : .manual,
                 featurePolicy: .init(refreshCodeIssuesMode: .proxy)
             ),
             dependencies: .init(
@@ -316,7 +320,7 @@ struct XcodeMCPProxyServerTests {
                 },
                 makeAutoApprover: { _, _ in
                     autoApproverCreations.withLockedValue { $0 += 1 }
-                    return RecordingAutoApprover()
+                    return autoApprover
                 },
                 makeRuntime: { config in
                     runtimeConfiguration.withLockedValue { $0 = config }
@@ -329,12 +333,14 @@ struct XcodeMCPProxyServerTests {
         let captured = try #require(runtimeConfiguration.withLockedValue { $0 })
         #expect(availabilityQueries.withLockedValue { $0 } == 1)
         #expect(captured.xcodeMode == .headless)
-        #expect(captured.usesPermissionDialogAutomation == false)
+        #expect(captured.usesPermissionDialogAutomation == autoApprove)
         #expect(captured.refreshCodeIssuesMode == .upstream)
         #expect(ProxyRuntime.supportsProcessBoundRouting(configuration: captured) == false)
         #expect(ProxyRuntime.documentationSearchIsConfigured(configuration: captured) == false)
-        #expect(autoApproverCreations.withLockedValue { $0 } == 0)
+        #expect(autoApproverCreations.withLockedValue { $0 } == (autoApprove ? 1 : 0))
+        #expect(autoApprover.startCount == (autoApprove ? 1 : 0))
         try await server.shutdown()
+        #expect(autoApprover.cancelCount == (autoApprove ? 1 : 0))
     }
 
     @Test func explicitGUIPreservesLegacyRoutingWithoutStatusQuery() async throws {

--- a/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
+++ b/Tests/XcodeMCPProxyRuntimeTests/RuntimeCoordinatorTests.swift
@@ -124,8 +124,16 @@ struct RuntimeCoordinatorProcessRoutingTests {
         #expect(manager.debugSnapshot().processRoutes.isEmpty)
     }
 
-    @Test func autoApprovalStartsProcessInventoryOutsideProcessRouting() {
+    @Test(arguments: [
+        ProxyRuntimeConfiguration.XcodeMode.gui,
+        .headless,
+        .custom,
+    ])
+    func autoApprovalStartsProcessInventoryOutsideProcessRouting(
+        xcodeMode: ProxyRuntimeConfiguration.XcodeMode
+    ) async {
         var config = makeConfig(requestTimeout: 0)
+        config.xcodeMode = xcodeMode
         config.usesPermissionDialogAutomation = true
         let monitor = StartRecordingXcodeProcessMonitor()
         let manager = RuntimeCoordinator(
@@ -136,11 +144,15 @@ struct RuntimeCoordinatorProcessRoutingTests {
             xcodeProcessEventMonitor: monitor,
             startImmediately: false
         )
-        defer { manager.shutdownAndWait() }
-
         manager.start()
 
         #expect(monitor.startCount() == 1)
+        #expect(monitor.changeHandlerCount() == 0)
+        #expect(manager.processRoutingEnabled == false)
+        #expect(manager.debugSnapshot().processRoutes.isEmpty)
+
+        await manager.shutdown()
+        #expect(monitor.stopCount() == 1)
     }
 
     @Test func defaultUpstreamsPassThroughInheritedMCPXcodePIDEnvironment() async throws {
@@ -18893,6 +18905,8 @@ private final class StartRecordingXcodeProcessMonitor:
 {
     private let lock = NSLock()
     private var starts = 0
+    private var stops = 0
+    private var changeHandlers = 0
 
     func start() {
         lock.withLock { starts += 1 }
@@ -18901,6 +18915,7 @@ private final class StartRecordingXcodeProcessMonitor:
     func setChangeHandler(
         _: @escaping @Sendable (String) -> Void
     ) {
+        lock.withLock { changeHandlers += 1 }
         start()
     }
 
@@ -18914,10 +18929,20 @@ private final class StartRecordingXcodeProcessMonitor:
 
     func waitForReadinessChange(after _: UInt64) async {}
 
-    func stop() {}
+    func stop() {
+        lock.withLock { stops += 1 }
+    }
 
     func startCount() -> Int {
         lock.withLock { starts }
+    }
+
+    func stopCount() -> Int {
+        lock.withLock { stops }
+    }
+
+    func changeHandlerCount() -> Int {
+        lock.withLock { changeHandlers }
     }
 }
 


### PR DESCRIPTION
## Purpose

Xcode 27 headless `DocumentationSearch` can still display a GUI connection approval dialog even when `unsafeAlwaysAllowAllAgents` is enabled. The proxy previously disabled approval automation in headless mode, so connections using `--auto-approve` could still wait for manual confirmation.

## Changes

- Honor the requested approval policy independently of GUI or headless routing.
- Enable the existing dialog process monitor for headless auto-approval, retaining name/PID matching, unbound bridges, and readiness that does not depend on GUI Xcode.
- Cover manual and automatic headless policies, monitor lifecycle, and startup reporting; update the documented behavior.

## Testing

- `scripts/check.sh` passed, including the full test run and process/STDIO adapter checks.
- Live Xcode 27.0 (`27A5252f`), with headless access and `unsafeAlwaysAllowAllAgents` enabled: an isolated proxy automatically approved its own GUI dialog and completed `XcodeListWorkspaces` and `DocumentationSearch`.
- Local Codex review of commit `393aed7150d97afed657ed755c080106a9c284d7`: no findings.
